### PR TITLE
Комерційний лендинг RadiologyOS (/product) у стилі Doctime

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -757,3 +757,146 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .themeDark .apptManage{border-top-color:#22303a}
 .themeDark .apptEmpty{background:#121a20!important;border-color:#22303a!important}
 .themeDark .apptEmpty p{color:#93a3ad}
+
+/* ================= Комерційний лендинг RadiologyOS (стиль Doctime) ================= */
+.rosLanding{--ros-bg:#f6f3ec;--ros-bg2:#ece7db;--ros-ink:#2b2621;--ros-muted:#6b655e;--ros-teal:#2e9e85;--ros-teal-deep:#256f60;--ros-orange:#e8794b;--ros-card:#fff;--ros-line:#e6e0d1;--ros-footer:#2b2621;background:var(--ros-bg);color:var(--ros-ink);font-family:var(--font-sans);line-height:1.5;letter-spacing:-.005em}
+.rosLanding *{box-sizing:border-box}
+.rosLanding h1,.rosLanding h2,.rosLanding h3{font-family:var(--font-serif);font-weight:600;letter-spacing:-.02em;margin:0;text-wrap:balance}
+.rosLanding a{color:inherit;text-decoration:none}
+.rosLanding section,.rosLanding header,.rosLanding footer{padding-left:clamp(16px,5vw,40px);padding-right:clamp(16px,5vw,40px)}
+.rosBtn{display:inline-flex;align-items:center;gap:8px;background:var(--ros-teal);color:#fff;border:0;border-radius:12px;padding:13px 22px;font:inherit;font-weight:800;font-size:14px;cursor:pointer;transition:.15s;white-space:nowrap}
+.rosBtn:hover{background:var(--ros-teal-deep);transform:translateY(-1px)}
+.rosBtnLg{padding:17px 30px;font-size:15px;border-radius:14px}
+.rosBtnOutline{background:transparent;border:1.6px solid var(--ros-teal);color:var(--ros-teal-deep)}
+.rosBtnOutline:hover{background:rgba(46,158,133,.08);transform:none}
+
+/* header */
+.rosHeader{position:sticky;top:0;z-index:30;height:72px;display:flex;align-items:center;gap:24px;background:rgba(246,243,236,.9);backdrop-filter:blur(10px);border-bottom:1px solid var(--ros-line)}
+.rosBrand{display:inline-flex;align-items:center;gap:9px;font-weight:800;font-size:18px;letter-spacing:-.02em}
+.rosBrandMark{display:grid;place-items:center;width:30px;height:30px;border-radius:9px;background:var(--ros-teal);color:#fff;font-size:15px}
+.rosNav{display:flex;gap:26px;margin:0 auto;font-size:14px;font-weight:600;color:#4a453f}
+.rosNav a:hover{color:var(--ros-teal-deep)}
+.rosHeaderActions{display:flex;align-items:center;gap:16px}
+.rosLogin{font-weight:700;font-size:14px}.rosLogin:hover{color:var(--ros-teal-deep)}
+
+/* hero */
+.rosHero{max-width:820px;margin:0 auto;text-align:center;padding-top:clamp(48px,8vw,96px);padding-bottom:clamp(40px,6vw,72px)}
+.rosEyebrow,.rosSectionEyebrow{display:inline-block;font-size:12px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:var(--ros-teal-deep)}
+.rosHero h1{font-size:clamp(34px,6vw,60px);line-height:1.06;margin:16px 0}
+.rosHero h1 em{font-style:normal;color:var(--ros-ink)}
+.rosHero>p{font-size:clamp(16px,2.2vw,19px);color:var(--ros-muted);max-width:620px;margin:0 auto;line-height:1.6}
+.rosHeroCta{margin:32px 0 14px}
+.rosHeroNote{font-size:14px;color:var(--ros-muted)}
+.rosHeroNote a{color:var(--ros-teal-deep);font-weight:700}
+
+/* integrations */
+.rosIntegr{background:var(--ros-bg2);text-align:center;padding-top:36px;padding-bottom:36px;border-top:1px solid var(--ros-line);border-bottom:1px solid var(--ros-line)}
+.rosIntegrCap{font-size:12px;font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:#8a8377;margin:0 0 18px}
+.rosIntegrChips{display:flex;flex-wrap:wrap;justify-content:center;gap:12px;max-width:1000px;margin:0 auto}
+.rosChip{display:inline-flex;align-items:center;gap:6px;background:#fff;border:1px solid var(--ros-line);border-radius:999px;padding:10px 20px;font-size:14px}
+.rosChip b{font-weight:800}.rosChip span{color:#9a9186}
+
+/* generic section */
+.rosSection{max-width:1140px;margin:0 auto;padding-top:clamp(56px,7vw,90px);padding-bottom:clamp(56px,7vw,90px);text-align:center}
+.rosSectionAlt{max-width:none;background:var(--ros-bg2)}
+.rosSectionAlt>*{max-width:1140px;margin-left:auto;margin-right:auto}
+.rosSection h2{font-size:clamp(28px,4.4vw,46px);line-height:1.08;margin:12px 0}
+.rosLead{color:var(--ros-muted);font-size:16px;max-width:620px;margin:0 auto 40px;line-height:1.6}
+
+/* features */
+.rosFeatureGrid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;text-align:left}
+.rosFeature{background:var(--ros-card);border:1px solid var(--ros-line);border-radius:16px;padding:24px;box-shadow:0 10px 26px rgba(43,38,33,.04)}
+.rosFeatureIcon{display:grid;place-items:center;width:42px;height:42px;border-radius:11px;background:rgba(46,158,133,.12);color:var(--ros-teal-deep);font-size:19px}
+.rosFeature h3{font-size:17px;margin:16px 0 8px}
+.rosFeature p{margin:0;color:var(--ros-muted);font-size:13.5px;line-height:1.55}
+
+/* calculator */
+.rosCalc{display:grid;grid-template-columns:1.1fr 1fr;gap:16px;text-align:left;max-width:940px;margin:0 auto}
+.rosCalcInputs{background:var(--ros-card);border:1px solid var(--ros-line);border-radius:16px;padding:26px;display:flex;flex-direction:column;gap:16px;box-shadow:0 10px 26px rgba(43,38,33,.04)}
+.rosCalcInputs label{display:block}
+.rosCalcInputs span{display:block;font-size:13px;font-weight:700;color:#4a453f;margin-bottom:7px}
+.rosCalcInputs input{width:100%;padding:13px 14px;border:1px solid var(--ros-line);border-radius:10px;font:inherit;font-size:16px;color:var(--ros-ink);background:#fdfcf9}
+.rosCalcInputs input:focus{outline:2px solid var(--ros-teal);outline-offset:1px;border-color:var(--ros-teal)}
+.rosCalcResult{background:var(--ros-footer);color:#f4efe6;border-radius:16px;padding:30px;display:flex;flex-direction:column;justify-content:center}
+.rosCalcResultCap{font-size:12px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:#a79f92}
+.rosCalcMonthly{font-family:var(--font-serif);font-size:clamp(34px,5vw,50px);line-height:1.05;margin:10px 0 2px;color:#fff}
+.rosCalcMonthly small{font-family:var(--font-sans);font-size:16px;color:#a79f92;margin-left:4px}
+.rosCalcYearly{font-size:15px;color:#cdbfa0}
+.rosCalcResult p{margin:16px 0 0;font-size:13px;line-height:1.55;color:#bcb3a4}
+
+/* audience */
+.rosAudienceGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;text-align:left}
+.rosAudience{background:var(--ros-card);border:1px solid var(--ros-line);border-radius:18px;padding:28px;display:flex;flex-direction:column;box-shadow:0 10px 26px rgba(43,38,33,.05)}
+.rosAudienceIcon{display:grid;place-items:center;width:46px;height:46px;border-radius:12px;font-size:22px;background:rgba(46,158,133,.12)}
+.rosAudience.tint-blue .rosAudienceIcon{background:rgba(60,107,166,.12)}
+.rosAudience.tint-orange .rosAudienceIcon{background:rgba(232,121,75,.14)}
+.rosAudience h3{font-size:21px;margin:18px 0 10px}
+.rosAudience>p{margin:0 0 16px;color:var(--ros-muted);font-size:14px;line-height:1.6}
+.rosAudience ul{list-style:none;margin:0 0 18px;padding:0;display:flex;flex-direction:column;gap:9px}
+.rosAudience li{position:relative;padding-left:24px;font-size:14px;color:#3f3a34}
+.rosAudience li::before{content:"✓";position:absolute;left:0;top:0;color:var(--ros-teal);font-weight:800}
+.rosAudience.tint-orange li::before{color:var(--ros-orange)}
+.rosAudienceCta{margin-top:auto;font-weight:800;font-size:14px;color:var(--ros-teal-deep)}
+.rosAudience.tint-orange .rosAudienceCta{color:var(--ros-orange)}
+.rosAudienceCta:hover{text-decoration:underline}
+
+/* pricing */
+.rosPricing{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;text-align:left;align-items:start}
+.rosTier{position:relative;background:var(--ros-card);border:1px solid var(--ros-line);border-radius:18px;padding:24px 20px;display:flex;flex-direction:column;box-shadow:0 10px 26px rgba(43,38,33,.05)}
+.rosTier.popular{background:var(--ros-teal);color:#fff;border-color:var(--ros-teal);transform:translateY(-8px);box-shadow:0 18px 40px rgba(37,111,96,.28)}
+.rosTierBadge{position:absolute;top:-12px;left:50%;transform:translateX(-50%);background:var(--ros-orange);color:#fff;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.05em;padding:5px 14px;border-radius:999px;white-space:nowrap}
+.rosTierName{font-size:16px;font-weight:800}
+.rosTierWho{font-size:12.5px;color:var(--ros-muted);margin:4px 0 14px}
+.rosTier.popular .rosTierWho{color:#d8efe8}
+.rosTierPrice{display:flex;align-items:baseline;gap:6px}
+.rosTierPrice b{font-family:var(--font-serif);font-size:30px;line-height:1}
+.rosTierPrice span{font-size:12px;color:var(--ros-muted)}
+.rosTier.popular .rosTierPrice span{color:#d8efe8}
+.rosTierSeats{display:block;font-size:12.5px;font-weight:700;margin:6px 0 16px;color:#3f3a34}
+.rosTier.popular .rosTierSeats{color:#eaf6f2}
+.rosTier ul{list-style:none;margin:0 0 20px;padding:0;display:flex;flex-direction:column;gap:9px;flex:1}
+.rosTier li{position:relative;padding-left:22px;font-size:13px;color:#3f3a34}
+.rosTier li::before{content:"✓";position:absolute;left:0;color:var(--ros-teal);font-weight:800}
+.rosTier.popular li{color:#eaf6f2}.rosTier.popular li::before{color:#fff}
+.rosTierBtn{justify-content:center;background:var(--ros-teal)}
+.rosTier.popular .rosTierBtn{background:#fff;color:var(--ros-teal-deep)}
+.rosTier.popular .rosTierBtn:hover{background:#eef7f4}
+.rosPricingNote{text-align:center;color:#9a9186;font-size:12.5px;margin:26px 0 0}
+
+/* faq */
+.rosFaq{max-width:820px;margin:0 auto;text-align:left;display:flex;flex-direction:column;gap:10px}
+.rosFaqItem{background:var(--ros-card);border:1px solid var(--ros-line);border-radius:14px;overflow:hidden;box-shadow:0 6px 18px rgba(43,38,33,.03)}
+.rosFaqQ{width:100%;display:flex;align-items:center;justify-content:space-between;gap:16px;background:transparent;border:0;padding:20px 22px;font:inherit;font-size:16px;font-weight:700;color:var(--ros-ink);cursor:pointer;text-align:left}
+.rosFaqSign{flex:0 0 auto;display:grid;place-items:center;width:28px;height:28px;border-radius:50%;background:#efeade;color:#6b655e;font-size:16px}
+.rosFaqItem.open .rosFaqSign{background:var(--ros-teal);color:#fff}
+.rosFaqA{margin:0;padding:0 22px 22px;color:var(--ros-muted);font-size:14.5px;line-height:1.65;max-width:70ch}
+
+/* final cta */
+.rosFinalCta{padding:clamp(40px,6vw,72px) clamp(16px,5vw,40px)}
+.rosFinalCard{max-width:720px;margin:0 auto;text-align:center;background:var(--ros-card);border:1px solid var(--ros-line);border-radius:20px;padding:clamp(30px,4vw,48px);box-shadow:0 16px 40px rgba(43,38,33,.06)}
+.rosFinalCard h2{font-size:clamp(24px,3.4vw,32px)}
+.rosFinalCard p{color:var(--ros-muted);font-size:15px;line-height:1.6;max-width:52ch;margin:12px auto 24px}
+
+/* footer */
+.rosFooter{background:var(--ros-footer);color:#cbc3b6;padding-top:56px;padding-bottom:34px}
+.rosFooterCols{max-width:1140px;margin:0 auto;display:grid;grid-template-columns:1.6fr 1fr 1fr 1fr;gap:30px}
+.rosFooter .rosBrand{color:#fff}
+.rosFooterBrand p{margin:14px 0 0;font-size:13.5px;color:#a79f92;max-width:32ch;line-height:1.6}
+.rosFooterCols>div>b{display:block;font-size:12px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:#8a8377;margin-bottom:14px}
+.rosFooterCols>div>a,.rosFooterCols>div>span{display:block;font-size:14px;color:#cbc3b6;margin-bottom:11px}
+.rosFooterCols>div>a:hover{color:#fff}
+.rosFooterBottom{max-width:1140px;margin:36px auto 0;padding-top:20px;border-top:1px solid rgba(255,255,255,.1);display:flex;flex-wrap:wrap;justify-content:space-between;gap:10px;font-size:12px;color:#8a8377}
+
+@media(max-width:960px){
+  .rosNav{display:none}
+  .rosFeatureGrid{grid-template-columns:1fr 1fr}
+  .rosAudienceGrid{grid-template-columns:1fr}
+  .rosPricing{grid-template-columns:1fr 1fr}
+  .rosTier.popular{transform:none}
+  .rosCalc{grid-template-columns:1fr}
+  .rosFooterCols{grid-template-columns:1fr 1fr}
+}
+@media(max-width:560px){
+  .rosFeatureGrid,.rosPricing,.rosFooterCols{grid-template-columns:1fr}
+  .rosHeaderActions .rosLogin{display:none}
+}

--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const money = new Intl.NumberFormat("uk-UA");
+
+const features = [
+  { icon:"◷", title:"Онлайн-запис і розклад", text:"Запис із сайту, бота й реєстратури в один календар — по днях, кабінетах і апаратах." },
+  { icon:"▤", title:"Медкартки й протоколи", text:"Історія візитів, конструктор протоколів дослідження з шаблонами й нормами." },
+  { icon:"◔", title:"Нагадування пацієнтам", text:"WhatsApp, SMS і Telegram про підтвердження та перенесення — без ручних дзвінків." },
+  { icon:"₴", title:"Каса, оплати та звірка", text:"Статуси оплат, каса й зміни, звірка з банком, рахунки й квитанції." },
+  { icon:"▦", title:"Знімки DICOM / PACS", text:"Прив'язка досліджень до знімків, перегляд у вебглядачі, обмін із лікарями." },
+  { icon:"▥", title:"Аналітика й звіти", text:"Виручка, завантаженість апаратів і лікарів, експорт у Excel одним кліком." },
+  { icon:"◉", title:"Ролі, права та аудит", text:"Адмін, реєстратор, лікар, лаборант. Журнал дій і захист медичних даних." },
+  { icon:"◑", title:"Свій бренд і домен", text:"Назва, логотип, кольори й домен вашого закладу — сайт і кабінет у вашому стилі." },
+];
+
+const audience = [
+  { icon:"🏥", tint:"teal", title:"Багатопрофільна клініка", text:"Кілька лікарів і реєстратура, що веде телефон, живу чергу й касу. RadiologyOS знімає рутину, а керівнику дає прозорі показники по кожному лікарю.", points:["Розклад і запис для всієї команди","Ролі: адміністратор, лікар, реєстратор","Зарплата лікарів за відсотком — без Excel","Аналітика по клініці й по кожному лікарю"], cta:"Почати як клініка" },
+  { icon:"🩻", tint:"blue", title:"Приватний КТ-кабінет", text:"Один-два апарати й потік досліджень. Онлайн-запис, слоти з реального розкладу апарата, протоколи й знімки — усе в одному місці.", points:["Запис за вільними слотами апарата","Протоколи КТ з шаблонами","Знімки DICOM під рукою","Каса й звіти по виручці"], cta:"Почати як кабінет" },
+  { icon:"🦷", tint:"orange", title:"Стоматологія та інші", text:"Панорамна рентгенографія й прийом без окремого адміністратора. Запис, нагадування й картки працюють самі, поки ви зайняті пацієнтом.", points:["Особистий кабінет і свій розклад","Сторінка запису зі своїм посиланням","Картка пацієнта завжди під рукою","WhatsApp-нагадування замість дзвінків"], cta:"Почати як лікар" },
+];
+
+const integrations = [
+  { name:"Приват24", note:"· приймання оплат" },
+  { name:"WhatsApp", note:"· нагадування й запис через бота" },
+  { name:"Telegram", note:"· сповіщення реєстратурі" },
+  { name:"Google Календар", note:"· синхронізація розкладу" },
+];
+
+const tiers = [
+  { name:"Базовий", who:"Для приватного прийому", price:"990", unit:"₴/міс", seats:"1 лікар", points:["Онлайн-запис пацієнтів","WhatsApp-нагадування","Картки пацієнтів"] },
+  { name:"Старт", who:"Для невеликої клініки", price:"2 490", unit:"₴/міс", seats:"до 5 лікарів", points:["Усе з Базового","Шаблони протоколів","Зарплата лікарів","Підтримка 24/7"] },
+  { name:"Про", who:"Для клініки, що росте", price:"4 990", unit:"₴/міс", seats:"до 15 лікарів", popular:true, points:["Усе зі Старту","Каса й рахунки","Аналітика по клініці","Пріоритетна підтримка"] },
+  { name:"Про+", who:"Клініка зі своїм сайтом", price:"7 990", unit:"₴/міс", seats:"до 25 лікарів", points:["Усе з Про","Сайт клініки на домені","5 тем оформлення","Онлайн-запис із сайту"] },
+  { name:"Мережа", who:"Для мережі чи центру", price:"14 990", unit:"₴/міс", seats:"без обмежень", points:["Усе з Про+","Безліміт лікарів","Свій номер WhatsApp","Персональний менеджер"] },
+];
+
+const faq = [
+  { q:"Розрахунок утрат — це реальна статистика?", a:"Ні, і ми не видаємо його за неї. Це відкрита формула на розумних припущеннях — кількість записів, частка неявок і середній чек. Підставте свої цифри — логіка залишиться тією ж, а результат стане вашим." },
+  { q:"Чи потрібна картка, щоб спробувати безкоштовно?", a:"Ні. 14 днів безкоштовно, усі функції включені, картка не потрібна. Наприкінці пробного періоду ви оберете тариф — дані й налаштування залишаться на місці." },
+  { q:"Скільки триває впровадження?", a:"Реєстрація займає близько 5 хвилин. Онлайн-запис, нагадування й картки працюють того ж дня. Перенесення послуг, апаратів і графіків налаштовується за пару годин." },
+  { q:"Наскільки захищені дані пацієнтів?", a:"Доступ — лише за ролями й паролями, кожна дія фіксується в журналі. Дані ізольовані по закладу; медичні реєстри зберігаються захищено." },
+  { q:"Чи можна перенести пацієнтів з Excel або іншої програми?", a:"Так. Ми допоможемо імпортувати пацієнтів, послуги й ціни зі звичайних таблиць — переносити вручну не доведеться." },
+  { q:"WhatsApp і SMS запрацюють одразу?", a:"Так, після підключення вашого шлюзу в налаштуваннях. До того нагадування ставляться в чергу й нічого не блокують." },
+  { q:"Як скасувати підписку, якщо не підійде?", a:"У будь-який момент, в один клік у налаштуваннях. Оплата за рік — зі знижкою 15%; за місяць — без зобов'язань." },
+];
+
+export default function ProductPage() {
+  const [visits, setVisits] = useState(400);
+  const [noShow, setNoShow] = useState(12);
+  const [avg, setAvg] = useState(600);
+  const [openFaq, setOpenFaq] = useState(0);
+
+  useEffect(() => { document.title = "RadiologyOS — розумна реєстратура для клінік і лікарів"; }, []);
+
+  const monthlyLoss = Math.round(visits * (noShow / 100) * avg);
+  const yearlyLoss = monthlyLoss * 12;
+
+  return <div className="rosLanding">
+    <header className="rosHeader">
+      <a className="rosBrand" href="#top"><span className="rosBrandMark">✦</span> RadiologyOS</a>
+      <nav className="rosNav">
+        <a href="#features">Можливості</a>
+        <a href="#calc">Розрахунок утрат</a>
+        <a href="#audience">Кому підходить</a>
+        <a href="#pricing">Тарифи</a>
+        <a href="#faq">Питання</a>
+      </nav>
+      <div className="rosHeaderActions">
+        <Link className="rosLogin" href="/staff/login">Увійти</Link>
+        <a className="rosBtn" href="#pricing">Почати безкоштовно</a>
+      </div>
+    </header>
+
+    <section className="rosHero" id="top">
+      <span className="rosEyebrow">Розумна реєстратура для клінік і лікарів</span>
+      <h1>Почніть з безкоштовного періоду<br/><em>— без картки й зобовʼязань</em></h1>
+      <p>Реєстрація займає 5 хвилин. Онлайн-запис, нагадування та медкартки запрацюють того ж дня — переносити дані вручну не доведеться.</p>
+      <div className="rosHeroCta">
+        <a className="rosBtn rosBtnLg" href="#pricing">Почати безкоштовно →</a>
+      </div>
+      <p className="rosHeroNote">Залишились питання? <a href="https://wa.me/380972808899">Напишіть у WhatsApp</a></p>
+    </section>
+
+    <section className="rosIntegr">
+      <p className="rosIntegrCap">Працює через сервіси, якими ваші пацієнти користуються щодня</p>
+      <div className="rosIntegrChips">
+        {integrations.map(i=><span className="rosChip" key={i.name}><b>{i.name}</b> <span>{i.note}</span></span>)}
+      </div>
+    </section>
+
+    <section className="rosSection" id="features">
+      <p className="rosSectionEyebrow">Можливості</p>
+      <h2>Єдине ядро для всього закладу</h2>
+      <p className="rosLead">Пацієнти, запис, дослідження, оплати й аналітика — в одній системі. Організація збирається з налаштувань і модулів.</p>
+      <div className="rosFeatureGrid">
+        {features.map(f=><article className="rosFeature" key={f.title}>
+          <span className="rosFeatureIcon" aria-hidden="true">{f.icon}</span>
+          <h3>{f.title}</h3><p>{f.text}</p>
+        </article>)}
+      </div>
+    </section>
+
+    <section className="rosSection rosSectionAlt" id="calc">
+      <p className="rosSectionEyebrow">Розрахунок утрат</p>
+      <h2>Скільки коштують неявки</h2>
+      <p className="rosLead">Відкрита формула на ваших цифрах. Порахуйте, скільки втрачає заклад на неявках — і скільки з цього повертають нагадування.</p>
+      <div className="rosCalc">
+        <div className="rosCalcInputs">
+          <label><span>Записів на місяць</span><input type="number" min={0} max={100000} value={visits} onChange={e=>setVisits(Math.max(0,Number(e.target.value)||0))}/></label>
+          <label><span>Частка неявок, %</span><input type="number" min={0} max={100} value={noShow} onChange={e=>setNoShow(Math.min(100,Math.max(0,Number(e.target.value)||0)))}/></label>
+          <label><span>Середній чек, ₴</span><input type="number" min={0} max={1000000} value={avg} onChange={e=>setAvg(Math.max(0,Number(e.target.value)||0))}/></label>
+        </div>
+        <div className="rosCalcResult">
+          <span className="rosCalcResultCap">Орієнтовні втрати</span>
+          <b className="rosCalcMonthly">{money.format(monthlyLoss)} ₴<small>/міс</small></b>
+          <span className="rosCalcYearly">≈ {money.format(yearlyLoss)} ₴ на рік</span>
+          <p>Місяць роботи на тарифі «Старт» дешевший за один день неявок із розрахунку вище.</p>
+        </div>
+      </div>
+    </section>
+
+    <section className="rosSection" id="audience">
+      <p className="rosSectionEyebrow">Кому підходить</p>
+      <h2>Клінікам, кабінетам і приватній практиці</h2>
+      <p className="rosLead">Система масштабується під розмір бізнесу: від одного кабінету до мережі з десятками лікарів.</p>
+      <div className="rosAudienceGrid">
+        {audience.map(a=><article className={`rosAudience tint-${a.tint}`} key={a.title}>
+          <span className="rosAudienceIcon" aria-hidden="true">{a.icon}</span>
+          <h3>{a.title}</h3><p>{a.text}</p>
+          <ul>{a.points.map(p=><li key={p}>{p}</li>)}</ul>
+          <a className="rosAudienceCta" href="#pricing">{a.cta} →</a>
+        </article>)}
+      </div>
+    </section>
+
+    <section className="rosSection rosSectionAlt" id="pricing">
+      <p className="rosSectionEyebrow">Тарифи</p>
+      <h2>Тарифи та вартість</h2>
+      <p className="rosLead">Вартість залежить лише від числа лікарів — платити за невикористані місця не потрібно.</p>
+      <div className="rosPricing">
+        {tiers.map(t=><article className={`rosTier${t.popular?" popular":""}`} key={t.name}>
+          {t.popular && <span className="rosTierBadge">Популярний</span>}
+          <b className="rosTierName">{t.name}</b>
+          <span className="rosTierWho">{t.who}</span>
+          <div className="rosTierPrice"><b>{t.price}</b> <span>{t.unit}</span></div>
+          <span className="rosTierSeats">{t.seats}</span>
+          <ul>{t.points.map(p=><li key={p}>{p}</li>)}</ul>
+          <a className="rosBtn rosTierBtn" href="#top">Обрати</a>
+        </article>)}
+      </div>
+      <p className="rosPricingNote">Обрали тариф — оплата одразу після реєстрації · Оплата за рік — знижка 15% · Скасування будь-коли</p>
+    </section>
+
+    <section className="rosSection" id="faq">
+      <p className="rosSectionEyebrow">Питання</p>
+      <h2>Часті питання</h2>
+      <div className="rosFaq">
+        {faq.map((item,i)=><div className={`rosFaqItem${openFaq===i?" open":""}`} key={i}>
+          <button type="button" className="rosFaqQ" aria-expanded={openFaq===i} onClick={()=>setOpenFaq(openFaq===i?-1:i)}>
+            <span>{item.q}</span><span className="rosFaqSign" aria-hidden="true">{openFaq===i?"×":"+"}</span>
+          </button>
+          {openFaq===i && <p className="rosFaqA">{item.a}</p>}
+        </div>)}
+      </div>
+    </section>
+
+    <section className="rosFinalCta">
+      <div className="rosFinalCard">
+        <h2>Хочете спочатку подивитися?</h2>
+        <p>14 днів безкоштовно, усі функції включені, картка не потрібна. Наприкінці пробного періоду оберете тариф — дані й налаштування залишаться на місці.</p>
+        <a className="rosBtn rosBtnOutline" href="#pricing">Спробувати безкоштовно 14 днів</a>
+      </div>
+    </section>
+
+    <footer className="rosFooter">
+      <div className="rosFooterCols">
+        <div className="rosFooterBrand">
+          <a className="rosBrand" href="#top"><span className="rosBrandMark">✦</span> RadiologyOS</a>
+          <p>Розумна медична система для клінік, кабінетів і приватних лікарів.</p>
+        </div>
+        <div><b>Продукт</b><a href="#features">Можливості</a><a href="#calc">Розрахунок утрат</a><a href="#pricing">Тарифи</a><a href="#audience">Кому підходить</a></div>
+        <div><b>Рішення</b><span>Госпітальна радіологія</span><span>Приватний КТ</span><span>Стоматологія</span><span>Клініка</span></div>
+        <div><b>Звʼязатися</b><a href="https://wa.me/380972808899">WhatsApp</a><a href="mailto:hello@radiologyos.tech">hello@radiologyos.tech</a><Link href="/">Сайт госпіталю</Link></div>
+      </div>
+      <div className="rosFooterBottom"><span>© {new Date().getFullYear()} RadiologyOS</span><span>Єдина кодова база — заклад збирається з налаштувань і модулів.</span></div>
+    </footer>
+  </div>;
+}


### PR DESCRIPTION
## Огляд
Перший крок до RadiologyOS як SaaS: окрема **маркетингова сторінка продукту** за маршрутом `/product`, у теплій айдентиці Doctime (cream + serif Lora + teal) — окремо від офіційної публічної сторінки госпіталю для пацієнтів.

## Секції
- Sticky-хедер з навігацією, «Увійти», «Почати безкоштовно».
- Hero «Почніть з безкоштовного періоду — без картки й зобовʼязань».
- Смуга інтеграцій (Приват24 / WhatsApp / Telegram / Google Календар).
- **Можливості** — єдине ядро (8 карток).
- **Розрахунок утрат** — інтерактивний калькулятор неявок (записи × %неявок × чек).
- **Кому підходить** — клініка / КТ-кабінет / стоматологія.
- **Тарифи** — 5 рівнів, популярний «Про» (teal + помаранчевий бейдж).
- **FAQ** — акордеон; фінальний CTA; темний футер.

## Технічно
- Клієнтський компонент `app/product/page.tsx`; scoped-стиль `.rosLanding` (Lora + Inter, self-hosted).
- Без змін API/схеми. Публічний сайт госпіталю й кабінет не зачеплені.

## Перевірка
- build ✓ (маршрут `/product` зареєстровано) · `lint` 0 · `tsc` чисто · `npm test` **74/74**.
- Візуально звірено рендер (hero, калькулятор, тарифи, футер).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_