### PR TITLE
Публічні сторінки один-в-один зі стилем v22 (Inter замість serif)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -307,4 +307,12 @@ a.dashKpi:hover{border-color:#8db7af;transform:translateY(-2px);box-shadow:0 12p
 .publicShell .button{background:#556349;color:#fff}.publicShell .button:hover{background:#465239}
 .publicShell .notice.success{background:#eef4e6;color:#33632c}.publicShell .notice.error{background:#fdf1ee;color:#a23c1d}
 .publicShell footer{background:transparent;border-top:1px solid var(--pub-line);color:#667062}.publicShell footer a{color:#4e5d46}.publicShell footer a:hover{color:#4f5d3e}
+/* v22-exact typography: Inter sans everywhere on public pages (no serif) */
+.publicShell .landingHeaderTitle b,.publicShell .categoryCopy b,.publicShell h1,.publicShell h2,.publicShell h3,.publicShell .bookingSummaryService,.publicShell .bookingTopTitle b,.publicShell .serviceCard h3,.publicShell .steps b,.publicShell .prepGrid h3{font-family:var(--font-sans)}
+.publicShell .landingHeaderTitle b{font-size:clamp(20px,3vw,27px);font-weight:700;letter-spacing:-.01em}
+.publicShell .landingHeaderTitle small{font-size:14px}
+.publicShell .categoryCopy b{font-size:clamp(22px,3.3vw,29px);font-weight:650;letter-spacing:-.005em}
+.publicShell h2{font-weight:700;letter-spacing:-.03em}
+.publicShell .serviceCard h3{font-weight:700}
+.publicShell .serviceCard>div b{color:#4f6140}
 @media(max-width:600px){.bookingTop{flex-direction:column;align-items:flex-start;gap:10px}}


### PR DESCRIPTION
## Що зроблено

Приведено типографіку публічних сторінок (головна + `/booking`) до референсу `radiologyossitev22`.

Світла палітра v22 (бежеве тло `#f5f3ed`, оливкові градієнти, бежево-золота картка) **вже була** в коді — єдина відмінність від v22 полягала у **шрифті заголовків**: використовувалася Lora (serif), тоді як v22 усюди Inter (sans).

- Заголовки публічних сторінок → **Inter (sans)** замість Lora (serif).
- Точні розміри й ваги v22: шапка `20–27px / 700`, картки аудиторій `22–29px / 650`, `h2` `700 / -0.03em`.
- Ціна послуги — оливкова `#4f6140` (як у v22).

Лише `app/globals.css`. `npm test` — **38/38**, lint без помилок; у зібраному CSS підтверджено світле тло `#f5f3ed`.

> ⚠️ Важливо: на `radiologyos.tech` зараз працює **старіша (темна) збірка** — світлий вигляд v22 з'явиться лише після повторного деплою.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_