### PR TITLE
Черга /staff у вигляді «Записи» (статус-таби, групи по днях, деталі запису)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -724,3 +724,36 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 /* У згорнутій/мобільній панелі підпункти й перемикач ховаються */
 .workspaceCollapsed .workspaceSubList,.workspaceCollapsed .workspaceSubToggle{display:none}
 @media(max-width:820px){.workspaceSubList,.workspaceSubToggle{display:none}.workspaceCollapsed .workspaceSubList,.workspaceCollapsed .workspaceSubToggle{display:none}}
+
+/* ================= «Записи» — таби, групи по днях, керування ================= */
+.apptTabs{max-width:1500px;margin:0 auto 12px;display:flex;flex-wrap:wrap;gap:6px}
+.apptTab{display:inline-flex;align-items:center;gap:7px;border:1px solid #dce4e3;background:#fff;color:#41544f;font:inherit;font-size:12.5px;font-weight:700;padding:7px 13px;border-radius:999px;cursor:pointer;transition:.15s}
+.apptTab:hover{border-color:var(--green);color:var(--green)}
+.apptTab.active{background:var(--green);border-color:var(--green);color:#fff}
+.apptTabCount{font-family:var(--font-sans);font-size:11px;font-weight:800;background:rgba(20,45,43,.08);border-radius:999px;padding:1px 7px;min-width:20px;text-align:center;font-variant-numeric:tabular-nums}
+.apptTab.active .apptTabCount{background:rgba(255,255,255,.24)}
+.apptDay{max-width:1500px;margin:0 auto 16px}
+.apptDayHead{display:flex;justify-content:space-between;align-items:baseline;gap:12px;padding:2px 4px 8px;margin-bottom:8px;border-bottom:1px solid #e0e7ea}
+.apptDayHead b{font-size:14.5px;font-weight:750;letter-spacing:-.01em}
+.apptDayHead span{font-size:11px;font-weight:700;color:#6c7c86;text-transform:uppercase;letter-spacing:.05em}
+.apptManage{grid-column:1/-1;border-top:1px solid #e1ded6;margin-top:6px;padding-top:4px}
+.apptManage>summary{cursor:pointer;color:var(--green);font-size:12px;font-weight:800;padding:6px 0;list-style:none}
+.apptManage>summary::-webkit-details-marker{display:none}
+.apptManage>summary::before{content:"▸ "}
+.apptManage[open]>summary::before{content:"▾ "}
+.apptEmpty{max-width:760px;margin:34px auto;display:flex;flex-direction:column;align-items:center;text-align:center;gap:8px;padding:48px 30px;background:#fff;border:1px solid #e7ece9;border-radius:16px;box-shadow:0 8px 24px rgba(23,54,52,.04)}
+.apptEmptyIcon{font-size:34px;opacity:.65}
+.apptEmpty b{font-size:16px}
+.apptEmpty p{margin:0;color:#6c7c86;font-size:13px;max-width:44ch;line-height:1.5}
+@media print{.apptTabs,.staffTools .toolButtons{display:none!important}}
+/* Темна тема */
+.themeDark .apptTab{background:#121a20;border-color:#26333d;color:#aebeca}
+.themeDark .apptTab:hover{border-color:#25b4c0;color:#25b4c0}
+.themeDark .apptTab.active{background:#25b4c0;border-color:#25b4c0;color:#06131a}
+.themeDark .apptTabCount{background:rgba(255,255,255,.1)}
+.themeDark .apptTab.active .apptTabCount{background:rgba(6,19,26,.25)}
+.themeDark .apptDayHead{border-bottom-color:#22303a}
+.themeDark .apptDayHead span{color:#8b98a1}
+.themeDark .apptManage{border-top-color:#22303a}
+.themeDark .apptEmpty{background:#121a20!important;border-color:#22303a!important}
+.themeDark .apptEmpty p{color:#93a3ad}

--- a/app/staff/page.tsx
+++ b/app/staff/page.tsx
@@ -87,6 +87,29 @@ function todayInKyiv() {
   }).format(new Date());
 }
 
+const uaApptDay = new Intl.DateTimeFormat("uk-UA", { weekday:"long", day:"numeric", month:"long" });
+function formatApptDay(dateStr:string) {
+  const date = new Date(`${dateStr}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return dateStr || "Без дати";
+  const label = uaApptDay.format(date);
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+function pluralAppt(n:number) {
+  const m10 = n % 10, m100 = n % 100;
+  if (m10 === 1 && m100 !== 11) return "запис";
+  if (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20)) return "записи";
+  return "записів";
+}
+
+const STATUS_TABS: Array<{ v:string; l:string }> = [
+  { v:"all", l:"Усі" },
+  { v:"new", l:"Нові" },
+  { v:"confirmed", l:"Підтверджені" },
+  { v:"rescheduled", l:"Перенесені" },
+  { v:"completed", l:"Завершені" },
+  { v:"cancelled", l:"Скасовані" },
+];
+
 // Перенесення запису з реального розкладу: показує лише вільні слоти обраного
 // апарата на обрану дату (через /api/availability), як у формі для пацієнта.
 function RescheduleForm({ item, today, onSubmit }:{
@@ -317,13 +340,28 @@ export default function StaffPage() {
     await load();
   }
 
-  const visible = useMemo(() => items
-    .filter(item => filter === "all" || item.status === filter)
+  // Базові фільтри (апарат/дата/пошук) — від них рахуються лічильники на табах.
+  const baseFiltered = useMemo(() => items
     .filter(item => equipmentFilter === "all" || item.equipmentId === equipmentFilter)
     .filter(item => !dayFilter || item.desiredDate === dayFilter)
     .filter(item => !query.trim() || `${item.name} ${item.phone} ${item.code} ${item.service} ${item.serviceCode}`.toLowerCase().includes(query.trim().toLowerCase()))
     .sort((a,b)=>`${a.desiredDate} ${a.desiredTime}`.localeCompare(`${b.desiredDate} ${b.desiredTime}`)),
-  [items,filter,equipmentFilter,dayFilter,query]);
+  [items,equipmentFilter,dayFilter,query]);
+  const statusCounts = useMemo(() => {
+    const counts:Record<string,number> = { all:baseFiltered.length };
+    for (const item of baseFiltered) counts[item.status] = (counts[item.status] || 0) + 1;
+    return counts;
+  }, [baseFiltered]);
+  const visible = useMemo(() => baseFiltered.filter(item => filter === "all" || item.status === filter), [baseFiltered, filter]);
+  const groupedByDay = useMemo(() => {
+    const map = new Map<string, Booking[]>();
+    for (const item of visible) {
+      const key = item.desiredDate || "";
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(item);
+    }
+    return [...map.entries()];
+  }, [visible]);
   const today = todayInKyiv();
   const canManage = staff?.role === "admin" || staff?.role === "registrar";
   const canProtocol = staff?.role === "admin" || staff?.role === "radiologist";
@@ -331,8 +369,8 @@ export default function StaffPage() {
 
   return <StaffWorkspaceShell
     active="overview"
-    title="Робочий кабінет"
-    description="Записи пацієнтів, виконання досліджень, протоколи та робота обладнання в одному просторі."
+    title="Записи"
+    description="Записи пацієнтів за статусами й днями. Керування кожним записом — протокол, оплата, виконання — у деталях запису."
     staffName={staff?.displayName || staff?.email}
     staffRole={staff ? roleLabels[staff.role] : undefined}
   >
@@ -356,14 +394,23 @@ export default function StaffPage() {
         <article><span>На сьогодні</span><b>{items.filter(i=>i.desiredDate===today).length}</b></article>
         <article><span>Підтверджені</span><b>{items.filter(i=>i.status==="confirmed").length}</b></article>
       </section>
-      <div className="staffTools" id="schedule">
-        <label>Статус <select value={filter} onChange={e=>setFilter(e.target.value)}><option value="all">Усі заявки</option>{Object.entries(labels).map(([v,l])=><option value={v} key={v}>{l}</option>)}</select></label>
-        <label>Апарат <select value={equipmentFilter} onChange={e=>setEquipmentFilter(e.target.value)}><option value="all">Усе обладнання</option>{equipment.map(item=><option value={item.id} key={item.id}>{item.name}</option>)}</select></label>
-        <label>Дата <input type="date" value={dayFilter} onChange={e=>setDayFilter(e.target.value)}/></label>
-        <label>Пошук <input type="search" value={query} onChange={e=>setQuery(e.target.value)} placeholder="Код, ім’я, телефон"/></label>
-        <div className="toolButtons"><button onClick={()=>{setDayFilter(today);setFilter("all")}}>Сьогодні</button><button onClick={()=>window.print()}>Друк</button><button onClick={()=>void load()}>Оновити</button></div>
+      <div className="apptTabs" id="schedule" role="tablist" aria-label="Статус записів">
+        {STATUS_TABS.map(tab=><button
+          key={tab.v}
+          type="button"
+          role="tab"
+          aria-selected={filter===tab.v}
+          className={`apptTab${filter===tab.v?" active":""}`}
+          onClick={()=>setFilter(tab.v)}
+        >{tab.l}<span className="apptTabCount">{statusCounts[tab.v] || 0}</span></button>)}
       </div>
-      <p className="scheduleCaption">{dayFilter?`Розклад на ${dayFilter}`:"Усі дати"} · {visible.length} записів</p>
+      <div className="staffTools">
+        <label>Дата <input type="date" value={dayFilter} onChange={e=>setDayFilter(e.target.value)}/></label>
+        <label>Апарат <select value={equipmentFilter} onChange={e=>setEquipmentFilter(e.target.value)}><option value="all">Усе обладнання</option>{equipment.map(item=><option value={item.id} key={item.id}>{item.name}</option>)}</select></label>
+        <label>Пошук <input type="search" value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пацієнт, код, телефон…"/></label>
+        <div className="toolButtons"><button onClick={()=>{setDayFilter(today);setFilter("all")}}>Сьогодні</button><button onClick={()=>{setDayFilter("");setFilter("all");setEquipmentFilter("all");setQuery("");}}>Скинути</button><button onClick={()=>window.print()}>Друк</button><button onClick={()=>void load()}>Оновити</button></div>
+      </div>
+      <p className="scheduleCaption">{dayFilter?`Записи на ${dayFilter}`:"Усі дати"} · {visible.length} {pluralAppt(visible.length)}</p>
       {actionError&&<p className="staffError" role="alert">{actionError}</p>}
       {actionSuccess&&<p className="staffSuccess" role="status">{actionSuccess}</p>}
 
@@ -417,8 +464,10 @@ export default function StaffPage() {
       </section>}
 
       <section className="bookingList" id="bookings">
-        {visible.length === 0 && <p className="empty">Заявок у цій категорії немає.</p>}
-        {visible.map(item => <article className="bookingRow" key={item.id}>
+        {visible.length === 0 ? <div className="apptEmpty"><span className="apptEmptyIcon" aria-hidden="true">🗓</span><b>Записів немає</b><p>На обрані фільтри записів не знайдено. Змініть дату, статус або пошук.</p></div> :
+        groupedByDay.map(([groupDate, rows]) => <div className="apptDay" key={groupDate || "nodate"}>
+        <div className="apptDayHead"><b>{formatApptDay(groupDate)}</b><span>{rows.length} {pluralAppt(rows.length)}</span></div>
+        {rows.map(item => <article className="bookingRow appointmentRow" key={item.id}>
           <div className="bookingPrimary"><span className={`statusTag ${item.status}`}>{labels[item.status] || item.status}</span><b>{item.name}</b><small>{item.code} · отримано {new Date(item.createdAt).toLocaleString("uk-UA")}</small></div>
           <div><small>Дослідження</small><b>{item.service}</b><span>Код {item.serviceCode} · {equipment.find(unit=>unit.id===item.equipmentId)?.name || item.equipmentId} · {item.durationMinutes} хв</span><span>{item.desiredDate} · {item.desiredTime}</span></div>
           <div><small>Контакт і маршрут</small><a href={`tel:${item.phone}`}>{item.phone}</a><a className="crmCardLink" href={`/staff/patients?phone=${encodeURIComponent(item.phone)}`}>Картка пацієнта →</a><span>{categoryLabels[item.patientCategory] || item.patientCategory}</span><span>{referralLabels[item.referralType] || item.referral}</span>{item.referralNumber&&<span>№ {item.referralNumber}</span>}{item.marketingSource&&<span>Джерело: {item.marketingSource}</span>}</div>
@@ -427,19 +476,15 @@ export default function StaffPage() {
             {canManage && (item.status==="new"||item.status==="rescheduled") && <button type="button" className="confirmBooking" onClick={()=>void confirmBooking(item.id)}>✓ Підтвердити й у розклад</button>}
             {(() => { const last = notifications.find(note=>note.bookingId===item.id); return last ? <span className={`reminderTag ${last.status}`}>Нагадування: {notificationStatusLabels[last.status]||last.status} · {notificationChannelLabels[last.channel]||last.channel}{last.status==="failed"&&last.error?` — ${last.error}`:""}</span> : null; })()}
           </div>
-          {canManage && <RescheduleForm item={item} today={today} onSubmit={(date,time)=>reschedule(item.id,date,time)}/>}
+          <details className="apptManage">
+            <summary>Керування записом · {item.performedAt ? "виконано" : "очікує виконання"} · протокол: {protocolLabels[item.protocolStatus] || item.protocolStatus} · оплата: {paymentLabels[item.paymentStatus] || item.paymentStatus}</summary>
+          {canManage && <RescheduleForm item={item} today={today} onSubmit={(newDate,newTime)=>reschedule(item.id,newDate,newTime)}/>}
           {item.comment && <p className="bookingComment">{item.comment}</p>}
           <form className="staffNoteForm" onSubmit={event=>{event.preventDefault();const data=new FormData(event.currentTarget);void saveNote(item.id,String(data.get("note")));}}>
             <label><small>Внутрішня нотатка персоналу</small><textarea name="note" maxLength={1200} defaultValue={notes.find(note=>note.bookingId===item.id)?.note||""} placeholder="Підготовка, уточнення направлення, домовленості…"/></label>
             <button type="submit">Зберегти нотатку</button>
             {notes.find(note=>note.bookingId===item.id)&&<span>Оновлено: {new Date(notes.find(note=>note.bookingId===item.id)!.updatedAt).toLocaleString("uk-UA")}</span>}
           </form>
-          <details className="bookingOperations">
-            <summary>
-              {item.performedAt ? `Виконано: ${new Date(item.performedAt).toLocaleString("uk-UA")} · ` : "Очікує виконання · "}
-              Протокол: {protocolLabels[item.protocolStatus] || item.protocolStatus} ·
-              Оплата: {paymentLabels[item.paymentStatus] || item.paymentStatus}
-            </summary>
             <div className="operationsGrid">
               <section>
                 <h3>Призначені виконавці</h3>
@@ -538,13 +583,14 @@ export default function StaffPage() {
               </section>
             </div>
             <p className="operationsNote">Це внутрішній облік. Фактичне списання коштів або перевірка в ЕСОЗ/НСЗУ відбуваються лише після підключення офіційного провайдера.</p>
-          </details>
           <details className="bookingHistory">
             <summary>Історія змін ({events.filter(event=>event.bookingId===item.id).length})</summary>
             {events.filter(event=>event.bookingId===item.id).length===0?<p>Змін ще не зафіксовано.</p>:
               <ol>{events.filter(event=>event.bookingId===item.id).map(event=><li key={event.id}><b>{eventLabels[event.action] || event.action}</b><span>{event.details}</span><small>{new Date(event.createdAt).toLocaleString("uk-UA")} · {event.actor==="patient"?"пацієнт":event.actor}</small></li>)}</ol>}
           </details>
+          </details>
         </article>)}
+        </div>)}
       </section>
     </>}
   </StaffWorkspaceShell>;


### PR DESCRIPTION
## Огляд
За референсом doctime «Записи»: переоформлено чергу заявок на `/staff` у чистий вигляд списку записів.

## Зміни
- **Статус-таби** з лічильниками (Усі / Нові / Підтверджені / Перенесені / Завершені / Скасовані) замість випадайки статусу.
- **Групування по днях**: заголовок дня (укр. дата, напр. «Середа, 29 липня») + кількість записів.
- Кожен запис — **компактний рядок**; уся операційна робота (перенесення, нотатка, виконавці, фактичне виконання, протокол, оплата/НСЗУ, історія) схована у складаний блок **«Керування записом»** — список лишається чистим.
- **Порожній стан** з іконкою; кнопка **«Скинути»** фільтри; фільтри «Дата / Апарат / Пошук».
- teal-стиль + темна тема; лише UI, без змін API/схеми.

## Перевірка
- build ✓ · `lint` 0 · `tsc` чисто · `npm test` **74/74**.
- Візуально звірено (таби, група дня, рядки, «Керування записом»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_