### PR TITLE
PR 6: Профілі організацій + feature flags (ядро конструктора)

### DIFF
--- a/app/api/staff/org-profile/route.ts
+++ b/app/api/staff/org-profile/route.ts
@@ -1,0 +1,80 @@
+import { requireOrgContext } from "../../../../lib/tenant";
+import {
+  FEATURE_FLAGS, FEATURE_LABELS, PROFILE_LABELS, PROFILE_TYPES,
+  getOrgProfile, isFeatureFlag, isProfileType, resolveFlags,
+  type FeatureFlag,
+} from "../../../../lib/org-profile";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+// Профіль організації та ефективні feature flags. organizationId — лише зі
+// серверної сесії (requireOrgContext). Читання доступне всьому персоналу,
+// зміна — лише адміністратору.
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+
+  const profile = await getOrgProfile(db, ctx);
+  return Response.json({
+    organization: { id: ctx.organizationId, name: ctx.organizationName, slug: ctx.slug },
+    canManage: ctx.role === "admin",
+    profileType: profile.profileType,
+    profileLabel: profile.profileLabel,
+    flags: profile.flags,
+    overrides: profile.overrides,
+    catalog: {
+      profiles: PROFILE_TYPES.map((v) => ({ v, l: PROFILE_LABELS[v] })),
+      features: FEATURE_FLAGS.map((v) => ({ v, l: FEATURE_LABELS[v] })),
+    },
+  });
+}
+
+export async function PATCH(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") {
+    return Response.json({ error: "Профіль організації може змінювати лише адміністратор" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as {
+    profileType?: string;
+    flags?: Record<string, unknown>;
+  };
+
+  const current = await getOrgProfile(db, ctx);
+  const profileType = body.profileType && isProfileType(body.profileType) ? body.profileType : current.profileType;
+  if (body.profileType && !isProfileType(body.profileType)) {
+    return Response.json({ error: "Невідомий профіль організації" }, { status: 400 });
+  }
+
+  // Прапорці зберігаємо лише як явні override-и відомих можливостей.
+  const overrides: Partial<Record<FeatureFlag, boolean>> = { ...current.overrides };
+  if (body.flags && typeof body.flags === "object") {
+    for (const [key, value] of Object.entries(body.flags)) {
+      if (isFeatureFlag(key)) overrides[key] = Boolean(value);
+    }
+  }
+
+  await db.prepare(
+    `INSERT INTO organization_profiles (organization_id, profile_type, feature_flags_json, updated_at)
+     VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(organization_id) DO UPDATE SET
+       profile_type = excluded.profile_type,
+       feature_flags_json = excluded.feature_flags_json,
+       updated_at = CURRENT_TIMESTAMP`
+  ).bind(ctx.organizationId, profileType, JSON.stringify(overrides)).run();
+
+  return Response.json({
+    ok: true,
+    profileType,
+    profileLabel: PROFILE_LABELS[profileType],
+    flags: resolveFlags(profileType, overrides),
+    overrides,
+  });
+}

--- a/app/api/staff/studies/route.ts
+++ b/app/api/staff/studies/route.ts
@@ -1,5 +1,6 @@
 import { canManageBookings, type StaffRole } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
+import { getOrgProfile } from "../../../../lib/org-profile";
 import { listOrgClinicians, listOrgStudies } from "../../../../lib/tenant-repo";
 import { STUDY_STATES, STUDY_STATE_LABELS, isTerminal, nextStates, stateLabel } from "../../../../lib/study-state";
 
@@ -18,9 +19,10 @@ export async function GET(request: Request) {
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
 
   const canManage = canManageBookings(ctx.role as StaffRole);
-  const [rows, clinicians] = await Promise.all([
+  const [rows, clinicians, profile] = await Promise.all([
     listOrgStudies(db, ctx),
     canManage ? listOrgClinicians(db, ctx) : Promise.resolve([]),
+    getOrgProfile(db, ctx),
   ]);
   const nameByEmail = new Map(clinicians.map((c) => [c.email, c.displayName || c.email]));
 
@@ -44,6 +46,9 @@ export async function GET(request: Request) {
     organization: { id: ctx.organizationId, name: ctx.organizationName, slug: ctx.slug },
     role: ctx.role,
     canManage,
+    profile: { type: profile.profileType, label: profile.profileLabel },
+    // Профіль організації керує видимістю можливостей (напр. DICOM/PACS).
+    features: { dicomPacs: profile.flags.dicom_pacs },
     states: STUDY_STATES.map((v) => ({ v, l: STUDY_STATE_LABELS[v], count: counts[v] ?? 0 })),
     // Виконавці для призначення: розділені за роллю (tenant-scoped).
     radiologists: clinicians.filter((c) => c.role === "radiologist").map((c) => ({ v: c.email, l: c.displayName || c.email })),

--- a/app/globals.css
+++ b/app/globals.css
@@ -966,3 +966,34 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .themeDark .dashQueueCell b{color:#25b4c0}
 .themeDark .dashQueueCell b.muted{color:#3a4650}
 @media(max-width:760px){.dashQueueRow{grid-template-columns:repeat(2,1fr)}}
+
+/* Організація та профіль (/staff/organization) — конструктор */
+.orgProfile{max-width:1000px;margin:0 auto;display:grid;gap:16px}
+.orgProfileHead{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.orgProfileHead small{color:#5f716d;font-size:12px}
+.orgProfileCard{border:1px solid #dce4e3;border-radius:14px;background:#fff;padding:18px 20px}
+.orgProfileCard h3{margin:0 0 4px;font-size:15px;color:var(--ink)}
+.orgProfileHint{margin:0 0 14px;color:#5f716d;font-size:12.5px;line-height:1.5}
+.orgProfilePicker{display:grid;grid-template-columns:repeat(2,1fr);gap:10px}
+.orgProfilePicker button{padding:14px;border:1px solid #d6ded9;border-radius:10px;background:#f7faf9;color:var(--ink);font:inherit;font-size:13.5px;font-weight:700;text-align:left;cursor:pointer;transition:border-color .12s,background .12s,color .12s}
+.orgProfilePicker button:hover:not(:disabled){border-color:var(--ws-accent);color:var(--ws-accent)}
+.orgProfilePicker button.active{background:var(--ws-accent);border-color:var(--ws-accent);color:#fff}
+.orgProfilePicker button:disabled{opacity:.65;cursor:not-allowed}
+.orgFlagList{display:grid;gap:8px}
+.orgFlag{display:flex;align-items:center;gap:12px;padding:11px 13px;border:1px solid #e6ece9;border-radius:10px;background:#fbfdfc}
+.orgFlag input{width:18px;height:18px;margin:0;flex:0 0 18px;accent-color:var(--ws-accent)}
+.orgFlagName{font-size:13.5px;color:var(--ink);font-weight:600;flex:1}
+.orgFlagState{font-size:11px;font-weight:800;padding:3px 9px;border-radius:999px}
+.orgFlagState.on{background:#e3f3ed;color:#075246}
+.orgFlagState.off{background:#eef2f0;color:#8a968f}
+.orgFlagBadge{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.05em;color:#a85b18;background:#fdefe0;border:1px solid #f5d7b3;padding:2px 7px;border-radius:999px}
+.themeDark .orgProfileHead small,.themeDark .orgProfileHint{color:#8b98a1}
+.themeDark .orgProfileCard{background:#121a20;border-color:#22303a}
+.themeDark .orgProfileCard h3{color:#e6edf1}
+.themeDark .orgProfilePicker button{background:#0e151a;border-color:#26333d;color:#cdd8de}
+.themeDark .orgProfilePicker button:hover:not(:disabled){border-color:#25b4c0;color:#25b4c0}
+.themeDark .orgProfilePicker button.active{background:#25b4c0;border-color:#25b4c0;color:#06131a}
+.themeDark .orgFlag{background:#0e151a;border-color:#22303a}
+.themeDark .orgFlagName{color:#e6edf1}
+.themeDark .orgFlagState.on{background:#0f2f2a;color:#6fd0b5}
+.themeDark .orgFlagState.off{background:#1c2831;color:#8b98a1}

--- a/app/staff/organization/page.tsx
+++ b/app/staff/organization/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type Option = { v:string; l:string };
+type Data = {
+  organization:{ id:number; name:string; slug:string };
+  canManage:boolean;
+  profileType:string;
+  profileLabel:string;
+  flags:Record<string,boolean>;
+  overrides:Record<string,boolean>;
+  catalog:{ profiles:Option[]; features:Option[] };
+};
+
+export default function OrganizationPage() {
+  const [data,setData] = useState<Data|null>(null);
+  const [error,setError] = useState("");
+  const [saving,setSaving] = useState(false);
+  const [savedAt,setSavedAt] = useState("");
+
+  async function load() {
+    const response = await fetch("/api/staff/org-profile", { cache:"no-store" });
+    const payload = await response.json() as Data & { error?:string };
+    if (!response.ok) { setError(payload.error || "Немає доступу"); return; }
+    setData(payload); setError("");
+  }
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void load(); }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  async function save(next:{ profileType?:string; flags?:Record<string,boolean> }) {
+    if (!data?.canManage) return;
+    setSaving(true);
+    try {
+      const response = await fetch("/api/staff/org-profile", {
+        method:"PATCH", headers:{"content-type":"application/json"},
+        body:JSON.stringify(next),
+      });
+      const payload = await response.json().catch(()=>({})) as { error?:string };
+      if (!response.ok) { window.alert(payload.error || "Не вдалося зберегти"); return; }
+      await load();
+      setSavedAt(new Date().toLocaleTimeString("uk-UA"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return <StaffWorkspaceShell
+    active="organization"
+    title="Організація та профіль"
+    description="Профіль-конфігурація й перемикачі можливостей (feature flags) цієї організації. Один код — різні профілі."
+  >
+    {error ? <section className="accessDenied">
+      <b>Захищений розділ</b>
+      <p>{error}. Увійдіть через дозволений робочий обліковий запис.</p>
+      <a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Forganization">Увійти для роботи</a>
+    </section> :
+    !data ? <p className="dashLoading">Завантаження профілю…</p> :
+    <div className="orgProfile">
+      <div className="orgProfileHead">
+        <span className="studiesOrgBadge">{data.organization.name}</span>
+        <small>Профіль: <b>{data.profileLabel}</b>{data.canManage ? "" : " · лише перегляд"}{savedAt ? ` · збережено ${savedAt}` : ""}</small>
+      </div>
+
+      <section className="orgProfileCard">
+        <h3>Профіль організації</h3>
+        <p className="orgProfileHint">Визначає набір можливостей за замовчуванням. Змінюйте обережно — впливає на поведінку модулів.</p>
+        <div className="orgProfilePicker">
+          {data.catalog.profiles.map((p)=><button
+            key={p.v} type="button"
+            className={p.v===data.profileType ? "active" : ""}
+            disabled={!data.canManage || saving}
+            onClick={()=>void save({ profileType:p.v })}
+          >{p.l}</button>)}
+        </div>
+      </section>
+
+      <section className="orgProfileCard">
+        <h3>Можливості (feature flags)</h3>
+        <p className="orgProfileHint">Точкові перевизначення дефолтів профілю для цієї організації.</p>
+        <div className="orgFlagList">
+          {data.catalog.features.map((f)=>{
+            const on = !!data.flags[f.v];
+            const overridden = f.v in data.overrides;
+            return <label key={f.v} className="orgFlag">
+              <input
+                type="checkbox" checked={on}
+                disabled={!data.canManage || saving}
+                onChange={(e)=>void save({ flags:{ [f.v]: e.target.checked } })}
+              />
+              <span className="orgFlagName">{f.l}</span>
+              <span className={`orgFlagState ${on?"on":"off"}`}>{on?"увімкнено":"вимкнено"}</span>
+              {overridden ? <span className="orgFlagBadge" title="Перевизначено вручну">override</span> : null}
+            </label>;
+          })}
+        </div>
+      </section>
+    </div>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -19,6 +19,8 @@ type Data = {
   organization:{ id:number; name:string; slug:string };
   role:StaffRole; canManage:boolean; states:StateInfo[]; studies:Study[];
   radiologists:Option[]; radiographers:Option[];
+  profile:{ type:string; label:string };
+  features:{ dicomPacs:boolean };
 };
 
 const roleLabels: Record<StaffRole,string> = {
@@ -126,7 +128,7 @@ export default function StudiesPage() {
     <>
       <div className="studiesOrgBar">
         <span className="studiesOrgBadge">{data.organization.name}</span>
-        <small>{data.studies.length} досліджень · роль: {roleLabels[data.role]}{data.canManage ? "" : " · лише перегляд"}</small>
+        <small>{data.profile?.label ? `${data.profile.label} · ` : ""}{data.studies.length} досліджень · роль: {roleLabels[data.role]}{data.canManage ? "" : " · лише перегляд"}</small>
       </div>
 
       <div className="studiesTabs" role="tablist" aria-label="Фільтр за станом">
@@ -145,7 +147,7 @@ export default function StudiesPage() {
         <table className="studiesTable">
           <thead><tr>
             <th>Код</th><th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
-            <th>Апарат</th><th>Стан</th><th>Лікар</th><th>Лаборант</th><th>Знімки</th><th>Дія</th>
+            <th>Апарат</th><th>Стан</th><th>Лікар</th><th>Лаборант</th>{data.features?.dicomPacs ? <th>Знімки</th> : null}<th>Дія</th>
           </tr></thead>
           <tbody>
             {visible.map((s)=><tr key={s.id}>
@@ -171,9 +173,9 @@ export default function StudiesPage() {
                     {data.radiographers.map((o)=><option key={o.v} value={o.v}>{o.l}</option>)}
                   </select>
                 : <span className={s.radiographerName ? "" : "studiesUnlinked"}>{s.radiographerName || "—"}</span>}</td>
-              <td>{s.studyStatus && s.studyStatus !== "not_linked"
+              {data.features?.dicomPacs ? <td>{s.studyStatus && s.studyStatus !== "not_linked"
                 ? <span className="studiesLinked" title={s.accessionNumber || ""}>прив’язано</span>
-                : <span className="studiesUnlinked">—</span>}</td>
+                : <span className="studiesUnlinked">—</span>}</td> : null}
               <td>
                 {data.canManage && s.nextStates.length > 0 ?
                   <select

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "system-map";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -79,6 +79,7 @@ const systemModules: NavModule[] = [
   ]},
   { n:"7", label:"Адмін / Наскрізне", href:"/staff/dashboard", section:"dashboard", items:[
     { label:"Пульт відділення", href:"/staff/dashboard" },
+    { label:"Організація та профіль", href:"/staff/organization" },
     { label:"Налаштування", href:"/staff/settings" },
     { label:"Ролі й права", href:"/staff#staff-admin" },
     { label:"Календар", href:"/staff/settings" },
@@ -232,14 +233,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/lib/org-profile.ts
+++ b/lib/org-profile.ts
@@ -1,0 +1,111 @@
+// Профілі організацій та feature flags — ядро SaaS-конструктора.
+//
+// Один і той самий код обслуговує різні профілі організацій. Профіль
+// (`organization_profiles.profile_type`) задає набір увімкнених можливостей
+// за замовчуванням; `feature_flags_json` дозволяє точково перевизначати їх для
+// конкретної організації. Резолвер — єдине джерело правди «що ввімкнено».
+//
+// Профіль і прапорці читаються за organizationId зі серверного контексту
+// (tenant-scoped), ніколи з тіла запиту.
+
+import type { OrgContext } from "./tenant";
+
+export const PROFILE_TYPES = ["hospital_radiology", "private_ct", "dental", "outpatient_clinic"] as const;
+export type ProfileType = (typeof PROFILE_TYPES)[number];
+
+export const PROFILE_LABELS: Record<ProfileType, string> = {
+  hospital_radiology: "Госпітальна променева діагностика",
+  private_ct: "Приватний КТ-центр",
+  dental: "Стоматологічна діагностика",
+  outpatient_clinic: "Амбулаторна клініка",
+};
+
+// Канонічні можливості, якими керує профіль/прапорці.
+export const FEATURE_FLAGS = [
+  "dicom_pacs",
+  "protocols",
+  "nszu",
+  "contrast",
+  "packages",
+  "patient_cabinet",
+  "reminders",
+] as const;
+export type FeatureFlag = (typeof FEATURE_FLAGS)[number];
+
+export const FEATURE_LABELS: Record<FeatureFlag, string> = {
+  dicom_pacs: "DICOM / PACS",
+  protocols: "Протоколи",
+  nszu: "НСЗУ",
+  contrast: "Контрастування",
+  packages: "Пакетні послуги",
+  patient_cabinet: "Кабінет пацієнта",
+  reminders: "Автонагадування",
+};
+
+// Значення за замовчуванням для кожного профілю (deny-by-default: усе, що не
+// перелічено як true, вважається вимкненим).
+const PROFILE_DEFAULTS: Record<ProfileType, Partial<Record<FeatureFlag, boolean>>> = {
+  hospital_radiology: { dicom_pacs: true, protocols: true, nszu: true, patient_cabinet: true, reminders: true },
+  private_ct: { dicom_pacs: true, protocols: true, contrast: true, packages: true, patient_cabinet: true, reminders: true },
+  dental: { protocols: true, packages: true, patient_cabinet: true, reminders: true },
+  outpatient_clinic: { protocols: true, patient_cabinet: true, reminders: true },
+};
+
+export function isProfileType(value: string): value is ProfileType {
+  return (PROFILE_TYPES as readonly string[]).includes(value);
+}
+
+export function isFeatureFlag(value: string): value is FeatureFlag {
+  return (FEATURE_FLAGS as readonly string[]).includes(value);
+}
+
+export interface OrgProfile {
+  profileType: ProfileType;
+  profileLabel: string;
+  flags: Record<FeatureFlag, boolean>;
+  overrides: Partial<Record<FeatureFlag, boolean>>;
+  settings: Record<string, unknown>;
+}
+
+function safeParse(json: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(json || "{}");
+    return value && typeof value === "object" ? value as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+// Обчислює ефективні прапорці: дефолти профілю, перекриті збереженими
+// override-ами організації.
+export function resolveFlags(profileType: ProfileType, overrides: Partial<Record<FeatureFlag, boolean>>): Record<FeatureFlag, boolean> {
+  const defaults = PROFILE_DEFAULTS[profileType] || {};
+  const flags = {} as Record<FeatureFlag, boolean>;
+  for (const flag of FEATURE_FLAGS) {
+    flags[flag] = flag in overrides ? Boolean(overrides[flag]) : Boolean(defaults[flag]);
+  }
+  return flags;
+}
+
+// Читає профіль організації контексту (tenant-scoped). Якщо запис відсутній —
+// повертає безпечний госпітальний профіль за замовчуванням.
+export async function getOrgProfile(db: D1Database, ctx: OrgContext): Promise<OrgProfile> {
+  const row = await db.prepare(
+    "SELECT profile_type AS profileType, feature_flags_json AS flagsJson, settings_json AS settingsJson FROM organization_profiles WHERE organization_id = ?"
+  ).bind(ctx.organizationId).first<{ profileType: string; flagsJson: string; settingsJson: string }>();
+
+  const profileType: ProfileType = row && isProfileType(row.profileType) ? row.profileType : "hospital_radiology";
+  const rawOverrides = row ? safeParse(row.flagsJson) : {};
+  const overrides: Partial<Record<FeatureFlag, boolean>> = {};
+  for (const [key, value] of Object.entries(rawOverrides)) {
+    if (isFeatureFlag(key)) overrides[key] = Boolean(value);
+  }
+
+  return {
+    profileType,
+    profileLabel: PROFILE_LABELS[profileType],
+    flags: resolveFlags(profileType, overrides),
+    overrides,
+    settings: row ? safeParse(row.settingsJson) : {},
+  };
+}

--- a/tests/org-profile.test.mjs
+++ b/tests/org-profile.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  FEATURE_FLAGS, PROFILE_TYPES, isFeatureFlag, isProfileType, resolveFlags,
+} from "../lib/org-profile.ts";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+// Профілі та прапорці — відомий канон, deny-by-default.
+test("profiles and feature flags form a known catalog", () => {
+  assert.deepEqual([...PROFILE_TYPES], ["hospital_radiology", "private_ct", "dental", "outpatient_clinic"]);
+  assert.ok(FEATURE_FLAGS.includes("dicom_pacs"));
+  assert.ok(isProfileType("private_ct") && !isProfileType("banana"));
+  assert.ok(isFeatureFlag("nszu") && !isFeatureFlag("nope"));
+});
+
+// Дефолти профілю: госпіталь має DICOM/НСЗУ, приватний КТ — контраст/пакети.
+test("profile defaults differ and every flag resolves to a boolean", () => {
+  const hospital = resolveFlags("hospital_radiology", {});
+  assert.equal(hospital.dicom_pacs, true);
+  assert.equal(hospital.nszu, true);
+  assert.equal(hospital.contrast, false);
+
+  const ct = resolveFlags("private_ct", {});
+  assert.equal(ct.contrast, true);
+  assert.equal(ct.packages, true);
+  assert.equal(ct.nszu, false);
+
+  // Кожен канонічний прапорець присутній і булевий.
+  for (const flag of FEATURE_FLAGS) {
+    assert.equal(typeof hospital[flag], "boolean", `${flag} resolved`);
+  }
+});
+
+// Override перекриває дефолт профілю в обидва боки.
+test("overrides win over profile defaults", () => {
+  assert.equal(resolveFlags("hospital_radiology", { dicom_pacs: false }).dicom_pacs, false);
+  assert.equal(resolveFlags("outpatient_clinic", { dicom_pacs: true }).dicom_pacs, true);
+  // Невідомі ключі overrides не впливають на канон (фільтруються при читанні).
+  assert.equal(resolveFlags("dental", {}).protocols, true);
+});
+
+// API профілю tenant-scoped; зміна — лише адмін; збереження — лише override-и.
+test("org-profile API is tenant-scoped and admin-gated", async () => {
+  const route = await read("app/api/staff/org-profile/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.role !== "admin"/);
+  assert.match(route, /getOrgProfile\(db, ctx\)/);
+  assert.match(route, /organization_profiles/);
+  assert.match(route, /ON CONFLICT\(organization_id\)/);
+});
+
+// Feature flag реально керує UI: колонка «Знімки» залежить від dicom_pacs.
+test("feature flags drive UI (studies PACS column gated by dicom_pacs)", async () => {
+  const studiesRoute = await read("app/api/staff/studies/route.ts");
+  assert.match(studiesRoute, /getOrgProfile\(db, ctx\)/);
+  assert.match(studiesRoute, /dicomPacs: profile\.flags\.dicom_pacs/);
+  const page = await read("app/staff/studies/page.tsx");
+  assert.match(page, /data\.features\?\.dicomPacs/);
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/organization"/);
+});


### PR DESCRIPTION
Ядро SaaS-конструктора: **один код — різні профілі**. Читає `organization_profiles` (закладено у PR 1) і керує можливостями за профілем/прапорцями. Суто **додатково** — поточна організація (`hospital_radiology`) зберігає всю наявну поведінку.

## Що зроблено

**`lib/org-profile.ts`** — єдине джерело правди «що ввімкнено»:
- канон профілів: `hospital_radiology`, `private_ct`, `dental`, `outpatient_clinic`;
- канон feature flags: `dicom_pacs`, `protocols`, `nszu`, `contrast`, `packages`, `patient_cabinet`, `reminders`;
- матриця дефолтів на профіль (**deny-by-default**) + резолвер, де override-и організації перекривають дефолти;
- `getOrgProfile` — **tenant-scoped** читання за `organizationId` зі сесії.

**`app/api/staff/org-profile`** (GET усім, **PATCH лише admin**):
- ефективні прапорці + каталог; зміна профілю/прапорців зберігає лише явні override-и у `feature_flags_json` (upsert по `organization_id`).

**`app/staff/organization`** (admin): вибір профілю та перемикачі можливостей із позначкою `override`. Shell: секція `organization`, підпункт «Організація та профіль».

**Реальне застосування прапорця**: колонка «Знімки» в реєстрі досліджень показується **лише коли `dicom_pacs` увімкнено** (studies API віддає `profile` + `features`; сторінка ховає колонку інакше). Для госпіталю прапорець увімкнено за замовчуванням → регресу немає.

## Перевірки

- `lint` — 0.
- `tsc --noEmit` — 0.
- `build` ✓
- Тести: **106/106** зелені (+5 у `tests/org-profile.test.mjs`): канон профілів/прапорців, різні дефолти (госпіталь ≠ приватний КТ), override перекриває дефолт в обидва боки, API tenant-scoped + admin-gated, прапорець реально керує UI.

## Поза межами цього PR

Гейтинг решти модулів (protocols/nszu/contrast/packages) за прапорцями, окремі UI приватного КТ/стоматології — наступні кроки. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_