### PR TITLE
Військова форма (безоплатні тарифи) зберігає заявку в D1 + фікс слот-пікера

### DIFF
--- a/public/site/assets/d1-bridge.js
+++ b/public/site/assets/d1-bridge.js
@@ -1,19 +1,33 @@
-/* RadiologyOS — міст між заявкою v22 і базою даних відділення (D1).
-   Перехоплює надсилання «Моєї заявки» й зберігає її через /api/site-booking,
-   щоб замовлення з сайту одразу з'являлось у кабінеті персоналу. Форму й
-   екран «Заявку прийнято» лишаємо від v22 — додаємо лише реальний код заявки. */
+/* RadiologyOS — міст між заявками v22 і базою даних відділення (D1).
+   Перехоплює надсилання «Моєї заявки» (цивільна форма на index/price та
+   військова форма на military) і зберігає її через /api/site-booking, щоб
+   замовлення одразу з'являлось у кабінеті персоналу. Екрани «Заявку прийнято»
+   лишаємо від v22 — додаємо лише реальний код заявки. */
 (function () {
-  const form = document.getElementById('requestForm');
-  if (!form) return;
-
-  const category = /military/i.test(location.pathname) ? 'military' : 'civilian';
+  const esc = (t) => String(t == null ? '' : t).replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m]));
+  const humanDate = (iso) => (iso ? String(iso).split('-').reverse().join('.') : '');
   const REFERRAL_MAP = {
     'Є направлення': 'paper_referral',
     'Направлення ще немає': 'none',
     'Потрібна консультація': 'other',
   };
-  const esc = (t) => String(t == null ? '' : t).replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m]));
-  const humanDate = (iso) => (iso ? iso.split('-').reverse().join('.') : '');
+
+  function codesLine(codes) {
+    if (!codes.length) return '';
+    return `<div style="margin-top:6px"><strong>${codes.length > 1 ? 'Коди заявок' : 'Код заявки'}:</strong> ${codes.map(esc).join(', ')}</div>` +
+      `<div style="margin-top:4px;color:#4e5d46;font-size:13px">Збережіть код — за ним і номером телефону можна відстежити статус у кабінеті пацієнта.</div>`;
+  }
+
+  async function postBooking(payload) {
+    const response = await fetch('/api/site-booking', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(data.error || 'Не вдалося надіслати заявку');
+    return data.codes || (data.code ? [data.code] : []);
+  }
 
   // Fill the confirmation screen's payment block from the department pay link.
   async function populatePayBlock() {
@@ -35,67 +49,96 @@
     } catch (e) { /* leave hidden on failure */ }
   }
 
-  // Capture phase: run before cart.js's own submit handler and take over.
-  form.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    event.stopImmediatePropagation();
+  // ----- Civilian request (index.html, price.html) -----
+  const civilForm = document.getElementById('requestForm');
+  if (civilForm) {
+    const category = /military/i.test(location.pathname) ? 'military' : 'civilian';
+    civilForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const items = (typeof cart !== 'undefined' && Array.isArray(cart)) ? cart : [];
+      if (!items.length) { alert('Спочатку додайте послугу до заявки.'); return; }
+      if (!civilForm.checkValidity()) { civilForm.classList.add('was-validated'); const bad = civilForm.querySelector(':invalid'); if (bad) bad.focus(); return; }
 
-    const items = (typeof cart !== 'undefined' && Array.isArray(cart)) ? cart : [];
-    if (!items.length) { alert('Спочатку додайте послугу до заявки.'); return; }
-    if (!form.checkValidity()) {
-      form.classList.add('was-validated');
-      const bad = form.querySelector(':invalid');
-      if (bad) bad.focus();
-      return;
-    }
+      const name = document.getElementById('patientName').value.trim();
+      const phone = '+380' + document.getElementById('patientPhone').value.replace(/\D/g, '');
+      const picked = (typeof pickedSlot !== 'undefined') ? pickedSlot : { date: '', time: '' };
+      const desiredDate = picked.date || document.getElementById('desiredDate').value || '';
+      const desiredTime = picked.time || document.getElementById('desiredTime').value || '';
+      const referralType = REFERRAL_MAP[document.getElementById('referral').value] || 'other';
+      const comment = document.getElementById('comment').value.trim();
+      const source = (typeof getTrafficSource === 'function') ? getTrafficSource() : '';
 
-    const name = document.getElementById('patientName').value.trim();
-    const phone = '+380' + document.getElementById('patientPhone').value.replace(/\D/g, '');
-    const picked = (typeof pickedSlot !== 'undefined') ? pickedSlot : { date: '', time: '' };
-    const desiredDate = picked.date || document.getElementById('desiredDate').value || '';
-    const desiredTime = picked.time || document.getElementById('desiredTime').value || '';
-    const referralType = REFERRAL_MAP[document.getElementById('referral').value] || 'other';
-    const comment = document.getElementById('comment').value.trim();
-    const source = (typeof getTrafficSource === 'function') ? getTrafficSource() : '';
-
-    const submitBtn = form.querySelector('.send-request');
-    const submitLabel = submitBtn ? submitBtn.textContent : '';
-    if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Надсилаємо…'; }
-
-    try {
-      const response = await fetch('/api/site-booking', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          name, phone, category, referralType, comment, desiredDate, desiredTime, source,
-          items: items.map((x) => ({ code: String(x.code) })),
-        }),
-      });
-      const data = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(data.error || 'Не вдалося надіслати заявку');
-
-      const codes = data.codes || (data.code ? [data.code] : []);
-      const names = items.map((x) => esc(x.name)).join('; ');
-      // showSuccess() belongs to cart.js — it clears the cart and swaps in the panel.
-      if (typeof showSuccess === 'function') {
-        showSuccess(
-          `<div><strong>Дослідження:</strong> ${names}</div>` +
-          (desiredDate ? `<div><strong>Бажана дата:</strong> ${esc(humanDate(desiredDate))}${desiredTime ? ' о ' + esc(desiredTime) : ''}</div>` : '') +
-          `<div><strong>Телефон для зв'язку:</strong> ${esc(phone)}</div>` +
-          (codes.length
-            ? `<div style="margin-top:6px"><strong>${codes.length > 1 ? 'Коди заявок' : 'Код заявки'}:</strong> ${codes.map(esc).join(', ')}</div>` +
-              `<div style="margin-top:4px;color:#4e5d46;font-size:13px">Збережіть код — за ним і номером телефону можна відстежити статус у кабінеті пацієнта.</div>`
-            : '')
-        );
+      const submitBtn = civilForm.querySelector('.send-request');
+      const submitLabel = submitBtn ? submitBtn.textContent : '';
+      if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Надсилаємо…'; }
+      try {
+        const codes = await postBooking({ name, phone, category, referralType, comment, desiredDate, desiredTime, source, items: items.map((x) => ({ code: String(x.code) })) });
+        if (typeof showSuccess === 'function') {
+          showSuccess(
+            `<div><strong>Дослідження:</strong> ${items.map((x) => esc(x.name)).join('; ')}</div>` +
+            (desiredDate ? `<div><strong>Бажана дата:</strong> ${esc(humanDate(desiredDate))}${desiredTime ? ' о ' + esc(desiredTime) : ''}</div>` : '') +
+            `<div><strong>Телефон для зв'язку:</strong> ${esc(phone)}</div>` + codesLine(codes)
+          );
+        }
+        const offline = document.getElementById('offlineNote');
+        if (offline) offline.hidden = true;
+        if (category === 'civilian') populatePayBlock();
+      } catch (error) {
+        if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = submitLabel || 'Сформувати заявку'; }
+        alert((error && error.message) || 'Не вдалося надіслати заявку. Зателефонуйте в реєстратуру: +380 97 280 88 99');
       }
-      // We saved to the server, so hide the "online transfer not configured" note.
-      const offline = document.getElementById('offlineNote');
-      if (offline) offline.hidden = true;
-      // Show the department payment link/QR for civilian patients.
-      if (category === 'civilian') populatePayBlock();
-    } catch (error) {
-      if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = submitLabel || 'Сформувати заявку'; }
-      alert((error && error.message) || 'Не вдалося надіслати заявку. Зателефонуйте в реєстратуру: +380 97 280 88 99');
-    }
-  }, true);
+    }, true);
+  }
+
+  // ----- Military request — free, category "military" (military.html) -----
+  const milForm = document.getElementById('militaryRequestForm');
+  if (milForm) {
+    milForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const items = (typeof militaryCart !== 'undefined' && Array.isArray(militaryCart)) ? militaryCart : [];
+      if (!items.length) { alert('Оберіть хоча б одне дослідження.'); return; }
+      if (!milForm.checkValidity()) { milForm.classList.add('was-validated'); const bad = milForm.querySelector(':invalid'); if (bad) bad.focus(); return; }
+
+      const name = document.getElementById('militaryPatientName').value.trim();
+      const phone = '+380' + document.getElementById('militaryPatientPhone').value.replace(/\D/g, '');
+      const picked = window.milPickedSlot || { date: '', time: '' };
+      const desiredDate = picked.date || document.getElementById('militaryDesiredDate').value || '';
+      const desiredTime = picked.time || document.getElementById('militaryDesiredTime').value || '';
+      const refText = (document.getElementById('militaryReferral') || {}).value || '';
+      const commentRaw = (document.getElementById('militaryComment') || {}).value || '';
+      const comment = [refText, commentRaw.trim()].filter(Boolean).join('. ');
+      const source = (typeof getTrafficSource === 'function') ? getTrafficSource() : '';
+
+      const submitBtn = milForm.querySelector('.send-request');
+      const submitLabel = submitBtn ? submitBtn.textContent : '';
+      if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Надсилаємо…'; }
+      try {
+        const codes = await postBooking({
+          name, phone, category: 'military', referralType: 'military_referral',
+          comment, desiredDate, desiredTime, source,
+          items: items.map((x) => ({ code: String(x.code) })),
+        });
+        const summary = document.getElementById('milSuccessSummary');
+        if (summary) {
+          summary.innerHTML =
+            `<div><strong>Дослідження:</strong> ${items.map((x) => esc(x.name)).join('; ')}</div>` +
+            (desiredDate ? `<div><strong>Бажана дата:</strong> ${esc(humanDate(desiredDate))}${desiredTime ? ' о ' + esc(desiredTime) : ''}</div>` : '') +
+            `<div><strong>Телефон для зв'язку:</strong> ${esc(phone)}</div>` + codesLine(codes);
+        }
+        const milOffline = document.getElementById('milOfflineNote');
+        if (milOffline) milOffline.hidden = true;
+        milForm.hidden = true;
+        const panel = document.getElementById('milSuccessPanel');
+        if (panel) panel.hidden = false;
+        const milList = document.getElementById('militaryCartItems');
+        if (milList) milList.style.display = 'none';
+        if (typeof militaryCart !== 'undefined') { militaryCart.length = 0; if (typeof saveMilitaryCart === 'function') saveMilitaryCart(); }
+      } catch (error) {
+        if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = submitLabel || 'Надіслати заявку'; }
+        alert((error && error.message) || 'Не вдалося надіслати заявку. Зателефонуйте в реєстратуру: +380 97 280 88 99');
+      }
+    }, true);
+  }
 })();

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -524,11 +524,10 @@ function openMilitaryCart() {
 
   /* вибір вільного часу для апарата обраних досліджень */
   if (typeof initSlotPicker === 'function' && militaryCart.length) {
-    const app = (typeof apparatusForCode === 'function' && militaryCart.some(x => apparatusForCode(x.code) === 'ct')) ? 'ct' : 'xray';
     window.milPickedSlot = { date: '', time: '' };
     initSlotPicker({
       container: document.getElementById('milSlotPicker'),
-      apparatus: app,
+      serviceCode: String(militaryCart[0].code),
       onPick: sl => {
         window.milPickedSlot = sl;
         const dd = document.getElementById('militaryDesiredDate');
@@ -642,6 +641,7 @@ renderMilitaryCart();
 </script>
 <script src="/site/assets/notify.js"></script>
 <script src="/site/assets/slots.js"></script>
+<script src="/site/assets/d1-bridge.js" defer></script>
 <script>
 const _mdd=document.getElementById('militaryDesiredDate');
 if(_mdd)_mdd.min=new Date().toISOString().slice(0,10);

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -98,3 +98,13 @@ test("the slot picker uses the real department schedule", async () => {
   const cart = await read("public/site/assets/cart.js");
   assert.match(cart, /serviceCode:\s*code/); // cart drives the picker by service code
 });
+
+test("the military free-booking form saves to D1 as category 'military'", async () => {
+  const bridge = await read("public/site/assets/d1-bridge.js");
+  assert.match(bridge, /getElementById\('militaryRequestForm'\)/);
+  assert.match(bridge, /category:\s*'military'/);
+  assert.match(bridge, /referralType:\s*'military_referral'/);
+  const military = await read("public/site/military.html");
+  assert.match(military, /assets\/d1-bridge\.js/); // bridge loaded on the military page
+  assert.match(military, /serviceCode:\s*String\(militaryCart\[0\]\.code\)/); // picker fixed to new signature
+});


### PR DESCRIPTION
## Контекст

Прайс-таблиці в v22 вже саме такі, як треба: **військовим — без ціни (безоплатно)**, **цивільним — з цінами**. Ці блоки залишаються як є. Доопрацьовано їхню **роботу**:

- `d1-bridge.js` тепер обслуговує **обидві** форми:
  - цивільну `#requestForm` (index/price) — як і було;
  - **військову `#militaryRequestForm`** (military.html) → `/api/site-booking` з `category=military`, `referralType=military_referral` (оплата `not_required` — безоплатно).
- `military.html` підключає `d1-bridge.js` (раніше не був).
- **Фікс регресії:** виклик слот-пікера на військовій сторінці переведено на `serviceCode` (після переходу `slots.js` на `/api/availability` старий `apparatus` більше не працював).

## Перевірка (in-memory D1)
Військова заявка: `201`, `patient_category=military`, `payment_status=not_required`, `referral_type=military_referral`.

`npm test` — **50/50**, lint — 0 помилок, build — успішний.

> Прайс-таблиці стануть видимі на `radiologyos.tech` після деплою v22-версії (**Actions → Deploy to Cloudflare → Run workflow**), якщо ще не деплоїли.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_