### PR TITLE
PR 5: Пульт відділення — клінічна черга за станами (tenant-aware)

### DIFF
--- a/app/api/staff/dashboard/route.ts
+++ b/app/api/staff/dashboard/route.ts
@@ -1,6 +1,11 @@
 import { serviceByCode } from "../../../../lib/catalog";
 import { todayInKyiv } from "../../../../lib/booking-rules";
 import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { stateLabel } from "../../../../lib/study-state";
+
+// Клінічна черга пульта — активні стани дослідження за єдиною state machine.
+const CLINICAL_QUEUE_STATES = ["queued", "in_progress", "images_ready", "reporting", "protocol_ready"] as const;
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
@@ -17,6 +22,11 @@ export async function GET(request: Request) {
     return Response.json({ error: "Зведена аналітика доступна лише адміністратору" }, { status: 403 });
   }
 
+  // Контекст організації — для tenant-scoped клінічної черги (organization_id
+  // лише із серверної сесії). За відсутності членства обмежуємося початковим tenant.
+  const ctx = await requireOrgContext(request, db);
+  const orgId = ctx?.organizationId ?? 1;
+
   const today = todayInKyiv();
   const one = (sql: string, ...bind: unknown[]) => db.prepare(sql).bind(...bind).first<Record<string, unknown>>();
   const many = (sql: string, ...bind: unknown[]) => db.prepare(sql).bind(...bind).all();
@@ -29,6 +39,7 @@ export async function GET(request: Request) {
     patients, repeatPatients, doNotContact,
     equipmentToday,
     needProtocolList, readyList, needImagingList, confirmList,
+    clinicalQueueRows,
   ] = await Promise.all([
     one("SELECT COUNT(*) AS c FROM bookings WHERE desired_date = ? AND status != 'cancelled'", today),
     one("SELECT SUM(status='new') AS newc, SUM(status='confirmed') AS confirmedc FROM bookings WHERE desired_date = ? AND status != 'cancelled'", today),
@@ -49,7 +60,20 @@ export async function GET(request: Request) {
     many("SELECT id, code, name, service_code AS serviceCode, protocol_number AS protocolNumber FROM bookings WHERE protocol_status = 'ready' ORDER BY protocol_updated_at DESC LIMIT 6"),
     many("SELECT b.id, b.code, b.name, b.service_code AS serviceCode, b.performed_at AS performedAt FROM bookings b LEFT JOIN imaging_studies i ON i.booking_id = b.id WHERE b.performed_at != '' AND b.status != 'cancelled' AND i.booking_id IS NULL ORDER BY b.performed_at DESC LIMIT 6"),
     many("SELECT id, code, name, service_code AS serviceCode, desired_date AS desiredDate, desired_time AS desiredTime FROM bookings WHERE status = 'new' ORDER BY desired_date, desired_time LIMIT 6"),
+    // Клінічна черга — лічильники активних станів дослідження (tenant-scoped).
+    many(
+      `SELECT status AS s, COUNT(*) AS c FROM bookings
+       WHERE organization_id = ? AND status IN ('queued','in_progress','images_ready','reporting','protocol_ready')
+       GROUP BY status`,
+      orgId,
+    ),
   ]);
+
+  const queueCounts = new Map(
+    ((clinicalQueueRows as { results?: Array<Record<string, unknown>> }).results || [])
+      .map((r) => [String(r.s), Number(r.c || 0)] as const),
+  );
+  const clinicalQueue = CLINICAL_QUEUE_STATES.map((v) => ({ v, l: stateLabel(v), count: queueCounts.get(v) ?? 0 }));
 
   const withTitle = (rows: unknown) => (rows as { results?: Array<Record<string, unknown>> }).results?.map((row) => ({
     ...row, serviceTitle: serviceByCode(String(row.serviceCode))?.title || String(row.serviceCode),
@@ -76,6 +100,7 @@ export async function GET(request: Request) {
       doNotContact: num(doNotContact),
     },
     equipmentToday: (equipmentToday as { results?: Array<Record<string, unknown>> }).results || [],
+    clinicalQueue,
     lists: {
       needProtocol: withTitle(needProtocolList),
       readyToIssue: withTitle(readyList),

--- a/app/globals.css
+++ b/app/globals.css
@@ -946,3 +946,23 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .themeDark .studiesState.grp-done{background:#0f2f2a;color:#6fd0b5;border-color:#1d4a40}
 .themeDark .studiesState.grp-stopped{background:#3a1c14;color:#e6906f;border-color:#552d1e}
 .studiesTable select.studiesAssign{min-width:130px}
+
+/* Пульт: клінічна черга за станами (state machine) */
+.dashQueue{display:block;max-width:1500px;margin:0 auto 16px;padding:16px 18px;border:1px solid #dce4e3;border-radius:14px;background:#fff;text-decoration:none;color:inherit;transition:border-color .12s,box-shadow .12s}
+.dashQueue:hover{border-color:var(--ws-accent);box-shadow:0 6px 22px rgba(12,122,133,.1)}
+.dashQueueHead{display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:12px}
+.dashQueueHead b{font-size:14px;color:var(--ink)}
+.dashQueueHead small{color:#5f716d;font-size:12px}
+.dashQueueRow{display:grid;grid-template-columns:repeat(5,1fr);gap:10px}
+.dashQueueCell{padding:12px;border-radius:10px;background:#f4f8f6;text-align:center}
+.dashQueueCell b{display:block;font-size:26px;line-height:1;color:var(--ws-deep);font-variant-numeric:tabular-nums}
+.dashQueueCell b.muted{color:#b6c1bd}
+.dashQueueCell span{display:block;margin-top:6px;font-size:11px;color:#5f716d}
+.themeDark .dashQueue{background:#121a20;border-color:#22303a}
+.themeDark .dashQueue:hover{border-color:#25b4c0}
+.themeDark .dashQueueHead b{color:#e6edf1}
+.themeDark .dashQueueHead small,.themeDark .dashQueueCell span{color:#8b98a1}
+.themeDark .dashQueueCell{background:#0e151a}
+.themeDark .dashQueueCell b{color:#25b4c0}
+.themeDark .dashQueueCell b.muted{color:#3a4650}
+@media(max-width:760px){.dashQueueRow{grid-template-columns:repeat(2,1fr)}}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -13,9 +13,11 @@ type Kpi = {
   patients:number; repeatPatients:number; doNotContact:number;
 };
 type ListItem = { id:number; code:string; name:string; serviceTitle:string; performedAt?:string; protocolNumber?:string; desiredDate?:string; desiredTime?:string };
+type QueueState = { v:string; l:string; count:number };
 type Data = {
   today:string; kpi:Kpi;
   equipmentToday:Array<{ id:string; c:number }>;
+  clinicalQueue:QueueState[];
   lists:{ needProtocol:ListItem[]; readyToIssue:ListItem[]; needImaging:ListItem[]; confirmQueue:ListItem[] };
   staff:StaffInfo;
 };
@@ -127,6 +129,15 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+
+      {data?.clinicalQueue?.length ? <a className="dashQueue" href="/staff/studies" aria-label="Відкрити реєстр досліджень">
+        <div className="dashQueueHead"><b>Клінічна черга</b><small>Активні стани дослідження · відкрити реєстр →</small></div>
+        <div className="dashQueueRow">
+          {data.clinicalQueue.map((q)=><div key={q.v} className="dashQueueCell">
+            <b className={q.count?"":"muted"}>{q.count}</b><span>{q.l}</span>
+          </div>)}
+        </div>
+      </a> : null}
 
       <div className="dashLists">
         <ActionList title="Потребують протоколу" items={data!.lists.needProtocol}

--- a/tests/dashboard.test.mjs
+++ b/tests/dashboard.test.mjs
@@ -17,6 +17,22 @@ test("dashboard API aggregates across pillars and never mutates schema", async (
   assert.doesNotMatch(route, /UPDATE\s+bookings/i);
 });
 
+test("dashboard exposes a tenant-scoped clinical queue by machine state", async () => {
+  const route = await read("app/api/staff/dashboard/route.ts");
+  // Черга рахує активні стани єдиної state machine.
+  assert.match(route, /CLINICAL_QUEUE_STATES/);
+  assert.match(route, /'queued','in_progress','images_ready','reporting','protocol_ready'/);
+  // Лічильники обмежені організацією зі серверного контексту.
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /organization_id = \?/);
+  assert.match(route, /clinicalQueue/);
+  // Сторінка показує чергу з переходом у реєстр досліджень.
+  const page = await read("app/staff/dashboard/page.tsx");
+  assert.match(page, /dashQueue/);
+  assert.match(page, /clinicalQueue/);
+  assert.match(page, /\/staff\/studies/);
+});
+
 async function renderPath(path) {
   const workerUrl = new URL("../dist/server/index.js", import.meta.url);
   workerUrl.searchParams.set("test", `${process.pid}-${Date.now()}`);


### PR DESCRIPTION
Оновлює пульт `/staff/dashboard` під єдину state machine. Суто **додаткова** зміна — наявні KPI, списки й доступ (admin-only) не змінюються.

## Що зроблено

**`app/api/staff/dashboard/route.ts`**
- нова **клінічна черга**: лічильники активних станів дослідження (`queued`, `in_progress`, `images_ready`, `reporting`, `protocol_ready`) за єдиною машиною; підписи станів беруться з `lib/study-state`;
- **tenant-scoped** — `organization_id` із `requireOrgContext` (серверна сесія), а не з клієнта; за відсутності членства — початковий tenant.

**`app/staff/dashboard/page.tsx`**
- смуга «Клінічна черга» з лічильниками станів і переходом у реєстр досліджень (`/staff/studies`). Стилі `.dashQueue*` (світла/темна теми).

## Перевірки

- `lint` — 0.
- `tsc --noEmit` — 0.
- `build` ✓
- Тести: **101/101** зелені (розширено `tests/dashboard.test.mjs`): черга рахує саме активні стани машини, обмежена організацією, сторінка показує чергу з переходом у реєстр.

## Контекст

Завершує клінічний контур на новій моделі: state machine (PR 2) → реєстр досліджень (PR 3) → призначення виконавців (PR 4) → пульт із чергою за станами (цей PR). Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_