### PR TITLE
PR 11: Tenant hardening — org-скоуп аналітики (reports)

### DIFF
--- a/app/api/staff/reports/export/route.ts
+++ b/app/api/staff/reports/export/route.ts
@@ -1,5 +1,6 @@
 import { logSecurityEvent } from "../../../../../lib/audit";
-import { canViewReports, requireStaff } from "../../../../../lib/staff-auth";
+import { canViewReports } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
 import {
   fetchReportSource,
   publicFilters,
@@ -15,25 +16,27 @@ function dbBinding() {
 export async function GET(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error:"База тимчасово недоступна" },{ status:503 });
-  const member = await requireStaff(request,db);
-  if (!member) return Response.json({ error:"Доступ лише для персоналу" },{ status:403 });
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" },{ status:403 });
+  const member = ctx.member;
   if (!canViewReports(member.role)) {
     return Response.json({ error:"Експорт звітів доступний лише адміністратору" },{ status:403 });
   }
 
   const filters = readReportFilters(new URL(request.url));
   if (!filters) return Response.json({ error:"Некоректні параметри звіту" },{ status:400 });
-  const source = await fetchReportSource(db,filters);
+  const source = await fetchReportSource(db,filters,ctx.organizationId);
   const { template,columns,rows } = reportPayload(filters,source);
   const workbook = createXlsx(template.label,columns,rows);
   const containsPersonalData = ["studies","protocols","finance"].includes(filters.template) ? 1 : 0;
 
   await db.prepare(
     `INSERT INTO report_exports (
-      requested_by, report_type, filters_json, columns_json, format,
+      organization_id, requested_by, report_type, filters_json, columns_json, format,
       row_count, contains_personal_data
-    ) VALUES (?, ?, ?, ?, 'xlsx', ?, ?)`
+    ) VALUES (?, ?, ?, ?, ?, 'xlsx', ?, ?)`
   ).bind(
+    ctx.organizationId,
     member.email,
     filters.template,
     JSON.stringify(publicFilters(filters)),

--- a/app/api/staff/reports/route.ts
+++ b/app/api/staff/reports/route.ts
@@ -1,5 +1,6 @@
 import { EQUIPMENT, SERVICES, serviceByCode } from "../../../../lib/catalog";
-import { canViewReports, requireStaff } from "../../../../lib/staff-auth";
+import { canViewReports } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { logSecurityEvent } from "../../../../lib/audit";
 import { REPORT_TEMPLATES } from "../../../../lib/reporting";
 import {
@@ -16,15 +17,16 @@ function dbBinding() {
 export async function GET(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error:"База тимчасово недоступна" },{ status:503 });
-  const member = await requireStaff(request,db);
-  if (!member) return Response.json({ error:"Доступ лише для персоналу" },{ status:403 });
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" },{ status:403 });
+  const member = ctx.member;
   if (!canViewReports(member.role)) {
     return Response.json({ error:"Звіти з медичними та фінансовими даними доступні лише адміністратору" },{ status:403 });
   }
 
   const filters = readReportFilters(new URL(request.url));
   if (!filters) return Response.json({ error:"Некоректний період або параметри звіту" },{ status:400 });
-  const source = await fetchReportSource(db,filters);
+  const source = await fetchReportSource(db,filters,ctx.organizationId);
   const activeRows = source.filter((row)=>row.status !== "cancelled");
   const completedRows = source.filter((row)=>row.status === "completed");
   const protocolReady = (status:string) => status === "ready" || status === "issued";

--- a/lib/reporting-server.ts
+++ b/lib/reporting-server.ts
@@ -117,10 +117,11 @@ export function readReportFilters(url:URL):ReportFilters | null {
   };
 }
 
-export async function fetchReportSource(db:D1Database,filters:ReportFilters) {
+export async function fetchReportSource(db:D1Database,filters:ReportFilters,organizationId:number) {
   const reportDate = "COALESCE(NULLIF(substr(b.performed_at, 1, 10), ''), b.desired_date)";
-  const where = [`${reportDate} BETWEEN ? AND ?`];
-  const values:Array<string> = [filters.from,filters.to];
+  // Аналітика строго в межах організації (tenant isolation).
+  const where = [`b.organization_id = ?`, `${reportDate} BETWEEN ? AND ?`];
+  const values:Array<string|number> = [organizationId,filters.from,filters.to];
   const add = (column:string,value:string) => {
     if (!value) return;
     where.push(`${column} = ?`);

--- a/tests/domain-model.test.mjs
+++ b/tests/domain-model.test.mjs
@@ -69,8 +69,8 @@ test("report builder provides five protected Excel templates without patient ide
   const exportRoute = await readFile(new URL("../app/api/staff/reports/export/route.ts", import.meta.url), "utf8");
   const reporting = await readFile(new URL("../lib/reporting.ts", import.meta.url), "utf8");
   const reportingServer = await readFile(new URL("../lib/reporting-server.ts", import.meta.url), "utf8");
-  assert.match(route, /requireStaff\(request,\s*db\)/);
-  assert.match(exportRoute, /requireStaff\(request,\s*db\)/);
+  assert.match(route, /requireOrgContext\(request,\s*db\)/);
+  assert.match(exportRoute, /requireOrgContext\(request,\s*db\)/);
   assert.match(exportRoute, /application\/vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet/);
   assert.match(exportRoute, /INSERT INTO report_exports/);
   for (const template of ["studies", "protocols", "staff", "equipment", "finance"]) {

--- a/tests/tenant-hardening.test.mjs
+++ b/tests/tenant-hardening.test.mjs
@@ -81,6 +81,21 @@ test("protocols route is tenant-scoped", async () => {
   assert.doesNotMatch(route, /requireStaff/);
 });
 
+// Аналітика: джерело звіту й експорт org-scoped.
+test("reports are tenant-scoped", async () => {
+  const source = await read("lib/reporting-server.ts");
+  assert.match(source, /fetchReportSource\(db:D1Database,filters:ReportFilters,organizationId:number\)/);
+  assert.match(source, /b\.organization_id = \?/);
+  for (const path of ["app/api/staff/reports/route.ts", "app/api/staff/reports/export/route.ts"]) {
+    const route = await read(path);
+    assert.match(route, /requireOrgContext\(request,db\)/);
+    assert.match(route, /fetchReportSource\(db,filters,ctx\.organizationId\)/);
+    assert.doesNotMatch(route, /requireStaff/);
+  }
+  const exportRoute = await read("app/api/staff/reports/export/route.ts");
+  assert.match(exportRoute, /INSERT INTO report_exports \(\s*\n?\s*organization_id/);
+});
+
 // Знімки: доступ, worklist і запис студії org-scoped.
 test("imaging route is tenant-scoped end-to-end", async () => {
   const route = await read("app/api/staff/imaging/route.ts");


### PR DESCRIPTION
Завершує ізоляцію staff-читань: **аналітика й експорт — строго в межах організації**. Для поточної (єдиної) поведінка **не змінюється**.

## Що зроблено

**`lib/reporting-server.ts`**
- `fetchReportSource` отримав `organizationId`; джерело звіту фільтрує `b.organization_id` (перша умова `WHERE`).

**`app/api/staff/reports/route.ts`, `.../reports/export/route.ts`**
- `requireOrgContext` (`organizationId` зі сесії); джерело тягнеться з org;
- запис `report_exports` несе `organization_id`.

## Перевірки

- `lint` — 0; `tsc --noEmit` — 0; `build` ✓
- Тести: **120/120** зелені. Нові org-scope кейси для аналітики; оновлено `domain-model` під новий вхід автентифікації (`requireOrgContext`).

## Стан hardening

Усі staff-читання/записи ключових доменів тепер tenant-scoped: заявки (#59), протоколи+знімки (#60), аналітика (цей PR). Публічний запис (site-booking) лишається на DEFAULT-tenant, доки не додамо резолвінг організації за доменом. Публічні сторінки не змінюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_