### PR TITLE
Головна у стилі «Армія+»: тільки картки + темна тема, запис на /booking

### DIFF
--- a/app/booking/page.tsx
+++ b/app/booking/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
+import { groupedServices, serviceByCode, SERVICES } from "../../lib/catalog";
+import { todayInKyiv } from "../../lib/booking-rules";
+
+const featuredServices = SERVICES.filter(service => service.featured);
+const serviceGroups = groupedServices();
+const money = new Intl.NumberFormat("uk-UA");
+const equipmentNames: Record<string,string> = {
+  ct:"Комп’ютерний томограф", xray:"Цифровий рентген", fluoro:"Флюорограф",
+};
+
+export default function BookingPage() {
+  const [status, setStatus] = useState<"idle" | "sending" | "success" | "error">("idle");
+  const [bookingCode, setBookingCode] = useState("");
+  const [bookingError, setBookingError] = useState("");
+  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedTime, setSelectedTime] = useState("");
+  const [serviceCode, setServiceCode] = useState("");
+  const [availableTimes, setAvailableTimes] = useState<string[]>([]);
+  const [slotsLoading, setSlotsLoading] = useState(false);
+  const [slotDetails, setSlotDetails] = useState("");
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [patientCategory, setPatientCategory] = useState("");
+  const [referralType, setReferralType] = useState("");
+
+  const selectedService = serviceByCode(serviceCode);
+  const phoneDigits = phone.replace(/\D/g, "");
+  const step1Done = !!(serviceCode && selectedDate && selectedTime);
+  const step2Done = name.trim().length >= 2 && phoneDigits.length >= 11 && !!patientCategory;
+  const step3Done = !!referralType;
+
+  useEffect(() => {
+    const category = new URLSearchParams(window.location.search).get("category");
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (category === "military" || category === "civilian") setPatientCategory(category);
+  }, []);
+
+  function formatPhone(raw:string) {
+    let d = raw.replace(/\D/g, "");
+    if (d.startsWith("380")) d = d.slice(3); else if (d.startsWith("0")) d = d.slice(1);
+    d = d.slice(0, 9);
+    if (!d) return "";
+    let out = "+380";
+    if (d.length) out += ` ${d.slice(0, 2)}`;
+    if (d.length > 2) out += ` ${d.slice(2, 5)}`;
+    if (d.length > 5) out += ` ${d.slice(5, 7)}`;
+    if (d.length > 7) out += ` ${d.slice(7, 9)}`;
+    return out;
+  }
+
+  function chooseService(code:string) {
+    setServiceCode(code);
+    setSelectedTime("");
+    if (typeof window === "undefined") return;
+    window.setTimeout(() => {
+      document.getElementById("booking")?.scrollIntoView({ behavior:"smooth", block:"start" });
+      document.getElementById("bookingDate")?.focus({ preventScroll:true });
+    }, 60);
+  }
+
+  useEffect(() => {
+    if (!selectedDate || !serviceCode) return;
+    let active = true;
+    async function loadSlots() {
+      setSlotsLoading(true);
+      setSelectedTime("");
+      try {
+        const response = await fetch(`/api/availability?date=${encodeURIComponent(selectedDate)}&serviceCode=${encodeURIComponent(serviceCode)}`, { cache:"no-store" });
+        const data = await response.json() as {times?:string[];durationMinutes?:number;equipment?:string};
+        if (active) setAvailableTimes(response.ok ? data.times || [] : []);
+        if (active) setSlotDetails(response.ok && data.equipment ? `${data.equipment} · ${data.durationMinutes} хв` : "");
+      } catch {
+        if (active) setAvailableTimes([]);
+      } finally {
+        if (active) setSlotsLoading(false);
+      }
+    }
+    void loadSlots();
+    return () => { active = false; };
+  }, [selectedDate, serviceCode]);
+
+  async function submitBooking(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("sending");
+    setBookingError("");
+    const form = event.currentTarget;
+    const data = Object.fromEntries(new FormData(form));
+    try {
+      const response = await fetch("/api/bookings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      const result = (await response.json()) as { code?: string; error?: string };
+      if (!response.ok) throw new Error(result.error || "Не вдалося надіслати заявку");
+      setBookingCode(result.code || "");
+      setStatus("success");
+      form.reset();
+      setSelectedDate(""); setSelectedTime(""); setServiceCode("");
+      setAvailableTimes([]); setSlotDetails("");
+      setName(""); setPhone(""); setPatientCategory(""); setReferralType("");
+    } catch (error) {
+      setBookingError(error instanceof Error ? error.message : "Не вдалося надіслати заявку");
+      setStatus("error");
+    }
+  }
+
+  return (
+    <main className="publicShell bookingPage">
+      <header className="bookingTop">
+        <Link className="bookingBack" href="/">← На головну</Link>
+        <div className="bookingTopTitle"><b>Чернігівський військовий госпіталь</b><small>Онлайн-запис на дослідження</small></div>
+      </header>
+
+      <section className="section" id="services">
+        <div className="sectionHead"><div><p className="eyebrow">Послуги</p><h2>Оберіть дослідження</h2></div><p>Остаточну програму дослідження визначає лікар з урахуванням направлення та клінічної ситуації.</p></div>
+        <div className="serviceGrid">
+          {featuredServices.map((service) => (
+            <article className="serviceCard" key={service.code}>
+              <span className="serviceIcon">{service.equipmentId === "ct" ? "CT" : service.equipmentId === "xray" ? "XR" : "FL"}</span>
+              <h3>{service.title}</h3><p>{service.description}</p>
+              <div><b>{money.format(service.price)} грн</b><a href="#booking" onClick={(event)=>{event.preventDefault();chooseService(service.code);}}>Записатися →</a></div>
+            </article>
+          ))}
+        </div>
+        <p className="catalogCount">Повний каталог: {SERVICES.length} послуг із внутрішніми кодами та кодами eHealth там, де відповідність визначена.</p>
+        <p className="tariffNote">Ціни на сайті мають інформаційний характер. Перед підтвердженням запису адміністратор уточнить вартість відповідно до чинного офіційного тарифу.</p>
+      </section>
+
+      <section className="section prepSection" id="preparation">
+        <div className="sectionHead"><div><p className="eyebrow">Підготовка</p><h2>Перед дослідженням</h2></div><p>Точні рекомендації залежать від ділянки та необхідності контрастування. Працівник відділення уточнить їх під час підтвердження запису.</p></div>
+        <div className="prepGrid">
+          <article><span>01</span><h3>Візьміть направлення</h3><p>Підготуйте попередні висновки та зображення КТ, МРТ або рентгенографії, якщо вони є.</p></article>
+          <article><span>02</span><h3>КТ без контрасту</h3><p>Для більшості досліджень спеціальна підготовка не потрібна. Дотримуйтеся інструкцій, отриманих під час запису.</p></article>
+          <article><span>03</span><h3>КТ із контрастом</h3><p>Проводиться за медичними показаннями. Завчасно повідомте про алергії, вагітність і відомі захворювання нирок.</p></article>
+        </div>
+        <div className="included"><b>У тариф входить:</b><span>проведення дослідження</span><span>обробка та реконструкції</span><span>оцінка лікарем-рентгенологом</span><span>письмовий висновок</span></div>
+      </section>
+
+      <section className="section bookingSection" id="booking">
+        <div className="bookingIntro">
+          <p className="eyebrow">Онлайн-запис</p>
+          <h2>Залиште заявку<br />на дослідження</h2>
+          <p>Це заявка на бажаний час. Працівник відділення зв’яжеться з вами для уточнення підготовки та остаточного підтвердження.</p>
+          <div className="steps"><span>1</span><p><b>Заповніть форму</b><small>Оберіть послугу, дату та час.</small></p><span>2</span><p><b>Дочекайтеся дзвінка</b><small>Ми підтвердимо запис і деталі.</small></p></div>
+          <div className="bookingSummary" aria-live="polite">
+            <p className="bookingSummaryTitle">Ваше замовлення</p>
+            {selectedService ? <>
+              <p className="bookingSummaryService">{selectedService.title}</p>
+              <ul>
+                <li><span>Апарат</span><b>{equipmentNames[selectedService.equipmentId]}</b></li>
+                <li><span>Тривалість</span><b>{selectedService.durationMinutes} хв</b></li>
+                <li><span>Дата й час</span><b>{selectedDate ? `${selectedDate}${selectedTime ? ` · ${selectedTime}` : ""}` : "не обрано"}</b></li>
+                <li className="price"><span>Орієнтовна ціна</span><b>{money.format(selectedService.price)} грн</b></li>
+              </ul>
+              <small>Остаточну вартість підтвердить адміністратор за чинним тарифом.</small>
+            </> : <p className="bookingSummaryEmpty">Оберіть послугу — тут з’явиться підсумок і орієнтовна ціна.</p>}
+          </div>
+        </div>
+        <form className="bookingForm" onSubmit={submitBooking}>
+          <div className="formSections">
+            <fieldset className="formSection">
+              <legend className={step1Done?"done":""}><span>{step1Done?"✓":"1"}</span> Послуга, дата та час</legend>
+              <div className="formGrid">
+                <label className="wide"><span>Дослідження *</span><select name="serviceCode" required value={serviceCode} onChange={event=>{setServiceCode(event.target.value);setSelectedTime("");}}><option value="" disabled>Оберіть послугу</option>{Object.entries(serviceGroups).map(([group,items])=><optgroup label={group} key={group}>{items.map(service=><option value={service.code} key={service.code}>{service.code} · {service.title} · {money.format(service.price)} грн</option>)}</optgroup>)}</select></label>
+                <label><span>Бажана дата *</span><input id="bookingDate" name="date" type="date" required min={todayInKyiv()} value={selectedDate} onChange={event=>{setSelectedDate(event.target.value);setSelectedTime("");}} /></label>
+                <label><span>Вільний час *</span><select name="time" required value={selectedTime} onChange={event=>setSelectedTime(event.target.value)} disabled={!selectedDate||!serviceCode||slotsLoading}><option value="" disabled>{!serviceCode?"Спершу оберіть послугу":!selectedDate?"Оберіть дату":slotsLoading?"Перевіряємо…":availableTimes.length?"Оберіть час":"Вільного часу немає"}</option>{availableTimes.map(t => <option key={t}>{t}</option>)}</select>{slotDetails&&<small className="slotDetails">{slotDetails}</small>}</label>
+              </div>
+            </fieldset>
+            <fieldset className="formSection">
+              <legend className={step2Done?"done":""}><span>{step2Done?"✓":"2"}</span> Ваші дані</legend>
+              <div className="formGrid">
+                <label><span>Ім’я та прізвище *</span><input name="name" required minLength={2} autoComplete="name" placeholder="Як до вас звертатися" value={name} onChange={event=>setName(event.target.value)} /></label>
+                <label><span>Телефон *</span><input name="phone" required inputMode="tel" autoComplete="tel" placeholder="+380 __ ___ __ __" value={phone} onChange={event=>setPhone(formatPhone(event.target.value))} /></label>
+                <label className="wide"><span>Категорія пацієнта *</span><select name="patientCategory" required value={patientCategory} onChange={event=>setPatientCategory(event.target.value)}><option value="" disabled>Оберіть категорію</option><option value="military">Військовослужбовець</option><option value="civilian">Цивільний пацієнт</option></select></label>
+              </div>
+            </fieldset>
+            <fieldset className="formSection">
+              <legend className={step3Done?"done":""}><span>{step3Done?"✓":"3"}</span> Направлення та деталі</legend>
+              <div className="formGrid">
+                <label><span>Тип направлення *</span><select name="referralType" required value={referralType} onChange={event=>setReferralType(event.target.value)}><option value="" disabled>Оберіть тип</option><option value="military_referral">Направлення військової частини/закладу</option><option value="eh_referral">Електронне направлення</option><option value="paper_referral">Паперове направлення</option><option value="none">Немає направлення</option><option value="other">Інше</option></select></label>
+                {referralType && referralType !== "none" ? <label><span>Номер направлення</span><input name="referralNumber" maxLength={80} placeholder="За наявності" /></label> : <input type="hidden" name="referralNumber" value="" />}
+                <label><span>Як дізналися про нас</span><select name="marketingSource" defaultValue=""><option value="">Не вказано</option><option value="google">Google</option><option value="facebook">Facebook</option><option value="instagram">Instagram</option><option value="recommendation">Рекомендація</option><option value="hospital">Направив медичний заклад</option><option value="other">Інше</option></select></label>
+                <label className="wide"><span>Коментар</span><textarea name="comment" rows={3} maxLength={700} placeholder="За потреби вкажіть важливі деталі" /></label>
+              </div>
+            </fieldset>
+          </div>
+          <label className="consent"><input type="checkbox" required name="consent" value="yes" /><span>Погоджуюся на обробку контактних даних для організації запису та ознайомився(-лася) з <Link href="/privacy">політикою конфіденційності</Link>.</span></label>
+          <button className="button submit" disabled={status === "sending"}>{status === "sending" ? "Надсилаємо…" : "Надіслати заявку →"}</button>
+          {status === "success" && <p className="notice success" role="status">Заявку прийнято. Ваш код: <b>{bookingCode}</b>. Очікуйте підтвердження телефоном.</p>}
+          {status === "error" && <p className="notice error" role="alert">{bookingError || "Не вдалося надіслати заявку. Спробуйте ще раз або зателефонуйте нам."}</p>}
+        </form>
+      </section>
+
+      <footer><p>© {new Date().getFullYear()} Відділення променевої діагностики</p><div className="footerLinks"><Link href="/cabinet">Статус заявки</Link><Link href="/privacy">Конфіденційність</Link><Link href="/">На головну</Link></div><p>Онлайн-запис не призначений для невідкладних станів.</p></footer>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -244,3 +244,56 @@ a.dashKpi:hover{border-color:#8db7af;transform:translateY(-2px);box-shadow:0 12p
 @media(max-width:1000px){.protocolWorkspace{grid-template-columns:1fr}.protocolQueue{position:static;max-height:none}.protocolQueueList{max-height:340px}.protocolFilterTabs{grid-template-columns:1fr 1fr 1fr 1fr}}
 @media(max-width:600px){.protocolRow,.protocolSectionFields{grid-template-columns:1fr}.protocolNormButton{width:100%}.protocolActions button{flex:1 1 auto}}
 @media print{.protocolQueue,.protocolQueueTools,.protocolEditorHead,.protocolFields,.protocolActions,.protocolReadonlyHint,.staffError,.staffSuccess{display:none!important}.protocolWorkspace{display:block}.protocolEditor{border:0;box-shadow:none;padding:0}.protocolPrint{display:block;color:#111;font-size:12px;line-height:1.55}.protocolPrint header{display:flex;flex-direction:column;padding-bottom:10px;border-bottom:2px solid #111}.protocolPrint header b{font-size:15px}.protocolPrint header span{margin-top:3px;color:#333;font-size:11px}.protocolPrint h1{font-size:19px;margin:16px 0 4px}.protocolPrintNumber{margin:0 0 12px;font-weight:700}.protocolPrintPatient{display:grid;grid-template-columns:1fr 1fr;gap:6px 24px;margin:12px 0;padding:12px 0;border-top:1px solid #999;border-bottom:1px solid #999}.protocolPrintPatient div{display:flex;gap:8px}.protocolPrintPatient dt{color:#555;min-width:110px}.protocolPrintPatient dd{margin:0;font-weight:700}.protocolPrint section{margin:12px 0;break-inside:avoid}.protocolPrint h2{font-size:12px;text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px;border-bottom:1px solid #ccc;padding-bottom:3px}.protocolPrint section p{margin:0;white-space:pre-wrap}.protocolPrint section dl{margin:0}.protocolPrint section dl div{display:flex;gap:8px;padding:3px 0}.protocolPrint section dt{min-width:180px;color:#333}.protocolPrint section dd{margin:0}.protocolPrint footer{display:flex;justify-content:space-between;gap:20px;margin-top:26px;padding-top:12px;border-top:1px solid #999}}
+
+/* ================= Армія+ public theme (dark military) ================= */
+.publicShell{min-height:100vh;background:radial-gradient(1100px 560px at 82% -12%,#1e2616,#13160f 62%);color:#e9ede0}
+/* landing surfaces */
+.publicShell .landingHeader,.publicShell .categoryCard.military,.publicShell .infoCard{background:#1e2417;border:1px solid rgba(255,255,255,.08);color:#e9ede0;box-shadow:0 12px 34px rgba(0,0,0,.28)}
+.publicShell .landingHeaderTitle b{color:#f3f6ea}.publicShell .landingHeaderTitle small{color:#9ea690}
+.publicShell .modalityChips li{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.12);color:#e0e7d3}
+.publicShell .modalityChips li span{background:#8ea94f;color:#12160c}
+.publicShell .landingLogin>summary{border-color:rgba(255,255,255,.28);color:#eef2e4}
+.publicShell .landingLogin>div{background:#20261a;border:1px solid rgba(255,255,255,.1);box-shadow:0 16px 40px rgba(0,0,0,.4)}
+.publicShell .landingLogin>div a{color:#e2e8d6}.publicShell .landingLogin>div a:hover{background:rgba(255,255,255,.06);color:#bcd08a}
+.publicShell .categoryIcon{background:rgba(255,255,255,.08)}
+.publicShell .categoryCard.military .categoryCopy b{color:#f3f6ea}.publicShell .categoryCard.military .categoryCopy small{color:#aeb69f}
+.publicShell .categoryCard:hover{transform:translateY(-2px);box-shadow:0 18px 44px rgba(0,0,0,.4);border-color:rgba(142,169,79,.5)}
+.publicShell .categoryCard.civilian{background:#cfc59d;color:#1b2013;border:1px solid rgba(0,0,0,.12)}
+.publicShell .categoryCard.civilian .categoryIcon{background:rgba(27,32,19,.14)}
+.publicShell .categoryCard.civilian .categoryCopy b{color:#1b2013}.publicShell .categoryCard.civilian .categoryCopy small{color:#4b4c33;opacity:1}
+.publicShell .categoryChevron{opacity:.5}
+.publicShell .infoText b{color:#bcd08a}.publicShell .infoText>span{color:#eef2e4}
+.landingFoot{display:flex;flex-wrap:wrap;justify-content:space-between;gap:10px;max-width:1140px;margin:6px auto 0;padding:14px 8px 40px;color:#8b937d;font-size:12px}
+
+/* booking page top bar */
+.bookingTop{max-width:1140px;margin:0 auto;display:flex;align-items:center;gap:20px;padding:22px clamp(14px,4vw,28px) 8px}
+.bookingBack{color:#bcd08a;font-weight:800;font-size:13px;white-space:nowrap}.bookingBack:hover{color:#d6e6ac}
+.bookingTopTitle b{display:block;font-family:var(--font-serif);font-size:19px;color:#f3f6ea;line-height:1.2}.bookingTopTitle small{display:block;margin-top:3px;color:#9ea690;font-size:12px}
+.bookingPage .section{max-width:1140px;padding-top:44px;padding-bottom:44px}
+
+/* shared dark typography + surfaces for booking sections */
+.publicShell .eyebrow{color:#9db85a}.publicShell .eyebrow span{background:#8ea94f}
+.publicShell h1,.publicShell h2,.publicShell h3{color:#f3f6ea}
+.publicShell .sectionHead>p,.publicShell .lead,.publicShell .bookingIntro>p:not(.eyebrow){color:#a9b096}
+.publicShell .serviceCard{background:#1d2216;border:1px solid rgba(255,255,255,.08)}
+.publicShell .serviceCard h3{color:#eef2e4}.publicShell .serviceCard p{color:#a9b096}
+.publicShell .serviceIcon{background:rgba(142,169,79,.18);color:#c1d492}
+.publicShell .serviceCard>div{border-top-color:rgba(255,255,255,.08)}.publicShell .serviceCard b{color:#f3f6ea}.publicShell .serviceCard>div a{color:#bcd08a}
+.publicShell .catalogCount,.publicShell .tariffNote{color:#8b937d}
+.publicShell .prepGrid article{background:#1d2216;border:1px solid rgba(255,255,255,.08)}.publicShell .prepGrid span{color:#8ea94f}.publicShell .prepGrid h3{color:#eef2e4}.publicShell .prepGrid p{color:#a9b096}
+.publicShell .included{background:#1d2216;border:1px solid rgba(255,255,255,.08);color:#cdd5be}.publicShell .included b{color:#bcd08a}.publicShell .included span{border-left-color:rgba(255,255,255,.14)}
+.publicShell .steps>span{background:rgba(142,169,79,.2);color:#c1d492}.publicShell .steps b{color:#eef2e4}.publicShell .steps small{color:#9ea690}
+.publicShell .bookingSummary{background:#171c11;border:1px solid rgba(255,255,255,.08)}.publicShell .bookingSummaryTitle{color:#9db85a!important}.publicShell .bookingSummaryService{color:#f3f6ea!important}.publicShell .bookingSummaryEmpty{color:#9ea690!important}
+.publicShell .bookingSummary ul,.publicShell .bookingSummary li{border-color:rgba(255,255,255,.08)}.publicShell .bookingSummary li span{color:#9ea690}.publicShell .bookingSummary li b{color:#eef2e4}.publicShell .bookingSummary li.price b{color:#bcd08a}.publicShell .bookingSummary>small{color:#8b937d}
+.publicShell .bookingForm{background:#1d2216;border:1px solid rgba(255,255,255,.08);box-shadow:0 16px 40px rgba(0,0,0,.28)}
+.publicShell .formSection>legend{color:#eef2e4}.publicShell .formSection>legend>span{background:#3c4530}.publicShell .formSection>legend.done>span{background:#8ea94f;color:#12160c}
+.publicShell label span{color:#b7bfa6}
+.publicShell .bookingForm input,.publicShell .bookingForm select,.publicShell .bookingForm textarea{background:#12160d;border:1px solid rgba(255,255,255,.14);color:#e9ede0}
+.publicShell .bookingForm input:focus,.publicShell .bookingForm select:focus,.publicShell .bookingForm textarea:focus{outline:2px solid #8ea94f;border-color:#8ea94f}
+.publicShell .bookingForm select option{color:#111}
+.publicShell .slotDetails{color:#9db85a}
+.publicShell .consent{color:#a9b096}.publicShell .consent a{color:#bcd08a}
+.publicShell .button{background:#8ea94f;color:#12160c}.publicShell .button:hover{background:#9db85a}
+.publicShell .notice.success{background:#1f2a16;color:#c6e2a5}.publicShell .notice.error{background:#2c1a15;color:#f0b7a0}
+.publicShell footer{background:transparent;border-top:1px solid rgba(255,255,255,.08);color:#8b937d}.publicShell footer a{color:#a9b096}.publicShell footer a:hover{color:#bcd08a}
+@media(max-width:600px){.bookingTop{flex-direction:column;align-items:flex-start;gap:10px}}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,120 +1,9 @@
-"use client";
-
-import { FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
-import { groupedServices, serviceByCode, SERVICES } from "../lib/catalog";
-import { todayInKyiv } from "../lib/booking-rules";
-
-const featuredServices = SERVICES.filter(service => service.featured);
-const serviceGroups = groupedServices();
-const money = new Intl.NumberFormat("uk-UA");
-const equipmentNames: Record<string,string> = {
-  ct:"Комп’ютерний томограф", xray:"Цифровий рентген", fluoro:"Флюорограф",
-};
 
 export default function Home() {
-  const [status, setStatus] = useState<"idle" | "sending" | "success" | "error">("idle");
-  const [bookingCode, setBookingCode] = useState("");
-  const [bookingError, setBookingError] = useState("");
-  const [selectedDate, setSelectedDate] = useState("");
-  const [selectedTime, setSelectedTime] = useState("");
-  const [serviceCode, setServiceCode] = useState("");
-  const [availableTimes, setAvailableTimes] = useState<string[]>([]);
-  const [slotsLoading, setSlotsLoading] = useState(false);
-  const [slotDetails, setSlotDetails] = useState("");
-  const [name, setName] = useState("");
-  const [phone, setPhone] = useState("");
-  const [patientCategory, setPatientCategory] = useState("");
-  const [referralType, setReferralType] = useState("");
-
-  const selectedService = serviceByCode(serviceCode);
-  const phoneDigits = phone.replace(/\D/g, "");
-  const step1Done = !!(serviceCode && selectedDate && selectedTime);
-  const step2Done = name.trim().length >= 2 && phoneDigits.length >= 11 && !!patientCategory;
-  const step3Done = !!referralType;
-
-  function formatPhone(raw:string) {
-    let d = raw.replace(/\D/g, "");
-    if (d.startsWith("380")) d = d.slice(3); else if (d.startsWith("0")) d = d.slice(1);
-    d = d.slice(0, 9);
-    if (!d) return "";
-    let out = "+380";
-    if (d.length) out += ` ${d.slice(0, 2)}`;
-    if (d.length > 2) out += ` ${d.slice(2, 5)}`;
-    if (d.length > 5) out += ` ${d.slice(5, 7)}`;
-    if (d.length > 7) out += ` ${d.slice(7, 9)}`;
-    return out;
-  }
-
-  function chooseService(code:string) {
-    setServiceCode(code);
-    setSelectedTime("");
-    if (typeof window === "undefined") return;
-    window.setTimeout(() => {
-      document.getElementById("booking")?.scrollIntoView({ behavior:"smooth", block:"start" });
-      document.getElementById("bookingDate")?.focus({ preventScroll:true });
-    }, 60);
-  }
-
-  useEffect(() => {
-    if (!selectedDate || !serviceCode) return;
-    let active = true;
-    async function loadSlots() {
-      setSlotsLoading(true);
-      setSelectedTime("");
-      try {
-        const response = await fetch(`/api/availability?date=${encodeURIComponent(selectedDate)}&serviceCode=${encodeURIComponent(serviceCode)}`, { cache:"no-store" });
-        const data = await response.json() as {times?:string[];durationMinutes?:number;equipment?:string};
-        if (active) setAvailableTimes(response.ok ? data.times || [] : []);
-        if (active) setSlotDetails(response.ok && data.equipment ? `${data.equipment} · ${data.durationMinutes} хв` : "");
-      } catch {
-        if (active) setAvailableTimes([]);
-      } finally {
-        if (active) setSlotsLoading(false);
-      }
-    }
-    void loadSlots();
-    return () => { active = false; };
-  }, [selectedDate, serviceCode]);
-
-  function goToCategory(category:string, target:string) {
-    setPatientCategory(category);
-    if (typeof window === "undefined") return;
-    document.getElementById(target)?.scrollIntoView({ behavior:"smooth", block:"start" });
-  }
-
-  async function submitBooking(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setStatus("sending");
-    setBookingError("");
-    const form = event.currentTarget;
-    const data = Object.fromEntries(new FormData(form));
-    try {
-      const response = await fetch("/api/bookings", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(data),
-      });
-      const result = (await response.json()) as { code?: string; error?: string };
-      if (!response.ok) throw new Error(result.error || "Не вдалося надіслати заявку");
-      setBookingCode(result.code || "");
-      setStatus("success");
-      form.reset();
-      setSelectedDate("");
-      setSelectedTime("");
-      setServiceCode("");
-      setAvailableTimes([]);
-      setSlotDetails("");
-      setName(""); setPhone(""); setPatientCategory(""); setReferralType("");
-    } catch (error) {
-      setBookingError(error instanceof Error ? error.message : "Не вдалося надіслати заявку");
-      setStatus("error");
-    }
-  }
-
   return (
-    <main>
-      <header className="landing" id="top">
+    <main className="publicShell">
+      <div className="landing" id="top">
         <div className="landingCard landingHeader">
           <div className="landingHeaderTop">
             <div className="landingHeaderTitle">
@@ -136,17 +25,17 @@ export default function Home() {
           </ul>
         </div>
 
-        <button type="button" className="landingCard categoryCard military" onClick={()=>goToCategory("military","booking")}>
+        <Link className="landingCard categoryCard military" href="/booking?category=military">
           <span className="categoryIcon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l8 3v6c0 5-3.4 8.6-8 11-4.6-2.4-8-6-8-11V5l8-3z"/></svg></span>
           <span className="categoryCopy"><b>Військовослужбовцям</b><small>Безоплатні дослідження за направленням</small></span>
           <span className="categoryChevron" aria-hidden="true">›</span>
-        </button>
+        </Link>
 
-        <button type="button" className="landingCard categoryCard civilian" onClick={()=>goToCategory("civilian","services")}>
+        <Link className="landingCard categoryCard civilian" href="/booking?category=civilian">
           <span className="categoryIcon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 3h4v7h7v4h-7v7h-4v-7H3v-4h7z"/></svg></span>
           <span className="categoryCopy"><b>Цивільним особам</b><small>Платні дослідження — повний прайс і запис</small></span>
           <span className="categoryChevron" aria-hidden="true">›</span>
-        </button>
+        </Link>
 
         <a className="landingCard infoCard" href="tel:+380972808899">
           <span className="infoText"><b>Телефон</b><span>+380 97 280 88 99</span></span>
@@ -156,96 +45,12 @@ export default function Home() {
           <span className="infoText"><b>Адреса</b><span>м. Чернігів, вул. Полуботка, 40</span></span>
           <span className="categoryChevron" aria-hidden="true">›</span>
         </a>
-      </header>
 
-      <section className="section" id="services">
-        <div className="sectionHead"><div><p className="eyebrow">Послуги</p><h2>Оберіть дослідження</h2></div><p>Остаточну програму дослідження визначає лікар з урахуванням направлення та клінічної ситуації.</p></div>
-        <div className="serviceGrid">
-          {featuredServices.map((service) => (
-            <article className="serviceCard" key={service.code}>
-              <span className="serviceIcon">{service.equipmentId === "ct" ? "CT" : service.equipmentId === "xray" ? "XR" : "FL"}</span>
-              <h3>{service.title}</h3><p>{service.description}</p>
-              <div><b>{money.format(service.price)} грн</b><a href="#booking" onClick={(event)=>{event.preventDefault();chooseService(service.code);}}>Записатися →</a></div>
-            </article>
-          ))}
-        </div>
-        <p className="catalogCount">Повний каталог: {SERVICES.length} послуг із внутрішніми кодами та кодами eHealth там, де відповідність визначена.</p>
-        <p className="tariffNote">Ціни на сайті мають інформаційний характер. Перед підтвердженням запису адміністратор уточнить вартість відповідно до чинного офіційного тарифу.</p>
-      </section>
-
-      <section className="section prepSection" id="preparation">
-        <div className="sectionHead"><div><p className="eyebrow">Підготовка</p><h2>Перед дослідженням</h2></div><p>Точні рекомендації залежать від ділянки та необхідності контрастування. Працівник відділення уточнить їх під час підтвердження запису.</p></div>
-        <div className="prepGrid">
-          <article><span>01</span><h3>Візьміть направлення</h3><p>Підготуйте попередні висновки та зображення КТ, МРТ або рентгенографії, якщо вони є.</p></article>
-          <article><span>02</span><h3>КТ без контрасту</h3><p>Для більшості досліджень спеціальна підготовка не потрібна. Дотримуйтеся інструкцій, отриманих під час запису.</p></article>
-          <article><span>03</span><h3>КТ із контрастом</h3><p>Проводиться за медичними показаннями. Завчасно повідомте про алергії, вагітність і відомі захворювання нирок.</p></article>
-        </div>
-        <div className="included"><b>У тариф входить:</b><span>проведення дослідження</span><span>обробка та реконструкції</span><span>оцінка лікарем-рентгенологом</span><span>письмовий висновок</span></div>
-      </section>
-
-      <section className="section bookingSection" id="booking">
-        <div className="bookingIntro">
-          <p className="eyebrow">Онлайн-запис</p>
-          <h2>Залиште заявку<br />на дослідження</h2>
-          <p>Це заявка на бажаний час. Працівник відділення зв’яжеться з вами для уточнення підготовки та остаточного підтвердження.</p>
-          <div className="steps"><span>1</span><p><b>Заповніть форму</b><small>Оберіть послугу, дату та час.</small></p><span>2</span><p><b>Дочекайтеся дзвінка</b><small>Ми підтвердимо запис і деталі.</small></p></div>
-          <div className="bookingSummary" aria-live="polite">
-            <p className="bookingSummaryTitle">Ваше замовлення</p>
-            {selectedService ? <>
-              <p className="bookingSummaryService">{selectedService.title}</p>
-              <ul>
-                <li><span>Апарат</span><b>{equipmentNames[selectedService.equipmentId]}</b></li>
-                <li><span>Тривалість</span><b>{selectedService.durationMinutes} хв</b></li>
-                <li><span>Дата й час</span><b>{selectedDate ? `${selectedDate}${selectedTime ? ` · ${selectedTime}` : ""}` : "не обрано"}</b></li>
-                <li className="price"><span>Орієнтовна ціна</span><b>{money.format(selectedService.price)} грн</b></li>
-              </ul>
-              <small>Остаточну вартість підтвердить адміністратор за чинним тарифом.</small>
-            </> : <p className="bookingSummaryEmpty">Оберіть послугу — тут з’явиться підсумок і орієнтовна ціна.</p>}
-          </div>
-        </div>
-        <form className="bookingForm" onSubmit={submitBooking}>
-          <div className="formSections">
-            <fieldset className="formSection">
-              <legend className={step1Done?"done":""}><span>{step1Done?"✓":"1"}</span> Послуга, дата та час</legend>
-              <div className="formGrid">
-                <label className="wide"><span>Дослідження *</span><select name="serviceCode" required value={serviceCode} onChange={event=>{setServiceCode(event.target.value);setSelectedTime("");}}><option value="" disabled>Оберіть послугу</option>{Object.entries(serviceGroups).map(([group,items])=><optgroup label={group} key={group}>{items.map(service=><option value={service.code} key={service.code}>{service.code} · {service.title} · {money.format(service.price)} грн</option>)}</optgroup>)}</select></label>
-                <label><span>Бажана дата *</span><input id="bookingDate" name="date" type="date" required min={todayInKyiv()} value={selectedDate} onChange={event=>{setSelectedDate(event.target.value);setSelectedTime("");}} /></label>
-                <label><span>Вільний час *</span><select name="time" required value={selectedTime} onChange={event=>setSelectedTime(event.target.value)} disabled={!selectedDate||!serviceCode||slotsLoading}><option value="" disabled>{!serviceCode?"Спершу оберіть послугу":!selectedDate?"Оберіть дату":slotsLoading?"Перевіряємо…":availableTimes.length?"Оберіть час":"Вільного часу немає"}</option>{availableTimes.map(t => <option key={t}>{t}</option>)}</select>{slotDetails&&<small className="slotDetails">{slotDetails}</small>}</label>
-              </div>
-            </fieldset>
-            <fieldset className="formSection">
-              <legend className={step2Done?"done":""}><span>{step2Done?"✓":"2"}</span> Ваші дані</legend>
-              <div className="formGrid">
-                <label><span>Ім’я та прізвище *</span><input name="name" required minLength={2} autoComplete="name" placeholder="Як до вас звертатися" value={name} onChange={event=>setName(event.target.value)} /></label>
-                <label><span>Телефон *</span><input name="phone" required inputMode="tel" autoComplete="tel" placeholder="+380 __ ___ __ __" value={phone} onChange={event=>setPhone(formatPhone(event.target.value))} /></label>
-                <label className="wide"><span>Категорія пацієнта *</span><select name="patientCategory" required value={patientCategory} onChange={event=>setPatientCategory(event.target.value)}><option value="" disabled>Оберіть категорію</option><option value="military">Військовослужбовець</option><option value="civilian">Цивільний пацієнт</option></select></label>
-              </div>
-            </fieldset>
-            <fieldset className="formSection">
-              <legend className={step3Done?"done":""}><span>{step3Done?"✓":"3"}</span> Направлення та деталі</legend>
-              <div className="formGrid">
-                <label><span>Тип направлення *</span><select name="referralType" required value={referralType} onChange={event=>setReferralType(event.target.value)}><option value="" disabled>Оберіть тип</option><option value="military_referral">Направлення військової частини/закладу</option><option value="eh_referral">Електронне направлення</option><option value="paper_referral">Паперове направлення</option><option value="none">Немає направлення</option><option value="other">Інше</option></select></label>
-                {referralType && referralType !== "none" ? <label><span>Номер направлення</span><input name="referralNumber" maxLength={80} placeholder="За наявності" /></label> : <input type="hidden" name="referralNumber" value="" />}
-                <label><span>Як дізналися про нас</span><select name="marketingSource" defaultValue=""><option value="">Не вказано</option><option value="google">Google</option><option value="facebook">Facebook</option><option value="instagram">Instagram</option><option value="recommendation">Рекомендація</option><option value="hospital">Направив медичний заклад</option><option value="other">Інше</option></select></label>
-                <label className="wide"><span>Коментар</span><textarea name="comment" rows={3} maxLength={700} placeholder="За потреби вкажіть важливі деталі" /></label>
-              </div>
-            </fieldset>
-          </div>
-          <label className="consent"><input type="checkbox" required name="consent" value="yes" /><span>Погоджуюся на обробку контактних даних для організації запису та ознайомився(-лася) з <Link href="/privacy">політикою конфіденційності</Link>.</span></label>
-          <button className="button submit" disabled={status === "sending"}>{status === "sending" ? "Надсилаємо…" : "Надіслати заявку →"}</button>
-          {status === "success" && <p className="notice success" role="status">Заявку прийнято. Ваш код: <b>{bookingCode}</b>. Очікуйте підтвердження телефоном.</p>}
-          {status === "error" && <p className="notice error" role="alert">{bookingError || "Не вдалося надіслати заявку. Спробуйте ще раз або зателефонуйте нам."}</p>}
-        </form>
-      </section>
-
-      <section className="contacts" id="contacts">
-        <div><p className="eyebrow light">Контакти</p><h2>Ми у Чернігові</h2></div>
-        <div><small>Адреса</small><b>м. Чернігів,<br />вул. Полуботка, 40</b></div>
-        <div><small>Телефон</small><a href="tel:+380972808899">+380 97 280 88 99</a></div>
-        <div><small>Графік</small><b>Пн–Сб<br />08:00–17:00</b></div>
-      </section>
-
-      <footer><p>© {new Date().getFullYear()} Відділення променевої діагностики</p><div className="footerLinks"><Link href="/cabinet">Статус заявки</Link><Link href="/privacy">Конфіденційність</Link><Link href="/staff">RadiologyOS для персоналу</Link></div><p>Онлайн-запис не призначений для невідкладних станів.</p></footer>
+        <footer className="landingFoot">
+          <span>Пн–Сб · 08:00–17:00</span>
+          <span>Онлайн-запис не призначений для невідкладних станів.</span>
+        </footer>
+      </div>
     </main>
   );
 }

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -4,13 +4,13 @@ import test from "node:test";
 const developmentPreviewMeta =
   /<meta(?=[^>]*\bname=["']codex-preview["'])(?=[^>]*\bcontent=["']development["'])[^>]*>/i;
 
-async function renderHome() {
+async function renderPath(path) {
   const workerUrl = new URL("../dist/server/index.js", import.meta.url);
   workerUrl.searchParams.set("test", `${process.pid}-${Date.now()}`);
   const { default: worker } = await import(workerUrl.href);
 
   return worker.fetch(
-    new Request("http://localhost/", {
+    new Request(`http://localhost${path}`, {
       headers: { accept: "text/html" },
     }),
     {
@@ -25,6 +25,8 @@ async function renderHome() {
   );
 }
 
+const renderHome = () => renderPath("/");
+
 test("renders development preview metadata", async () => {
   const response = await renderHome();
 
@@ -36,11 +38,19 @@ test("renders development preview metadata", async () => {
   assert.match(await response.text(), developmentPreviewMeta);
 });
 
-test("renders the full service catalog and same-system staff link", async () => {
+test("home is a card landing that routes into booking and staff login", async () => {
   const response = await renderHome();
+  const html = await response.text();
+  assert.match(html, /Чернігівський військовий госпіталь/);
+  assert.match(html, /href=["']\/booking\?category=military["']/);
+  assert.match(html, /href=["']\/booking\?category=civilian["']/);
+  assert.match(html, /href=["']\/staff\/login["']/);
+  assert.doesNotMatch(html, /radiologyos-app\.adamenko-artem96\.chatgpt\.site/);
+});
+
+test("booking page renders the full service catalog", async () => {
+  const response = await renderPath("/booking");
   const html = await response.text();
   const visibleHtml = html.replace(/<!--.*?-->/g, "");
   assert.match(visibleHtml, /Повний каталог:\s*38\s*послуг/);
-  assert.match(html, /href=["']\/staff["']/);
-  assert.doesNotMatch(html, /radiologyos-app\.adamenko-artem96\.chatgpt\.site/);
 });


### PR DESCRIPTION
## Що змінено

**Головна — лише картки.** Прибрано з першої сторінки блок «Оберіть дослідження» (послуги) і форму онлайн-запису. Тепер головна — чистий стек карток: шапка з модальностями, «Військовослужбовцям / Цивільним особам», телефон, адреса.

**Запис — окрема сторінка `/booking`.** Туди перенесено послуги, підготовку та форму запису. Картки на головній ведуть на неї з передвибором категорії (`?category=military|civilian`).

**Тема «Армія+» (темна військова).** Застосована лише до публічних сторінок (`.publicShell`) — кабінет персоналу лишається на світлій темі. Глибокий оливковий фон, оливково-хакі поверхні, хакі-акцент для картки «Цивільним», оливково-зелені підсвітки, темні поля форми.

**Тести оновлено:** головна веде на `/booking` і `/staff/login`; каталог 38 послуг тепер рендериться на `/booking`.

`lint`, `tsc`, `npm test` — зелені (33 тести). Перевірено на живому dev-сервері (скріншоти в чаті).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_