### PR TITLE
PR 10: Tenant hardening — org-скоуп для протоколів і знімків

### DIFF
--- a/app/api/staff/imaging/route.ts
+++ b/app/api/staff/imaging/route.ts
@@ -1,5 +1,5 @@
 import { serviceByCode } from "../../../../lib/catalog";
-import { canAccessBooking, canManageImaging, requireStaff } from "../../../../lib/staff-auth";
+import { canAccessBooking, canManageImaging } from "../../../../lib/staff-auth";
 import {
   parseQidoSeries,
   qidoSeriesUrl,
@@ -11,15 +11,6 @@ import { getOrgProfile } from "../../../../lib/org-profile";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
-}
-
-// Модуль DICOM/PACS доступний лише коли профіль організації вмикає його
-// (feature flag dicom_pacs). organizationId — лише зі серверної сесії.
-async function pacsModuleEnabled(request: Request, db: D1Database): Promise<boolean> {
-  const ctx = await requireOrgContext(request, db);
-  if (!ctx) return true; // немає членства — не гейтимо (сумісність)
-  const profile = await getOrgProfile(db, ctx);
-  return profile.flags.dicom_pacs;
 }
 
 type PacsRow = {
@@ -68,12 +59,13 @@ async function querySeries(pacs:PacsRow, studyInstanceUid:string) {
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
   if (!canManageImaging(member.role)) {
     return Response.json({ error: "Доступ до знімків має лише залучений медичний персонал" }, { status: 403 });
   }
-  if (!await pacsModuleEnabled(request, db)) {
+  if (!(await getOrgProfile(db, ctx)).flags.dicom_pacs) {
     return Response.json({ error: "Модуль DICOM / PACS вимкнено для цієї організації" }, { status: 403 });
   }
 
@@ -81,7 +73,7 @@ export async function GET(request: Request) {
   const bookingId = Number(new URL(request.url).searchParams.get("bookingId"));
 
   if (Number.isInteger(bookingId) && bookingId > 0) {
-    if (!await canAccessBooking(db, member, bookingId)) {
+    if (!await canAccessBooking(db, member, bookingId, ctx.organizationId)) {
       return Response.json({ error: "Немає доступу до цього дослідження" }, { status: 403 });
     }
     const [booking, study] = await Promise.all([
@@ -127,14 +119,15 @@ export async function GET(request: Request) {
        COALESCE(i.series_count, 0) AS seriesCount
      FROM bookings b
      LEFT JOIN imaging_studies i ON i.booking_id = b.id
-     WHERE b.status != 'cancelled' AND (b.performed_at != '' OR i.booking_id IS NOT NULL)
+     WHERE b.organization_id = ? AND b.status != 'cancelled' AND (b.performed_at != '' OR i.booking_id IS NOT NULL)
      ${assignmentClause}
      ORDER BY (b.performed_at != '') DESC, b.desired_date DESC, b.desired_time DESC
      LIMIT 300`
   );
-  const worklist = assignmentClause
-    ? await worklistStatement.bind(member.email).all()
-    : await worklistStatement.all();
+  const worklistBinds: Array<string | number> = assignmentClause
+    ? [ctx.organizationId, member.email]
+    : [ctx.organizationId];
+  const worklist = await worklistStatement.bind(...worklistBinds).all();
   const items = (worklist.results as Array<Record<string, unknown>>).map((item) => ({
     ...item,
     serviceTitle: serviceByCode(String(item.serviceCode))?.title || String(item.service),
@@ -145,38 +138,41 @@ export async function GET(request: Request) {
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
   if (!canManageImaging(member.role)) {
     return Response.json({ error: "Прив’язувати дослідження може лаборант, лікар або адміністратор" }, { status: 403 });
   }
-  if (!await pacsModuleEnabled(request, db)) {
+  if (!(await getOrgProfile(db, ctx)).flags.dicom_pacs) {
     return Response.json({ error: "Модуль DICOM / PACS вимкнено для цієї організації" }, { status: 403 });
   }
 
   const body = await request.json() as Record<string, unknown>;
   const bookingId = Number(body.bookingId);
   if (!Number.isInteger(bookingId) || bookingId <= 0) return Response.json({ error: "Некоректні дані" }, { status: 400 });
-  if (!await canAccessBooking(db, member, bookingId)) {
+  if (!await canAccessBooking(db, member, bookingId, ctx.organizationId)) {
     return Response.json({ error: "Немає доступу до цього дослідження" }, { status: 403 });
   }
   const parsed = sanitizeImagingStudy(body);
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
   const { study } = parsed;
 
-  const booking = await db.prepare("SELECT id FROM bookings WHERE id = ? LIMIT 1").bind(bookingId).first();
+  const booking = await db.prepare("SELECT id FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1")
+    .bind(bookingId, ctx.organizationId).first();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
 
+  // Нова студія успадковує організацію заявки (tenant tag на запис).
   await db.prepare(
     `INSERT INTO imaging_studies
-       (booking_id, accession_number, study_instance_uid, modality, study_status, study_datetime, source, updated_by, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, 'manual', ?, CURRENT_TIMESTAMP)
+       (organization_id, booking_id, accession_number, study_instance_uid, modality, study_status, study_datetime, source, updated_by, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'manual', ?, CURRENT_TIMESTAMP)
      ON CONFLICT(booking_id) DO UPDATE SET
        accession_number = excluded.accession_number, study_instance_uid = excluded.study_instance_uid,
        modality = excluded.modality, study_status = excluded.study_status,
        study_datetime = excluded.study_datetime, updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
   ).bind(
-    bookingId, study.accessionNumber, study.studyInstanceUid, study.modality,
+    ctx.organizationId, bookingId, study.accessionNumber, study.studyInstanceUid, study.modality,
     study.studyStatus, study.studyDatetime, member.email,
   ).run();
 

--- a/app/api/staff/protocols/route.ts
+++ b/app/api/staff/protocols/route.ts
@@ -1,6 +1,7 @@
 import { serviceByCode } from "../../../../lib/catalog";
 import { logSecurityEvent } from "../../../../lib/audit";
-import { canAccessBooking, canManageProtocols, requireStaff } from "../../../../lib/staff-auth";
+import { canAccessBooking, canManageProtocols } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import {
   ProtocolSectionValues,
   bookingProtocolStatus,
@@ -37,15 +38,16 @@ function parseSections(raw: string): ProtocolSectionValues {
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
   if (!canManageProtocols(member.role)) {
     return Response.json({ error: "Протоколи доступні лише лікарю або адміністратору" }, { status: 403 });
   }
 
   const bookingId = Number(new URL(request.url).searchParams.get("bookingId"));
   if (Number.isInteger(bookingId) && bookingId > 0) {
-    if (!(await canAccessBooking(db, member, bookingId))) {
+    if (!(await canAccessBooking(db, member, bookingId, ctx.organizationId))) {
       return Response.json({ error: "Заявку не знайдено або її не призначено вам" }, { status: 404 });
     }
     const booking = await db.prepare(
@@ -98,16 +100,15 @@ export async function GET(request: Request) {
     );
   }
 
-  const queueSql = member.role === "admin"
-    ? QUEUE_SQL
-    : QUEUE_SQL.replace(
-        "WHERE b.status != 'cancelled'",
-        "WHERE b.status != 'cancelled' AND b.assigned_radiologist_email = ?",
-      );
-  const queueStatement = db.prepare(queueSql);
-  const queue = member.role === "admin"
-    ? await queueStatement.all()
-    : await queueStatement.bind(member.email).all();
+  // Черга протоколів обмежена організацією (tenant), далі — роллю лікаря.
+  const roleClause = member.role === "admin"
+    ? "WHERE b.organization_id = ? AND b.status != 'cancelled'"
+    : "WHERE b.organization_id = ? AND b.status != 'cancelled' AND b.assigned_radiologist_email = ?";
+  const queueSql = QUEUE_SQL.replace("WHERE b.status != 'cancelled'", roleClause);
+  const queueBinds: Array<string | number> = member.role === "admin"
+    ? [ctx.organizationId]
+    : [ctx.organizationId, member.email];
+  const queue = await db.prepare(queueSql).bind(...queueBinds).all();
   const items = (queue.results as Array<Record<string, unknown>>).map((item) => ({
     ...item,
     serviceTitle: serviceByCode(String(item.serviceCode))?.title || String(item.service),
@@ -118,8 +119,9 @@ export async function GET(request: Request) {
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
   if (!canManageProtocols(member.role)) {
     return Response.json({ error: "Протоколи може змінювати лише лікар або адміністратор" }, { status: 403 });
   }
@@ -133,7 +135,7 @@ export async function PUT(request: Request) {
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
   const { document } = parsed;
 
-  if (!(await canAccessBooking(db, member, bookingId))) {
+  if (!(await canAccessBooking(db, member, bookingId, ctx.organizationId))) {
     return Response.json({ error: "Заявку не знайдено або її не призначено вам" }, { status: 404 });
   }
   const booking = await db.prepare(

--- a/tests/dicom-pacs.test.mjs
+++ b/tests/dicom-pacs.test.mjs
@@ -37,7 +37,7 @@ test("DICOM library validates identifiers and builds DICOMweb URLs", async () =>
 test("imaging API guards writes, keeps PACS calls best-effort, no runtime DDL", async () => {
   const route = await read("app/api/staff/imaging/route.ts");
   const settingsRoute = await read("app/api/staff/imaging/settings/route.ts");
-  assert.match(route, /requireStaff\(request, db\)/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
   assert.match(route, /canManageImaging\(member\.role\)/);
   assert.match(route, /sanitizeImagingStudy\(/);
   assert.match(route, /imaging_linked/);

--- a/tests/feature-gating.test.mjs
+++ b/tests/feature-gating.test.mjs
@@ -7,13 +7,11 @@ const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 // Модуль DICOM/PACS гейтиться сервером за feature flag профілю організації.
 test("imaging API is gated by the dicom_pacs feature flag", async () => {
   const route = await read("app/api/staff/imaging/route.ts");
-  assert.match(route, /pacsModuleEnabled/);
-  assert.match(route, /getOrgProfile\(db, ctx\)/);
   assert.match(route, /requireOrgContext\(request, db\)/);
-  assert.match(route, /profile\.flags\.dicom_pacs/);
+  assert.match(route, /\.flags\.dicom_pacs/);
   assert.match(route, /Модуль DICOM \/ PACS вимкнено/);
   // Гейт застосовано і на читання (GET), і на прив'язку (PUT).
-  const guards = route.match(/pacsModuleEnabled\(request, db\)/g) || [];
+  const guards = route.match(/getOrgProfile\(db, ctx\)\)\.flags\.dicom_pacs/g) || [];
   assert.ok(guards.length >= 2, "both GET and PUT are gated");
 });
 

--- a/tests/protocol-builder.test.mjs
+++ b/tests/protocol-builder.test.mjs
@@ -37,7 +37,7 @@ test("protocol library ships structured templates for every modality", async () 
 
 test("protocol API guards writes and never defines schema at runtime", async () => {
   const route = await read("app/api/staff/protocols/route.ts");
-  assert.match(route, /requireStaff\(request, db\)/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
   assert.match(route, /canManageProtocols\(member\.role\)/);
   assert.match(route, /sanitizeDocument\(body\)/);
   assert.match(route, /INSERT INTO booking_events/);

--- a/tests/tenant-hardening.test.mjs
+++ b/tests/tenant-hardening.test.mjs
@@ -70,3 +70,26 @@ test("canAccessBooking enforces organization when provided", async () => {
   assert.match(src, /organizationId\?: number/);
   assert.match(src, /AND organization_id = \?/);
 });
+
+// Протоколи: доступ і черга org-scoped.
+test("protocols route is tenant-scoped", async () => {
+  const route = await read("app/api/staff/protocols/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /canAccessBooking\(db, member, bookingId, ctx\.organizationId\)/);
+  // Черга протоколів фільтрує організацію.
+  assert.match(route, /b\.organization_id = \?/);
+  assert.doesNotMatch(route, /requireStaff/);
+});
+
+// Знімки: доступ, worklist і запис студії org-scoped.
+test("imaging route is tenant-scoped end-to-end", async () => {
+  const route = await read("app/api/staff/imaging/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /canAccessBooking\(db, member, bookingId, ctx\.organizationId\)/);
+  // worklist і перевірка заявки обмежені організацією.
+  assert.match(route, /b\.organization_id = \?/);
+  assert.match(route, /FROM bookings WHERE id = \? AND organization_id = \?/);
+  // Нова студія несе organization_id.
+  assert.match(route, /INSERT INTO imaging_studies\s*\n?\s*\(organization_id, booking_id/);
+  assert.doesNotMatch(route, /requireStaff/);
+});


### PR DESCRIPTION
Розширює ізоляцію PR #59 на клінічні per-booking маршрути (протоколи, знімки/PACS). Персонал працює лише в межах своєї організації; для поточної (єдиної) поведінка **не змінюється**.

## Що зроблено

**`app/api/staff/protocols/route.ts`**
- `GET`/`PUT` переведено на `requireOrgContext` (`organizationId` зі сесії);
- доступ до заявки звірено з організацією — `canAccessBooking(..., ctx.organizationId)`;
- черга протоколів фільтрує `b.organization_id`.

**`app/api/staff/imaging/route.ts`**
- `GET`/`PUT` на `requireOrgContext`; DICOM-гейт (`dicom_pacs`) інлайново з `getOrgProfile` (зайвий helper прибрано);
- доступ до заявки org-scoped; worklist фільтрує `b.organization_id`;
- перевірка заявки й запис студії обмежені організацією; нова `imaging_studies` несе `organization_id` заявки.

## Перевірки

- `lint` — 0; `tsc --noEmit` — 0; `build` ✓
- Тести: **119/119** зелені. Нові org-scope кейси для протоколів і знімків; оновлено `dicom-pacs`, `protocol-builder`, `feature-gating` під новий вхід автентифікації (`requireOrgContext`) та інлайновий DICOM-гейт (інваріанти — auth-гейт, ролі, відсутність runtime-DDL — збережено).

## Поза межами цього PR

Reports-роут (admin-only аналітика) і явний запис `organization_id` у всі решта staff-INSERT-и — наступний крок. Публічний запис лишається на DEFAULT-tenant. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_