### PR TITLE
Кабінет: заявки за телефоном + протокол із D1; слоти v22 з реального розкладу

### DIFF
--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -1,0 +1,40 @@
+// Patient self-service: list every booking tied to a phone number. Requires the
+// full phone number (not just the last four digits) so the list isn't trivially
+// enumerable. Returns only non-sensitive fields; the protocol document itself is
+// gated separately behind the booking code (see /api/my-protocol).
+
+import { normalizeUkrainianPhone } from "../../../lib/phone";
+import { isRateLimited } from "../../../lib/rate-limit";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+  if (await isRateLimited(db, request, "my-bookings", 12, 15)) {
+    return Response.json({ error: "Забагато спроб. Повторіть перевірку пізніше." }, { status: 429 });
+  }
+
+  const body = await request.json().catch(() => ({})) as { phone?: string };
+  const phoneNormalized = normalizeUkrainianPhone(String(body.phone || ""));
+  if (!phoneNormalized) {
+    return Response.json({ error: "Введіть повний номер телефону" }, { status: 400 });
+  }
+
+  const rows = await db.prepare(
+    `SELECT code, service, desired_date AS desiredDate, desired_time AS desiredTime,
+       status, created_at AS createdAt,
+       CASE WHEN protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol
+     FROM bookings WHERE phone_normalized = ?
+     ORDER BY created_at DESC, id DESC
+     LIMIT 50`
+  ).bind(phoneNormalized).all();
+
+  const bookings = (rows.results || []).map((row) => ({
+    ...row,
+    hasProtocol: Number((row as { hasProtocol: number }).hasProtocol) === 1,
+  }));
+  return Response.json({ bookings });
+}

--- a/app/api/my-protocol/route.ts
+++ b/app/api/my-protocol/route.ts
@@ -1,0 +1,56 @@
+// Patient self-service: return the finalized radiology protocol for one booking,
+// gated behind the booking code + phone (two factors) and only once the protocol
+// has been officially issued to the patient.
+
+import { isRateLimited } from "../../../lib/rate-limit";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+  if (await isRateLimited(db, request, "my-protocol", 12, 15)) {
+    return Response.json({ error: "Забагато спроб. Повторіть пізніше." }, { status: 429 });
+  }
+
+  const body = await request.json().catch(() => ({})) as { code?: string; phoneLast4?: string };
+  const code = (body.code || "").trim().toUpperCase().slice(0, 20);
+  const phoneLast4 = (body.phoneLast4 || "").replace(/\D/g, "").slice(-4);
+  if (!/^RD-[A-Z0-9]{8}$/.test(code) || phoneLast4.length !== 4) {
+    return Response.json({ error: "Перевірте код і останні 4 цифри телефону" }, { status: 400 });
+  }
+
+  const booking = await db.prepare(
+    `SELECT id, name, service, protocol_status AS protocolStatus, protocol_issued_at AS issuedAt
+     FROM bookings WHERE code = ? AND substr(phone_normalized, -4) = ? LIMIT 1`
+  ).bind(code, phoneLast4).first<{
+    id: number; name: string; service: string; protocolStatus: string; issuedAt: string;
+  }>();
+  if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  if (booking.protocolStatus !== "issued") {
+    return Response.json({ error: "Протокол ще не готовий" }, { status: 409 });
+  }
+
+  const proto = await db.prepare(
+    `SELECT number, method, findings, conclusion, recommendations
+     FROM protocols WHERE booking_id = ? LIMIT 1`
+  ).bind(booking.id).first<{
+    number: string; method: string; findings: string; conclusion: string; recommendations: string;
+  }>();
+  if (!proto) return Response.json({ error: "Протокол ще не готовий" }, { status: 409 });
+
+  return Response.json({
+    protocol: {
+      patient: booking.name,
+      service: booking.service,
+      issuedAt: booking.issuedAt,
+      number: proto.number,
+      method: proto.method,
+      findings: proto.findings,
+      conclusion: proto.conclusion,
+      recommendations: proto.recommendations,
+    },
+  });
+}

--- a/public/site/assets/cart.js
+++ b/public/site/assets/cart.js
@@ -16,7 +16,7 @@ function saveCart() {
 }
 
 function addToCart(code, name, price) {
-  _lastPickerApp = null;
+  _lastPickerCode = null;
   if (!cart.some(x => x.code === String(code))) {
     cart.push({ code: String(code), name, price: Number(price) });
     saveCart();
@@ -142,22 +142,25 @@ function cartApparatus() {
   return cart.some(x => apparatusForCode(x.code) === 'ct') ? 'ct' : 'xray';
 }
 
-let _lastPickerApp = null;
+let _lastPickerCode = null;
 function refreshSlotPicker() {
   const box = document.getElementById('slotPicker');
   if (!box || typeof initSlotPicker !== 'function') return;
   if (!cart.length) {
     box.innerHTML = '<div class="sp-loading">Оберіть послугу — і тут з’явиться вільний час</div>';
-    _lastPickerApp = null;
+    _lastPickerCode = null;
     return;
   }
-  const app = cartApparatus();
-  if (app === _lastPickerApp) return;
-  _lastPickerApp = app;
+  // Real free times come from the department schedule for the first service in
+  // the cart (see /api/availability). The chosen time is a preferred slot the
+  // registrar confirms for every service in the request.
+  const code = String(cart[0].code);
+  if (code === _lastPickerCode) return;
+  _lastPickerCode = code;
   pickedSlot = { date: '', time: '' };
   initSlotPicker({
     container: box,
-    apparatus: app,
+    serviceCode: code,
     onPick: s => {
       pickedSlot = s;
       const dd = document.getElementById('desiredDate');

--- a/public/site/assets/slots.js
+++ b/public/site/assets/slots.js
@@ -1,132 +1,78 @@
-/* RadiologyOS — вибір вільного часу пацієнтом.
-   Показує на тиждень уперед вільні слоти обраного апарата
-   (КТ — крок 30 хв, рентген — 15 хв). Зайнятість тягнеться з Google
-   Таблиці через безпечний endpoint (без персональних даних).
-   Якщо зв'язку немає — показує графік за замовчуванням із позначкою,
-   що час орієнтовний.
+/* RadiologyOS — вибір вільного часу пацієнтом (підключено до розкладу відділення).
+   Тягне реальні вільні слоти обраної послуги з /api/availability, тож обраний
+   час одразу узгоджений із зайнятістю апарата та блокуваннями графіка.
 
    Використання:
      initSlotPicker({
        container: HTMLElement,
-       apparatus: 'ct' | 'xray',
-       onPick: ({date, time}) => {}
-     })
-   Потребує: assets/department.js (APPARATUS, slotTimesFor, getWorkHours),
-             assets/notify.js (syncFetchBusy). */
+       serviceCode: '401',            // код послуги (той самий, що в кошику)
+       onPick: ({date, time}) => {}   // '' коли вибір скинуто
+     }) */
 
-async function initSlotPicker({ container, apparatus, onPick }) {
-  container.innerHTML = '<div class="sp-loading">Шукаю вільний час…</div>';
+async function initSlotPicker({ container, serviceCode, onPick }) {
+  const pad = (n) => String(n).padStart(2, '0');
+  const dayNames = ['Нд', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'];
 
-  let hours = (typeof getWorkHours === 'function') ? getWorkHours()
-            : { start: '08:00', end: '17:00', days: [1, 2, 3, 4, 5, 6] };
-  let busy = [];
-  let live = false;
-  let avail = null; /* доступність апаратів: {ct:{active,days:[...]}, ...} */
-
-  if (typeof syncFetchBusy === 'function') {
-    const data = await syncFetchBusy();
-    if (data && data.hours) {
-      hours = data.hours; busy = data.busy || []; live = true;
-      avail = data.availability || null;
-    }
+  // Наступні робочі дні (Пн–Сб). Недоступні дати сервер поверне порожніми.
+  const days = [];
+  for (let i = 0; i < 21 && days.length < 12; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() + i);
+    if (d.getDay() === 0) continue; // неділя — вихідний
+    const iso = d.toISOString().slice(0, 10);
+    days.push({ iso, label: dayNames[d.getDay()] + ' ' + pad(d.getDate()) + '.' + pad(d.getMonth() + 1) });
   }
-  if (!avail && typeof apparatusAvailabilityPublic === 'function') {
-    avail = apparatusAvailabilityPublic(); /* локальний стан (той самий пристрій) */
-  }
-
-
-  /* Машини потрібного типу (пацієнт бачить тип; вільно = вільна БУДЬ-ЯКА машина типу) */
-  const unitsAvail = {}; /* unitId -> {days:[...]} лише активні машини типу */
-  if (avail) {
-    Object.keys(avail).forEach(id => {
-      const u = avail[id];
-      if ((u.type || id) === apparatus && u.active !== false) unitsAvail[id] = { days: u.days || [] };
-    });
-  } else if (typeof unitsOfType === 'function') {
-    unitsOfType(apparatus).forEach(u => { unitsAvail[u.id] = { days: [0,1,2,3,4,5,6] }; });
-  }
-  const unitIds = Object.keys(unitsAvail);
-
-  /* жодної працюючої машини цього типу */
-  if (unitIds.length === 0) {
-    container.innerHTML = '<div class="sp-head">Вільний час — ' + apparatusById(apparatus).name + '</div>' +
-      '<div class="sp-empty">На жаль, апарат тимчасово не працює. Залиште заявку з бажаною датою — реєстратура запропонує варіанти, або зателефонуйте.</div>';
+  if (!days.length) {
+    container.innerHTML = '<div class="sp-empty">Найближчим часом вільних днів немає. Залиште бажану дату — реєстратура запропонує варіанти.</div>';
     if (onPick) onPick({ date: '', time: '' });
     return;
   }
 
-  /* зайнятість по машинах; легасі-записи ct/xray відносимо до першої машини типу */
-  const legacyFirst = unitIds[0];
-  const busyByUnit = {};
-  unitIds.forEach(id => busyByUnit[id] = new Set());
-  busy.forEach(b => {
-    let id = b.apparatus || '';
-    if (id === 'ct' || id === 'xray') id = (id === apparatus) ? legacyFirst : null;
-    if (id && busyByUnit[id]) busyByUnit[id].add(b.date + ' ' + b.time);
-  });
-
-  function slotFreeOnAnyUnit(iso, t) {
-    const dow = new Date(iso + 'T00:00:00').getDay();
-    return unitIds.some(id =>
-      unitsAvail[id].days.includes(dow) && !busyByUnit[id].has(iso + ' ' + t));
-  }
-
-  const pad = n => String(n).padStart(2, '0');
-  const todayISO = new Date().toISOString().slice(0, 10);
-  const dayNames = ['Нд', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'];
-  const times = slotTimesFor(apparatus, hours);
-
-  /* 7 днів уперед, лише робочі */
-  const appDays = [0, 1, 2, 3, 4, 5, 6].filter(d => unitIds.some(id => unitsAvail[id].days.includes(d)));
-  const days = [];
-  for (let i = 0; i < 14 && days.length < 7; i++) {
-    const d = new Date(); d.setDate(d.getDate() + i);
-    if (!hours.days.includes(d.getDay())) continue;
-    if (!appDays.includes(d.getDay())) continue; /* зміни немає */
-    const iso = d.toISOString().slice(0, 10);
-    days.push({ iso, label: dayNames[d.getDay()] + ' ' + pad(d.getDate()) + '.' + pad(d.getMonth() + 1) });
-  }
-
-  function freeTimesFor(iso) {
-    const now = new Date();
-    return times.filter(t => {
-      if (!slotFreeOnAnyUnit(iso, t)) return false;
-      if (iso === todayISO) {
-        const [h, m] = t.split(':').map(Number);
-        const c = new Date(); c.setHours(h, m, 0, 0);
-        if (c <= now) return false;
-      }
-      return true;
-    });
-  }
-
-  let selDay = days.find(d => freeTimesFor(d.iso).length) || days[0];
+  let selDay = days[0];
   let selTime = null;
+  let times = [];
+  let loading = false;
 
   function render() {
-    const appName = apparatusById(apparatus).name;
     container.innerHTML = `
-      <div class="sp-head">Вільний час — ${appName}${live ? '' : ' <span class="sp-note">(орієнтовно, підтвердить реєстратура)</span>'}</div>
-      <div class="sp-days">${days.map(d =>
+      <div class="sp-head">Вільний час${loading ? ' <span class="sp-note">(оновлюю…)</span>' : ' <span class="sp-note">(за розкладом відділення)</span>'}</div>
+      <div class="sp-days">${days.map((d) =>
         `<button type="button" class="sp-day ${d.iso === selDay.iso ? 'on' : ''}" data-day="${d.iso}">${d.label}</button>`).join('')}
       </div>
-      <div class="sp-times">${(function () {
-        const free = freeTimesFor(selDay.iso);
-        if (!free.length) return '<div class="sp-empty">На цей день вільних слотів немає</div>';
-        return free.map(t =>
-          `<button type="button" class="sp-time ${t === selTime ? 'on' : ''}" data-time="${t}">${t}</button>`).join('');
-      })()}
+      <div class="sp-times">${loading
+        ? '<div class="sp-loading">Перевіряю…</div>'
+        : (times.length
+          ? times.map((t) => `<button type="button" class="sp-time ${t === selTime ? 'on' : ''}" data-time="${t}">${t}</button>`).join('')
+          : '<div class="sp-empty">На цей день вільних слотів немає</div>')}
       </div>
       ${selTime ? `<div class="sp-picked">✓ Обрано: <strong>${selDay.label} о ${selTime}</strong></div>` : ''}`;
 
-    container.querySelectorAll('.sp-day').forEach(b => b.addEventListener('click', () => {
-      selDay = days.find(d => d.iso === b.dataset.day); selTime = null; render();
+    container.querySelectorAll('.sp-day').forEach((b) => b.addEventListener('click', () => {
+      selDay = days.find((d) => d.iso === b.dataset.day);
+      selTime = null;
       if (onPick) onPick({ date: '', time: '' });
+      loadTimes(selDay.iso);
     }));
-    container.querySelectorAll('.sp-time').forEach(b => b.addEventListener('click', () => {
-      selTime = b.dataset.time; render();
+    container.querySelectorAll('.sp-time').forEach((b) => b.addEventListener('click', () => {
+      selTime = b.dataset.time;
+      render();
       if (onPick) onPick({ date: selDay.iso, time: selTime });
     }));
   }
-  render();
+
+  async function loadTimes(iso) {
+    loading = true;
+    render();
+    try {
+      const r = await fetch('/api/availability?date=' + encodeURIComponent(iso) + '&serviceCode=' + encodeURIComponent(serviceCode), { cache: 'no-store' });
+      const data = await r.json();
+      times = r.ok ? (data.times || []) : [];
+    } catch (e) {
+      times = [];
+    }
+    loading = false;
+    render();
+  }
+
+  loadTimes(selDay.iso);
 }

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Особистий кабінет — RadiologyOS</title>
-<meta name="description" content="Особистий кабінет пацієнта відділення променевої діагностики: статус заявки та дата запису."/>
+<meta name="description" content="Особистий кабінет пацієнта відділення променевої діагностики: статус заявок, дата запису та протокол дослідження."/>
 <meta name="robots" content="noindex"/>
 <meta name="theme-color" content="#4f5d3e"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ead7ad'/%3E%3C/svg%3E"/>
@@ -30,12 +30,10 @@ header{padding:0 14px;margin-bottom:18px}
 
 .card{background:#fff;border:1px solid var(--line);border-radius:18px;padding:20px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
 .gate p{color:var(--muted);font-size:14px;margin:6px 0 14px}
-.field-label{display:block;font-size:13px;font-weight:700;margin:12px 0 6px}
-.code-input{width:100%;padding:12px;border:1px solid #cfd4c8;border-radius:11px;font:inherit;text-transform:uppercase}
-.code-input:focus,.phone-wrap input:focus{outline:2px solid var(--olive);outline-offset:1px;border-color:var(--olive)}
 .phone-wrap{display:flex}
 .phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #cfd4c8;border-right:0;border-radius:11px 0 0 11px;background:#f1f3ed;font-weight:700;color:#4f5d3e}
 .phone-wrap input{flex:1;min-width:0;padding:12px;border:1px solid #cfd4c8;border-radius:0 11px 11px 0;font:inherit}
+.phone-wrap input:focus{outline:2px solid var(--olive);outline-offset:1px;border-color:var(--olive)}
 .gate .btn{margin-top:14px}
 .btn{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:48px;padding:0 18px;border:0;border-radius:13px;background:var(--olive);color:#fff;font:inherit;font-weight:800;cursor:pointer}
 .btn:disabled{opacity:.6}
@@ -69,13 +67,31 @@ header{padding:0 14px;margin-bottom:18px}
 .step.on::after{background:var(--olive)}
 .step.on::before{background:var(--olive)}
 
-.visit-row{display:flex;gap:10px;align-items:center;background:#f7f8f4;border:1px solid var(--line);border-radius:13px;padding:12px 14px;margin-top:14px;font-size:14px}
-.visit-row strong{font-weight:800}
-.cancel-btn{margin-top:14px}
+.actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:14px}
+.actions .btn{width:auto;flex:1;min-width:150px;min-height:44px}
+
+.protocol{display:none;margin-top:14px;border:1px solid var(--line);border-radius:14px;padding:18px;background:#fdfdfb}
+.protocol.open{display:block}
+.protocol h4{margin:0 0 2px;font-size:15px}
+.protocol .p-org{font-size:12px;color:var(--muted);margin-bottom:12px}
+.p-field{margin:10px 0}
+.p-field b{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:#6c7562;margin-bottom:3px}
+.p-field div{font-size:14px;white-space:pre-wrap}
+.p-caveat{margin-top:12px;font-size:11px;color:#8a927f}
+.print-btn{margin-top:14px}
 
 .empty{text-align:center;color:var(--muted);padding:30px 10px}
+.empty a{color:#3c4a30;font-weight:700}
 .hint{font-size:12px;color:var(--muted);text-align:center;margin-top:18px;line-height:1.5}
 .hint a{color:#3c4a30;font-weight:700}
+
+@media print{
+  body{background:#fff;padding:0}
+  header,.cab-head,.gate,.hint,.logout,.actions,.app-top,.stepper{display:none!important}
+  .app-card{border:0;box-shadow:none;padding:0;margin:0}
+  .app-card:not(.printing){display:none!important}
+  .protocol{display:block!important;border:0;padding:0}
+}
 </style>
 </head>
 <body>
@@ -92,38 +108,43 @@ header{padding:0 14px;margin-bottom:18px}
 
 <main class="wrap">
 
-  <!-- Перевірка статусу за кодом заявки + телефоном -->
+  <!-- Вхід за номером телефону -->
   <div class="card gate" id="gate">
-    <h1 style="margin:0;font-size:20px">Статус заявки</h1>
-    <p>Введіть код заявки (він показаний одразу після подання, напр. RD-AB12CD34) і номер телефону, який ви вказували під час запису.</p>
-    <label class="field-label" for="gateCode">Код заявки</label>
-    <input class="code-input" id="gateCode" placeholder="RD-XXXXXXXX" autocomplete="off"/>
-    <label class="field-label" for="gatePhone">Номер телефону</label>
+    <h1 style="margin:0;font-size:20px">Вхід до кабінету</h1>
+    <p>Введіть номер телефону, який ви вказували в заявці. Ви побачите статуси своїх заявок, дату запису та готові протоколи.</p>
     <div class="phone-wrap">
       <span class="phone-prefix">+380</span>
       <input id="gatePhone" inputmode="numeric" maxlength="9" placeholder="97 000 00 00" aria-label="Номер телефону"/>
     </div>
     <span class="gate-error" id="gateError"></span>
-    <button class="btn" id="gateBtn" type="button">Переглянути статус</button>
+    <button class="btn" id="gateBtn" type="button">Переглянути заявки</button>
   </div>
 
-  <!-- Результат -->
+  <!-- Кабінет -->
   <div id="cabinet" hidden>
     <div class="cab-head">
       <div>
-        <h1>Ваша заявка</h1>
-        <div class="cab-phone" id="cabCode"></div>
+        <h1>Мої заявки</h1>
+        <div class="cab-phone" id="cabPhone"></div>
       </div>
-      <button class="logout" id="resetBtn" type="button">Нова перевірка</button>
+      <button class="logout" id="logoutBtn" type="button">Вийти</button>
     </div>
     <div id="appList"></div>
-    <p class="hint"><a href="/site/price.html">Подати нову заявку →</a></p>
+    <div class="empty" id="emptyState" hidden>
+      За цим номером заявок не знайдено.<br/>
+      <a href="/site/price.html">Подати заявку →</a>
+    </div>
+    <p class="hint">Показуються заявки, оформлені на цей номер телефону. Протокол дослідження стає доступним після того, як лікар його видасть.</p>
   </div>
 
 </main>
 
 <script>
+const MY_BOOKINGS = '/api/my-bookings';
 const STATUS_API = '/api/booking-status';
+const PROTOCOL_API = '/api/my-protocol';
+const PHONE_KEY = 'radiologyos_cabinet_phone';
+
 const statusMeta = {
   new:         { badge: 'new',       label: 'Нова',           step: 'new' },
   confirmed:   { badge: 'booked',    label: 'Підтверджена',   step: 'booked' },
@@ -137,12 +158,9 @@ const humanDate = (iso) => (iso ? String(iso).split('-').reverse().join('.') : '
 const gate = document.getElementById('gate');
 const cabinet = document.getElementById('cabinet');
 const errorBox = document.getElementById('gateError');
-let current = null; // { code, phoneLast4 }
+let phoneDigits = '';
 
-function showError(message) {
-  errorBox.textContent = message;
-  errorBox.classList.add('show');
-}
+function showError(message) { errorBox.textContent = message; errorBox.classList.add('show'); }
 
 function stepper(status) {
   const order = ['new', 'booked', 'done'];
@@ -153,95 +171,118 @@ function stepper(status) {
     `<div class="step ${i <= idx ? 'on' : ''}">${l}</div>`).join('') + '</div>';
 }
 
-function renderBooking(b) {
+function cardHtml(b) {
   const meta = statusMeta[b.status] || { badge: 'new', label: b.status };
   const when = b.desiredDate ? `бажана дата: ${esc(humanDate(b.desiredDate))}${b.desiredTime ? ' о ' + esc(b.desiredTime) : ''}` : '';
   const canCancel = ['new', 'confirmed', 'rescheduled'].includes(b.status);
-  document.getElementById('appList').innerHTML =
-    `<div class="card app-card">
-      <div class="app-top">
-        <div>
-          <div class="app-study">${esc(b.service)}</div>
-          <div class="app-meta">Код ${esc(b.code)}${when ? ' · ' + when : ''}</div>
-        </div>
-        <span class="badge ${meta.badge}">${esc(meta.label)}</span>
+  return `<div class="card app-card" id="card-${esc(b.code)}">
+    <div class="app-top">
+      <div>
+        <div class="app-study">${esc(b.service)}</div>
+        <div class="app-meta">Код ${esc(b.code)}${when ? ' · ' + when : ''}</div>
       </div>
-      ${b.status !== 'cancelled' ? stepper(b.status) : ''}
-      ${canCancel ? '<button class="btn danger cancel-btn" id="cancelBtn" type="button">Скасувати заявку</button>' : ''}
-    </div>`;
-  const cancelBtn = document.getElementById('cancelBtn');
-  if (cancelBtn) cancelBtn.addEventListener('click', cancelBooking);
+      <span class="badge ${meta.badge}">${esc(meta.label)}</span>
+    </div>
+    ${b.status !== 'cancelled' ? stepper(b.status) : ''}
+    <div class="actions">
+      ${b.hasProtocol ? `<button class="btn secondary" type="button" data-protocol="${esc(b.code)}">Переглянути протокол</button>` : ''}
+      ${canCancel ? `<button class="btn danger" type="button" data-cancel="${esc(b.code)}">Скасувати заявку</button>` : ''}
+    </div>
+    <div class="protocol" id="prot-${esc(b.code)}"></div>
+  </div>`;
 }
 
-async function lookup() {
-  const code = document.getElementById('gateCode').value.trim().toUpperCase();
-  const phoneLast4 = document.getElementById('gatePhone').value.replace(/\D/g, '').slice(-4);
-  errorBox.classList.remove('show');
-  if (!/^RD-[A-Z0-9]{8}$/.test(code)) { showError('Код має вигляд RD-XXXXXXXX'); return; }
-  if (phoneLast4.length !== 4) { showError('Введіть номер телефону (мінімум останні 4 цифри)'); return; }
-  const btn = document.getElementById('gateBtn');
-  btn.disabled = true; btn.textContent = 'Перевіряємо…';
-  try {
-    const res = await fetch(STATUS_API, {
-      method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ code, phoneLast4 }),
-    });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || !data.booking) { showError(data.error || 'Заявку не знайдено'); return; }
-    current = { code, phoneLast4 };
-    document.getElementById('cabCode').textContent = 'Код заявки: ' + code;
-    gate.hidden = true; cabinet.hidden = false;
-    renderBooking(data.booking);
-  } catch (e) {
-    showError('Не вдалося перевірити статус. Спробуйте пізніше.');
-  } finally {
-    btn.disabled = false; btn.textContent = 'Переглянути статус';
-  }
-}
-
-async function cancelBooking() {
-  if (!current) return;
-  if (!confirm('Скасувати цю заявку?')) return;
-  const btn = document.getElementById('cancelBtn');
-  if (btn) { btn.disabled = true; btn.textContent = 'Скасовуємо…'; }
-  try {
-    const res = await fetch(STATUS_API, {
-      method: 'PATCH', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ ...current, action: 'cancel' }),
-    });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || !data.ok) { alert(data.error || 'Не вдалося скасувати заявку'); if (btn) { btn.disabled = false; btn.textContent = 'Скасувати заявку'; } return; }
-    await lookupSilent();
-  } catch (e) {
-    alert('Не вдалося скасувати заявку. Спробуйте пізніше.');
-    if (btn) { btn.disabled = false; btn.textContent = 'Скасувати заявку'; }
-  }
-}
-
-async function lookupSilent() {
-  if (!current) return;
-  const res = await fetch(STATUS_API, {
+async function loadBookings() {
+  const res = await fetch(MY_BOOKINGS, {
     method: 'POST', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(current),
+    body: JSON.stringify({ phone: '+380' + phoneDigits }),
   });
   const data = await res.json().catch(() => ({}));
-  if (res.ok && data.booking) renderBooking(data.booking);
+  if (!res.ok) { showError(data.error || 'Не вдалося завантажити заявки'); return false; }
+  const list = document.getElementById('appList');
+  const bookings = data.bookings || [];
+  document.getElementById('emptyState').hidden = bookings.length > 0;
+  list.innerHTML = bookings.map(cardHtml).join('');
+  list.querySelectorAll('[data-cancel]').forEach((b) => b.addEventListener('click', () => cancelBooking(b.dataset.cancel)));
+  list.querySelectorAll('[data-protocol]').forEach((b) => b.addEventListener('click', () => toggleProtocol(b.dataset.protocol, b)));
+  return true;
 }
 
-document.getElementById('gateBtn').addEventListener('click', lookup);
-document.getElementById('gateCode').addEventListener('keydown', (e) => { if (e.key === 'Enter') document.getElementById('gatePhone').focus(); });
-document.getElementById('gatePhone').addEventListener('keydown', (e) => { if (e.key === 'Enter') lookup(); });
-document.getElementById('resetBtn').addEventListener('click', () => {
-  current = null;
-  cabinet.hidden = true; gate.hidden = false;
+function enter(digits) {
+  phoneDigits = digits;
+  localStorage.setItem(PHONE_KEY, digits);
+  document.getElementById('cabPhone').textContent = '+380 ' + digits.replace(/(\d{2})(\d{3})(\d{2})(\d{2})/, '$1 $2 $3 $4');
+  gate.hidden = true; cabinet.hidden = false;
+  loadBookings();
+}
+
+async function cancelBooking(code) {
+  if (!confirm('Скасувати цю заявку?')) return;
+  const res = await fetch(STATUS_API, {
+    method: 'PATCH', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ code, phoneLast4: phoneDigits.slice(-4), action: 'cancel' }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) { alert(data.error || 'Не вдалося скасувати заявку'); return; }
+  loadBookings();
+}
+
+async function toggleProtocol(code, btn) {
+  const box = document.getElementById('prot-' + code);
+  if (box.classList.contains('open')) { box.classList.remove('open'); return; }
+  if (!box.dataset.loaded) {
+    btn.disabled = true; btn.textContent = 'Завантажую…';
+    try {
+      const res = await fetch(PROTOCOL_API, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code, phoneLast4: phoneDigits.slice(-4) }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.protocol) { alert(data.error || 'Протокол недоступний'); return; }
+      const p = data.protocol;
+      box.innerHTML =
+        `<h4>Протокол променевого дослідження ${p.number ? '№ ' + esc(p.number) : ''}</h4>
+         <div class="p-org">Чернігівський військовий госпіталь · Відділення променевої діагностики</div>
+         <div class="p-field"><b>Пацієнт</b><div>${esc(p.patient)}</div></div>
+         <div class="p-field"><b>Дослідження</b><div>${esc(p.service)}${p.method ? ' · ' + esc(p.method) : ''}</div></div>
+         ${p.findings ? `<div class="p-field"><b>Опис</b><div>${esc(p.findings)}</div></div>` : ''}
+         <div class="p-field"><b>Висновок</b><div>${esc(p.conclusion || '—')}</div></div>
+         ${p.recommendations ? `<div class="p-field"><b>Рекомендації</b><div>${esc(p.recommendations)}</div></div>` : ''}
+         <div class="p-caveat">Роздруківка з інформаційної системи. Юридичну силу має протокол, засвідчений закладом у встановленому порядку.</div>
+         <button class="btn secondary print-btn" type="button" data-print="${esc(code)}">🖨 Роздрукувати / зберегти PDF</button>`;
+      box.dataset.loaded = '1';
+      box.querySelector('[data-print]').addEventListener('click', () => printProtocol(code));
+    } finally {
+      btn.disabled = false; btn.textContent = 'Переглянути протокол';
+    }
+  }
+  box.classList.add('open');
+}
+
+function printProtocol(code) {
+  const card = document.getElementById('card-' + code);
+  card.classList.add('printing');
+  window.print();
+  card.classList.remove('printing');
+}
+
+document.getElementById('gateBtn').addEventListener('click', () => {
+  const digits = document.getElementById('gatePhone').value.replace(/\D/g, '');
   errorBox.classList.remove('show');
-  document.getElementById('gateCode').value = '';
+  if (digits.length !== 9) { showError('Введіть 9 цифр номера'); return; }
+  enter(digits);
+});
+document.getElementById('gatePhone').addEventListener('keydown', (e) => { if (e.key === 'Enter') document.getElementById('gateBtn').click(); });
+document.getElementById('logoutBtn').addEventListener('click', () => {
+  localStorage.removeItem(PHONE_KEY);
+  phoneDigits = '';
+  cabinet.hidden = true; gate.hidden = false;
   document.getElementById('gatePhone').value = '';
 });
 
-// Prefill the code from ?code=RD-... (e.g. a link from the confirmation screen).
-const codeParam = new URLSearchParams(location.search).get('code');
-if (codeParam) document.getElementById('gateCode').value = codeParam.toUpperCase();
+// Auto-open if a phone was remembered on this device.
+const saved = localStorage.getItem(PHONE_KEY);
+if (saved && /^\d{9}$/.test(saved)) enter(saved);
 </script>
 </body>
 </html>

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -34,10 +34,34 @@ test("the booking pages load the D1 bridge after cart.js", async () => {
   }
 });
 
-test("patient cabinet reads status from D1, not localStorage", async () => {
+test("patient cabinet lists bookings by phone and reads protocols from D1", async () => {
   const cabinet = await read("public/site/cabinet.html");
-  assert.match(cabinet, /\/api\/booking-status/);
+  assert.match(cabinet, /\/api\/my-bookings/); // list every booking for the phone
+  assert.match(cabinet, /\/api\/my-protocol/); // finalized protocol
   assert.match(cabinet, /method:\s*'PATCH'[\s\S]*action:\s*'cancel'/); // self-service cancel
-  assert.match(cabinet, /RD-\[A-Z0-9\]\{8\}/); // gate validates the booking code
-  assert.doesNotMatch(cabinet, /radiologyos_applications_v1/); // no more localStorage store
+  assert.doesNotMatch(cabinet, /radiologyos_applications_v1/); // no more localStorage data store
+});
+
+test("my-bookings lists every booking for a full phone number", async () => {
+  const route = await read("app/api/my-bookings/route.ts");
+  assert.match(route, /normalizeUkrainianPhone\(/);
+  assert.match(route, /WHERE phone_normalized = \?/);
+  assert.match(route, /protocol_status = 'issued'/); // exposes hasProtocol flag
+  assert.match(route, /isRateLimited\(/);
+});
+
+test("my-protocol only returns an issued protocol behind code + phone", async () => {
+  const route = await read("app/api/my-protocol/route.ts");
+  assert.match(route, /RD-\[A-Z0-9\]\{8\}/); // code required
+  assert.match(route, /substr\(phone_normalized, -4\)/); // phone required
+  assert.match(route, /protocolStatus !== "issued"/); // gated until issued
+  assert.match(route, /FROM protocols WHERE booking_id = \?/);
+});
+
+test("the slot picker uses the real department schedule", async () => {
+  const slots = await read("public/site/assets/slots.js");
+  assert.match(slots, /\/api\/availability\?date=/);
+  assert.match(slots, /serviceCode=/);
+  const cart = await read("public/site/assets/cart.js");
+  assert.match(cart, /serviceCode:\s*code/); // cart drives the picker by service code
 });


### PR DESCRIPTION
## Три доопрацювання за вашим списком

### 1. Кабінет: усі заявки за номером телефону
- **`/api/my-bookings`** — за повним номером телефону повертає всі заявки (код, послуга, дата, статус, прапорець «є протокол»).
- Захист: потрібен **повний** номер (не лише 4 цифри), щоб перелік не можна було легко підібрати.

### 2. Готовий протокол у кабінеті
- **`/api/my-protocol`** — віддає протокол **лише після статусу `issued`** (лікар його видав) і **лише за кодом заявки + телефоном** (два фактори для медичного документа).
- У кабінеті — кнопка «Переглянути протокол», перегляд і друк/збереження PDF.

### 3. Вибір часу у формі v22 — з реального розкладу
- Слот-пікер тепер тягне вільні слоти з **`/api/availability`** за кодом послуги (`slots.js` + `cart.js`) — обраний час одразу узгоджений із зайнятістю апарата й блокуваннями графіка.

## Перевірка (наскрізно, in-memory D1)
- перелік заявок за телефоном; `hasProtocol` вмикається після видачі протоколу;
- `/api/my-protocol`: **409** до видачі, **200** після (повертає висновок і №);
- `/api/availability`: реальні слоти (17 слотів КТ, перший 08:00).

`npm test` — **46/46**, lint — 0 помилок, build — успішний. Нових міграцій немає.

> ⚠️ Побачити на бойовому — після деплою (**Actions → Deploy to Cloudflare → Run workflow**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_