### PR TITLE
PR 3: Реєстр досліджень (tenant-aware, на єдиній state machine)

### DIFF
--- a/app/api/staff/studies/route.ts
+++ b/app/api/staff/studies/route.ts
@@ -1,0 +1,42 @@
+import { canManageBookings, type StaffRole } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { listOrgStudies } from "../../../../lib/tenant-repo";
+import { STUDY_STATES, STUDY_STATE_LABELS, isTerminal, nextStates, stateLabel } from "../../../../lib/study-state";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+// Реєстр досліджень організації — tenant-scoped (organization_id зі серверної
+// сесії) і machine-aware: кожен запис несе підпис поточного стану й перелік
+// дозволених переходів згідно з єдиною state machine. Самі переходи виконує
+// PATCH /api/staff/bookings (canTransition), тут — лише читання.
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+
+  const rows = await listOrgStudies(db, ctx);
+  const studies = rows.map((r) => ({
+    ...r,
+    stateLabel: stateLabel(r.status),
+    terminal: isTerminal(r.status),
+    // Дозволені наступні стани (лише для тих, хто веде заявки).
+    nextStates: canManageBookings(ctx.role as StaffRole)
+      ? nextStates(r.status).map((v) => ({ v, l: stateLabel(v) }))
+      : [],
+  }));
+
+  // Лічильники за клінічними станами для черги/фільтрів.
+  const counts: Record<string, number> = {};
+  for (const r of rows) counts[r.status] = (counts[r.status] ?? 0) + 1;
+
+  return Response.json({
+    organization: { id: ctx.organizationId, name: ctx.organizationName, slug: ctx.slug },
+    role: ctx.role,
+    canManage: canManageBookings(ctx.role as StaffRole),
+    states: STUDY_STATES.map((v) => ({ v, l: STUDY_STATE_LABELS[v], count: counts[v] ?? 0 })),
+    studies,
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -900,3 +900,48 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
   .rosFeatureGrid,.rosPricing,.rosFooterCols{grid-template-columns:1fr}
   .rosHeaderActions .rosLogin{display:none}
 }
+
+/* Реєстр досліджень (/staff/studies) — tenant + state machine */
+.studiesOrgBar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;max-width:1500px;margin:0 auto 16px}
+.studiesOrgBadge{display:inline-flex;align-items:center;gap:8px;padding:7px 13px;border-radius:999px;background:var(--ws-soft);color:var(--ws-deep);font-size:12px;font-weight:800;border:1px solid rgba(12,122,133,.28)}
+.studiesOrgBar small{color:#5f716d;font-size:12px}
+.studiesTabs{display:flex;flex-wrap:wrap;gap:8px;max-width:1500px;margin:0 auto 16px}
+.studiesTabs button{display:inline-flex;align-items:center;gap:7px;padding:8px 13px;border:1px solid #d6ded9;border-radius:999px;background:#f7faf9;color:#41544f;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer;transition:border-color .12s,background .12s,color .12s}
+.studiesTabs button:hover{border-color:var(--ws-accent);color:var(--ws-accent)}
+.studiesTabs button.active{background:var(--ws-accent);border-color:var(--ws-accent);color:#fff}
+.studiesTabs button b{font-size:11px;padding:1px 7px;border-radius:999px;background:rgba(12,122,133,.12);color:inherit}
+.studiesTabs button.active b{background:rgba(255,255,255,.24)}
+.studiesTableWrap{max-width:1500px;margin:0 auto;overflow-x:auto;border:1px solid #dce4e3;border-radius:12px;background:#fff}
+.studiesTable{width:100%;border-collapse:collapse;min-width:900px}
+.studiesTable th{position:sticky;top:0;text-align:left;padding:12px 14px;background:#f4f8f6;color:#41544f;font-size:11px;font-weight:900;text-transform:uppercase;letter-spacing:.05em;border-bottom:1px solid #dce4e3}
+.studiesTable td{padding:11px 14px;border-bottom:1px solid #eef2f0;font-size:13.5px;color:var(--ink);vertical-align:middle}
+.studiesTable tr:last-child td{border-bottom:0}
+.studiesTable tbody tr:hover{background:#f7faf9}
+.studiesCode{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:var(--ws-deep);font-weight:700}
+.studiesWhen{white-space:nowrap;font-variant-numeric:tabular-nums}
+.studiesState{display:inline-block;padding:4px 10px;border-radius:999px;font-size:11px;font-weight:800;border:1px solid transparent}
+.studiesState.grp-intake{background:#e6f1fb;color:#1f5c94;border-color:#c9e0f4}
+.studiesState.grp-active{background:#fdefe0;color:#a85b18;border-color:#f5d7b3}
+.studiesState.grp-reporting{background:#efe9fb;color:#5a3fa0;border-color:#dccff2}
+.studiesState.grp-done{background:#e3f3ed;color:#075246;border-color:#c2e4d7}
+.studiesState.grp-stopped{background:#fdece7;color:#a23c1d;border-color:#f4d1c5}
+.studiesLinked{color:#075246;font-size:12px;font-weight:700}
+.studiesUnlinked,.studiesTerminal{color:#93a19c;font-size:12px}
+.studiesTable select{min-width:150px;padding:8px 10px;border:1px solid #cbd8d6;border-radius:8px;background:#fff;font:inherit;font-size:12.5px;color:var(--ink)}
+.studiesTable select:focus{outline:2px solid var(--ws-accent);outline-offset:1px;border-color:var(--ws-accent)}
+
+.themeDark .studiesOrgBar small{color:#8b98a1}
+.themeDark .studiesTabs button{background:#121a20;border-color:#26333d;color:#aebeca}
+.themeDark .studiesTabs button:hover{border-color:#25b4c0;color:#25b4c0}
+.themeDark .studiesTabs button.active{background:#25b4c0;border-color:#25b4c0;color:#06131a}
+.themeDark .studiesTableWrap{background:#121a20;border-color:#22303a}
+.themeDark .studiesTable th{background:#0e151a;color:#9fb0bb;border-bottom-color:#22303a}
+.themeDark .studiesTable td{border-bottom-color:#1c2831;color:#e6edf1}
+.themeDark .studiesTable tbody tr:hover{background:#17212a}
+.themeDark .studiesTable select{background:#0e151a;border-color:#2a3843;color:#e6edf1}
+.themeDark .studiesCode{color:#7fd4dc}
+.themeDark .studiesState.grp-intake{background:#12283b;color:#8fc2ec;border-color:#1e3d55}
+.themeDark .studiesState.grp-active{background:#3a2a14;color:#e6b072;border-color:#553f1e}
+.themeDark .studiesState.grp-reporting{background:#241d3b;color:#b6a2e6;border-color:#392d55}
+.themeDark .studiesState.grp-done{background:#0f2f2a;color:#6fd0b5;border-color:#1d4a40}
+.themeDark .studiesState.grp-stopped{background:#3a1c14;color:#e6906f;border-color:#552d1e}

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer";
+type StaffInfo = { email:string; displayName:string; role:StaffRole };
+type NextState = { v:string; l:string };
+type Study = {
+  id:number; code:string; name:string; service:string; equipmentId:string;
+  desiredDate:string; desiredTime:string; status:string; stateLabel:string;
+  terminal:boolean; performedAt:string; protocolStatus:string;
+  studyStatus:string|null; accessionNumber:string|null; nextStates:NextState[];
+};
+type StateInfo = { v:string; l:string; count:number };
+type Data = {
+  organization:{ id:number; name:string; slug:string };
+  role:StaffRole; canManage:boolean; states:StateInfo[]; studies:Study[];
+};
+
+const roleLabels: Record<StaffRole,string> = {
+  admin:"Адміністратор", registrar:"Реєстратор",
+  radiologist:"Лікар-рентгенолог", radiographer:"Рентгенолаборант",
+};
+const equipmentNames: Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
+
+// Клінічні групи станів — для кольору бейджа й логічного порядку черги.
+const STATE_GROUP: Record<string,"intake"|"active"|"reporting"|"done"|"stopped"> = {
+  new:"intake", requested:"intake", needs_verification:"intake", scheduled:"intake",
+  confirmed:"intake", rescheduled:"intake",
+  arrived:"active", queued:"active", in_progress:"active", performed:"active", images_ready:"active",
+  reporting:"reporting", protocol_ready:"reporting", issued:"reporting",
+  completed:"done",
+  cancelled:"stopped", no_show:"stopped",
+};
+
+export default function StudiesPage() {
+  const [data,setData] = useState<Data|null>(null);
+  const [staff,setStaff] = useState<StaffInfo|null>(null);
+  const [error,setError] = useState("");
+  const [filter,setFilter] = useState("all");
+  const [busy,setBusy] = useState(0);
+
+  async function load() {
+    const response = await fetch("/api/staff/studies", { cache:"no-store" });
+    const payload = await response.json() as Data & { error?:string };
+    if (!response.ok) { setError(payload.error || "Немає доступу"); return; }
+    setData(payload);
+    setStaff({ email:"", displayName:"", role:payload.role });
+    setError("");
+  }
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void load(); }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  async function transition(id:number, status:string) {
+    if (!status) return;
+    setBusy(id);
+    try {
+      const response = await fetch("/api/staff/bookings", {
+        method:"PATCH", headers:{"content-type":"application/json"},
+        body:JSON.stringify({ id, status }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(()=>({})) as { error?:string };
+        window.alert(payload.error || "Не вдалося змінити стан");
+      } else {
+        await load();
+      }
+    } finally {
+      setBusy(0);
+    }
+  }
+
+  const visible = useMemo(() => {
+    if (!data) return [];
+    return filter === "all" ? data.studies : data.studies.filter((s)=>s.status===filter);
+  }, [data, filter]);
+
+  const activeStates = useMemo(
+    () => (data?.states || []).filter((s)=>s.count > 0),
+    [data],
+  );
+
+  return <StaffWorkspaceShell
+    active="studies"
+    title="Реєстр досліджень"
+    description="Усі дослідження організації з єдиним життєвим циклом: стан, обладнання, протокол і знімки в одному місці."
+    staffName={staff ? roleLabels[staff.role] : undefined}
+    staffRole={staff ? roleLabels[staff.role] : undefined}
+  >
+    {error ? <section className="accessDenied">
+      <b>Захищений розділ</b>
+      <p>{error}. Увійдіть через дозволений робочий обліковий запис.</p>
+      <a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Fstudies">Увійти для роботи</a>
+    </section> :
+    !data ? <p className="dashLoading">Завантаження реєстру…</p> :
+    <>
+      <div className="studiesOrgBar">
+        <span className="studiesOrgBadge">{data.organization.name}</span>
+        <small>{data.studies.length} досліджень · роль: {roleLabels[data.role]}{data.canManage ? "" : " · лише перегляд"}</small>
+      </div>
+
+      <div className="studiesTabs" role="tablist" aria-label="Фільтр за станом">
+        <button type="button" role="tab" aria-selected={filter==="all"}
+          className={filter==="all"?"active":""} onClick={()=>setFilter("all")}>
+          Усі <b>{data.studies.length}</b>
+        </button>
+        {activeStates.map((s)=><button key={s.v} type="button" role="tab" aria-selected={filter===s.v}
+          className={filter===s.v?"active":""} onClick={()=>setFilter(s.v)}>
+          {s.l} <b>{s.count}</b>
+        </button>)}
+      </div>
+
+      {visible.length === 0 ? <p className="dashListEmpty">У цьому стані досліджень немає.</p> :
+      <div className="studiesTableWrap">
+        <table className="studiesTable">
+          <thead><tr>
+            <th>Код</th><th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
+            <th>Апарат</th><th>Стан</th><th>Знімки</th><th>Дія</th>
+          </tr></thead>
+          <tbody>
+            {visible.map((s)=><tr key={s.id}>
+              <td className="studiesCode">{s.code}</td>
+              <td>{s.name || "—"}</td>
+              <td>{s.service}</td>
+              <td className="studiesWhen">{s.desiredDate}{s.desiredTime ? ` ${s.desiredTime}` : ""}</td>
+              <td>{equipmentNames[s.equipmentId] || s.equipmentId}</td>
+              <td><span className={`studiesState grp-${STATE_GROUP[s.status] || "intake"}`}>{s.stateLabel}</span></td>
+              <td>{s.studyStatus && s.studyStatus !== "not_linked"
+                ? <span className="studiesLinked" title={s.accessionNumber || ""}>прив’язано</span>
+                : <span className="studiesUnlinked">—</span>}</td>
+              <td>
+                {data.canManage && s.nextStates.length > 0 ?
+                  <select
+                    aria-label={`Змінити стан для ${s.code}`}
+                    disabled={busy===s.id}
+                    value=""
+                    onChange={(e)=>void transition(s.id, e.target.value)}
+                  >
+                    <option value="">Перевести →</option>
+                    {s.nextStates.map((n)=><option key={n.v} value={n.v}>{n.l}</option>)}
+                  </select>
+                  : <span className="studiesTerminal">{s.terminal ? "завершено" : "—"}</span>}
+              </td>
+            </tr>)}
+          </tbody>
+        </table>
+      </div>}
+    </>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "system-map";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "system-map";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -35,6 +35,7 @@ const systemModules: NavModule[] = [
     { label:"Вибір часу", href:"/staff/dashboard" },
     { label:"Кабінет пацієнта", href:"/site/cabinet.html" },
     { label:"Черга реєстратури", href:"/staff#bookings" },
+    { label:"Реєстр досліджень", href:"/staff/studies" },
     { label:"Розклад дня", href:"/staff/dashboard" },
     { label:"Нагадування", href:"/staff/settings" },
     { label:"Повторний запис", href:"/staff/system-map#mod-2" },
@@ -231,14 +232,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/lib/tenant-repo.ts
+++ b/lib/tenant-repo.ts
@@ -49,6 +49,38 @@ export async function countOrgBookings(db: D1Database, ctx: OrgContext): Promise
   return row?.n ?? 0;
 }
 
+export interface OrgStudyRow {
+  id: number;
+  code: string;
+  name: string;
+  service: string;
+  equipmentId: string;
+  desiredDate: string;
+  desiredTime: string;
+  status: string;
+  performedAt: string;
+  protocolStatus: string;
+  studyStatus: string | null;
+  accessionNumber: string | null;
+}
+
+// Реєстр досліджень організації: заявки, збагачені прив'язкою до DICOM-студії.
+// Строго tenant-scoped — фільтр organization_id зі серверного контексту.
+export async function listOrgStudies(db: D1Database, ctx: OrgContext, limit = 500): Promise<OrgStudyRow[]> {
+  const result = await db.prepare(
+    `SELECT b.id AS id, b.code AS code, b.name AS name, b.service AS service,
+       b.equipment_id AS equipmentId, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
+       b.status AS status, b.performed_at AS performedAt, b.protocol_status AS protocolStatus,
+       s.study_status AS studyStatus, s.accession_number AS accessionNumber
+     FROM bookings b
+     LEFT JOIN imaging_studies s ON s.booking_id = b.id AND s.organization_id = b.organization_id
+     WHERE b.organization_id = ?
+     ORDER BY b.desired_date DESC, b.desired_time DESC
+     LIMIT ?`
+  ).bind(ctx.organizationId, limit).all<OrgStudyRow>();
+  return result.results ?? [];
+}
+
 // Підрозділи (departments) організації контексту.
 export async function listOrgDepartments(db: D1Database, ctx: OrgContext): Promise<Array<{ id: number; name: string; branchId: number }>> {
   const result = await db.prepare(

--- a/tests/studies-registry.test.mjs
+++ b/tests/studies-registry.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+// Реєстр досліджень читає лише свій tenant і несе стан машини + переходи.
+test("studies API is tenant-aware and machine-aware", async () => {
+  const route = await read("app/api/staff/studies/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /listOrgStudies\(db, ctx\)/);
+  assert.match(route, /nextStates\(/);
+  assert.match(route, /stateLabel\(/);
+  // Переходи пропонуються лише тим, хто веде заявки.
+  assert.match(route, /canManageBookings\(/);
+  // Стан/organizationId не приймаються з клієнта тут — лише читання GET.
+  assert.doesNotMatch(route, /export async function (POST|PATCH|PUT|DELETE)/);
+});
+
+// Репозиторій досліджень строго фільтрує organization_id.
+test("listOrgStudies filters by organization_id", async () => {
+  const repo = await read("lib/tenant-repo.ts");
+  assert.match(repo, /export async function listOrgStudies/);
+  assert.match(repo, /WHERE b\.organization_id = \?/);
+  // JOIN зі студіями теж обмежений тим самим tenant.
+  assert.match(repo, /s\.organization_id = b\.organization_id/);
+});
+
+// Сторінка реєстру: shell-секція, transition-aware керування, tenant-бейдж.
+test("studies page renders a transition-aware, tenant-scoped registry", async () => {
+  const page = await read("app/staff/studies/page.tsx");
+  assert.match(page, /active="studies"/);
+  assert.match(page, /\/api\/staff\/studies/);
+  // Перехід виконується через єдиний ендпойнт бронювань (canTransition на сервері).
+  assert.match(page, /\/api\/staff\/bookings/);
+  assert.match(page, /s\.nextStates\.map/);
+  assert.match(page, /studiesOrgBadge/);
+  // Лише керівники заявок бачать керування станом.
+  assert.match(page, /data\.canManage/);
+});
+
+// Робочий shell інтегрує реєстр досліджень.
+test("workspace shell wires the studies registry", async () => {
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/studies"/);
+  assert.match(shell, /"studies"/); // секція у типі WorkspaceSection
+});


### PR DESCRIPTION
Третій крок SaaS-переходу. Додає робочий **реєстр досліджень**, що споживає фундамент PR 1 (мультитенантність) і PR 2 (state machine). Це **нова сторінка** — наявні екрани, «Записи», запис і публічний сайт не змінюються.

## Що зроблено

**`lib/tenant-repo.ts`** — `listOrgStudies`:
- заявки + прив'язка DICOM-студії, **строго tenant-scoped** (`organization_id` зі серверного контексту; `LEFT JOIN` теж обмежений тим самим tenant).

**`app/api/staff/studies/route.ts`** (GET, лише читання):
- `requireOrgContext` → `organizationId` береться **лише** із сесії;
- кожен запис несе `stateLabel` і перелік **дозволених переходів** (`nextStates`) згідно з машиною; переходи пропонуються лише тим, хто веде заявки (`canManageBookings`);
- лічильники за станами для фільтрів/черги.

**`app/staff/studies/page.tsx`**:
- реєстр із фільтром за станом, **бейдж організації** (tenant), таблиця з кольоровими бейджами клінічних груп станів (intake / active / reporting / done / stopped);
- **transition-aware керування**: перехід виконує єдиний `PATCH /api/staff/bookings` (`canTransition` на сервері) — недопустимий перехід повертає `409`.

**Навігація**: секція `studies` у shell, підпункт «Реєстр досліджень» → `/staff/studies`. Стилі `.studies*` (світла й темна теми).

## Перевірки

- `lint` — 0 помилок (1 попередній warning не з цього PR).
- `tsc --noEmit` — 0.
- `build` ✓
- Тести: **90/90** зелені (+4 у `tests/studies-registry.test.mjs`):
  - API tenant-aware і machine-aware, лише читання;
  - `listOrgStudies` фільтрує `organization_id` (і в JOIN);
  - сторінка transition-aware та tenant-scoped;
  - інтеграція в робочий shell.

## Поза межами цього PR

Призначення лікаря/лаборанта на дослідження й оновлений пульт під нову машину — наступний крок. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_