### PR TITLE
PR 4: Призначення лікаря/лаборанта у реєстрі досліджень (tenant-aware)

### DIFF
--- a/app/api/staff/studies/route.ts
+++ b/app/api/staff/studies/route.ts
@@ -1,6 +1,6 @@
 import { canManageBookings, type StaffRole } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
-import { listOrgStudies } from "../../../../lib/tenant-repo";
+import { listOrgClinicians, listOrgStudies } from "../../../../lib/tenant-repo";
 import { STUDY_STATES, STUDY_STATE_LABELS, isTerminal, nextStates, stateLabel } from "../../../../lib/study-state";
 
 function dbBinding() {
@@ -17,13 +17,21 @@ export async function GET(request: Request) {
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
 
-  const rows = await listOrgStudies(db, ctx);
+  const canManage = canManageBookings(ctx.role as StaffRole);
+  const [rows, clinicians] = await Promise.all([
+    listOrgStudies(db, ctx),
+    canManage ? listOrgClinicians(db, ctx) : Promise.resolve([]),
+  ]);
+  const nameByEmail = new Map(clinicians.map((c) => [c.email, c.displayName || c.email]));
+
   const studies = rows.map((r) => ({
     ...r,
     stateLabel: stateLabel(r.status),
     terminal: isTerminal(r.status),
+    radiologistName: r.assignedRadiologistEmail ? (nameByEmail.get(r.assignedRadiologistEmail) || r.assignedRadiologistEmail) : "",
+    radiographerName: r.assignedRadiographerEmail ? (nameByEmail.get(r.assignedRadiographerEmail) || r.assignedRadiographerEmail) : "",
     // Дозволені наступні стани (лише для тих, хто веде заявки).
-    nextStates: canManageBookings(ctx.role as StaffRole)
+    nextStates: canManage
       ? nextStates(r.status).map((v) => ({ v, l: stateLabel(v) }))
       : [],
   }));
@@ -35,8 +43,11 @@ export async function GET(request: Request) {
   return Response.json({
     organization: { id: ctx.organizationId, name: ctx.organizationName, slug: ctx.slug },
     role: ctx.role,
-    canManage: canManageBookings(ctx.role as StaffRole),
+    canManage,
     states: STUDY_STATES.map((v) => ({ v, l: STUDY_STATE_LABELS[v], count: counts[v] ?? 0 })),
+    // Виконавці для призначення: розділені за роллю (tenant-scoped).
+    radiologists: clinicians.filter((c) => c.role === "radiologist").map((c) => ({ v: c.email, l: c.displayName || c.email })),
+    radiographers: clinicians.filter((c) => c.role === "radiographer").map((c) => ({ v: c.email, l: c.displayName || c.email })),
     studies,
   });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -945,3 +945,4 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .themeDark .studiesState.grp-reporting{background:#241d3b;color:#b6a2e6;border-color:#392d55}
 .themeDark .studiesState.grp-done{background:#0f2f2a;color:#6fd0b5;border-color:#1d4a40}
 .themeDark .studiesState.grp-stopped{background:#3a1c14;color:#e6906f;border-color:#552d1e}
+.studiesTable select.studiesAssign{min-width:130px}

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -5,17 +5,20 @@ import StaffWorkspaceShell from "../workspace-shell";
 
 type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer";
 type StaffInfo = { email:string; displayName:string; role:StaffRole };
-type NextState = { v:string; l:string };
+type Option = { v:string; l:string };
 type Study = {
   id:number; code:string; name:string; service:string; equipmentId:string;
   desiredDate:string; desiredTime:string; status:string; stateLabel:string;
   terminal:boolean; performedAt:string; protocolStatus:string;
-  studyStatus:string|null; accessionNumber:string|null; nextStates:NextState[];
+  studyStatus:string|null; accessionNumber:string|null; nextStates:Option[];
+  assignedRadiologistEmail:string; assignedRadiographerEmail:string;
+  radiologistName:string; radiographerName:string;
 };
 type StateInfo = { v:string; l:string; count:number };
 type Data = {
   organization:{ id:number; name:string; slug:string };
   role:StaffRole; canManage:boolean; states:StateInfo[]; studies:Study[];
+  radiologists:Option[]; radiographers:Option[];
 };
 
 const roleLabels: Record<StaffRole,string> = {
@@ -74,6 +77,29 @@ export default function StudiesPage() {
     }
   }
 
+  // Призначення виконавця: reg/admin шлють оновлення на той самий PATCH
+  // /api/staff/bookings, що валідує роль виконавця й фіксує подію.
+  async function assign(study:Study, field:"radiologist"|"radiographer", email:string) {
+    setBusy(study.id);
+    try {
+      const body = field === "radiologist"
+        ? { id:study.id, assignedRadiologistEmail:email, assignedRadiographerEmail:study.assignedRadiographerEmail }
+        : { id:study.id, assignedRadiologistEmail:study.assignedRadiologistEmail, assignedRadiographerEmail:email };
+      const response = await fetch("/api/staff/bookings", {
+        method:"PATCH", headers:{"content-type":"application/json"},
+        body:JSON.stringify(body),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(()=>({})) as { error?:string };
+        window.alert(payload.error || "Не вдалося призначити виконавця");
+      } else {
+        await load();
+      }
+    } finally {
+      setBusy(0);
+    }
+  }
+
   const visible = useMemo(() => {
     if (!data) return [];
     return filter === "all" ? data.studies : data.studies.filter((s)=>s.status===filter);
@@ -119,7 +145,7 @@ export default function StudiesPage() {
         <table className="studiesTable">
           <thead><tr>
             <th>Код</th><th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
-            <th>Апарат</th><th>Стан</th><th>Знімки</th><th>Дія</th>
+            <th>Апарат</th><th>Стан</th><th>Лікар</th><th>Лаборант</th><th>Знімки</th><th>Дія</th>
           </tr></thead>
           <tbody>
             {visible.map((s)=><tr key={s.id}>
@@ -129,6 +155,22 @@ export default function StudiesPage() {
               <td className="studiesWhen">{s.desiredDate}{s.desiredTime ? ` ${s.desiredTime}` : ""}</td>
               <td>{equipmentNames[s.equipmentId] || s.equipmentId}</td>
               <td><span className={`studiesState grp-${STATE_GROUP[s.status] || "intake"}`}>{s.stateLabel}</span></td>
+              <td>{data.canManage
+                ? <select className="studiesAssign" aria-label={`Лікар для ${s.code}`} disabled={busy===s.id}
+                    value={s.assignedRadiologistEmail}
+                    onChange={(e)=>void assign(s, "radiologist", e.target.value)}>
+                    <option value="">— не призначено —</option>
+                    {data.radiologists.map((o)=><option key={o.v} value={o.v}>{o.l}</option>)}
+                  </select>
+                : <span className={s.radiologistName ? "" : "studiesUnlinked"}>{s.radiologistName || "—"}</span>}</td>
+              <td>{data.canManage
+                ? <select className="studiesAssign" aria-label={`Лаборант для ${s.code}`} disabled={busy===s.id}
+                    value={s.assignedRadiographerEmail}
+                    onChange={(e)=>void assign(s, "radiographer", e.target.value)}>
+                    <option value="">— не призначено —</option>
+                    {data.radiographers.map((o)=><option key={o.v} value={o.v}>{o.l}</option>)}
+                  </select>
+                : <span className={s.radiographerName ? "" : "studiesUnlinked"}>{s.radiographerName || "—"}</span>}</td>
               <td>{s.studyStatus && s.studyStatus !== "not_linked"
                 ? <span className="studiesLinked" title={s.accessionNumber || ""}>прив’язано</span>
                 : <span className="studiesUnlinked">—</span>}</td>

--- a/lib/tenant-repo.ts
+++ b/lib/tenant-repo.ts
@@ -62,15 +62,20 @@ export interface OrgStudyRow {
   protocolStatus: string;
   studyStatus: string | null;
   accessionNumber: string | null;
+  assignedRadiologistEmail: string;
+  assignedRadiographerEmail: string;
 }
 
-// Реєстр досліджень організації: заявки, збагачені прив'язкою до DICOM-студії.
-// Строго tenant-scoped — фільтр organization_id зі серверного контексту.
+// Реєстр досліджень організації: заявки, збагачені прив'язкою до DICOM-студії
+// та призначеними виконавцями. Строго tenant-scoped — фільтр organization_id
+// зі серверного контексту.
 export async function listOrgStudies(db: D1Database, ctx: OrgContext, limit = 500): Promise<OrgStudyRow[]> {
   const result = await db.prepare(
     `SELECT b.id AS id, b.code AS code, b.name AS name, b.service AS service,
        b.equipment_id AS equipmentId, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
        b.status AS status, b.performed_at AS performedAt, b.protocol_status AS protocolStatus,
+       b.assigned_radiologist_email AS assignedRadiologistEmail,
+       b.assigned_radiographer_email AS assignedRadiographerEmail,
        s.study_status AS studyStatus, s.accession_number AS accessionNumber
      FROM bookings b
      LEFT JOIN imaging_studies s ON s.booking_id = b.id AND s.organization_id = b.organization_id
@@ -78,6 +83,26 @@ export async function listOrgStudies(db: D1Database, ctx: OrgContext, limit = 50
      ORDER BY b.desired_date DESC, b.desired_time DESC
      LIMIT ?`
   ).bind(ctx.organizationId, limit).all<OrgStudyRow>();
+  return result.results ?? [];
+}
+
+export interface OrgClinician {
+  email: string;
+  displayName: string;
+  role: string;
+}
+
+// Виконавці організації, яких можна призначати на дослідження: активні
+// лікарі-рентгенологи та рентгенолаборанти — учасники цього tenant.
+export async function listOrgClinicians(db: D1Database, ctx: OrgContext): Promise<OrgClinician[]> {
+  const result = await db.prepare(
+    `SELECT sm.email AS email, sm.display_name AS displayName, sm.role AS role
+     FROM memberships m
+     JOIN staff_members sm ON sm.email = m.member_email AND sm.active = 1
+     WHERE m.organization_id = ? AND m.active = 1
+       AND sm.role IN ('radiologist','radiographer')
+     ORDER BY sm.role, sm.display_name, sm.email`
+  ).bind(ctx.organizationId).all<OrgClinician>();
   return result.results ?? [];
 }
 

--- a/tests/studies-registry.test.mjs
+++ b/tests/studies-registry.test.mjs
@@ -24,6 +24,34 @@ test("listOrgStudies filters by organization_id", async () => {
   assert.match(repo, /WHERE b\.organization_id = \?/);
   // JOIN зі студіями теж обмежений тим самим tenant.
   assert.match(repo, /s\.organization_id = b\.organization_id/);
+  // Реєстр несе призначених виконавців.
+  assert.match(repo, /assigned_radiologist_email AS assignedRadiologistEmail/);
+});
+
+// Виконавці для призначення — лише учасники цього tenant.
+test("listOrgClinicians is tenant-scoped to radiologists/radiographers", async () => {
+  const repo = await read("lib/tenant-repo.ts");
+  assert.match(repo, /export async function listOrgClinicians/);
+  assert.match(repo, /FROM memberships m/);
+  assert.match(repo, /m\.organization_id = \?/);
+  assert.match(repo, /IN \('radiologist','radiographer'\)/);
+});
+
+// Призначення виконавців у реєстрі: API віддає список виконавців (лише
+// керівникам), сторінка призначає через єдиний PATCH бронювань.
+test("studies registry supports tenant-scoped assignment", async () => {
+  const route = await read("app/api/staff/studies/route.ts");
+  assert.match(route, /listOrgClinicians\(db, ctx\)/);
+  assert.match(route, /radiologists:/);
+  assert.match(route, /radiographers:/);
+  // Список виконавців тягнеться лише коли є право вести заявки.
+  assert.match(route, /canManage \? listOrgClinicians/);
+
+  const page = await read("app/staff/studies/page.tsx");
+  assert.match(page, /function assign\(/);
+  assert.match(page, /assignedRadiologistEmail/);
+  assert.match(page, /assignedRadiographerEmail/);
+  assert.match(page, /\/api\/staff\/bookings/);
 });
 
 // Сторінка реєстру: shell-секція, transition-aware керування, tenant-бейдж.


### PR DESCRIPTION
Продовження SaaS-переходу. Додає керування **виконавцями** (лікар-рентгенолог / рентгенолаборант) просто в реєстрі досліджень. Використовує наявні колонки `bookings.assigned_*` і наявний валідований `PATCH /api/staff/bookings` — **жодних нових мутацій на сервері**.

## Що зроблено

**`lib/tenant-repo.ts`**
- `listOrgStudies` тепер повертає призначених виконавців (`assigned_radiologist_email`, `assigned_radiographer_email`);
- `listOrgClinicians` — активні лікарі-рентгенологи й рентгенолаборанти, що є **учасниками цього tenant** (`JOIN memberships ↔ staff_members`, `organization_id` зі серверного контексту).

**`app/api/staff/studies/route.ts`**
- GET віддає списки `radiologists` / `radiographers` для призначення — **лише тим, хто веде заявки** (`canManageBookings`); імена виконавців підставляються до записів реєстру.

**`app/staff/studies/page.tsx`**
- нові колонки «Лікар» і «Лаборант»: керівникам — інлайн-селект призначення (через той самий `PATCH /api/staff/bookings`, що звіряє роль виконавця й фіксує подію в журналі); решті — лише перегляд.

## Перевірки

- `lint` — 0.
- `tsc --noEmit` — 0.
- `build` ✓
- Тести: **100/100** зелені (розширено `tests/studies-registry.test.mjs`):
  - `listOrgClinicians` tenant-scoped до radiologist/radiographer;
  - реєстр несе призначення;
  - список виконавців віддається лише для `canManage`;
  - сторінка призначає через єдиний ендпойнт бронювань.

## Поза межами цього PR

Оновлення пульта відділення під нову state machine (клінічна черга за станами) — наступний крок. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_