### PR TITLE
Головна у світлій темі «Армія+» (оливковий градієнт)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -245,55 +245,55 @@ a.dashKpi:hover{border-color:#8db7af;transform:translateY(-2px);box-shadow:0 12p
 @media(max-width:600px){.protocolRow,.protocolSectionFields{grid-template-columns:1fr}.protocolNormButton{width:100%}.protocolActions button{flex:1 1 auto}}
 @media print{.protocolQueue,.protocolQueueTools,.protocolEditorHead,.protocolFields,.protocolActions,.protocolReadonlyHint,.staffError,.staffSuccess{display:none!important}.protocolWorkspace{display:block}.protocolEditor{border:0;box-shadow:none;padding:0}.protocolPrint{display:block;color:#111;font-size:12px;line-height:1.55}.protocolPrint header{display:flex;flex-direction:column;padding-bottom:10px;border-bottom:2px solid #111}.protocolPrint header b{font-size:15px}.protocolPrint header span{margin-top:3px;color:#333;font-size:11px}.protocolPrint h1{font-size:19px;margin:16px 0 4px}.protocolPrintNumber{margin:0 0 12px;font-weight:700}.protocolPrintPatient{display:grid;grid-template-columns:1fr 1fr;gap:6px 24px;margin:12px 0;padding:12px 0;border-top:1px solid #999;border-bottom:1px solid #999}.protocolPrintPatient div{display:flex;gap:8px}.protocolPrintPatient dt{color:#555;min-width:110px}.protocolPrintPatient dd{margin:0;font-weight:700}.protocolPrint section{margin:12px 0;break-inside:avoid}.protocolPrint h2{font-size:12px;text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px;border-bottom:1px solid #ccc;padding-bottom:3px}.protocolPrint section p{margin:0;white-space:pre-wrap}.protocolPrint section dl{margin:0}.protocolPrint section dl div{display:flex;gap:8px;padding:3px 0}.protocolPrint section dt{min-width:180px;color:#333}.protocolPrint section dd{margin:0}.protocolPrint footer{display:flex;justify-content:space-between;gap:20px;margin-top:26px;padding-top:12px;border-top:1px solid #999}}
 
-/* ================= Армія+ public theme (dark military) ================= */
-.publicShell{min-height:100vh;background:radial-gradient(1100px 560px at 82% -12%,#1e2616,#13160f 62%);color:#e9ede0}
+/* ================= Армія+ public theme (light military) ================= */
+.publicShell{--mil-grad:linear-gradient(135deg,#4f5d3e,#6c7c59);--mil-solid:#556349;--civ-grad:linear-gradient(135deg,#f4e8cf,#e6cb95);--pub-gold:#f4c64f;--pub-line:#e0e4da;--pub-muted:#667062;--pub-shadow:0 16px 42px rgba(24,34,19,.12);min-height:100vh;background:#f5f3ed;color:#141712}
 /* landing surfaces */
-.publicShell .landingHeader,.publicShell .categoryCard.military,.publicShell .infoCard{background:#1e2417;border:1px solid rgba(255,255,255,.08);color:#e9ede0;box-shadow:0 12px 34px rgba(0,0,0,.28)}
-.publicShell .landingHeaderTitle b{color:#f3f6ea}.publicShell .landingHeaderTitle small{color:#9ea690}
-.publicShell .modalityChips li{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.12);color:#e0e7d3}
-.publicShell .modalityChips li span{background:#8ea94f;color:#12160c}
-.publicShell .landingLogin>summary{border-color:rgba(255,255,255,.28);color:#eef2e4}
-.publicShell .landingLogin>div{background:#20261a;border:1px solid rgba(255,255,255,.1);box-shadow:0 16px 40px rgba(0,0,0,.4)}
-.publicShell .landingLogin>div a{color:#e2e8d6}.publicShell .landingLogin>div a:hover{background:rgba(255,255,255,.06);color:#bcd08a}
-.publicShell .categoryIcon{background:rgba(255,255,255,.08)}
-.publicShell .categoryCard.military .categoryCopy b{color:#f3f6ea}.publicShell .categoryCard.military .categoryCopy small{color:#aeb69f}
-.publicShell .categoryCard:hover{transform:translateY(-2px);box-shadow:0 18px 44px rgba(0,0,0,.4);border-color:rgba(142,169,79,.5)}
-.publicShell .categoryCard.civilian{background:#cfc59d;color:#1b2013;border:1px solid rgba(0,0,0,.12)}
-.publicShell .categoryCard.civilian .categoryIcon{background:rgba(27,32,19,.14)}
-.publicShell .categoryCard.civilian .categoryCopy b{color:#1b2013}.publicShell .categoryCard.civilian .categoryCopy small{color:#4b4c33;opacity:1}
-.publicShell .categoryChevron{opacity:.5}
-.publicShell .infoText b{color:#bcd08a}.publicShell .infoText>span{color:#eef2e4}
-.landingFoot{display:flex;flex-wrap:wrap;justify-content:space-between;gap:10px;max-width:1140px;margin:6px auto 0;padding:14px 8px 40px;color:#8b937d;font-size:12px}
+.publicShell .landingHeader,.publicShell .categoryCard.military,.publicShell .infoCard{background:var(--mil-grad);border:0;color:#fff;box-shadow:var(--pub-shadow)}
+.publicShell .landingHeaderTitle b{color:#fff}.publicShell .landingHeaderTitle small{color:#e6eadf}
+.publicShell .modalityChips li{background:rgba(255,255,255,.09);border-color:rgba(255,255,255,.18);color:#eef3e6}
+.publicShell .modalityChips li span{background:rgba(255,255,255,.18);color:#fff}
+.publicShell .landingLogin>summary{border-color:rgba(255,255,255,.4);color:#fff}
+.publicShell .landingLogin>div{background:#f7f8f4;border:1px solid #d7ddd1;box-shadow:0 18px 46px rgba(14,22,11,.24)}
+.publicShell .landingLogin>div a{color:#1d2419}.publicShell .landingLogin>div a:hover{background:#f1f3ed;color:#4f5d3e}
+.publicShell .categoryIcon{background:rgba(255,255,255,.14)}
+.publicShell .categoryCard.military .categoryCopy b{color:#fff}.publicShell .categoryCard.military .categoryCopy small{color:#e9eee3}
+.publicShell .categoryCard:hover{transform:translateY(-2px);box-shadow:0 20px 48px rgba(24,34,19,.18)}
+.publicShell .categoryCard.civilian{background:var(--civ-grad);color:#2a2417;border:0}
+.publicShell .categoryCard.civilian .categoryIcon{background:rgba(79,93,62,.1);color:#4f5d3e}
+.publicShell .categoryCard.civilian .categoryCopy b{color:#2a2417}.publicShell .categoryCard.civilian .categoryCopy small{color:#5a4c2c;opacity:1}
+.publicShell .categoryChevron{opacity:.85}
+.publicShell .infoText b{color:#fff}.publicShell .infoText>span{color:#e9eee3}
+.landingFoot{display:flex;flex-wrap:wrap;justify-content:space-between;gap:10px;max-width:1140px;margin:6px auto 0;padding:14px 8px 40px;color:#667062;font-size:12px}
 
 /* booking page top bar */
 .bookingTop{max-width:1140px;margin:0 auto;display:flex;align-items:center;gap:20px;padding:22px clamp(14px,4vw,28px) 8px}
-.bookingBack{color:#bcd08a;font-weight:800;font-size:13px;white-space:nowrap}.bookingBack:hover{color:#d6e6ac}
-.bookingTopTitle b{display:block;font-family:var(--font-serif);font-size:19px;color:#f3f6ea;line-height:1.2}.bookingTopTitle small{display:block;margin-top:3px;color:#9ea690;font-size:12px}
+.bookingBack{color:#4f5d3e;font-weight:800;font-size:13px;white-space:nowrap}.bookingBack:hover{color:#3c4a30}
+.bookingTopTitle b{display:block;font-family:var(--font-serif);font-size:19px;color:#141712;line-height:1.2}.bookingTopTitle small{display:block;margin-top:3px;color:#667062;font-size:12px}
 .bookingPage .section{max-width:1140px;padding-top:44px;padding-bottom:44px}
 
-/* shared dark typography + surfaces for booking sections */
-.publicShell .eyebrow{color:#9db85a}.publicShell .eyebrow span{background:#8ea94f}
-.publicShell h1,.publicShell h2,.publicShell h3{color:#f3f6ea}
-.publicShell .sectionHead>p,.publicShell .lead,.publicShell .bookingIntro>p:not(.eyebrow){color:#a9b096}
-.publicShell .serviceCard{background:#1d2216;border:1px solid rgba(255,255,255,.08)}
-.publicShell .serviceCard h3{color:#eef2e4}.publicShell .serviceCard p{color:#a9b096}
-.publicShell .serviceIcon{background:rgba(142,169,79,.18);color:#c1d492}
-.publicShell .serviceCard>div{border-top-color:rgba(255,255,255,.08)}.publicShell .serviceCard b{color:#f3f6ea}.publicShell .serviceCard>div a{color:#bcd08a}
-.publicShell .catalogCount,.publicShell .tariffNote{color:#8b937d}
-.publicShell .prepGrid article{background:#1d2216;border:1px solid rgba(255,255,255,.08)}.publicShell .prepGrid span{color:#8ea94f}.publicShell .prepGrid h3{color:#eef2e4}.publicShell .prepGrid p{color:#a9b096}
-.publicShell .included{background:#1d2216;border:1px solid rgba(255,255,255,.08);color:#cdd5be}.publicShell .included b{color:#bcd08a}.publicShell .included span{border-left-color:rgba(255,255,255,.14)}
-.publicShell .steps>span{background:rgba(142,169,79,.2);color:#c1d492}.publicShell .steps b{color:#eef2e4}.publicShell .steps small{color:#9ea690}
-.publicShell .bookingSummary{background:#171c11;border:1px solid rgba(255,255,255,.08)}.publicShell .bookingSummaryTitle{color:#9db85a!important}.publicShell .bookingSummaryService{color:#f3f6ea!important}.publicShell .bookingSummaryEmpty{color:#9ea690!important}
-.publicShell .bookingSummary ul,.publicShell .bookingSummary li{border-color:rgba(255,255,255,.08)}.publicShell .bookingSummary li span{color:#9ea690}.publicShell .bookingSummary li b{color:#eef2e4}.publicShell .bookingSummary li.price b{color:#bcd08a}.publicShell .bookingSummary>small{color:#8b937d}
-.publicShell .bookingForm{background:#1d2216;border:1px solid rgba(255,255,255,.08);box-shadow:0 16px 40px rgba(0,0,0,.28)}
-.publicShell .formSection>legend{color:#eef2e4}.publicShell .formSection>legend>span{background:#3c4530}.publicShell .formSection>legend.done>span{background:#8ea94f;color:#12160c}
-.publicShell label span{color:#b7bfa6}
-.publicShell .bookingForm input,.publicShell .bookingForm select,.publicShell .bookingForm textarea{background:#12160d;border:1px solid rgba(255,255,255,.14);color:#e9ede0}
-.publicShell .bookingForm input:focus,.publicShell .bookingForm select:focus,.publicShell .bookingForm textarea:focus{outline:2px solid #8ea94f;border-color:#8ea94f}
+/* shared light typography + surfaces for booking sections */
+.publicShell .eyebrow{color:#4f5d3e}.publicShell .eyebrow span{background:#556349}
+.publicShell h1,.publicShell h2,.publicShell h3{color:#141712}
+.publicShell .sectionHead>p,.publicShell .lead,.publicShell .bookingIntro>p:not(.eyebrow){color:#4e5d46}
+.publicShell .serviceCard{background:#fff;border:1px solid var(--pub-line);box-shadow:0 10px 26px rgba(24,34,19,.06)}
+.publicShell .serviceCard h3{color:#141712}.publicShell .serviceCard p{color:#4e5d46}
+.publicShell .serviceIcon{background:rgba(85,99,73,.12);color:#4f5d3e}
+.publicShell .serviceCard>div{border-top-color:var(--pub-line)}.publicShell .serviceCard b{color:#141712}.publicShell .serviceCard>div a{color:#4f5d3e}
+.publicShell .catalogCount,.publicShell .tariffNote{color:#667062}
+.publicShell .prepGrid article{background:#fff;border:1px solid var(--pub-line)}.publicShell .prepGrid span{color:#556349}.publicShell .prepGrid h3{color:#141712}.publicShell .prepGrid p{color:#4e5d46}
+.publicShell .included{background:#eef1e9;border:1px solid #dbe2d1;color:#3c4a30}.publicShell .included b{color:#3c4a30}.publicShell .included span{border-left-color:#cdd6bf}
+.publicShell .steps>span{background:rgba(85,99,73,.14);color:#4f5d3e}.publicShell .steps b{color:#141712}.publicShell .steps small{color:#667062}
+.publicShell .bookingSummary{background:#fff;border:1px solid var(--pub-line);box-shadow:0 10px 26px rgba(24,34,19,.06)}.publicShell .bookingSummaryTitle{color:#4f5d3e!important}.publicShell .bookingSummaryService{color:#141712!important}.publicShell .bookingSummaryEmpty{color:#667062!important}
+.publicShell .bookingSummary ul,.publicShell .bookingSummary li{border-color:var(--pub-line)}.publicShell .bookingSummary li span{color:#667062}.publicShell .bookingSummary li b{color:#141712}.publicShell .bookingSummary li.price b{color:#4f5d3e}.publicShell .bookingSummary>small{color:#8a927f}
+.publicShell .bookingForm{background:#fff;border:1px solid var(--pub-line);box-shadow:var(--pub-shadow)}
+.publicShell .formSection>legend{color:#141712}.publicShell .formSection>legend>span{background:#c7cebc;color:#3c4a30}.publicShell .formSection>legend.done>span{background:#556349;color:#fff}
+.publicShell label span{color:#41544f}
+.publicShell .bookingForm input,.publicShell .bookingForm select,.publicShell .bookingForm textarea{background:#fff;border:1px solid #cfd4c8;color:#141712}
+.publicShell .bookingForm input:focus,.publicShell .bookingForm select:focus,.publicShell .bookingForm textarea:focus{outline:2px solid #556349;border-color:#556349}
 .publicShell .bookingForm select option{color:#111}
-.publicShell .slotDetails{color:#9db85a}
-.publicShell .consent{color:#a9b096}.publicShell .consent a{color:#bcd08a}
-.publicShell .button{background:#8ea94f;color:#12160c}.publicShell .button:hover{background:#9db85a}
-.publicShell .notice.success{background:#1f2a16;color:#c6e2a5}.publicShell .notice.error{background:#2c1a15;color:#f0b7a0}
-.publicShell footer{background:transparent;border-top:1px solid rgba(255,255,255,.08);color:#8b937d}.publicShell footer a{color:#a9b096}.publicShell footer a:hover{color:#bcd08a}
+.publicShell .slotDetails{color:#4f5d3e}
+.publicShell .consent{color:#556050}.publicShell .consent a{color:#4f5d3e}
+.publicShell .button{background:#556349;color:#fff}.publicShell .button:hover{background:#465239}
+.publicShell .notice.success{background:#eef4e6;color:#33632c}.publicShell .notice.error{background:#fdf1ee;color:#a23c1d}
+.publicShell footer{background:transparent;border-top:1px solid var(--pub-line);color:#667062}.publicShell footer a{color:#4e5d46}.publicShell footer a:hover{color:#4f5d3e}
 @media(max-width:600px){.bookingTop{flex-direction:column;align-items:flex-start;gap:10px}}


### PR DESCRIPTION
## Що змінено

Публічні сторінки (головна `/` + запис `/booking`) переведено з **темної** оливкової теми на **світлу «Армія+»** — відповідно до референсу `radiologyossitev22`, який ви надіслали.

Палітра:
- бежеве тло `#f5f3ed` замість темного;
- оливковий градієнт `#4f5d3e → #6c7c59` для картки військовослужбовців, шапки та контактних карток (телефон/адреса), білий текст;
- бежево-золота картка `#f4e8cf → #e6cb95` для цивільних, темний текст;
- білі поверхні й поля форми на `/booking`, оливкові кнопки `#556349`, м’які тіні `rgba(24,34,19,.12)`.

## Обсяг
- Змінено лише `app/globals.css` (блок `.publicShell`, 44 рядки) — перефарбування з темної на світлу тему.
- Розмітка `app/page.tsx` і `app/booking/page.tsx` **без змін**.
- Тести без змін: `npm test` — 33/33 зелені; `eslint` — без помилок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_