### PR TITLE
fix(deploy): correct D1 recovery bookmark command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build
 
       - name: Record D1 recovery bookmark
-        run: npx wrangler d1 time-travel info radiologyos --remote --config wrangler.cloudflare.toml
+        run: npx wrangler d1 time-travel info radiologyos --config wrangler.cloudflare.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Что исправлено
- удалён неподдерживаемый флаг `--remote` у `wrangler d1 time-travel info`
- команда и без него работает только с удалённой D1 базой

## Причина
Production run #13 остановился до миграций и деплоя с `Unknown argument: remote`.

## Безопасность
Остальные production-проверки, включая наличие защищённого активного администратора, сохранены без изменений.