### PR TITLE
Вкладка «Тарифи» в кабінеті: редагування прайсу з базою

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -2,6 +2,7 @@ import { addMinutes, serviceByCode } from "../../../lib/catalog";
 import { isBookableDate, isTimeForService } from "../../../lib/booking-rules";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isRateLimited } from "../../../lib/rate-limit";
+import { effectivePrice } from "../../../lib/tariffs";
 
 function clean(value: unknown, max = 200) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -47,6 +48,7 @@ export async function POST(request: Request) {
     const referral = referralType === "none" ? "Немає направлення" : referralType;
     const paymentStatus = patientCategory === "civilian" ? "pending" : "not_required";
     const nszuStatus = referralType === "eh_referral" ? "pending" : "not_applicable";
+    const price = await effectivePrice(db, service.code);
     const result = await db.prepare(
       `INSERT INTO bookings (
         code, name, phone, phone_normalized, service, service_code, equipment_id,
@@ -71,7 +73,7 @@ export async function POST(request: Request) {
       code, name, phone, phoneNormalized, service.title, service.code, service.equipmentId,
       service.durationMinutes, desiredDate, desiredTime, referral, patientCategory,
       referralType, referralNumber, marketingSource, paymentStatus,
-      service.price, nszuStatus, comment,
+      price, nszuStatus, comment,
       service.equipmentId, desiredDate, endTime, desiredTime,
       service.equipmentId, desiredDate, endTime, desiredTime,
     ).run();

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -7,6 +7,7 @@ import { serviceByCode } from "../../../lib/catalog";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { bookingMessage, sendTelegram } from "../../../lib/telegram";
+import { effectivePrice } from "../../../lib/tariffs";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
@@ -59,6 +60,7 @@ export async function POST(request: Request) {
       const code = `RD-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
       const paymentStatus = category === "civilian" ? "pending" : "not_required";
       const nszuStatus = referralType === "eh_referral" ? "pending" : "not_applicable";
+      const price = await effectivePrice(db, service.code);
       const result = await db.prepare(
         `INSERT INTO bookings (
           code, name, phone, phone_normalized, service, service_code, equipment_id,
@@ -68,7 +70,7 @@ export async function POST(request: Request) {
       ).bind(
         code, name, phone, phoneNormalized, service.title, service.code, service.equipmentId,
         service.durationMinutes, desiredDate, desiredTime, referral, category,
-        referralType, marketingSource, paymentStatus, service.price, nszuStatus, comment,
+        referralType, marketingSource, paymentStatus, price, nszuStatus, comment,
       ).run();
       if (result.meta.last_row_id) {
         await db.prepare(

--- a/app/api/staff/tariffs/route.ts
+++ b/app/api/staff/tariffs/route.ts
@@ -1,0 +1,49 @@
+// Staff tariffs: view the full price list; admins can override prices. Overrides
+// are stored per service code; setting a price back to the catalog default (or
+// blank) removes the override.
+
+import { requireStaff } from "../../../../lib/staff-auth";
+import { serviceByCode } from "../../../../lib/catalog";
+import { tariffList } from "../../../../lib/tariffs";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  return Response.json({ tariffs: await tariffList(db), staff: member }, { headers: { "cache-control": "no-store" } });
+}
+
+export async function PUT(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Змінювати тарифи може лише адміністратор" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as { prices?: Record<string, unknown> };
+  const prices = body.prices && typeof body.prices === "object" ? body.prices : {};
+
+  for (const [code, rawValue] of Object.entries(prices)) {
+    const service = serviceByCode(code);
+    if (!service) continue;
+    const value = Math.round(Number(rawValue));
+    if (!Number.isFinite(value) || value < 0 || value > 1_000_000) {
+      return Response.json({ error: `Некоректна ціна для послуги ${code}` }, { status: 400 });
+    }
+    if (value === service.price) {
+      await db.prepare("DELETE FROM service_prices WHERE code = ?").bind(code).run();
+    } else {
+      await db.prepare(
+        `INSERT INTO service_prices (code, price) VALUES (?, ?)
+         ON CONFLICT(code) DO UPDATE SET price = excluded.price`
+      ).bind(code, value).run();
+    }
+  }
+
+  return Response.json({ ok: true, tariffs: await tariffList(db) });
+}

--- a/app/api/tariffs/route.ts
+++ b/app/api/tariffs/route.ts
@@ -1,0 +1,14 @@
+// Public: price overrides for the static price list. Only changed prices are
+// returned; the page keeps its built-in defaults for everything else.
+
+import { priceOverrides } from "../../../lib/tariffs";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET() {
+  const db = dbBinding();
+  if (!db) return Response.json({ prices: {} });
+  return Response.json({ prices: await priceOverrides(db) }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -364,3 +364,22 @@ a.dashKpi:hover{border-color:#8db7af;transform:translateY(-2px);box-shadow:0 12p
   outline:none;border-color:var(--green);box-shadow:0 0 0 3px rgba(13,91,80,.12);
 }
 .passwordField input{padding-right:44px}
+
+/* ================= Тарифи (кабінет) ================= */
+.tariffPage{max-width:1000px;margin:0 auto}
+.tariffBar{display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap;background:#fff;border:1px solid #dce4e3;border-radius:8px;padding:14px 16px;margin-bottom:14px;box-shadow:0 8px 24px rgba(23,54,52,.035)}
+.tariffBar>span{color:#66756f;font-size:12.5px;line-height:1.4;max-width:640px}
+.tariffBar .button{min-height:42px;padding:0 20px;border:0;border-radius:7px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.tariffBar .button:hover:not(:disabled){background:#0a4b42}.tariffBar .button:disabled{opacity:.5;cursor:not-allowed}
+.tariffGroup{margin-bottom:16px;background:#fff;border:1px solid #dce4e3;border-radius:8px;overflow:hidden;box-shadow:0 8px 24px rgba(23,54,52,.035)}
+.tariffGroup h2{margin:0;padding:14px 18px;background:linear-gradient(135deg,#0d5b50,#124b44);color:#fff;font-size:15px;font-weight:700;letter-spacing:-.01em}
+.tariffTable{width:100%;border-collapse:collapse}
+.tariffTable th{text-align:left;padding:10px 16px;font-size:10px;text-transform:uppercase;letter-spacing:.07em;color:#728079;border-bottom:1px solid #e7ecea}
+.tariffTable td{padding:11px 16px;border-bottom:1px solid #eef2f0;font-size:13.5px;color:var(--ink);vertical-align:middle}
+.tariffTable tr:last-child td{border-bottom:0}
+.tariffCode{width:64px;color:#728079;font-variant-numeric:tabular-nums}
+.tariffPrice{width:150px;text-align:right}
+.tariffPrice input{width:110px;text-align:right;padding:8px 10px;border:1px solid var(--field-border);border-radius:8px;font:inherit;font-size:13.5px;color:var(--ink)}
+.tariffPrice input:focus{outline:none;border-color:var(--green);box-shadow:0 0 0 3px rgba(13,91,80,.12)}
+.tariffPrice b{font-variant-numeric:tabular-nums}
+.tariffCustom{display:inline-block;margin-left:8px;padding:2px 7px;border-radius:99px;background:#fef2e0;color:#a15a1e;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em}
+@media(max-width:600px){.tariffPrice{width:120px}.tariffPrice input{width:88px}}

--- a/app/staff/tariffs/page.tsx
+++ b/app/staff/tariffs/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+type Tariff = { code: string; title: string; group: string; defaultPrice: number; price: number; custom: boolean };
+
+const money = new Intl.NumberFormat("uk-UA");
+
+export default function StaffTariffsPage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [tariffs, setTariffs] = useState<Tariff[]>([]);
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<"idle" | "saving">("idle");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+
+  const isAdmin = staff?.role === "admin";
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const res = await fetch("/api/staff/tariffs", { cache: "no-store" });
+      const data = await res.json().catch(() => ({})) as { tariffs?: Tariff[]; staff?: StaffInfo; error?: string };
+      if (!active) return;
+      if (data.tariffs) setTariffs(data.tariffs);
+      if (data.staff) setStaff(data.staff);
+      if (!res.ok) setError(data.error || "Не вдалося завантажити тарифи");
+    })();
+    return () => { active = false; };
+  }, []);
+
+  const groups = useMemo(() => {
+    const map = new Map<string, Tariff[]>();
+    for (const t of tariffs) { if (!map.has(t.group)) map.set(t.group, []); map.get(t.group)!.push(t); }
+    return [...map.entries()];
+  }, [tariffs]);
+
+  async function save() {
+    setStatus("saving"); setNotice(""); setError("");
+    const prices: Record<string, number> = {};
+    for (const [code, raw] of Object.entries(edits)) {
+      const n = Number(raw);
+      if (raw.trim() !== "" && Number.isFinite(n)) prices[code] = Math.round(n);
+    }
+    try {
+      const res = await fetch("/api/staff/tariffs", {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prices }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; tariffs?: Tariff[] };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
+      if (data.tariffs) setTariffs(data.tariffs);
+      setEdits({});
+      setNotice("Тарифи збережено");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося зберегти");
+    } finally {
+      setStatus("idle");
+    }
+  }
+
+  const dirty = Object.keys(edits).length > 0;
+
+  return (
+    <StaffWorkspaceShell
+      active="tariffs"
+      title="Тарифи"
+      description="Прайс на платні дослідження для цивільних пацієнтів. Військовим — безоплатно."
+      staffName={staff?.displayName}
+      staffRole={staff?.role}
+    >
+      <div className="tariffPage">
+        {isAdmin && (
+          <div className="tariffBar">
+            <span>Змініть ціну в полі й натисніть «Зберегти». Порожнє поле або значення = стандартному повертає тариф до типового.</span>
+            <button className="button" onClick={save} disabled={!dirty || status === "saving"}>
+              {status === "saving" ? "Зберігаємо…" : "Зберегти тарифи"}
+            </button>
+          </div>
+        )}
+        {notice && <p className="notice success" role="status">{notice}</p>}
+        {error && <p className="notice error" role="alert">{error}</p>}
+
+        {groups.map(([group, items]) => (
+          <section className="tariffGroup" key={group}>
+            <h2>{group}</h2>
+            <table className="tariffTable">
+              <thead><tr><th>Код</th><th>Дослідження</th><th>Ціна, грн</th></tr></thead>
+              <tbody>
+                {items.map((t) => {
+                  const value = edits[t.code] ?? String(t.price);
+                  return (
+                    <tr key={t.code}>
+                      <td className="tariffCode">{t.code}</td>
+                      <td>{t.title}{t.custom && <span className="tariffCustom">змінено</span>}</td>
+                      <td className="tariffPrice">
+                        {isAdmin ? (
+                          <input inputMode="numeric" value={value}
+                            onChange={(e) => setEdits((prev) => ({ ...prev, [t.code]: e.target.value.replace(/\D/g, "") }))} />
+                        ) : (
+                          <b>{money.format(t.price)}</b>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </section>
+        ))}
+      </div>
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "patients" | "protocols" | "imaging" | "reports" | "settings";
+type WorkspaceSection = "dashboard" | "overview" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -25,6 +25,7 @@ const navigation = [
   { href:"/staff/protocols", label:"Протоколи", glyph:"▤", section:"protocols" as WorkspaceSection },
   { href:"/staff/imaging", label:"Знімки DICOM", glyph:"▦", section:"imaging" as WorkspaceSection },
   { href:"/staff/reports", label:"Звіти", glyph:"▥", section:"reports" as WorkspaceSection },
+  { href:"/staff/tariffs", label:"Тарифи", glyph:"₴", section:"tariffs" as WorkspaceSection },
 ];
 
 const administration = [
@@ -135,14 +136,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "settings" ? "Налаштування":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -88,6 +88,11 @@ export const appSettings = sqliteTable("app_settings", {
   value: text("value").notNull().default(""),
 });
 
+export const servicePrices = sqliteTable("service_prices", {
+  code: text("code").primaryKey(),
+  price: integer("price").notNull(),
+});
+
 export const equipment = sqliteTable("equipment", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),

--- a/drizzle/0011_service_prices.sql
+++ b/drizzle/0011_service_prices.sql
@@ -1,0 +1,7 @@
+-- Editable tariffs: per-service price overrides managed by an admin in the
+-- "Тарифи" tab. A missing row means the default catalog price applies.
+
+CREATE TABLE IF NOT EXISTS `service_prices` (
+  `code` text PRIMARY KEY NOT NULL,
+  `price` integer NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785200400000,
       "tag": "0010_department_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1785204000000,
+      "tag": "0011_service_prices",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/tariffs.ts
+++ b/lib/tariffs.ts
@@ -1,0 +1,41 @@
+// Editable tariffs: catalog prices are the defaults; an admin can override any
+// service price in the "Тарифи" tab. Overrides live in `service_prices`.
+
+import { SERVICES, serviceByCode } from "./catalog";
+
+export interface TariffRow {
+  code: string;
+  title: string;
+  group: string;
+  defaultPrice: number;
+  price: number;
+  custom: boolean;
+}
+
+export async function priceOverrides(db: D1Database): Promise<Record<string, number>> {
+  const rows = await db.prepare("SELECT code, price FROM service_prices").all<{ code: string; price: number }>();
+  const map: Record<string, number> = {};
+  for (const row of rows.results || []) map[String(row.code)] = Number(row.price);
+  return map;
+}
+
+// Price actually charged for a service (override if set, otherwise catalog default).
+export async function effectivePrice(db: D1Database, code: string): Promise<number> {
+  const service = serviceByCode(code);
+  if (!service) return 0;
+  const row = await db.prepare("SELECT price FROM service_prices WHERE code = ? LIMIT 1")
+    .bind(code).first<{ price: number }>();
+  return row ? Number(row.price) : service.price;
+}
+
+export async function tariffList(db: D1Database): Promise<TariffRow[]> {
+  const overrides = await priceOverrides(db);
+  return SERVICES.map((service) => ({
+    code: service.code,
+    title: service.title,
+    group: service.group,
+    defaultPrice: service.price,
+    price: overrides[service.code] ?? service.price,
+    custom: overrides[service.code] != null,
+  }));
+}

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -561,4 +561,22 @@ header .brand{flex:1;min-width:0}
 <script src="/site/assets/cart.js" defer></script>
 <script src="/site/assets/d1-bridge.js" defer></script>
 
+<script>
+/* Підтягуємо змінені персоналом тарифи (кабінет → «Тарифи») і оновлюємо ціни в таблиці. */
+(function(){
+  var fmt=new Intl.NumberFormat('uk-UA');
+  fetch('/api/tariffs',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
+    var prices=(d&&d.prices)||{};
+    if(!prices||!Object.keys(prices).length)return;
+    document.querySelectorAll('table tr').forEach(function(tr){
+      var codeCell=tr.querySelector('td.code');if(!codeCell)return;
+      var code=codeCell.textContent.trim();
+      if(prices[code]==null)return;
+      var cells=[].slice.call(tr.querySelectorAll('td'));
+      var priceCell=cells.filter(function(td){return /грн/.test(td.textContent);})[0];
+      if(priceCell)priceCell.textContent=fmt.format(prices[code])+' грн';
+    });
+  }).catch(function(){});
+})();
+</script>
 </body></html>

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("tariffs migration + schema define the overrides table", async () => {
+  const migration = await read("drizzle/0011_service_prices.sql");
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS `service_prices`/);
+  assert.match(migration, /`code` text PRIMARY KEY/);
+  const journal = JSON.parse(await read("drizzle/meta/_journal.json"));
+  assert.ok(journal.entries.some((e) => e.tag === "0011_service_prices"));
+  const schema = await read("db/schema.ts");
+  assert.match(schema, /export const servicePrices = sqliteTable\("service_prices"/);
+});
+
+test("tariffs API: all staff read, only admin writes", async () => {
+  const route = await read("app/api/staff/tariffs/route.ts");
+  assert.match(route, /tariffList\(/);
+  assert.match(route, /member\.role !== "admin"/); // PUT is admin-only
+  assert.match(route, /INSERT INTO service_prices/);
+  assert.match(route, /DELETE FROM service_prices WHERE code = \?/); // reset to default
+});
+
+test("bookings charge the effective (override-aware) price", async () => {
+  const lib = await read("lib/tariffs.ts");
+  assert.match(lib, /export async function effectivePrice/);
+  const site = await read("app/api/site-booking/route.ts");
+  assert.match(site, /effectivePrice\(db, service\.code\)/);
+  const legacy = await read("app/api/bookings/route.ts");
+  assert.match(legacy, /effectivePrice\(db, service\.code\)/);
+});
+
+test("the Тарифи tab is wired into the workspace and the public price list syncs", async () => {
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/tariffs", label:"Тарифи"/);
+  const page = await read("app/staff/tariffs/page.tsx");
+  assert.match(page, /active="tariffs"/);
+  const priceHtml = await read("public/site/price.html");
+  assert.match(priceHtml, /\/api\/tariffs/); // public prices reflect overrides
+});


### PR DESCRIPTION
## Що зроблено

Додано вкладку **«Тарифи»** в кабінет персоналу (за вашим запитом).

- **`/staff/tariffs`** — усі бачать прайс, згрупований за розділами (таблиці як у v22); **адмін редагує ціни** й зберігає. Значення = типовому знімає перевизначення (позначка «змінено»).
- **База:** ціни-перевизначення в таблиці `service_prices` (міграція **0011**). `/api/staff/tariffs` (GET усім, PUT лише адмін), `lib/tariffs.ts`.
- **Заявки рахують оплату за актуальною ціною** (`effectivePrice`) — і публічна форма, і стара `/api/bookings`.
- **Публічний прайс `price.html`** підтягує змінені ціни через новий **`/api/tariffs`** — відредагував у кабінеті → одразу видно на сайті.

## Перевірка (in-memory D1)
Адмін змінює 101: 300 → **350** → публічний `/api/tariffs` віддає `{101:350}` → заявка на 101 списує **350** → скидання до 300 прибирає перевизначення.

`npm test` — **55/55**, lint — 0 помилок, build — успішний.

> Після мержу — **деплой** (Actions → Deploy to Cloudflare → Run workflow): застосує міграцію 0011 і додасть вкладку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_