### PR TITLE
PR 7: Гейтинг робочого простору за feature flags

### DIFF
--- a/app/api/staff/imaging/route.ts
+++ b/app/api/staff/imaging/route.ts
@@ -6,9 +6,20 @@ import {
   sanitizeImagingStudy,
 } from "../../../../lib/dicom";
 import { fetchLimited, readLimitedText, safeOutboundUrl } from "../../../../lib/outbound";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { getOrgProfile } from "../../../../lib/org-profile";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+// Модуль DICOM/PACS доступний лише коли профіль організації вмикає його
+// (feature flag dicom_pacs). organizationId — лише зі серверної сесії.
+async function pacsModuleEnabled(request: Request, db: D1Database): Promise<boolean> {
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return true; // немає членства — не гейтимо (сумісність)
+  const profile = await getOrgProfile(db, ctx);
+  return profile.flags.dicom_pacs;
 }
 
 type PacsRow = {
@@ -61,6 +72,9 @@ export async function GET(request: Request) {
   if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   if (!canManageImaging(member.role)) {
     return Response.json({ error: "Доступ до знімків має лише залучений медичний персонал" }, { status: 403 });
+  }
+  if (!await pacsModuleEnabled(request, db)) {
+    return Response.json({ error: "Модуль DICOM / PACS вимкнено для цієї організації" }, { status: 403 });
   }
 
   const pacs = await loadPacs(db);
@@ -135,6 +149,9 @@ export async function PUT(request: Request) {
   if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   if (!canManageImaging(member.role)) {
     return Response.json({ error: "Прив’язувати дослідження може лаборант, лікар або адміністратор" }, { status: 403 });
+  }
+  if (!await pacsModuleEnabled(request, db)) {
+    return Response.json({ error: "Модуль DICOM / PACS вимкнено для цієї організації" }, { status: 403 });
   }
 
   const body = await request.json() as Record<string, unknown>;

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -18,7 +18,9 @@ type StaffWorkspaceShellProps = {
 // Бічна панель = модулі цільової структури (у порядку «Карти системи»).
 // Кожен модуль веде на робочу сторінку й розгортається у підпункти-екрани;
 // кожен підпункт — на свою сторінку (нереалізовані ведуть у блок карти).
-type NavChild = { label:string; href:string };
+// Підпункт може залежати від feature flag профілю організації: якщо
+// відповідну можливість вимкнено, пункт ховається (конструктор).
+type NavChild = { label:string; href:string; flag?:string };
 type NavModule = { n:string; label:string; href:string; section?:WorkspaceSection; items:NavChild[] };
 const systemModules: NavModule[] = [
   { n:"1", label:"Головна / Продаж послуг", href:"/", items:[
@@ -33,11 +35,11 @@ const systemModules: NavModule[] = [
   { n:"2", label:"Запис і заявки", href:"/staff", section:"overview", items:[
     { label:"Форма заявки", href:"/site/price.html" },
     { label:"Вибір часу", href:"/staff/dashboard" },
-    { label:"Кабінет пацієнта", href:"/site/cabinet.html" },
+    { label:"Кабінет пацієнта", href:"/site/cabinet.html", flag:"patient_cabinet" },
     { label:"Черга реєстратури", href:"/staff#bookings" },
     { label:"Реєстр досліджень", href:"/staff/studies" },
     { label:"Розклад дня", href:"/staff/dashboard" },
-    { label:"Нагадування", href:"/staff/settings" },
+    { label:"Нагадування", href:"/staff/settings", flag:"reminders" },
     { label:"Повторний запис", href:"/staff/system-map#mod-2" },
   ]},
   { n:"3", label:"CRM (пацієнти/клієнти)", href:"/staff/patients", section:"patients", items:[
@@ -72,7 +74,7 @@ const systemModules: NavModule[] = [
   { n:"6", label:"Обладнання", href:"/staff/imaging", section:"imaging", items:[
     { label:"Реєстр апаратів", href:"/staff#equipment" },
     { label:"Завантаженість", href:"/staff/dashboard" },
-    { label:"Знімки / PACS", href:"/staff/imaging" },
+    { label:"Знімки / PACS", href:"/staff/imaging", flag:"dicom_pacs" },
     { label:"Обслуговування (ТО)", href:"/staff/system-map#mod-6" },
     { label:"Простої / поломки", href:"/staff#equipment" },
     { label:"Витратні матеріали", href:"/staff/system-map#mod-6" },
@@ -115,10 +117,29 @@ export default function StaffWorkspaceShell({
   const [now,setNow] = useState<Date | null>(null);
   const [dark,setDark] = useState(false);
   const [openModules,setOpenModules] = useState<Record<string,boolean>>({});
+  // Ефективні feature flags організації; null — ще не завантажено (показуємо все).
+  const [flags,setFlags] = useState<Record<string,boolean> | null>(null);
 
   function toggleModule(n:string) {
     setOpenModules((current)=>({ ...current, [n]:!current[n] }));
   }
+
+  // Пункт видимий, доки прапорці не завантажені; після — лише якщо його
+  // можливість увімкнена (пункти без flag завжди видимі).
+  function childVisible(child:NavChild) {
+    if (!child.flag) return true;
+    if (!flags) return true;
+    return flags[child.flag] !== false;
+  }
+
+  useEffect(()=>{
+    let active = true;
+    fetch("/api/staff/org-profile", { cache:"no-store" })
+      .then((r)=>r.ok ? r.json() : null)
+      .then((d)=>{ if (active && d?.flags) setFlags(d.flags as Record<string,boolean>); })
+      .catch(()=>{});
+    return ()=>{ active = false; };
+  },[]);
 
   useEffect(()=>{
     const timer = window.setInterval(()=>setNow(new Date()),1000);
@@ -184,7 +205,7 @@ export default function StaffWorkspaceShell({
               >▾</button>
             </div>
             {isOpen && <div className="workspaceSubList">
-              {item.items.map((sub,i)=><Link key={i} href={sub.href} className="workspaceSubLink">{sub.label}</Link>)}
+              {item.items.filter(childVisible).map((sub,i)=><Link key={i} href={sub.href} className="workspaceSubLink">{sub.label}</Link>)}
             </div>}
           </div>;
         })}

--- a/tests/feature-gating.test.mjs
+++ b/tests/feature-gating.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+// Модуль DICOM/PACS гейтиться сервером за feature flag профілю організації.
+test("imaging API is gated by the dicom_pacs feature flag", async () => {
+  const route = await read("app/api/staff/imaging/route.ts");
+  assert.match(route, /pacsModuleEnabled/);
+  assert.match(route, /getOrgProfile\(db, ctx\)/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /profile\.flags\.dicom_pacs/);
+  assert.match(route, /Модуль DICOM \/ PACS вимкнено/);
+  // Гейт застосовано і на читання (GET), і на прив'язку (PUT).
+  const guards = route.match(/pacsModuleEnabled\(request, db\)/g) || [];
+  assert.ok(guards.length >= 2, "both GET and PUT are gated");
+});
+
+// Бічна панель ховає підпункти вимкнених можливостей (конструктор).
+test("workspace sidebar hides sublinks for disabled features", async () => {
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /function childVisible\(/);
+  assert.match(shell, /flag:"dicom_pacs"/);
+  assert.match(shell, /flag:"patient_cabinet"/);
+  assert.match(shell, /flag:"reminders"/);
+  assert.match(shell, /\.filter\(childVisible\)/);
+  // Прапорці тягнуться з профілю організації.
+  assert.match(shell, /\/api\/staff\/org-profile/);
+  // До завантаження прапорців нічого не ховаємо (без блимання).
+  assert.match(shell, /if \(!flags\) return true/);
+});


### PR DESCRIPTION
Робить конструктор відчутним: профіль/прапорці організації тепер керують **доступом до модулів** і **навігацією**. Госпіталь має `dicom_pacs` / `patient_cabinet` / `reminders` увімкненими за замовчуванням — **регресу немає**.

## Що зроблено

**`app/api/staff/imaging/route.ts`** — серверний гейт:
- модуль DICOM/PACS доступний лише коли профіль вмикає `dicom_pacs` (`requireOrgContext → getOrgProfile`);
- **обидва** обробники (`GET` читання й `PUT` прив'язка) повертають `403`, якщо можливість вимкнена; без членства — не гейтимо (сумісність).

**`app/staff/workspace-shell.tsx`** — навігація за прапорцями:
- бічна панель тягне ефективні прапорці з `/api/staff/org-profile` і **ховає підпункти** вимкнених можливостей: «Знімки / PACS»→`dicom_pacs`, «Кабінет пацієнта»→`patient_cabinet`, «Нагадування»→`reminders`;
- до завантаження прапорців нічого не ховаємо (без блимання).

## Перевірки

- `lint` — 0.
- `tsc --noEmit` — 0.
- `build` ✓
- Тести: **108/108** зелені (+2 у `tests/feature-gating.test.mjs`): imaging гейтиться на `GET` і `PUT`, сайдбар ховає підпункти за прапорцями й тягне їх із профілю.

## Ефект

Разом із PR 6 профіль організації тепер по-справжньому реконфігурує робочий простір: вимкнув `dicom_pacs` у `/staff/organization` → зник модуль PACS і в навігації, і на сервері. Це база для профілів Private CT / Dental / Clinic. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_