### PR TITLE
QR-оплата: показ платіжного QR у кабінеті пацієнта

### DIFF
--- a/public/site/assets/d1-bridge.js
+++ b/public/site/assets/d1-bridge.js
@@ -39,7 +39,11 @@
       const link = (data && data.payLink) || '';
       if (!link) { block.hidden = true; return; }
       const btn = document.getElementById('payBtn');
-      if (btn) btn.href = link;
+      // The button must be a real link; a raw bank-QR payload is scan-only.
+      if (btn) {
+        if (/^https?:\/\//i.test(link)) { btn.href = link; btn.hidden = false; }
+        else { btn.removeAttribute('href'); btn.hidden = true; }
+      }
       const qrBox = document.getElementById('payQr');
       if (qrBox && typeof qrcode === 'function') {
         try { const qr = qrcode(0, 'M'); qr.addData(link); qr.make(); qrBox.innerHTML = qr.createImgTag(4, 6); }

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -141,6 +141,7 @@ header{padding:0 14px;margin-bottom:18px}
 
 </main>
 
+<script src="/site/assets/qrgen.js"></script>
 <script>
 const MY_BOOKINGS = '/api/my-bookings';
 const STATUS_API = '/api/booking-status';
@@ -157,6 +158,12 @@ const statusMeta = {
 const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[m]));
 const humanDate = (iso) => (iso ? String(iso).split('-').reverse().join('.') : '');
 const money = (n) => new Intl.NumberFormat('uk-UA').format(Number(n) || 0);
+const isPayUrl = (s) => /^https?:\/\//i.test(String(s || ''));
+function payQrImg(payload) {
+  if (!payload || typeof qrcode !== 'function') return '';
+  try { const qr = qrcode(0, 'M'); qr.addData(payload); qr.make(); return qr.createImgTag(4, 6); }
+  catch (e) { return ''; }
+}
 
 const gate = document.getElementById('gate');
 const cabinet = document.getElementById('cabinet');
@@ -190,8 +197,9 @@ function cardHtml(b) {
     </div>
     ${b.status !== 'cancelled' ? stepper(b.status) : ''}
     ${awaitingPayment ? `<div class="pay-row">💳 <span>Очікує оплати: <strong>${esc(money(b.paymentAmount))} грн</strong></span></div>` : ''}
+    ${awaitingPayment && payLink ? `<div class="pay-qr" style="text-align:center;margin:4px 0 8px">${payQrImg(payLink)}<div style="font-size:12px;color:#6b7280;margin-top:4px">Наведіть камеру банку, щоб сплатити</div></div>` : ''}
     <div class="actions">
-      ${awaitingPayment && payLink ? `<a class="btn" href="${esc(payLink)}" target="_blank" rel="noopener">Оплатити</a>` : ''}
+      ${awaitingPayment && isPayUrl(payLink) ? `<a class="btn" href="${esc(payLink)}" target="_blank" rel="noopener">Оплатити</a>` : ''}
       ${b.hasProtocol ? `<button class="btn secondary" type="button" data-protocol="${esc(b.code)}">Переглянути протокол</button>` : ''}
       ${canCancel ? `<button class="btn danger" type="button" data-cancel="${esc(b.code)}">Скасувати заявку</button>` : ''}
     </div>

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -102,6 +102,20 @@ test("payment link is served publicly and used by the site, not hardcoded", asyn
   assert.match(cabinet, /Очікує оплати/);
 });
 
+test("the payment QR renders on the site and in the cabinet; button only for real URLs", async () => {
+  // site: button hidden for a raw bank-QR payload, QR still drawn
+  const bridge = await read("public/site/assets/d1-bridge.js");
+  assert.match(bridge, /if \(\/\^https\?:/); // button gated on a real http(s) URL
+  assert.match(bridge, /btn\.removeAttribute\('href'\); btn\.hidden = true/); // raw QR payload => scan-only
+  assert.match(bridge, /qr\.createImgTag/);
+  // cabinet: loads the QR generator and draws a QR for pending payments
+  const cabinet = await read("public/site/cabinet.html");
+  assert.match(cabinet, /assets\/qrgen\.js/);
+  assert.match(cabinet, /function payQrImg/);
+  assert.match(cabinet, /awaitingPayment && payLink \? `<div class="pay-qr"/);
+  assert.match(cabinet, /awaitingPayment && isPayUrl\(payLink\)/); // link button gated on http(s)
+});
+
 test("the slot picker uses the real department schedule", async () => {
   const slots = await read("public/site/assets/slots.js");
   assert.match(slots, /\/api\/availability\?date=/);


### PR DESCRIPTION
## Що це

Пацієнт може **сканувати платіжний QR банком** прямо в особистому кабінеті, а не лише переходити за посиланням. QR будується на сайті з платіжного рядка, який адміністратор зберігає в **Налаштуваннях** — у публічний репозиторій **не потрапляють** жодні реквізити (номер картки/IBAN/QR військової частини лишаються тільки в приватній базі D1).

## Зміни

- **Кабінет пацієнта** (`cabinet.html`): для заявок зі статусом «Очікує оплати» тепер малюється QR (через наявний `qrgen.js`) поруч із сумою, з підписом «Наведіть камеру банку, щоб сплатити».
- **Кнопка «Оплатити»** показується лише коли платіжне посилання — справжній `http(s)`-URL. Якщо в Налаштуваннях збережено **сирий рядок банківського QR** (реквізити), кнопка ховається (натиснути ні на що), а QR усе одно генерується.
- **Сторінка оплати сайту** (`d1-bridge.js`, `populatePayBlock`): та сама логіка — QR завжди, кнопка лише для URL.

## Як користуватися

Вставте у Налаштування → **«Посилання на оплату»** або свій лінк Приват24 (тоді працюють і QR, і кнопка), або текстовий рядок, який кодує ваш банківський QR (тоді на сайті згенерується той самий QR, що у вашому PDF).

## Перевірки

- `npm run lint` — чисто (лише наявне попередження imaging).
- `npm test` — 67/67 (новий тест перевіряє генерацію QR на сайті й у кабінеті та приховування кнопки для не-URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_