### PR TITLE
Розклад із Google у кабінеті: підключення зовнішнього iCal-календаря

### DIFF
--- a/app/api/staff/external-calendar/route.ts
+++ b/app/api/staff/external-calendar/route.ts
@@ -1,0 +1,30 @@
+// Reads the configured external Google Calendar (iCal URL) server-side and
+// returns upcoming events for the staff dashboard. Staff-only.
+
+import { requireStaff } from "../../../../lib/staff-auth";
+import { getSetting } from "../../../../lib/settings";
+import { parseIcs } from "../../../../lib/ics-parse";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+
+  const url = await getSetting(db, "external_ics_url");
+  if (!url) return Response.json({ configured: false, events: [] }, { headers: { "cache-control": "no-store" } });
+
+  try {
+    const response = await fetch(url, { cf: { cacheTtl: 300 } } as RequestInit);
+    if (!response.ok) return Response.json({ configured: true, events: [], error: "Не вдалося завантажити календар" });
+    const text = await response.text();
+    const events = parseIcs(text, Date.now() - 12 * 60 * 60 * 1000, 40);
+    return Response.json({ configured: true, events }, { headers: { "cache-control": "no-store" } });
+  } catch {
+    return Response.json({ configured: true, events: [], error: "Не вдалося завантажити календар" });
+  }
+}

--- a/app/api/staff/settings/route.ts
+++ b/app/api/staff/settings/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
   if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   if (member.role !== "admin") return Response.json({ error: "Налаштування доступні лише адміністратору" }, { status: 403 });
 
-  const values = await getSettings(db, ["telegram_bot_token", "telegram_chat_id", "pay_link", "registration_code_hash", "calendar_token"]);
+  const values = await getSettings(db, ["telegram_bot_token", "telegram_chat_id", "pay_link", "registration_code_hash", "calendar_token", "external_ics_url"]);
   return Response.json({
     settings: {
       telegramConfigured: Boolean(values.telegram_bot_token && values.telegram_chat_id),
@@ -28,6 +28,7 @@ export async function GET(request: Request) {
       payLink: values.pay_link,
       registrationCodeSet: Boolean(values.registration_code_hash),
       calendarToken: values.calendar_token,
+      externalIcsUrl: values.external_ics_url,
     },
     staff: member,
   }, { headers: { "cache-control": "no-store" } });
@@ -42,9 +43,11 @@ export async function PUT(request: Request) {
 
   const body = await request.json().catch(() => ({})) as {
     telegramBotToken?: string; telegramChatId?: string; payLink?: string; accessCode?: string;
+    externalIcsUrl?: string;
   };
   const chatId = clean(body.telegramChatId, 40);
   const payLink = clean(body.payLink, 500);
+  const externalIcsUrl = clean(body.externalIcsUrl, 600);
   // Empty token keeps the stored one (so the admin isn't forced to re-enter the
   // secret on every save); a value of "-" explicitly clears it.
   const token = clean(body.telegramBotToken, 120);
@@ -53,6 +56,9 @@ export async function PUT(request: Request) {
 
   if (payLink && !/^https:\/\//i.test(payLink)) {
     return Response.json({ error: "Посилання на оплату має починатися з https://" }, { status: 400 });
+  }
+  if (externalIcsUrl && !/^https?:\/\//i.test(externalIcsUrl)) {
+    return Response.json({ error: "Посилання на календар має починатися з http(s)://" }, { status: 400 });
   }
   if (token && token !== "-" && !/^\d{6,}:[A-Za-z0-9_-]{20,}$/.test(token)) {
     return Response.json({ error: "Некоректний токен бота Telegram" }, { status: 400 });
@@ -65,9 +71,10 @@ export async function PUT(request: Request) {
   else if (token) await setSetting(db, "telegram_bot_token", token);
   await setSetting(db, "telegram_chat_id", chatId);
   await setSetting(db, "pay_link", payLink);
+  await setSetting(db, "external_ics_url", externalIcsUrl);
   if (accessCode) await setSetting(db, "registration_code_hash", await hashPassword(accessCode));
 
-  const values = await getSettings(db, ["telegram_bot_token", "telegram_chat_id", "pay_link", "registration_code_hash", "calendar_token"]);
+  const values = await getSettings(db, ["telegram_bot_token", "telegram_chat_id", "pay_link", "registration_code_hash", "calendar_token", "external_ics_url"]);
   return Response.json({
     ok: true,
     settings: {
@@ -76,6 +83,7 @@ export async function PUT(request: Request) {
       payLink: values.pay_link,
       registrationCodeSet: Boolean(values.registration_code_hash),
       calendarToken: values.calendar_token,
+      externalIcsUrl: values.external_ics_url,
     },
   });
 }

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -44,6 +44,28 @@ function ActionList({ title, items, hint, href, empty }:{
   </section>;
 }
 
+type ExtEvent = { display: string; summary: string };
+
+function ExternalCalendar() {
+  const [state, setState] = useState<{ configured: boolean; events: ExtEvent[]; error?: string } | null>(null);
+  useEffect(() => {
+    let active = true;
+    fetch("/api/staff/external-calendar", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((d) => { if (active) setState(d); })
+      .catch(() => { if (active) setState({ configured: false, events: [] }); });
+    return () => { active = false; };
+  }, []);
+  if (!state || !state.configured) return null;
+  return <section className="dashList" style={{ maxWidth: 1500, margin: "16px auto 0" }}>
+    <div className="dashListHead"><h3>Google Календар — найближчі події</h3><span>{state.events.length || ""}</span></div>
+    <p className="dashListHint">Події з підключеного Google Календаря (налаштування — у розділі «Налаштування»).</p>
+    {state.error ? <p className="dashListEmpty">{state.error}</p>
+      : state.events.length === 0 ? <p className="dashListEmpty">Найближчих подій немає.</p>
+      : <ul>{state.events.map((e, i) => <li key={i}><a><b>{e.summary}</b><small>{e.display}</small></a></li>)}</ul>}
+  </section>;
+}
+
 export default function DashboardPage() {
   const [data,setData] = useState<Data | null>(null);
   const [staff,setStaff] = useState<StaffInfo | null>(null);
@@ -120,6 +142,7 @@ export default function DashboardPage() {
           hint="Нові заявки, що очікують на реакцію реєстратури" empty="Нових непідтверджених заявок немає."
           href={()=>"/staff#bookings"}/>
       </div>
+      <ExternalCalendar/>
     </>}
   </StaffWorkspaceShell>;
 }

--- a/app/staff/settings/page.tsx
+++ b/app/staff/settings/page.tsx
@@ -4,7 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
 
 type StaffInfo = { email: string; displayName: string; role: string };
-type Settings = { telegramConfigured: boolean; telegramChatId: string; payLink: string; registrationCodeSet: boolean; calendarToken: string };
+type Settings = { telegramConfigured: boolean; telegramChatId: string; payLink: string; registrationCodeSet: boolean; calendarToken: string; externalIcsUrl: string };
 
 export default function StaffSettingsPage() {
   const [staff, setStaff] = useState<StaffInfo | null>(null);
@@ -14,6 +14,7 @@ export default function StaffSettingsPage() {
   const [payLink, setPayLink] = useState("");
   const [token, setToken] = useState("");
   const [accessCode, setAccessCode] = useState("");
+  const [externalIcsUrl, setExternalIcsUrl] = useState("");
   const [status, setStatus] = useState<"idle" | "saving">("idle");
   const [testing, setTesting] = useState(false);
   const [calBusy, setCalBusy] = useState(false);
@@ -28,7 +29,7 @@ export default function StaffSettingsPage() {
       if (res.status === 403) { if (active) setForbidden(true); return; }
       const data = await res.json().catch(() => ({})) as { settings?: Settings; staff?: StaffInfo };
       if (!active) return;
-      if (data.settings) { setSettings(data.settings); setChatId(data.settings.telegramChatId); setPayLink(data.settings.payLink); }
+      if (data.settings) { setSettings(data.settings); setChatId(data.settings.telegramChatId); setPayLink(data.settings.payLink); setExternalIcsUrl(data.settings.externalIcsUrl || ""); }
       if (data.staff) setStaff(data.staff);
     })();
     return () => { active = false; };
@@ -40,7 +41,7 @@ export default function StaffSettingsPage() {
     try {
       const res = await fetch("/api/staff/settings", {
         method: "PUT", headers: { "content-type": "application/json" },
-        body: JSON.stringify({ telegramBotToken: token, telegramChatId: chatId, payLink, accessCode }),
+        body: JSON.stringify({ telegramBotToken: token, telegramChatId: chatId, payLink, accessCode, externalIcsUrl }),
       });
       const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; settings?: Settings };
       if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
@@ -137,6 +138,15 @@ export default function StaffSettingsPage() {
           {calBusy ? "Оновлюємо…" : settings?.calendarToken ? "Оновити посилання" : "Створити посилання"}
         </button>
         {settings?.calendarToken && <small className="settingsHint">Оновлення посилання вимкне попереднє (стару підписку доведеться додати заново).</small>}
+      </section>
+
+      <section className="settingsBlock">
+        <h2>Розклад із Google (у кабінеті)</h2>
+        <p>Щоб персонал бачив події з вашого Google Календаря в пульті: у Google Календарі → «Налаштування календаря» → «Секретна адреса у форматі iCal» → скопіюйте й вставте сюди.</p>
+        <label><span>Адреса календаря (iCal)</span>
+          <input value={externalIcsUrl} onChange={(e) => setExternalIcsUrl(e.target.value)} placeholder="https://calendar.google.com/calendar/ical/.../basic.ics" autoComplete="off" inputMode="url" />
+          <small>Порожнє поле вимикає показ. Найближчі події зʼявляться на «Пульті».</small>
+        </label>
       </section>
 
       {notice && <p className="notice success" role="status">{notice}</p>}

--- a/drizzle/0013_external_calendar.sql
+++ b/drizzle/0013_external_calendar.sql
@@ -1,0 +1,4 @@
+-- Optional external Google Calendar (iCal secret address). When set, the staff
+-- dashboard shows upcoming events pulled from it.
+
+INSERT OR IGNORE INTO `app_settings` (`key`, `value`) VALUES ('external_ics_url', '');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785207600000,
       "tag": "0012_calendar_token",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1785211200000,
+      "tag": "0013_external_calendar",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/ics-parse.ts
+++ b/lib/ics-parse.ts
@@ -1,0 +1,70 @@
+// Minimal iCalendar parser for reading an external Google Calendar feed.
+// Extracts upcoming events (start time + title) for the staff dashboard.
+
+export interface ExternalEvent {
+  display: string;   // "10.08.2026 12:00" or "10.08.2026 · весь день"
+  summary: string;
+  sortMs: number;
+  allDay: boolean;
+}
+
+function unescapeText(value: string): string {
+  return value.replace(/\\n/gi, " ").replace(/\\,/g, ",").replace(/\\;/g, ";").replace(/\\\\/g, "\\");
+}
+
+function pad(n: number): string { return String(n).padStart(2, "0"); }
+
+function formatKyiv(instant: Date): string {
+  const parts = new Intl.DateTimeFormat("uk-UA", {
+    timeZone: "Europe/Kyiv", day: "2-digit", month: "2-digit", year: "numeric",
+    hour: "2-digit", minute: "2-digit", hour12: false,
+  }).formatToParts(instant);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value || "";
+  return `${get("day")}.${get("month")}.${get("year")} ${get("hour")}:${get("minute")}`;
+}
+
+// Parse an ICS document; returns upcoming events sorted ascending, capped.
+export function parseIcs(text: string, cutoffMs: number, limit = 60): ExternalEvent[] {
+  const unfolded = text.replace(/\r?\n[ \t]/g, "");
+  const lines = unfolded.split(/\r?\n/);
+  const events: ExternalEvent[] = [];
+  let inEvent = false;
+  let start = "";
+  let summary = "";
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") { inEvent = true; start = ""; summary = ""; continue; }
+    if (line === "END:VEVENT") {
+      if (start) {
+        const m = start.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})?(Z)?)?$/);
+        if (m) {
+          const [, Y, Mo, D, h, mi, s, z] = m;
+          const y = +Y, mo = +Mo, d = +D;
+          if (h === undefined) {
+            const sortMs = Date.UTC(y, mo - 1, d);
+            events.push({ allDay: true, summary: summary || "Подія", sortMs, display: `${pad(d)}.${pad(mo)}.${y} · весь день` });
+          } else if (z) {
+            const dt = new Date(Date.UTC(y, mo - 1, d, +h, +mi, s ? +s : 0));
+            events.push({ allDay: false, summary: summary || "Подія", sortMs: dt.getTime(), display: formatKyiv(dt) });
+          } else {
+            const sortMs = Date.UTC(y, mo - 1, d, +h, +mi);
+            events.push({ allDay: false, summary: summary || "Подія", sortMs, display: `${pad(d)}.${pad(mo)}.${y} ${pad(+h)}:${pad(+mi)}` });
+          }
+        }
+      }
+      inEvent = false; continue;
+    }
+    if (!inEvent) continue;
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    const name = line.slice(0, idx).split(";")[0];
+    const value = line.slice(idx + 1);
+    if (name === "DTSTART") start = value.trim();
+    else if (name === "SUMMARY") summary = unescapeText(value).slice(0, 200);
+  }
+
+  return events
+    .filter((e) => e.sortMs >= cutoffMs)
+    .sort((a, b) => a.sortMs - b.sortMs)
+    .slice(0, limit);
+}

--- a/tests/external-calendar.test.mjs
+++ b/tests/external-calendar.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("external-calendar migration + journal", async () => {
+  const migration = await read("drizzle/0013_external_calendar.sql");
+  assert.match(migration, /external_ics_url/);
+  const journal = JSON.parse(await read("drizzle/meta/_journal.json"));
+  assert.ok(journal.entries.some((e) => e.tag === "0013_external_calendar"));
+});
+
+test("ICS parser reads VEVENTs and formats Kyiv time", async () => {
+  const lib = await read("lib/ics-parse.ts");
+  assert.match(lib, /export function parseIcs/);
+  assert.match(lib, /BEGIN:VEVENT/);
+  assert.match(lib, /Europe\/Kyiv/);
+  assert.match(lib, /DTSTART/);
+});
+
+test("external-calendar endpoint fetches the configured feed for staff", async () => {
+  const route = await read("app/api/staff/external-calendar/route.ts");
+  assert.match(route, /requireStaff\(/);
+  assert.match(route, /getSetting\(db, "external_ics_url"\)/);
+  assert.match(route, /parseIcs\(/);
+  assert.match(route, /await fetch\(url/);
+});
+
+test("settings expose the external calendar URL and the dashboard shows events", async () => {
+  const route = await read("app/api/staff/settings/route.ts");
+  assert.match(route, /external_ics_url/);
+  const page = await read("app/staff/settings/page.tsx");
+  assert.match(page, /externalIcsUrl/);
+  const dash = await read("app/staff/dashboard/page.tsx");
+  assert.match(dash, /\/api\/staff\/external-calendar/);
+  assert.match(dash, /Google Календар — найближчі події/);
+});


### PR DESCRIPTION
## Що зроблено (зворотній бік)

Тепер персонал бачить у кабінеті події **з** Google Календаря.

- **Налаштування (адмін) → «Розклад із Google»**: вставте «Секретну адресу у форматі iCal» свого Google Календаря (міграція **0013**, `app_settings.external_ics_url`).
- **`/api/staff/external-calendar`** тягне цей iCal на сервері, парсить події (`lib/ics-parse.ts`) і повертає найближчі; час у зоні **Europe/Kyiv**.
- На **«Пульті»** зʼявляється панель **«Google Календар — найближчі події»**.

## Перевірка (in-memory D1, мок iCal)
Подія `09:00Z` → показується як **12:00** (Київ, літній час); подія-«весь день» → «12.08.2026 · весь день». Парсинг згорнутих рядків і `VALUE=DATE` — коректний.

`npm test` — **64/64**, lint — 0 помилок, build — успішний.

## Як користуватись
Google Календар → «Налаштування календаря» → «Секретна адреса у форматі iCal» → скопіювати → вставити в Налаштування RadiologyOS. Після деплою застосується міграція 0013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_