### PR TITLE
PR 2: Єдина state machine дослідження (server-side, deny-by-default)

### DIFF
--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -1,6 +1,7 @@
 import { addMinutes, serviceByCode } from "../../../../lib/catalog";
 import { isBookableDate, isTimeForService } from "../../../../lib/booking-rules";
 import { sendPatientReminder, type ReminderBooking } from "../../../../lib/notify";
+import { canTransition, isStudyState, stateLabel } from "../../../../lib/study-state";
 import {
   canManageBookings,
   canManageFinance,
@@ -345,10 +346,21 @@ export async function PATCH(request: Request) {
     return Response.json({ ok: true, status: "confirmed", reminder });
   }
 
-  const allowed = new Set(["new", "confirmed", "rescheduled", "completed", "cancelled"]);
-  if (!body.status || !allowed.has(body.status)) return Response.json({ error: "Некоректний статус" }, { status: 400 });
-  const updated = await db.prepare("UPDATE bookings SET status = ? WHERE id = ?").bind(body.status, body.id).run();
-  if (!updated.meta.changes) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  // Зміна статусу проходить через єдину state machine дослідження
+  // (deny-by-default): цільовий стан має бути відомим і досяжним із поточного.
+  if (!body.status || !isStudyState(body.status)) {
+    return Response.json({ error: "Некоректний статус" }, { status: 400 });
+  }
+  const current = await db.prepare("SELECT status FROM bookings WHERE id = ?")
+    .bind(body.id).first<{ status: string }>();
+  if (!current) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  if (!canTransition(current.status, body.status)) {
+    return Response.json(
+      { error: `Перехід «${stateLabel(current.status)}» → «${stateLabel(body.status)}» недопустимий` },
+      { status: 409 },
+    );
+  }
+  await db.prepare("UPDATE bookings SET status = ? WHERE id = ?").bind(body.status, body.id).run();
   await db.prepare(
     "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'status_changed', ?, ?)"
   ).bind(body.id, body.status, member.email).run();

--- a/lib/study-state.ts
+++ b/lib/study-state.ts
@@ -1,0 +1,119 @@
+// Єдина state machine дослідження (server-side, deny-by-default).
+//
+// Це єдине джерело правди про життєвий цикл дослідження. Клінічний шлях:
+//   requested → needs_verification → scheduled → confirmed → arrived →
+//   queued → in_progress → performed → images_ready → reporting →
+//   protocol_ready → issued → completed
+// плюс термінальні cancelled / no_show.
+//
+// Сумісність: діючий персональний UI оперує спрощеним набором станів
+// (new, confirmed, rescheduled, completed, cancelled). Щоб нічого не зламати,
+// ці legacy-стани лишаються повноправними, а перехід між ними — вільним.
+// Посилення (прибрати вільні legacy-переходи) — окремий крок hardening за
+// погодженням (див. ADR 0001). Будь-який перехід, відсутній у мапі, —
+// заборонено.
+
+// Канонічні клінічні стани у порядку прогресу.
+export const STUDY_STATES = [
+  "requested",
+  "needs_verification",
+  "scheduled",
+  "confirmed",
+  "arrived",
+  "queued",
+  "in_progress",
+  "performed",
+  "images_ready",
+  "reporting",
+  "protocol_ready",
+  "issued",
+  "completed",
+  "cancelled",
+  "no_show",
+] as const;
+
+export type StudyState = (typeof STUDY_STATES)[number];
+
+// Legacy-стани діючого UI (не входять до канонічного переліку, але визнаються).
+export const LEGACY_STATES = ["new", "rescheduled"] as const;
+export type LegacyState = (typeof LEGACY_STATES)[number];
+
+export type AnyState = StudyState | LegacyState;
+
+export const STUDY_STATE_LABELS: Record<AnyState, string> = {
+  requested: "Заявка",
+  needs_verification: "Потребує перевірки",
+  scheduled: "Заплановано",
+  confirmed: "Підтверджено",
+  arrived: "Прибув",
+  queued: "У черзі",
+  in_progress: "Виконується",
+  performed: "Виконано",
+  images_ready: "Зображення готові",
+  reporting: "Опис",
+  protocol_ready: "Протокол готовий",
+  issued: "Видано",
+  completed: "Завершено",
+  cancelled: "Скасовано",
+  no_show: "Неявка",
+  new: "Нова",
+  rescheduled: "Перенесено",
+};
+
+// Термінальні стани — далі рухатися нікуди (крім явного повторного циклу).
+export const TERMINAL_STATES: ReadonlySet<AnyState> = new Set(["completed", "cancelled"]);
+
+// Legacy-набір, який діючий персональний UI дозволяє виставляти вручну.
+const LEGACY_SETTABLE: AnyState[] = ["new", "confirmed", "rescheduled", "completed", "cancelled"];
+
+// Мапа дозволених переходів. Клінічний шлях + вхід у нього з confirmed/scheduled;
+// legacy-стани повністю зв'язані між собою заради сумісності.
+export const TRANSITIONS: Record<AnyState, AnyState[]> = {
+  // Вхідні / планування.
+  new: [...LEGACY_SETTABLE, "needs_verification", "scheduled", "arrived"],
+  requested: ["needs_verification", "scheduled", "cancelled"],
+  needs_verification: ["scheduled", "cancelled"],
+  scheduled: ["confirmed", "rescheduled", "cancelled", "no_show"],
+  confirmed: [...LEGACY_SETTABLE, "arrived", "no_show"],
+  rescheduled: [...LEGACY_SETTABLE, "scheduled"],
+  // Клінічний прогрес.
+  arrived: ["queued", "cancelled", "no_show"],
+  queued: ["in_progress", "cancelled"],
+  in_progress: ["performed", "cancelled"],
+  performed: ["images_ready", "cancelled"],
+  images_ready: ["reporting"],
+  reporting: ["protocol_ready"],
+  protocol_ready: ["issued"],
+  issued: ["completed"],
+  // Термінальні (legacy лишаються зв'язаними; no_show можна перепланувати).
+  completed: [...LEGACY_SETTABLE],
+  cancelled: [...LEGACY_SETTABLE],
+  no_show: ["scheduled", "cancelled"],
+};
+
+export function isStudyState(value: string): value is AnyState {
+  return value in STUDY_STATE_LABELS;
+}
+
+export function isTerminal(state: string): boolean {
+  return TERMINAL_STATES.has(state as AnyState);
+}
+
+// Дозволені наступні стани (без самоповтору).
+export function nextStates(from: string): AnyState[] {
+  if (!isStudyState(from)) return [];
+  return TRANSITIONS[from] ?? [];
+}
+
+// Deny-by-default: перехід дозволено лише якщо він явно є у мапі. Перехід у той
+// самий стан (no-op) дозволено, щоб повторне збереження не давало помилки.
+export function canTransition(from: string, to: string): boolean {
+  if (!isStudyState(to)) return false;
+  if (from === to) return true;
+  if (!isStudyState(from)) return false;
+  return (TRANSITIONS[from] ?? []).includes(to as AnyState);
+}
+
+export function stateLabel(state: string): string {
+  return isStudyState(state) ? STUDY_STATE_LABELS[state] : state;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vite",
     "build": "bash scripts/build-verified.sh",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
-    "test": "npm run build && node --test tests/*.test.mjs",
+    "test": "npm run build && node --experimental-strip-types --test tests/*.test.mjs",
     "validate:artifact": "bash scripts/validate-artifact.sh",
     "lint": "bash scripts/sites-env.sh -- eslint . --ignore-pattern dist --ignore-pattern .next --ignore-pattern public",
     "db:generate": "bash scripts/sites-env.sh -- drizzle-kit generate"

--- a/tests/study-state.test.mjs
+++ b/tests/study-state.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  STUDY_STATES,
+  STUDY_STATE_LABELS,
+  TRANSITIONS,
+  canTransition,
+  isStudyState,
+  isTerminal,
+  nextStates,
+  stateLabel,
+} from "../lib/study-state.ts";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+// 15 канонічних станів у клінічному порядку.
+test("machine defines the 15 canonical states with labels", () => {
+  assert.equal(STUDY_STATES.length, 15);
+  const expected = [
+    "requested", "needs_verification", "scheduled", "confirmed", "arrived",
+    "queued", "in_progress", "performed", "images_ready", "reporting",
+    "protocol_ready", "issued", "completed", "cancelled", "no_show",
+  ];
+  assert.deepEqual([...STUDY_STATES], expected);
+  for (const s of STUDY_STATES) {
+    assert.ok(STUDY_STATE_LABELS[s], `label for ${s}`);
+    assert.ok(isStudyState(s));
+  }
+  // Legacy-стани діючого UI визнаються, але не входять до канонічного переліку.
+  assert.ok(isStudyState("new") && isStudyState("rescheduled"));
+  assert.ok(!STUDY_STATES.includes("new"));
+});
+
+// Повний клінічний шлях проходиться крок за кроком.
+test("the full clinical path is walkable end-to-end", () => {
+  const path = [
+    "requested", "needs_verification", "scheduled", "confirmed", "arrived",
+    "queued", "in_progress", "performed", "images_ready", "reporting",
+    "protocol_ready", "issued", "completed",
+  ];
+  for (let i = 0; i < path.length - 1; i += 1) {
+    assert.ok(canTransition(path[i], path[i + 1]), `${path[i]} → ${path[i + 1]} allowed`);
+  }
+});
+
+// Deny-by-default: перескоки й виходи з термінальних станів заборонені.
+test("illegal jumps are rejected (deny-by-default)", () => {
+  assert.equal(canTransition("requested", "in_progress"), false);
+  assert.equal(canTransition("scheduled", "performed"), false);
+  assert.equal(canTransition("completed", "in_progress"), false);
+  assert.equal(canTransition("queued", "issued"), false);
+  assert.equal(canTransition("anything", "made_up"), false);
+  assert.equal(canTransition("in_progress", "unknown_state"), false);
+  // Той самий стан (no-op) дозволено, щоб повторне збереження не падало.
+  assert.equal(canTransition("confirmed", "confirmed"), true);
+});
+
+// Кожен клінічний шлях може завершитися скасуванням до видачі.
+test("cancellation is reachable from active states, terminals are terminal", () => {
+  for (const s of ["scheduled", "arrived", "queued", "in_progress", "performed"]) {
+    assert.ok(canTransition(s, "cancelled"), `${s} → cancelled`);
+  }
+  assert.ok(isTerminal("completed"));
+  assert.ok(isTerminal("cancelled"));
+  assert.ok(!isTerminal("in_progress"));
+});
+
+// Сумісність: діючий UI виставляє 5 legacy-станів; переходи між ними вільні.
+test("legacy UI statuses remain fully interchangeable (no regression)", () => {
+  const legacy = ["new", "confirmed", "rescheduled", "completed", "cancelled"];
+  for (const from of legacy) {
+    for (const to of legacy) {
+      assert.ok(canTransition(from, to), `legacy ${from} → ${to} preserved`);
+    }
+  }
+  assert.equal(stateLabel("new"), "Нова");
+  assert.equal(nextStates("issued").includes("completed"), true);
+});
+
+// Жоден стан не має «мертвих» переходів у невідомі стани.
+test("every transition target is a known state", () => {
+  for (const [from, targets] of Object.entries(TRANSITIONS)) {
+    for (const to of targets) {
+      assert.ok(isStudyState(to), `${from} → ${to} target is known`);
+    }
+  }
+});
+
+// Сервер застосовує машину замість плаского списку статусів.
+test("staff bookings route enforces the machine, not a flat allow-list", async () => {
+  const src = await read("app/api/staff/bookings/route.ts");
+  assert.match(src, /canTransition\(current\.status, body\.status\)/);
+  assert.match(src, /isStudyState\(body\.status\)/);
+  // Старий плаский Set статусів прибрано.
+  assert.doesNotMatch(src, /new Set\(\["new", "confirmed", "rescheduled", "completed", "cancelled"\]\)/);
+});


### PR DESCRIPTION
Другий крок SaaS-переходу. Вводить канонічний життєвий цикл дослідження як **єдине джерело правди на сервері**, не змінюючи діючий персональний UI й наявні потоки запису/підтвердження/перенесення.

## Що зроблено

**`lib/study-state.ts`** — єдина state machine:
- 15 канонічних станів у клінічному порядку: `requested → needs_verification → scheduled → confirmed → arrived → queued → in_progress → performed → images_ready → reporting → protocol_ready → issued → completed`, плюс термінальні `cancelled` / `no_show`;
- українські підписи станів + мапа дозволених переходів (**deny-by-default** — будь-який перехід поза мапою заборонено);
- helpers: `canTransition`, `nextStates`, `isTerminal`, `isStudyState`, `stateLabel`, `STUDY_STATE_LABELS`.

**`app/api/staff/bookings/route.ts`**:
- зміна статусу проходить через `canTransition(current, target)` замість плаского `Set`; недопустимий перехід → `409` з поясненням переходу.

## Сумісність (без регресу)

Діючий персональний UI оперує спрощеним набором станів (`new`, `confirmed`, `rescheduled`, `completed`, `cancelled`). Ці legacy-стани лишаються повноправними й **вільно взаємозамінними** — жоден поточний потік не ламається. Посилення (прибрати вільні legacy-переходи) — окремий крок hardening за погодженням (ADR 0001, крок 7).

## Перевірки

- `lint` — 0 помилок (1 попередній warning не з цього PR).
- `tsc --noEmit` — 0.
- `build` ✓
- Тести: **86/86** зелені (+7 нових у `tests/study-state.test.mjs`):
  - повний клінічний шлях прохідний крок за кроком;
  - **deny-by-default** — перескоки (`requested → in_progress`) і виходи з термінальних станів відхиляються;
  - legacy-сумісність усіх 5 станів UI;
  - усі цілі переходів — відомі стани;
  - сервер застосовує машину, а не плоский список.

Тест виконує **реальну логіку** `.ts` через `--experimental-strip-types` (додано у скрипт `test`, підтримується Node 22.13 у CI).

## Поза межами цього PR

UI-реєстр/картка/черга досліджень, що споживають цю машину (transition-aware елементи керування), — наступний PR 3. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_