### PR TITLE
Тарифи на головній: військовим безоплатно, цивільним за ціною + запис

### DIFF
--- a/app/api/catalog/route.ts
+++ b/app/api/catalog/route.ts
@@ -1,0 +1,25 @@
+// Public catalog with effective prices, grouped for the home-page tariff list.
+// Military price is always 0 (free); the civilian price is the effective tariff.
+
+import { SERVICES } from "../../../lib/catalog";
+import { priceOverrides } from "../../../lib/tariffs";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET() {
+  const db = dbBinding();
+  const overrides = db ? await priceOverrides(db) : {};
+  const order: string[] = [];
+  const byGroup = new Map<string, Array<{ code: string; title: string; description: string; price: number }>>();
+  for (const s of SERVICES) {
+    if (!byGroup.has(s.group)) { byGroup.set(s.group, []); order.push(s.group); }
+    byGroup.get(s.group)!.push({
+      code: s.code, title: s.title, description: s.description,
+      price: overrides[s.code] ?? s.price,
+    });
+  }
+  const groups = order.map((group) => ({ group, items: byGroup.get(group)! }));
+  return Response.json({ groups }, { headers: { "cache-control": "no-store" } });
+}

--- a/public/site/assets/d1-bridge.js
+++ b/public/site/assets/d1-bridge.js
@@ -52,7 +52,6 @@
   // ----- Civilian request (index.html, price.html) -----
   const civilForm = document.getElementById('requestForm');
   if (civilForm) {
-    const category = /military/i.test(location.pathname) ? 'military' : 'civilian';
     civilForm.addEventListener('submit', async (event) => {
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -60,12 +59,20 @@
       if (!items.length) { alert('Спочатку додайте послугу до заявки.'); return; }
       if (!civilForm.checkValidity()) { civilForm.classList.add('was-validated'); const bad = civilForm.querySelector(':invalid'); if (bad) bad.focus(); return; }
 
+      // Category comes from the form selector when present (home page), else the page.
+      const catSel = document.getElementById('patientCategory');
+      const category = catSel
+        ? (catSel.value === 'military' ? 'military' : 'civilian')
+        : (/military/i.test(location.pathname) ? 'military' : 'civilian');
+
       const name = document.getElementById('patientName').value.trim();
       const phone = '+380' + document.getElementById('patientPhone').value.replace(/\D/g, '');
       const picked = (typeof pickedSlot !== 'undefined') ? pickedSlot : { date: '', time: '' };
       const desiredDate = picked.date || document.getElementById('desiredDate').value || '';
       const desiredTime = picked.time || document.getElementById('desiredTime').value || '';
-      const referralType = REFERRAL_MAP[document.getElementById('referral').value] || 'other';
+      const referralType = category === 'military'
+        ? 'military_referral'
+        : (REFERRAL_MAP[document.getElementById('referral').value] || 'other');
       const comment = document.getElementById('comment').value.trim();
       const source = (typeof getTrafficSource === 'function') ? getTrafficSource() : '';
 

--- a/public/site/assets/home-tariffs.js
+++ b/public/site/assets/home-tariffs.js
@@ -1,0 +1,51 @@
+/* Головна: тарифи з бази (кабінет → «Тарифи») — військовим безоплатно,
+   цивільним за ціною. Кнопка «Записатися» додає послугу в «Мою заявку». */
+(function () {
+  var box = document.getElementById('homeTariffs');
+  if (!box) return;
+  var fmt = new Intl.NumberFormat('uk-UA');
+  var esc = function (s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (m) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[m];
+    });
+  };
+  var failMsg = '<div class="ht-loading">Тарифи тимчасово недоступні. Зателефонуйте в реєстратуру: +380 97 280 88 99</div>';
+
+  // Категорія у формі: показуємо підказку про безоплатність для військових.
+  var cat = document.getElementById('patientCategory');
+  var note = document.getElementById('categoryNote');
+  function updateNote() {
+    if (!cat || !note) return;
+    note.textContent = cat.value === 'military'
+      ? 'Для військовослужбовців за направленням дослідження безоплатні.'
+      : 'Цивільним особам — оплата за чинним тарифом.';
+  }
+  if (cat) { cat.addEventListener('change', updateNote); updateNote(); }
+
+  fetch('/api/catalog', { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
+    var groups = (d && d.groups) || [];
+    if (!groups.length) { box.innerHTML = failMsg; return; }
+    box.innerHTML = groups.map(function (g) {
+      return '<div class="ht-group"><h3>' + esc(g.group) + '</h3>' +
+        '<table class="ht-table"><thead><tr><th>Дослідження</th><th class="num">Військовим</th><th class="num">Цивільним</th><th></th></tr></thead><tbody>' +
+        g.items.map(function (it) {
+          return '<tr>' +
+            '<td><div class="ht-title">' + esc(it.title) + '</div>' + (it.description ? '<div class="ht-help">' + esc(it.description) + '</div>' : '') + '</td>' +
+            '<td class="num" data-label="Військовим"><span class="ht-mil">безоплатно</span></td>' +
+            '<td class="num" data-label="Цивільним"><span class="ht-civ">' + fmt.format(it.price) + ' грн</span></td>' +
+            '<td class="num"><button type="button" class="ht-book" data-code="' + esc(it.code) + '" data-name="' + esc(it.title) + '" data-price="' + Number(it.price) + '">Записатися</button></td>' +
+            '</tr>';
+        }).join('') +
+        '</tbody></table></div>';
+    }).join('');
+
+    box.querySelectorAll('.ht-book').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        if (typeof addToCart === 'function') addToCart(btn.dataset.code, btn.dataset.name, Number(btn.dataset.price));
+        btn.classList.add('added');
+        btn.textContent = 'Додано ✓';
+        setTimeout(function () { btn.classList.remove('added'); btn.textContent = 'Записатися'; }, 1500);
+      });
+    });
+  }).catch(function () { box.innerHTML = failMsg; });
+})();

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -196,6 +196,36 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .sp-time{padding:8px 4px;border-radius:9px;border:1.5px solid #cfd4c8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
 .sp-time.on{border-color:#556349;background:#556349;color:#fff}
 .sp-picked{margin-top:9px;font-size:13px;color:#2f5c2a}
+/* ===== Тарифи на головній ===== */
+.tariffs-home{padding:22px 0 0}
+.tariffs-head{margin-bottom:14px}
+.tariffs-head h2{font-size:clamp(24px,3.2vw,32px);font-weight:700;letter-spacing:-.02em;margin:6px 0}
+.tariffs-head p{color:var(--muted);max-width:760px;margin:0}
+.tariffs-head p b{color:#4f5d3e}
+.ht-loading{padding:22px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:18px}
+.ht-group{background:#fff;border:1px solid var(--line);border-radius:18px;overflow:hidden;margin-bottom:14px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
+.ht-group>h3{margin:0;padding:15px 18px;background:linear-gradient(135deg,#4f5d3e,#6c7c59);color:#fff;font-size:17px;font-weight:700}
+.ht-table{width:100%;border-collapse:collapse}
+.ht-table th{text-align:left;padding:10px 16px;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);border-bottom:1px solid var(--line);white-space:nowrap}
+.ht-table th.num,.ht-table td.num{text-align:right}
+.ht-table td{padding:13px 16px;border-bottom:1px solid var(--line);vertical-align:middle;font-size:14px}
+.ht-table tr:last-child td{border-bottom:0}
+.ht-title{font-weight:700;color:#1b2118}
+.ht-help{margin-top:3px;color:var(--muted);font-size:12.5px;line-height:1.35}
+.ht-mil{color:#4f5d3e;font-weight:800;white-space:nowrap}
+.ht-civ{font-weight:800;white-space:nowrap;font-variant-numeric:tabular-nums}
+.ht-book{border:0;background:#556349;color:#fff;border-radius:10px;padding:9px 14px;font-weight:700;cursor:pointer;white-space:nowrap}
+.ht-book:hover{background:#465239}.ht-book.added{background:#75816d}
+.field-note{display:block;margin-top:6px;font-size:12px;color:#4f5d3e}
+@media(max-width:640px){
+  .ht-table thead{display:none}
+  .ht-table,.ht-table tbody,.ht-table tr,.ht-table td{display:block;width:100%}
+  .ht-table tr{border-bottom:1px solid var(--line);padding:6px 0}
+  .ht-table td{border:0;padding:4px 16px}
+  .ht-table td.num{text-align:left}
+  .ht-table td.num::before{content:attr(data-label)": ";color:var(--muted);font-weight:600}
+  .ht-book{width:100%;margin-top:6px}
+}
 </style>
 </head>
 <body>
@@ -254,6 +284,17 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
     </div>
   </section>
 
+  <section class="tariffs-home" id="tariffs">
+    <div class="wrap">
+      <div class="tariffs-head">
+        <div class="eyebrow" style="color:#4f5d3e">Тарифи</div>
+        <h2>Дослідження та вартість</h2>
+        <p>Військовослужбовцям — <b>безоплатно</b> за направленням. Цивільним особам — за тарифом. Оберіть дослідження, натисніть «Записатися» та вкажіть категорію.</p>
+      </div>
+      <div id="homeTariffs" class="home-tariffs"><div class="ht-loading">Завантаження тарифів…</div></div>
+    </div>
+  </section>
+
   <section class="contact" id="contacts">
     <div class="wrap">
       <a class="contact-card address-row" href="tel:+380972808899" aria-label="Зателефонувати в реєстратуру" style="margin-bottom:14px">
@@ -300,6 +341,14 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
             <input autocomplete="tel-national" id="patientPhone" inputmode="numeric" pattern="[0-9]{9}" maxlength="9" placeholder="97 000 00 00" required/>
           </div>
           <span class="field-error">Введіть 9 цифр після +380</span>
+        </div>
+        <div class="field">
+          <label for="patientCategory">Категорія пацієнта <span class="req">*</span></label>
+          <select id="patientCategory" required>
+            <option value="civilian">Цивільна особа — платно</option>
+            <option value="military">Військовослужбовець — безоплатно (за направленням)</option>
+          </select>
+          <span class="field-note" id="categoryNote"></span>
         </div>
       </div>
 
@@ -396,5 +445,6 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 <script src="/site/assets/slots.js"></script>
 <script src="/site/assets/cart.js" defer></script>
 <script src="/site/assets/d1-bridge.js" defer></script>
+<script src="/site/assets/home-tariffs.js" defer></script>
 </body>
 </html>

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -31,6 +31,22 @@ test("bookings charge the effective (override-aware) price", async () => {
   assert.match(legacy, /effectivePrice\(db, service\.code\)/);
 });
 
+test("home page shows tariffs (military free / civilian priced) with booking", async () => {
+  const route = await read("app/api/catalog/route.ts");
+  assert.match(route, /priceOverrides\(/);
+  assert.match(route, /groups/);
+  const index = await read("public/site/index.html");
+  assert.match(index, /id="homeTariffs"/);
+  assert.match(index, /assets\/home-tariffs\.js/);
+  assert.match(index, /id="patientCategory"/); // category chooser on the home form
+  const js = await read("public/site/assets/home-tariffs.js");
+  assert.match(js, /\/api\/catalog/);
+  assert.match(js, /безоплатно/); // military column
+  assert.match(js, /addToCart\(/); // booking from a tariff row
+  const bridge = await read("public/site/assets/d1-bridge.js");
+  assert.match(bridge, /getElementById\('patientCategory'\)/); // category read at submit
+});
+
 test("the Тарифи tab is wired into the workspace and the public price list syncs", async () => {
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /href:"\/staff\/tariffs", label:"Тарифи"/);


### PR DESCRIPTION
## Що зроблено

На **першій сторінці** зʼявився розділ **«Тарифи»** з двома колонками у кожному рядку:
- **Військовим — безоплатно** (0);
- **Цивільним — ціна** (за чинним тарифом);
- кнопка **«Записатися»** біля кожного дослідження.

Деталі:
- Ціни тягнуться з **`/api/catalog`** — це актуальні тарифи з кабінету (вкладка «Тарифи»), рендер `assets/home-tariffs.js`. Змінили ціну в кабінеті → одразу видно на головній.
- У формі заявки додано **вибір категорії пацієнта**; `d1-bridge` читає її при надсиланні: військовий → `military_referral`, оплата `not_required` (безоплатно); цивільний → оплата за тарифом.
- Підказка про безоплатність для військовослужбовців.

## Перевірка (in-memory D1)
`/api/catalog` → 6 груп / 38 послуг; ціна-перевизначення (401 → 1750) відображається.

`npm test` — **56/56**, lint — 0 помилок, build — успішний.

> Видно після деплою (Actions → Deploy to Cloudflare → Run workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_