### PR TITLE
Старі /booking та /cabinet → сторінки v22; кнопка тесту Telegram

### DIFF
--- a/app/api/staff/settings/telegram-test/route.ts
+++ b/app/api/staff/settings/telegram-test/route.ts
@@ -1,0 +1,22 @@
+// Sends a test message to the department Telegram chat using the saved
+// settings, so an admin can verify the bot token and chat id in one click.
+
+import { requireStaff } from "../../../../../lib/staff-auth";
+import { sendTelegramResult } from "../../../../../lib/telegram";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+
+  const text = "✅ <b>RadiologyOS</b>\nТестове повідомлення. Сповіщення про заявки налаштовано правильно.";
+  const result = await sendTelegramResult(db, text);
+  if (!result.ok) return Response.json({ error: result.error || "Не вдалося надіслати" }, { status: 400 });
+  return Response.json({ ok: true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -237,7 +237,9 @@ a.dashKpi:hover{border-color:#8db7af;transform:translateY(-2px);box-shadow:0 12p
 .settingsCard label{display:block;margin-top:12px}.settingsCard label>span{display:block;margin-bottom:6px;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.06em;color:#41544f}
 .settingsCard input{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink)}.settingsCard input:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
 .settingsCard label>small{display:block;margin-top:5px;color:#7a8b88;font-size:11px}
-.settingsCard .button{align-self:flex-start;min-height:44px;padding:0 20px;border:0;border-radius:7px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.settingsCard .button:hover:not(:disabled){background:#0a4b42}.settingsCard .button:disabled{opacity:.6}
+.settingsCard .button{align-self:flex-start;min-height:44px;padding:0 20px;border:0;border-radius:7px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.settingsCard .button:hover:not(:disabled){background:#0a4b42}.settingsCard .button:disabled{opacity:.5;cursor:not-allowed}
+.settingsBlock .button.secondary{margin-top:14px;background:#eef1e9;color:#3c4a30}.settingsBlock .button.secondary:hover:not(:disabled){background:#e2e8dc}
+.settingsHint{display:block;margin-top:8px;color:#7a8b88;font-size:11px}
 .settingsCard .notice{margin:0;padding:11px 13px;border-radius:7px;font-size:13px}.settingsCard .notice.success{background:#eef4e6;color:#33632c}.settingsCard .notice.error{background:#fdf1ee;color:#a23c1d}
 .dashLists{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .dashList{padding:20px;background:#fff;border:1px solid #dce4e3;border-radius:8px;box-shadow:0 8px 24px rgba(23,54,52,.035)}

--- a/app/staff/settings/page.tsx
+++ b/app/staff/settings/page.tsx
@@ -14,6 +14,7 @@ export default function StaffSettingsPage() {
   const [payLink, setPayLink] = useState("");
   const [token, setToken] = useState("");
   const [status, setStatus] = useState<"idle" | "saving">("idle");
+  const [testing, setTesting] = useState(false);
   const [notice, setNotice] = useState("");
   const [error, setError] = useState("");
 
@@ -67,6 +68,10 @@ export default function StaffSettingsPage() {
         <label><span>ID чату</span>
           <input value={chatId} onChange={(e) => setChatId(e.target.value)} placeholder="-1001234567890 або 123456789" autoComplete="off" />
         </label>
+        <button type="button" className="button secondary" onClick={sendTest} disabled={testing || !settings?.telegramConfigured}>
+          {testing ? "Надсилаємо…" : "Надіслати тестове повідомлення"}
+        </button>
+        {!settings?.telegramConfigured && <small className="settingsHint">Спершу збережіть токен і ID чату — тоді кнопку буде розблоковано.</small>}
       </section>
 
       <section className="settingsBlock">
@@ -82,6 +87,20 @@ export default function StaffSettingsPage() {
       <button className="button" disabled={status === "saving"}>{status === "saving" ? "Зберігаємо…" : "Зберегти налаштування"}</button>
     </form>
   );
+
+  async function sendTest() {
+    setTesting(true); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/settings/telegram-test", { method: "POST" });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося надіслати");
+      setNotice("Тестове повідомлення надіслано — перевірте чат");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося надіслати");
+    } finally {
+      setTesting(false);
+    }
+  }
 
   return (
     <StaffWorkspaceShell

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -35,25 +35,27 @@ export function bookingMessage(notice: BookingNotice): string {
   return lines.join("\n");
 }
 
-// Sends a message to the department chat. Returns false when Telegram is not
-// configured or the call fails — callers must never let this break the booking.
-export async function sendTelegram(db: D1Database, text: string): Promise<boolean> {
+// Sends a message to the department chat and reports the outcome. Returns a
+// human-readable Ukrainian error on failure (used by the "send test" button).
+export async function sendTelegramResult(db: D1Database, text: string): Promise<{ ok: boolean; error?: string }> {
   const { telegram_bot_token: token, telegram_chat_id: chatId } =
     await getSettings(db, ["telegram_bot_token", "telegram_chat_id"]);
-  if (!token || !chatId) return false;
+  if (!token || !chatId) return { ok: false, error: "Спочатку збережіть токен бота та ID чату" };
   try {
     const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        chat_id: chatId,
-        text,
-        parse_mode: "HTML",
-        disable_web_page_preview: true,
-      }),
+      body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML", disable_web_page_preview: true }),
     });
-    return response.ok;
+    if (response.ok) return { ok: true };
+    const data = await response.json().catch(() => ({})) as { description?: string };
+    return { ok: false, error: data.description || `Telegram відповів помилкою (${response.status})` };
   } catch {
-    return false;
+    return { ok: false, error: "Не вдалося з'єднатися з Telegram" };
   }
+}
+
+// Best-effort variant for the booking path — never throws, ignores the reason.
+export async function sendTelegram(db: D1Database, text: string): Promise<boolean> {
+  return (await sendTelegramResult(db, text)).ok;
 }

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -77,9 +77,16 @@ test("home is a card landing that routes into booking and staff login", async ()
   assert.doesNotMatch(html, /radiologyos-app\.adamenko-artem96\.chatgpt\.site/);
 });
 
-test("booking page renders the full service catalog", async () => {
-  const response = await renderPath("/booking");
-  const html = await response.text();
-  const visibleHtml = html.replace(/<!--.*?-->/g, "");
-  assert.match(visibleHtml, /Повний каталог:\s*38\s*послуг/);
+test("legacy /booking and /cabinet redirect to the v22 static pages", async () => {
+  const civ = await renderPath("/booking?category=civilian");
+  assert.equal(civ.status, 302);
+  assert.match(civ.headers.get("location") ?? "", /\/site\/price\.html$/);
+
+  const mil = await renderPath("/booking?category=military");
+  assert.equal(mil.status, 302);
+  assert.match(mil.headers.get("location") ?? "", /\/site\/military\.html$/);
+
+  const cab = await renderPath("/cabinet");
+  assert.equal(cab.status, 302);
+  assert.match(cab.headers.get("location") ?? "", /\/site\/cabinet\.html$/);
 });

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -61,7 +61,7 @@ test("my-protocol only returns an issued protocol behind code + phone", async ()
 test("new bookings notify the registrar via Telegram (best-effort)", async () => {
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /api\.telegram\.org\/bot/);
-  assert.match(lib, /if \(!token \|\| !chatId\) return false/); // no-op until configured
+  assert.match(lib, /if \(!token \|\| !chatId\) return \{ ok: false/); // no-op until configured
   const route = await read("app/api/site-booking/route.ts");
   assert.match(route, /sendTelegram\(/);
   assert.match(route, /bookingMessage\(/);
@@ -78,6 +78,15 @@ test("department settings are admin-only and validated", async () => {
   assert.match(migration, /pay_link/);
   const journal = JSON.parse(await read("drizzle/meta/_journal.json"));
   assert.ok(journal.entries.some((e) => e.tag === "0010_department_settings"));
+});
+
+test("a test-message endpoint verifies the Telegram connection (admin-only)", async () => {
+  const route = await read("app/api/staff/settings/telegram-test/route.ts");
+  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /sendTelegramResult\(/);
+  const lib = await read("lib/telegram.ts");
+  assert.match(lib, /export async function sendTelegramResult/);
+  assert.match(lib, /description \|\|/); // surfaces Telegram's error reason
 });
 
 test("payment link is served publicly and used by the site, not hardcoded", async () => {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -46,6 +46,16 @@ const worker = {
       }
     }
 
+    // Legacy Next public routes → v22 static pages, so nobody lands on the old
+    // card-grid booking screen. Civilian price list / military free list / cabinet.
+    if (url.pathname === "/booking") {
+      const target = url.searchParams.get("category") === "military" ? "/site/military.html" : "/site/price.html";
+      return Response.redirect(new URL(target, request.url).toString(), 302);
+    }
+    if (url.pathname === "/cabinet") {
+      return Response.redirect(new URL("/site/cabinet.html", request.url).toString(), 302);
+    }
+
     if (url.pathname === "/_vinext/image") {
       const allowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
       return handleImageOptimization(request, {


### PR DESCRIPTION
## Чому

На `radiologyos.tech/` вже віддається v22 (останній деплой містив цей код), але стара сторінка **`/booking`** (сітка карток із Next) досі існувала — саме її видно на скріншотах замість таблиць v22.

## Що зроблено
- **Редіректи в worker** (302), щоб ніхто не потрапляв на стару картку:
  - `/booking?category=civilian` → `/site/price.html` (таблиця цін для цивільних);
  - `/booking?category=military` → `/site/military.html` (безоплатні таблиці);
  - `/cabinet` → `/site/cabinet.html`.
- **Кнопка «Надіслати тестове повідомлення»** на `/staff/settings` + ендпоінт `/api/staff/settings/telegram-test` (лише admin): шле тест у чат і показує **причину** помилки від Telegram (`sendTelegramResult`). Кнопка активна лише коли токен+чат збережені.

`npm test` — **51/51**, lint — 0 помилок, build — успішний.

> ⚠️ Потрібен **деплой**, щоб редіректи та кнопка тесту з'явились на бойовому (**Actions → Deploy to Cloudflare → Run workflow**). Заодно підтягнуться попередні PR (військові таблиці в D1, налаштування).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_