### PR TITLE
Telegram-сповіщення реєстратурі + оплата ПриватБанк; сторінка налаштувань

### DIFF
--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -25,7 +25,8 @@ export async function POST(request: Request) {
 
   const rows = await db.prepare(
     `SELECT code, service, desired_date AS desiredDate, desired_time AS desiredTime,
-       status, created_at AS createdAt,
+       status, created_at AS createdAt, patient_category AS category,
+       payment_status AS paymentStatus, payment_amount AS paymentAmount,
        CASE WHEN protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol
      FROM bookings WHERE phone_normalized = ?
      ORDER BY created_at DESC, id DESC

--- a/app/api/pay-link/route.ts
+++ b/app/api/pay-link/route.ts
@@ -1,0 +1,15 @@
+// Public: the department's payment link, if an admin configured one. Used by the
+// booking confirmation screen and the patient cabinet for civilian patients.
+
+import { getSetting } from "../../../lib/settings";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET() {
+  const db = dbBinding();
+  if (!db) return Response.json({ payLink: "" });
+  const payLink = await getSetting(db, "pay_link");
+  return Response.json({ payLink }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -6,6 +6,7 @@
 import { serviceByCode } from "../../../lib/catalog";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isRateLimited } from "../../../lib/rate-limit";
+import { bookingMessage, sendTelegram } from "../../../lib/telegram";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
@@ -75,6 +76,17 @@ export async function POST(request: Request) {
         ).bind(result.meta.last_row_id, `${service.code} ${desiredDate} ${desiredTime || "час не обрано"}`).run();
       }
       codes.push(code);
+    }
+
+    // Best-effort registrar notification; never let it break the booking.
+    try {
+      await sendTelegram(db, bookingMessage({
+        codes, name, phone, category,
+        services: services.map((s) => s.title),
+        desiredDate, desiredTime, comment,
+      }));
+    } catch (notifyError) {
+      console.error("site_booking_notify_failed", notifyError);
     }
 
     return Response.json({ codes, code: codes[0] }, { status: 201 });

--- a/app/api/staff/settings/route.ts
+++ b/app/api/staff/settings/route.ts
@@ -1,0 +1,70 @@
+// Department settings managed by an administrator: Telegram notifications for
+// new bookings and the PrivatBank payment link for civilian patients.
+
+import { requireStaff } from "../../../../lib/staff-auth";
+import { getSettings, setSetting } from "../../../../lib/settings";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+function clean(value: unknown, max: number) {
+  return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Налаштування доступні лише адміністратору" }, { status: 403 });
+
+  const values = await getSettings(db, ["telegram_bot_token", "telegram_chat_id", "pay_link"]);
+  return Response.json({
+    settings: {
+      telegramConfigured: Boolean(values.telegram_bot_token && values.telegram_chat_id),
+      telegramChatId: values.telegram_chat_id,
+      payLink: values.pay_link,
+    },
+    staff: member,
+  }, { headers: { "cache-control": "no-store" } });
+}
+
+export async function PUT(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Змінювати налаштування може лише адміністратор" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as {
+    telegramBotToken?: string; telegramChatId?: string; payLink?: string;
+  };
+  const chatId = clean(body.telegramChatId, 40);
+  const payLink = clean(body.payLink, 500);
+  // Empty token keeps the stored one (so the admin isn't forced to re-enter the
+  // secret on every save); a value of "-" explicitly clears it.
+  const token = clean(body.telegramBotToken, 120);
+
+  if (payLink && !/^https:\/\//i.test(payLink)) {
+    return Response.json({ error: "Посилання на оплату має починатися з https://" }, { status: 400 });
+  }
+  if (token && token !== "-" && !/^\d{6,}:[A-Za-z0-9_-]{20,}$/.test(token)) {
+    return Response.json({ error: "Некоректний токен бота Telegram" }, { status: 400 });
+  }
+
+  if (token === "-") await setSetting(db, "telegram_bot_token", "");
+  else if (token) await setSetting(db, "telegram_bot_token", token);
+  await setSetting(db, "telegram_chat_id", chatId);
+  await setSetting(db, "pay_link", payLink);
+
+  const values = await getSettings(db, ["telegram_bot_token", "telegram_chat_id", "pay_link"]);
+  return Response.json({
+    ok: true,
+    settings: {
+      telegramConfigured: Boolean(values.telegram_bot_token && values.telegram_chat_id),
+      telegramChatId: values.telegram_chat_id,
+      payLink: values.pay_link,
+    },
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -227,6 +227,18 @@ a.dashKpi:hover{border-color:#8db7af;transform:translateY(-2px);box-shadow:0 12p
 .dashKpi>small{display:block;color:#71807c;font-size:11px;line-height:1.5}
 .dashKpi.dashHero{background:linear-gradient(125deg,#0d5b50,#174641);border-color:#0d5b50;color:#fff}.dashKpi.dashHero>span{color:#a9d3ca}.dashKpi.dashHero>b{color:#fff}.dashKpi.dashHero>small{color:#bcdad3}
 .dashKpi.equipment>span{margin-bottom:14px}.dashEquip{display:flex;gap:10px}.dashEquip>div{flex:1;padding:10px;background:#f4f8f6;border-radius:6px;text-align:center}.dashEquip b{display:block;font-family:var(--font-serif);font-size:19px;color:#123d3a}.dashEquip small{display:block;margin-top:3px;color:#71807c;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.05em}
+/* Department settings page */
+.settingsCard{max-width:760px;margin:0 auto;display:flex;flex-direction:column;gap:18px}
+.settingsBlock{background:#fff;border:1px solid #dce4e3;border-radius:8px;padding:20px;box-shadow:0 8px 24px rgba(23,54,52,.035)}
+.settingsBlock h2{font-size:16px;font-weight:700;letter-spacing:-.01em;margin:0 0 6px}
+.settingsBlock>p{margin:0 0 12px;color:#66756f;font-size:12.5px;line-height:1.5}
+.settingsState{display:inline-block;margin-bottom:12px;padding:4px 10px;border-radius:99px;font-size:11px;font-weight:800}
+.settingsState.on{background:#e2efe0;color:#2f5c2a}.settingsState.off{background:#f0eee7;color:#7a8b88}
+.settingsCard label{display:block;margin-top:12px}.settingsCard label>span{display:block;margin-bottom:6px;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.06em;color:#41544f}
+.settingsCard input{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink)}.settingsCard input:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+.settingsCard label>small{display:block;margin-top:5px;color:#7a8b88;font-size:11px}
+.settingsCard .button{align-self:flex-start;min-height:44px;padding:0 20px;border:0;border-radius:7px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.settingsCard .button:hover:not(:disabled){background:#0a4b42}.settingsCard .button:disabled{opacity:.6}
+.settingsCard .notice{margin:0;padding:11px 13px;border-radius:7px;font-size:13px}.settingsCard .notice.success{background:#eef4e6;color:#33632c}.settingsCard .notice.error{background:#fdf1ee;color:#a23c1d}
 .dashLists{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .dashList{padding:20px;background:#fff;border:1px solid #dce4e3;border-radius:8px;box-shadow:0 8px 24px rgba(23,54,52,.035)}
 .dashListHead{display:flex;justify-content:space-between;align-items:baseline;gap:12px}.dashListHead h3{font-family:var(--font-serif);font-size:16px;color:#20423d}.dashListHead span{font-size:12px;font-weight:900;color:#c15a2b}

--- a/app/staff/settings/page.tsx
+++ b/app/staff/settings/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+type Settings = { telegramConfigured: boolean; telegramChatId: string; payLink: string };
+
+export default function StaffSettingsPage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [chatId, setChatId] = useState("");
+  const [payLink, setPayLink] = useState("");
+  const [token, setToken] = useState("");
+  const [status, setStatus] = useState<"idle" | "saving">("idle");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const res = await fetch("/api/staff/settings", { cache: "no-store" });
+      if (res.status === 403) { if (active) setForbidden(true); return; }
+      const data = await res.json().catch(() => ({})) as { settings?: Settings; staff?: StaffInfo };
+      if (!active) return;
+      if (data.settings) { setSettings(data.settings); setChatId(data.settings.telegramChatId); setPayLink(data.settings.payLink); }
+      if (data.staff) setStaff(data.staff);
+    })();
+    return () => { active = false; };
+  }, []);
+
+  async function save(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("saving"); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/settings", {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ telegramBotToken: token, telegramChatId: chatId, payLink }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; settings?: Settings };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
+      if (data.settings) setSettings(data.settings);
+      setToken("");
+      setNotice("Налаштування збережено");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося зберегти");
+    } finally {
+      setStatus("idle");
+    }
+  }
+
+  const body = forbidden ? (
+    <div className="accessDenied"><b>Доступ обмежено</b><p>Налаштування відділення доступні лише адміністратору.</p></div>
+  ) : (
+    <form className="settingsCard" onSubmit={save}>
+      <section className="settingsBlock">
+        <h2>Telegram-сповіщення реєстратурі</h2>
+        <p>Бот надсилатиме повідомлення про кожну нову заявку в чат відділення. Створіть бота через <b>@BotFather</b>, додайте його в чат і вставте токен та ID чату.</p>
+        <span className={`settingsState ${settings?.telegramConfigured ? "on" : "off"}`}>
+          {settings?.telegramConfigured ? "✓ Увімкнено" : "Вимкнено"}
+        </span>
+        <label><span>Токен бота</span>
+          <input value={token} onChange={(e) => setToken(e.target.value)} placeholder={settings?.telegramConfigured ? "Збережено — введіть, щоб змінити" : "123456:AA…"} autoComplete="off" />
+          <small>Порожнє поле — лишити збережений токен. «-» — вимкнути сповіщення.</small>
+        </label>
+        <label><span>ID чату</span>
+          <input value={chatId} onChange={(e) => setChatId(e.target.value)} placeholder="-1001234567890 або 123456789" autoComplete="off" />
+        </label>
+      </section>
+
+      <section className="settingsBlock">
+        <h2>Оплата (ПриватБанк) для цивільних</h2>
+        <p>Посилання на оплату (напр. кнопка/QR «Оплатити частинами» або checkout ПриватБанку). Його побачать цивільні пацієнти після заявки та в кабінеті.</p>
+        <label><span>Посилання на оплату</span>
+          <input value={payLink} onChange={(e) => setPayLink(e.target.value)} placeholder="https://…" autoComplete="off" inputMode="url" />
+        </label>
+      </section>
+
+      {notice && <p className="notice success" role="status">{notice}</p>}
+      {error && <p className="notice error" role="alert">{error}</p>}
+      <button className="button" disabled={status === "saving"}>{status === "saving" ? "Зберігаємо…" : "Зберегти налаштування"}</button>
+    </form>
+  );
+
+  return (
+    <StaffWorkspaceShell
+      active="settings"
+      title="Налаштування відділення"
+      description="Сповіщення реєстратурі та оплата — керує адміністратор."
+      staffName={staff?.displayName}
+      staffRole={staff?.role}
+    >
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "patients" | "protocols" | "imaging" | "reports";
+type WorkspaceSection = "dashboard" | "overview" | "patients" | "protocols" | "imaging" | "reports" | "settings";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -30,6 +30,7 @@ const navigation = [
 const administration = [
   { href:"/staff#staff-admin", label:"Персонал", glyph:"◉" },
   { href:"/staff#equipment", label:"Обладнання", glyph:"◇" },
+  { href:"/staff/settings", label:"Налаштування", glyph:"⚙", section:"settings" as WorkspaceSection },
   { href:"/", label:"Публічний сайт", glyph:"↗" },
 ];
 
@@ -93,6 +94,8 @@ export default function StaffWorkspaceShell({
         {administration.map((item)=><Link
           href={item.href}
           key={item.label}
+          className={"section" in item && item.section === active ? "active":""}
+          aria-current={"section" in item && item.section === active ? "page":undefined}
           title={collapsed ? item.label:undefined}
         ><span aria-hidden="true">{item.glyph}</span><b>{item.label}</b></Link>)}
       </nav>
@@ -132,14 +135,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "settings" ? "Налаштування":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/drizzle/0010_department_settings.sql
+++ b/drizzle/0010_department_settings.sql
@@ -1,0 +1,8 @@
+-- Department-configurable settings (managed by an admin in /staff/settings):
+-- Telegram notifications for new bookings and the PrivatBank payment link for
+-- civilian patients. Empty values mean the feature is simply off.
+
+INSERT OR IGNORE INTO `app_settings` (`key`, `value`) VALUES
+  ('telegram_bot_token', ''),
+  ('telegram_chat_id', ''),
+  ('pay_link', '');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785189600000,
       "tag": "0009_staff_self_service",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1785200400000,
+      "tag": "0010_department_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,0 +1,21 @@
+// Shared key/value access for the `app_settings` table — department-configurable
+// values such as the Telegram bot credentials and the payment link.
+
+export async function getSetting(db: D1Database, key: string): Promise<string> {
+  const row = await db.prepare("SELECT value FROM app_settings WHERE key = ? LIMIT 1")
+    .bind(key).first<{ value: string }>();
+  return row?.value || "";
+}
+
+export async function getSettings(db: D1Database, keys: string[]): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const key of keys) out[key] = await getSetting(db, key);
+  return out;
+}
+
+export async function setSetting(db: D1Database, key: string, value: string): Promise<void> {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  ).bind(key, value).run();
+}

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -1,0 +1,59 @@
+// Best-effort Telegram notifications for the registrar. Disabled (a no-op)
+// until an admin saves a bot token and chat id in /staff/settings.
+
+import { getSettings } from "./settings";
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>]/g, (m) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[m] as string));
+}
+
+export interface BookingNotice {
+  codes: string[];
+  name: string;
+  phone: string;
+  category: string;
+  services: string[];
+  desiredDate: string;
+  desiredTime: string;
+  comment?: string;
+}
+
+export function bookingMessage(notice: BookingNotice): string {
+  const who = notice.category === "military" ? "Військовослужбовець" : "Цивільний пацієнт";
+  const when = notice.desiredDate
+    ? `${notice.desiredDate}${notice.desiredTime ? ` о ${notice.desiredTime}` : ""}`
+    : "не вказано";
+  const lines = [
+    "🆕 <b>Нова заявка</b>",
+    `👤 ${escapeHtml(notice.name)} · ${who}`,
+    `📞 ${escapeHtml(notice.phone)}`,
+    `🩻 ${notice.services.map(escapeHtml).join("; ")}`,
+    `📅 Бажаний час: ${escapeHtml(when)}`,
+    `🔖 Код: ${notice.codes.map(escapeHtml).join(", ")}`,
+  ];
+  if (notice.comment) lines.push(`💬 ${escapeHtml(notice.comment)}`);
+  return lines.join("\n");
+}
+
+// Sends a message to the department chat. Returns false when Telegram is not
+// configured or the call fails — callers must never let this break the booking.
+export async function sendTelegram(db: D1Database, text: string): Promise<boolean> {
+  const { telegram_bot_token: token, telegram_chat_id: chatId } =
+    await getSettings(db, ["telegram_bot_token", "telegram_chat_id"]);
+  if (!token || !chatId) return false;
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: "HTML",
+        disable_web_page_preview: true,
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/public/site/assets/d1-bridge.js
+++ b/public/site/assets/d1-bridge.js
@@ -15,6 +15,26 @@
   const esc = (t) => String(t == null ? '' : t).replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m]));
   const humanDate = (iso) => (iso ? iso.split('-').reverse().join('.') : '');
 
+  // Fill the confirmation screen's payment block from the department pay link.
+  async function populatePayBlock() {
+    const block = document.getElementById('payBlock');
+    if (!block) return;
+    try {
+      const res = await fetch('/api/pay-link', { cache: 'no-store' });
+      const data = await res.json().catch(() => ({}));
+      const link = (data && data.payLink) || '';
+      if (!link) { block.hidden = true; return; }
+      const btn = document.getElementById('payBtn');
+      if (btn) btn.href = link;
+      const qrBox = document.getElementById('payQr');
+      if (qrBox && typeof qrcode === 'function') {
+        try { const qr = qrcode(0, 'M'); qr.addData(link); qr.make(); qrBox.innerHTML = qr.createImgTag(4, 6); }
+        catch (e) { qrBox.innerHTML = ''; }
+      }
+      block.hidden = false;
+    } catch (e) { /* leave hidden on failure */ }
+  }
+
   // Capture phase: run before cart.js's own submit handler and take over.
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
@@ -71,6 +91,8 @@
       // We saved to the server, so hide the "online transfer not configured" note.
       const offline = document.getElementById('offlineNote');
       if (offline) offline.hidden = true;
+      // Show the department payment link/QR for civilian patients.
+      if (category === 'civilian') populatePayBlock();
     } catch (error) {
       if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = submitLabel || 'Сформувати заявку'; }
       alert((error && error.message) || 'Не вдалося надіслати заявку. Зателефонуйте в реєстратуру: +380 97 280 88 99');

--- a/public/site/assets/notify.js
+++ b/public/site/assets/notify.js
@@ -13,8 +13,10 @@ const REGISTRY_EMAIL = '';
 /* Оплата платних послуг — офіційне посилання ПриватБанку в/ч А3120
    (розшифровано з QR-плаката бухгалтерії). Значення з панелі
    («Комунікації та оплата») має пріоритет над цим стандартом. */
-const DEFAULT_PAY_LINK_RAW = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params={"token":"cadc7a4d-d56c-4005-9cfe-04a96077f8c1"}';
-const DEFAULT_PAY_LINK = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params=%7B%22token%22%3A%22cadc7a4d-d56c-4005-9cfe-04a96077f8c1%22%7D';
+/* Посилання на оплату більше не «зашите» в код — його задає адміністратор у
+   /staff/settings, а клієнт бере через /api/pay-link (див. d1-bridge.js). */
+const DEFAULT_PAY_LINK_RAW = '';
+const DEFAULT_PAY_LINK = '';
 
 function notifyAdmin(payload) {
   if (!NOTIFY_ENDPOINT) return;

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -69,6 +69,8 @@ header{padding:0 14px;margin-bottom:18px}
 
 .actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:14px}
 .actions .btn{width:auto;flex:1;min-width:150px;min-height:44px}
+.pay-row{display:flex;gap:10px;align-items:center;background:#fff8e8;border:1px solid #ead8b2;border-radius:13px;padding:12px 14px;margin-top:14px;font-size:14px;color:#5a4b25}
+.pay-row strong{font-weight:800}
 
 .protocol{display:none;margin-top:14px;border:1px solid var(--line);border-radius:14px;padding:18px;background:#fdfdfb}
 .protocol.open{display:block}
@@ -154,11 +156,13 @@ const statusMeta = {
 };
 const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[m]));
 const humanDate = (iso) => (iso ? String(iso).split('-').reverse().join('.') : '');
+const money = (n) => new Intl.NumberFormat('uk-UA').format(Number(n) || 0);
 
 const gate = document.getElementById('gate');
 const cabinet = document.getElementById('cabinet');
 const errorBox = document.getElementById('gateError');
 let phoneDigits = '';
+let payLink = '';
 
 function showError(message) { errorBox.textContent = message; errorBox.classList.add('show'); }
 
@@ -175,6 +179,7 @@ function cardHtml(b) {
   const meta = statusMeta[b.status] || { badge: 'new', label: b.status };
   const when = b.desiredDate ? `бажана дата: ${esc(humanDate(b.desiredDate))}${b.desiredTime ? ' о ' + esc(b.desiredTime) : ''}` : '';
   const canCancel = ['new', 'confirmed', 'rescheduled'].includes(b.status);
+  const awaitingPayment = b.paymentStatus === 'pending' && Number(b.paymentAmount) > 0 && b.status !== 'cancelled' && b.status !== 'completed';
   return `<div class="card app-card" id="card-${esc(b.code)}">
     <div class="app-top">
       <div>
@@ -184,7 +189,9 @@ function cardHtml(b) {
       <span class="badge ${meta.badge}">${esc(meta.label)}</span>
     </div>
     ${b.status !== 'cancelled' ? stepper(b.status) : ''}
+    ${awaitingPayment ? `<div class="pay-row">💳 <span>Очікує оплати: <strong>${esc(money(b.paymentAmount))} грн</strong></span></div>` : ''}
     <div class="actions">
+      ${awaitingPayment && payLink ? `<a class="btn" href="${esc(payLink)}" target="_blank" rel="noopener">Оплатити</a>` : ''}
       ${b.hasProtocol ? `<button class="btn secondary" type="button" data-protocol="${esc(b.code)}">Переглянути протокол</button>` : ''}
       ${canCancel ? `<button class="btn danger" type="button" data-cancel="${esc(b.code)}">Скасувати заявку</button>` : ''}
     </div>
@@ -193,6 +200,11 @@ function cardHtml(b) {
 }
 
 async function loadBookings() {
+  try {
+    const pr = await fetch('/api/pay-link', { cache: 'no-store' });
+    const pd = await pr.json().catch(() => ({}));
+    payLink = (pd && pd.payLink) || '';
+  } catch (e) { payLink = ''; }
   const res = await fetch(MY_BOOKINGS, {
     method: 'POST', headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ phone: '+380' + phoneDigits }),

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -58,6 +58,39 @@ test("my-protocol only returns an issued protocol behind code + phone", async ()
   assert.match(route, /FROM protocols WHERE booking_id = \?/);
 });
 
+test("new bookings notify the registrar via Telegram (best-effort)", async () => {
+  const lib = await read("lib/telegram.ts");
+  assert.match(lib, /api\.telegram\.org\/bot/);
+  assert.match(lib, /if \(!token \|\| !chatId\) return false/); // no-op until configured
+  const route = await read("app/api/site-booking/route.ts");
+  assert.match(route, /sendTelegram\(/);
+  assert.match(route, /bookingMessage\(/);
+});
+
+test("department settings are admin-only and validated", async () => {
+  const route = await read("app/api/staff/settings/route.ts");
+  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /telegram_bot_token/);
+  assert.match(route, /pay_link/);
+  assert.match(route, /https:\\\/\\\//); // pay link must be https
+  const migration = await read("drizzle/0010_department_settings.sql");
+  assert.match(migration, /telegram_bot_token/);
+  assert.match(migration, /pay_link/);
+  const journal = JSON.parse(await read("drizzle/meta/_journal.json"));
+  assert.ok(journal.entries.some((e) => e.tag === "0010_department_settings"));
+});
+
+test("payment link is served publicly and used by the site, not hardcoded", async () => {
+  const route = await read("app/api/pay-link/route.ts");
+  assert.match(route, /pay_link/);
+  const bridge = await read("public/site/assets/d1-bridge.js");
+  assert.match(bridge, /\/api\/pay-link/);
+  const notify = await read("public/site/assets/notify.js");
+  assert.doesNotMatch(notify, /cadc7a4d/); // hardcoded PrivatBank token removed
+  const cabinet = await read("public/site/cabinet.html");
+  assert.match(cabinet, /Очікує оплати/);
+});
+
 test("the slot picker uses the real department schedule", async () => {
   const slots = await read("public/site/assets/slots.js");
   assert.match(slots, /\/api\/availability\?date=/);


### PR DESCRIPTION
## Два доопрацювання

### 1. Telegram-сповіщення реєстратурі
- Кожна нова заявка з сайту йде в **чат відділення** окремим повідомленням (хто, телефон, дослідження, бажаний час, код).
- `lib/telegram.ts` + виклик у `/api/site-booking`. **Best-effort**: помилка сповіщення ніколи не ламає заявку; вимкнено, доки не задано токен і чат.

### 2. Оплата (ПриватБанк) для цивільних
- **`/api/pay-link`** (публічний) віддає налаштоване посилання.
- Екран «Заявку прийнято» показує **QR/кнопку оплати** з цим посиланням.
- У кабінеті пацієнта — рядок **«Очікує оплати: N грн»** і кнопка **«Оплатити»** (сума й статус із `/api/my-bookings`).
- Прибрано «зашитий» токен ПриватБанку з `notify.js` — тепер лише конфіг.

### Спільне: сторінка налаштувань
- **`/staff/settings`** (лише адміністратор): токен бота, ID чату, посилання на оплату. Пункт «Налаштування» додано в бічне меню кабінету.
- `/api/staff/settings` (GET/PUT, admin-only, валідація), спільний `lib/settings.ts`.
- Міграція **0010**: ключі `app_settings` (`telegram_bot_token`, `telegram_chat_id`, `pay_link`).

## Перевірка (наскрізно, in-memory D1)
- адмін зберігає налаштування → **200**; без сесії → **403**;
- цивільна заявка → у чат надійшло форматоване повідомлення (код, послуга, час);
- `/api/pay-link` віддає посилання; `/api/my-bookings` → `pending / 1500 грн`.

`npm test` — **49/49**, lint — 0 помилок, build — успішний.

## Налаштувати після деплою
1. **Деплой** (застосує міграцію 0010): Actions → Deploy to Cloudflare → Run workflow.
2. У кабінеті: **Налаштування** → створіть бота через **@BotFather**, додайте його в чат відділення, вставте **токен** і **ID чату**; за потреби — **посилання на оплату** ПриватБанку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_