### PR TITLE
Сайдбар: усі підпункти модулів розгорнуті за замовчуванням

### DIFF
--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -164,7 +164,7 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = !!item.section && item.section === active;
-          const isOpen = openModules[item.n] ?? isActive;
+          const isOpen = openModules[item.n] ?? true;
           return <div className="workspaceModuleGroup" key={item.n}>
             <div className="workspaceModuleRow">
               <Link


### PR DESCRIPTION
## Огляд
За запитом «зроби щоб були всі субвкладки»: тепер усі підпункти модулів показуються одразу — кожен модуль відкритий за замовчуванням. Згорнути окремий модуль можна кареткою.

## Зміни
- `workspace-shell`: типова розкритість модуля — `true` (замість «лише активний»).

## Перевірка
- build ✓ · `lint` 0 · `tsc` чисто · `npm test` **74/74**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_