### PR TITLE
PR 8: Провайдер-адаптери інтеграцій (messaging адаптовано, tenant-резолвер)

### DIFF
--- a/app/api/staff/providers/route.ts
+++ b/app/api/staff/providers/route.ts
@@ -1,0 +1,29 @@
+import { requireOrgContext } from "../../../../lib/tenant";
+import { resolveProviders } from "../../../../lib/providers";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+// Стан провайдер-адаптерів організації (діагностика). organizationId — лише зі
+// серверної сесії; перегляд для адміністратора.
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") {
+    return Response.json({ error: "Стан інтеграцій доступний лише адміністратору" }, { status: 403 });
+  }
+
+  const providers = await resolveProviders(db, ctx);
+  return Response.json({
+    organization: { id: ctx.organizationId, name: ctx.organizationName },
+    providers: {
+      messaging: { name: providers.messaging.name, ...providers.messaging.capabilities },
+      payment: { name: providers.payment.name, configured: providers.payment.configured },
+      pacs: { name: providers.pacs.name, ...providers.pacs.describe() },
+      calendar: { name: providers.calendar.name, configured: providers.calendar.configured },
+    },
+  });
+}

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -7,7 +7,7 @@
 // підтвердження / перенесення не має падати через недоступний шлюз.
 
 import { getSettings } from "./settings";
-import { fetchLimited, readLimitedText, safeOutboundUrl } from "./outbound";
+import { createMessagingProvider } from "./providers/messaging";
 
 export type ReminderKind = "confirmed" | "rescheduled";
 
@@ -64,22 +64,6 @@ async function record(
   }
 }
 
-async function postJson(url: string, auth: string, payload: Record<string, string>): Promise<void> {
-  const outbound = safeOutboundUrl(url);
-  if (!outbound) throw new Error("Адреса шлюзу заборонена політикою зовнішніх підключень");
-  const headers: Record<string, string> = { "content-type": "application/json" };
-  if (auth) headers.authorization = auth;
-  const response = await fetchLimited(outbound, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  }, 5000);
-  if (!response.ok) {
-    const detail = await readLimitedText(response).catch(() => "");
-    throw new Error(`Шлюз відповів ${response.status}${detail ? `: ${detail.slice(0, 120)}` : ""}`);
-  }
-}
-
 // Ставить нагадування в чергу і намагається відправити наявними каналами.
 // Повертає зведення для UI; помилки каналів не пробрасуються.
 export async function sendPatientReminder(
@@ -97,6 +81,12 @@ export async function sendPatientReminder(
   ]);
   const enabled = truthy(cfg.patient_reminders_enabled || "");
 
+  // Доставлення абстраговане месенджинг-провайдером (див. lib/providers).
+  const messaging = createMessagingProvider({
+    sms: { url: cfg.sms_gateway_url || "", auth: cfg.sms_gateway_auth || "" },
+    email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
+  });
+
   // Повага до позначки «не турбувати» у картці пацієнта.
   if (booking.phoneNormalized) {
     const profile = await db.prepare(
@@ -113,18 +103,17 @@ export async function sendPatientReminder(
   if (booking.phone) {
     channels.push({
       channel: "sms", recipient: booking.phone, url: cfg.sms_gateway_url || "",
-      send: () => postJson(cfg.sms_gateway_url, cfg.sms_gateway_auth || "", { to: booking.phone, text: body }),
+      send: () => messaging.sendSms(booking.phone, body),
     });
   }
   if (booking.patientEmail) {
     channels.push({
       channel: "email", recipient: booking.patientEmail, url: cfg.email_gateway_url || "",
-      send: () => postJson(cfg.email_gateway_url, cfg.email_gateway_auth || "", {
-        to: booking.patientEmail,
-        from: cfg.email_gateway_from || "",
-        subject: kind === "confirmed" ? "Запис підтверджено" : "Запис перенесено",
-        text: body,
-      }),
+      send: () => messaging.sendEmail(
+        booking.patientEmail,
+        kind === "confirmed" ? "Запис підтверджено" : "Запис перенесено",
+        body,
+      ),
     });
   }
 

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,0 +1,58 @@
+// Резолвер провайдерів — добирає реалізації інтеграцій у tenant-контексті.
+//
+// Наразі конфігурація інтеграцій зберігається глобально (app_settings /
+// pacs_settings), але резолвер — це єдиний шов, куди згодом зайде per-org
+// конфігурація. Профіль організації (feature flags) вже впливає на доступність
+// (напр. PACS вимкнено прапорцем dicom_pacs → provider.enabled = false).
+
+import { getSettings } from "../settings";
+import { getOrgProfile } from "../org-profile";
+import type { OrgContext } from "../tenant";
+import { createMessagingProvider } from "./messaging";
+import type {
+  CalendarProvider, PacsProvider, PaymentProvider, ResolvedProviders,
+} from "./types";
+
+const nullPayment: PaymentProvider = {
+  name: "none",
+  configured: false,
+  async createCharge() { throw new Error("Платіжний провайдер не налаштовано"); },
+};
+
+export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise<ResolvedProviders> {
+  const [cfg, profile, pacsRow, icsUrl] = await Promise.all([
+    getSettings(db, [
+      "sms_gateway_url", "sms_gateway_auth",
+      "email_gateway_url", "email_gateway_auth", "email_gateway_from",
+    ]),
+    getOrgProfile(db, ctx),
+    db.prepare("SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE id = 1")
+      .first<{ enabled: number; viewer: string; dicomweb: string }>().catch(() => null),
+    getSettings(db, ["external_ics_url"]).then((s) => s.external_ics_url || "").catch(() => ""),
+  ]);
+
+  const messaging = createMessagingProvider({
+    sms: { url: cfg.sms_gateway_url || "", auth: cfg.sms_gateway_auth || "" },
+    email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
+  });
+
+  // PACS доступний лише коли профіль вмикає dicom_pacs і PACS увімкнено в
+  // налаштуваннях — інтеграція під контролем feature flag.
+  const pacsEnabled = Boolean(profile.flags.dicom_pacs) && Boolean(pacsRow?.enabled);
+  const pacs: PacsProvider = {
+    name: pacsEnabled ? "dicomweb" : "none",
+    enabled: pacsEnabled,
+    describe: () => ({
+      enabled: pacsEnabled,
+      viewerConfigured: Boolean(pacsRow?.viewer),
+      dicomwebConfigured: Boolean(pacsRow?.dicomweb),
+    }),
+  };
+
+  const calendar: CalendarProvider = {
+    name: icsUrl ? "ics" : "none",
+    configured: Boolean(icsUrl),
+  };
+
+  return { messaging, payment: nullPayment, pacs, calendar };
+}

--- a/lib/providers/messaging.ts
+++ b/lib/providers/messaging.ts
@@ -1,0 +1,42 @@
+// Месенджинг-провайдер: доставлення SMS / e-mail через налаштовувані HTTP-шлюзи.
+// Уся зовнішня взаємодія проходить через політику зовнішніх підключень
+// (safeOutboundUrl + fetchLimited), як і раніше.
+
+import { fetchLimited, readLimitedText, safeOutboundUrl } from "../outbound";
+import { ProviderNotConfiguredError, type MessagingProvider } from "./types";
+
+export interface MessagingConfig {
+  sms: { url: string; auth: string };
+  email: { url: string; auth: string; from: string };
+}
+
+async function postJson(url: string, auth: string, payload: Record<string, string>): Promise<void> {
+  const outbound = safeOutboundUrl(url);
+  if (!outbound) throw new Error("Адреса шлюзу заборонена політикою зовнішніх підключень");
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (auth) headers.authorization = auth;
+  const response = await fetchLimited(outbound, { method: "POST", headers, body: JSON.stringify(payload) }, 5000);
+  if (!response.ok) {
+    const detail = await readLimitedText(response).catch(() => "");
+    throw new Error(`Шлюз відповів ${response.status}${detail ? `: ${detail.slice(0, 120)}` : ""}`);
+  }
+}
+
+// HTTP-провайдер: шле у налаштовані шлюзи; для ненастроєного каналу кидає
+// ProviderNotConfiguredError (щоб викликач міг позначити «пропущено»).
+export function createMessagingProvider(cfg: MessagingConfig): MessagingProvider {
+  const smsUrl = cfg.sms.url || "";
+  const emailUrl = cfg.email.url || "";
+  return {
+    name: "http-gateway",
+    capabilities: { sms: !!smsUrl, email: !!emailUrl },
+    async sendSms(to: string, text: string): Promise<void> {
+      if (!smsUrl) throw new ProviderNotConfiguredError("SMS");
+      await postJson(smsUrl, cfg.sms.auth || "", { to, text });
+    },
+    async sendEmail(to: string, subject: string, text: string): Promise<void> {
+      if (!emailUrl) throw new ProviderNotConfiguredError("email");
+      await postJson(emailUrl, cfg.email.auth || "", { to, from: cfg.email.from || "", subject, text });
+    },
+  };
+}

--- a/lib/providers/types.ts
+++ b/lib/providers/types.ts
@@ -1,0 +1,45 @@
+// Провайдер-адаптери — єдині інтерфейси зовнішніх інтеграцій.
+//
+// Мета: абстрагувати месенджинг, платежі, PACS і календар так, щоб під різні
+// профілі/організації можна було підмінювати реалізації, не змінюючи бізнес-код.
+// Реалізації добираються резолвером (lib/providers/index.ts) у tenant-контексті.
+
+export interface MessagingProvider {
+  readonly name: string;
+  readonly capabilities: { sms: boolean; email: boolean };
+  sendSms(to: string, text: string): Promise<void>;
+  sendEmail(to: string, subject: string, text: string): Promise<void>;
+}
+
+export interface PaymentProvider {
+  readonly name: string;
+  readonly configured: boolean;
+  // Контракт для майбутніх реалізацій (LiqPay/Приват24 тощо).
+  createCharge(input: { amount: number; currency: string; reference: string }): Promise<{ id: string; url?: string }>;
+}
+
+export interface PacsProvider {
+  readonly name: string;
+  readonly enabled: boolean;
+  describe(): { enabled: boolean; viewerConfigured: boolean; dicomwebConfigured: boolean };
+}
+
+export interface CalendarProvider {
+  readonly name: string;
+  readonly configured: boolean;
+}
+
+export interface ResolvedProviders {
+  messaging: MessagingProvider;
+  payment: PaymentProvider;
+  pacs: PacsProvider;
+  calendar: CalendarProvider;
+}
+
+// Помилка «канал не налаштовано» — відрізняється від помилки доставлення.
+export class ProviderNotConfiguredError extends Error {
+  constructor(channel: string) {
+    super(`Канал ${channel} не налаштовано`);
+    this.name = "ProviderNotConfiguredError";
+  }
+}

--- a/tests/providers.test.mjs
+++ b/tests/providers.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+// Контракти провайдерів визначені як єдині інтерфейси інтеграцій.
+test("provider contracts define the four integration interfaces", async () => {
+  const types = await read("lib/providers/types.ts");
+  for (const iface of ["MessagingProvider", "PaymentProvider", "PacsProvider", "CalendarProvider"]) {
+    assert.match(types, new RegExp(`interface ${iface}`), `${iface} defined`);
+  }
+  assert.match(types, /class ProviderNotConfiguredError/);
+});
+
+// Месенджинг-адаптер шле через політику зовнішніх підключень; ненастроєний
+// канал кидає типізовану помилку «не налаштовано».
+test("messaging provider goes through outbound policy and flags unconfigured channels", async () => {
+  const msg = await read("lib/providers/messaging.ts");
+  assert.match(msg, /export function createMessagingProvider/);
+  assert.match(msg, /safeOutboundUrl/);
+  assert.match(msg, /fetchLimited/);
+  assert.match(msg, /capabilities: \{ sms: !!smsUrl, email: !!emailUrl \}/);
+  assert.match(msg, /ProviderNotConfiguredError\("SMS"\)/);
+  assert.match(msg, /ProviderNotConfiguredError\("email"\)/);
+});
+
+// Резолвер — tenant-контекст; PACS під контролем feature flag профілю.
+test("resolver is tenant-aware and PACS honors the dicom_pacs flag", async () => {
+  const idx = await read("lib/providers/index.ts");
+  assert.match(idx, /export async function resolveProviders\(db: D1Database, ctx: OrgContext\)/);
+  assert.match(idx, /getOrgProfile\(db, ctx\)/);
+  assert.match(idx, /profile\.flags\.dicom_pacs.*pacsRow\?\.enabled|Boolean\(profile\.flags\.dicom_pacs\)/);
+  assert.match(idx, /createMessagingProvider/);
+});
+
+// Рушій нагадувань тепер доставляє через месенджинг-провайдер (адаптовано).
+test("reminder engine delegates delivery to the messaging provider", async () => {
+  const notify = await read("lib/notify.ts");
+  assert.match(notify, /createMessagingProvider/);
+  assert.match(notify, /messaging\.sendSms\(/);
+  assert.match(notify, /messaging\.sendEmail\(/);
+  // Інлайновий postJson прибрано — доставлення живе у провайдері.
+  assert.doesNotMatch(notify, /async function postJson/);
+  // Незламна семантика збережена: канали, «не турбувати», best-effort.
+  assert.match(notify, /do_not_contact/);
+  assert.match(notify, /catch/);
+});
+
+// Діагностичний ендпойнт стану інтеграцій — tenant-scoped, лише адмін.
+test("providers status endpoint is tenant-scoped and admin-only", async () => {
+  const route = await read("app/api/staff/providers/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.role !== "admin"/);
+  assert.match(route, /resolveProviders\(db, ctx\)/);
+});

--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -66,15 +66,17 @@ test("protocols use optimistic concurrency and immutable revision history", asyn
 
 test("server-side integrations block SSRF and oversized responses", async () => {
   const outbound = await read("lib/outbound.ts");
-  const notifications = await read("lib/notify.ts");
+  // Доставлення нагадувань перенесено у месенджинг-провайдер; захист від SSRF
+  // лишається на кожному зовнішньому виклику (safeOutboundUrl + fetchLimited).
+  const messaging = await read("lib/providers/messaging.ts");
   const telegram = await read("lib/telegram.ts");
   assert.match(outbound, /privateHostname/);
   assert.match(outbound, /url\.protocol !== "https:"/);
   assert.match(outbound, /redirect: "error"/);
   assert.match(outbound, /MAX_RESPONSE_BYTES/);
   assert.match(outbound, /AbortController/);
-  assert.match(notifications, /safeOutboundUrl\(url\)/);
-  assert.match(notifications, /fetchLimited\(/);
+  assert.match(messaging, /safeOutboundUrl\(url\)/);
+  assert.match(messaging, /fetchLimited\(/);
   assert.doesNotMatch(telegram, /notice\.category|notice\.services/);
 });
 


### PR DESCRIPTION
Абстрагує зовнішні інтеграції під **єдині контракти**, щоб під різні профілі/організації можна було підмінювати реалізації, не чіпаючи бізнес-код. Суто додатково; поведінка нагадувань не змінюється.

## Що зроблено

**`lib/providers/types.ts`** — контракти `MessagingProvider` / `PaymentProvider` / `PacsProvider` / `CalendarProvider` + `ProviderNotConfiguredError`.

**`lib/providers/messaging.ts`** — HTTP-месенджинг-провайдер (SMS/email через налаштовувані шлюзи); уся зовнішня взаємодія — через політику підключень (`safeOutboundUrl` + `fetchLimited`); ненастроєний канал кидає типізовану помилку.

**`lib/providers/index.ts`** — `resolveProviders(db, ctx)` у **tenant-контексті**; PACS-провайдер під контролем feature flag профілю (`dicom_pacs`) і налаштувань. Це єдиний шов для майбутньої per-org конфігурації.

**`lib/notify.ts`** — рушій нагадувань доставляє **через месенджинг-провайдер** (`postJson` винесено у провайдер); незламна семантика (канали, «не турбувати», best-effort) збережена.

**`app/api/staff/providers`** — діагностика стану інтеграцій (tenant-scoped, admin-only).

## Перевірки

- `lint` — 0; `tsc --noEmit` — 0; `build` ✓
- Тести: **113/113** зелені (+ `tests/providers.test.mjs`): контракти, месенджинг через outbound-політику, tenant-резолвер із PACS-гейтом, адаптація notify, admin-ендпойнт.
- Захист від SSRF тепер перевіряється у messaging-провайдері (`tests/security-hardening.test.mjs` оновлено — захист **перенесено разом із викликом**, не прибрано).

## Поза межами цього PR

Реальні реалізації Payment (LiqPay/Приват24) і Calendar (двобічна синхронізація), per-org зберігання ключів інтеграцій — наступні кроки. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_