### PR TITLE
Автодеплой на Cloudflare через GitHub Actions + D1 id

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to Cloudflare
+
+# Manual trigger only — run it from the Actions tab after the two repository
+# secrets (CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID) are set. The build runs
+# on GitHub's Linux runner, so nothing needs to be built locally.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-cloudflare
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build artifact
+        run: npm run build
+
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply DB --remote --config wrangler.cloudflare.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy Worker and assets
+        run: npx wrangler deploy --config wrangler.cloudflare.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.cloudflare.toml
+++ b/wrangler.cloudflare.toml
@@ -29,7 +29,7 @@ binding = "ASSETS"
 [[d1_databases]]
 binding = "DB"
 database_name = "radiologyos"
-database_id = "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+database_id = "dc9997c2-7157-42e8-b7f0-2d05654b261c"
 migrations_dir = "drizzle"
 
 # Cloudflare Images binding — powers the /_vinext/image optimizer. Left OUT


### PR DESCRIPTION
## Мета

Дати змогу деплоїти на Cloudflare **без локальної збірки** — збірка йде на Linux-раннері GitHub (на Windows Linux-тулчейн збірки не запускається).

## Що додано

- **`.github/workflows/deploy.yml`** — ручний запуск (`workflow_dispatch`): `npm ci` + `npm run build` на Ubuntu, далі `wrangler d1 migrations apply` і `wrangler deploy`, автентифікація через секрети `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`.
- **`wrangler.cloudflare.toml`** — вписано реальний `database_id` створеної D1.

## Перевірка

Шлях застосування міграцій перевірено локально: `wrangler d1 migrations apply` чисто прогнав усі `0000…0008` на новій базі (`✅` по кожній, «commands executed successfully»).

Тригер — лише ручний, тож мерж цього PR **не запускає деплой автоматично** (спочатку треба додати секрети).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_