### PR TITLE
Бічна панель: модулі «Карти системи» в порядку артефакта з переходом до блоку

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -493,7 +493,7 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 
 .sysmapColhead{display:grid;grid-template-columns:26px minmax(150px,1.15fr) minmax(200px,2fr) 92px 108px minmax(150px,1.1fr);gap:12px;padding:0 18px 8px 22px;font-family:var(--sm-mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--sm-faint)}
 
-.sysmapMod{border:1px solid var(--sm-hair);background:var(--sm-panel);border-radius:12px;margin-bottom:12px;box-shadow:var(--sm-shadow);overflow:hidden}
+.sysmapMod{border:1px solid var(--sm-hair);background:var(--sm-panel);border-radius:12px;margin-bottom:12px;box-shadow:var(--sm-shadow);overflow:hidden;scroll-margin-top:84px}
 .sysmapModhead{width:100%;text-align:left;font:inherit;cursor:pointer;background:transparent;border:0;display:flex;align-items:center;gap:14px;padding:14px 18px;color:var(--sm-ink)}
 .sysmapModhead:hover{background:var(--sm-panel-2)}
 .sysmapNum{font-family:var(--sm-mono);font-size:12px;font-weight:600;color:var(--sm-accent);border:1px solid var(--sm-hair);border-radius:7px;padding:4px 8px;background:var(--sm-accent-soft);flex:0 0 auto;min-width:30px;text-align:center}
@@ -703,3 +703,7 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .themeDark .protocolFilterTabs button,.themeDark .crmSegmentTabs button,.themeDark .reportTemplateTabs button{background:#0e151a;border-color:#26333d;color:#aebeca}
 .themeDark .reportTemplateTabs button span{color:#93a3ad}
 .themeDark .protocolActions button,.themeDark .pacsFormActions button.ghost{background:#0e151a;border-color:#26333d;color:#cdd8de}
+
+/* Пункти-модулі «Карти системи» в бічній панелі — номерні бейджі */
+.workspaceNavigation a.workspaceModuleLink>span{display:grid;place-items:center;width:20px;height:20px;flex:0 0 20px;border-radius:6px;background:rgba(37,180,192,.16);color:#7fd4dc;font-size:11px;font-weight:700}
+.workspaceNavigation a.workspaceModuleLink.active>span,.workspaceNavigation a.workspaceModuleLink:hover>span{background:rgba(37,180,192,.28);color:#bff0f5}

--- a/app/staff/system-map/page.tsx
+++ b/app/staff/system-map/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
 
 type Status = "ok" | "warn" | "new";
@@ -93,6 +93,22 @@ export default function SystemMapPage() {
   const [dark, setDark] = useState(true);
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
+  // Перехід до блоку модуля за якорем (#mod-N) із бічної панелі.
+  useEffect(() => {
+    function jump() {
+      const hash = window.location.hash;
+      if (!hash.startsWith("#mod-")) return;
+      const id = hash.slice(1);
+      setCollapsed((current) => ({ ...current, [id.replace("mod-", "")]: false }));
+      window.setTimeout(() => {
+        document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 60);
+    }
+    jump();
+    window.addEventListener("hashchange", jump);
+    return () => window.removeEventListener("hashchange", jump);
+  }, []);
+
   const totals = useMemo(() => {
     const t = { ok: 0, warn: 0, new: 0, all: 0, ph2: 0, ph3: 0, ph4: 0 };
     for (const m of DATA) for (const it of m.items) {
@@ -184,7 +200,7 @@ export default function SystemMapPage() {
           for (const it of m.items) counts[it.st]++;
           const pct = Math.round((counts.ok / m.items.length) * 100);
           const isCollapsed = !!collapsed[m.num];
-          return <section className={`sysmapMod${isCollapsed ? " collapsed" : ""}`} key={m.num}>
+          return <section id={`mod-${m.num}`} className={`sysmapMod${isCollapsed ? " collapsed" : ""}`} key={m.num}>
             <button type="button" className="sysmapModhead" aria-expanded={!isCollapsed}
               onClick={() => setCollapsed((c) => ({ ...c, [m.num]: !c[m.num] }))}>
               <span className="sysmapNum">{m.num}</span>

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -36,6 +36,18 @@ const administration = [
   { href:"/", label:"Публічний сайт", glyph:"↗" },
 ];
 
+// Модулі цільової структури — у тому ж порядку, що й «Карта системи».
+// Кожен пункт веде до відповідного блоку в дереві (#mod-N).
+const systemModules = [
+  { n:"1", label:"Головна / Продаж" },
+  { n:"2", label:"Запис і заявки" },
+  { n:"3", label:"CRM (пацієнти)" },
+  { n:"4", label:"Бухгалтерія / Фінанси" },
+  { n:"5", label:"Персонал (HR)" },
+  { n:"6", label:"Обладнання" },
+  { n:"7", label:"Адмін / Наскрізне" },
+];
+
 function formatDateTime(value:Date) {
   const date = new Intl.DateTimeFormat("uk-UA", {
     timeZone:"Europe/Kyiv",
@@ -116,6 +128,13 @@ export default function StaffWorkspaceShell({
           aria-current={"section" in item && item.section === active ? "page":undefined}
           title={collapsed ? item.label:undefined}
         ><span aria-hidden="true">{item.glyph}</span><b>{item.label}</b></Link>)}
+        <p>Карта системи</p>
+        {systemModules.map((item)=><Link
+          href={`/staff/system-map#mod-${item.n}`}
+          key={item.n}
+          className="workspaceModuleLink"
+          title={collapsed ? item.label:undefined}
+        ><span aria-hidden="true">{item.n}</span><b>{item.label}</b></Link>)}
       </nav>
 
       <div className="workspaceSidebarFoot">


### PR DESCRIPTION
## Огляд

Додає в бічну панель кабінету розділ **«Карта системи»** зі списком 7 модулів цільової структури — у тому ж порядку, що й дерево на `/staff/system-map`. Кожен пункт веде до відповідного блоку модуля.

## Зміни
- Нова група навігації **«Карта системи»** (сайдбар): 7 модулів у порядку артефакта, номерні teal-бейджі
  (1 Головна/Продаж · 2 Запис і заявки · 3 CRM · 4 Бухгалтерія · 5 Персонал · 6 Обладнання · 7 Адмін).
- Кожен пункт — якірне посилання `#mod-N`: на сторінці «Карта системи» блок модуля отримав `id`, а сторінка плавно прокручується до нього й **розгортає** його (обробка `hashchange` + `scroll-margin-top` під липкий топбар).
- Дозволяє поступово відкривати й доопрацьовувати кожен модуль.

## Перевірка
- `lint` — 0 помилок; `tsc --noEmit` — чисто; `npm test` — **74/74**; build ✓.
- Візуально звірено рендер сайдбара (бейджі 1–7 у правильному порядку).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_