### PR TITLE
PR 12: Календар-провайдер — реальний ICS у tenant-контексті

### DIFF
--- a/app/api/staff/external-calendar/route.ts
+++ b/app/api/staff/external-calendar/route.ts
@@ -1,10 +1,10 @@
-// Reads the configured external Google Calendar (iCal URL) server-side and
-// returns upcoming events for the staff dashboard. Staff-only.
+// Найближчі події зовнішнього календаря організації для дашборду персоналу.
+// Доставку абстраговано календар-провайдером (lib/providers/calendar); джерело
+// (external_ics_url) добирається резолвером у tenant-контексті. Staff-only.
 
-import { canAccessAllBookings, requireStaff } from "../../../../lib/staff-auth";
-import { getSetting } from "../../../../lib/settings";
-import { parseIcs } from "../../../../lib/ics-parse";
-import { fetchLimited, readLimitedText, safeOutboundUrl } from "../../../../lib/outbound";
+import { canAccessAllBookings } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { resolveProviders } from "../../../../lib/providers";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
@@ -13,30 +13,13 @@ function dbBinding() {
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (!canAccessAllBookings(member.role)) {
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canAccessAllBookings(ctx.member.role)) {
     return Response.json({ error: "Календар доступний лише реєстратору або адміністратору" }, { status: 403 });
   }
 
-  const url = await getSetting(db, "external_ics_url");
-  if (!url) return Response.json({ configured: false, events: [] }, { headers: { "cache-control": "no-store" } });
-  const safeUrl = safeOutboundUrl(url);
-  if (!safeUrl) {
-    return Response.json({
-      configured: true,
-      events: [],
-      error: "Адресу календаря заблоковано політикою вихідних з’єднань",
-    });
-  }
-
-  try {
-    const response = await fetchLimited(safeUrl, { cf: { cacheTtl: 300 } } as RequestInit, 5000);
-    if (!response.ok) return Response.json({ configured: true, events: [], error: "Не вдалося завантажити календар" });
-    const text = await readLimitedText(response);
-    const events = parseIcs(text, Date.now() - 12 * 60 * 60 * 1000, 40);
-    return Response.json({ configured: true, events }, { headers: { "cache-control": "no-store" } });
-  } catch {
-    return Response.json({ configured: true, events: [], error: "Не вдалося завантажити календар" });
-  }
+  const { calendar } = await resolveProviders(db, ctx);
+  const result = await calendar.listUpcoming();
+  return Response.json(result, { headers: { "cache-control": "no-store" } });
 }

--- a/lib/providers/calendar.ts
+++ b/lib/providers/calendar.ts
@@ -1,0 +1,31 @@
+// Календар-провайдер: читає зовнішній iCal-фід (external_ics_url) організації
+// й повертає найближчі події. Уся зовнішня взаємодія — через політику
+// підключень (safeOutboundUrl + fetchLimited). Best-effort: ніколи не кидає.
+
+import { parseIcs } from "../ics-parse";
+import { fetchLimited, readLimitedText, safeOutboundUrl } from "../outbound";
+import type { CalendarProvider } from "./types";
+
+export function createCalendarProvider(icsUrl: string): CalendarProvider {
+  const url = icsUrl || "";
+  return {
+    name: url ? "ics" : "none",
+    configured: !!url,
+    async listUpcoming() {
+      if (!url) return { configured: false, events: [] };
+      const safeUrl = safeOutboundUrl(url);
+      if (!safeUrl) {
+        return { configured: true, events: [], error: "Адресу календаря заблоковано політикою вихідних з’єднань" };
+      }
+      try {
+        const response = await fetchLimited(safeUrl, { cf: { cacheTtl: 300 } } as RequestInit, 5000);
+        if (!response.ok) return { configured: true, events: [], error: "Не вдалося завантажити календар" };
+        const text = await readLimitedText(response);
+        const events = parseIcs(text, Date.now() - 12 * 60 * 60 * 1000, 40);
+        return { configured: true, events };
+      } catch {
+        return { configured: true, events: [], error: "Не вдалося завантажити календар" };
+      }
+    },
+  };
+}

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -9,8 +9,9 @@ import { getSettings } from "../settings";
 import { getOrgProfile } from "../org-profile";
 import type { OrgContext } from "../tenant";
 import { createMessagingProvider } from "./messaging";
+import { createCalendarProvider } from "./calendar";
 import type {
-  CalendarProvider, PacsProvider, PaymentProvider, ResolvedProviders,
+  PacsProvider, PaymentProvider, ResolvedProviders,
 } from "./types";
 
 const nullPayment: PaymentProvider = {
@@ -49,10 +50,7 @@ export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise
     }),
   };
 
-  const calendar: CalendarProvider = {
-    name: icsUrl ? "ics" : "none",
-    configured: Boolean(icsUrl),
-  };
+  const calendar = createCalendarProvider(icsUrl);
 
   return { messaging, payment: nullPayment, pacs, calendar };
 }

--- a/lib/providers/types.ts
+++ b/lib/providers/types.ts
@@ -24,9 +24,23 @@ export interface PacsProvider {
   describe(): { enabled: boolean; viewerConfigured: boolean; dicomwebConfigured: boolean };
 }
 
+export interface CalendarEvent {
+  summary: string;
+  display: string;
+  allDay: boolean;
+}
+
+export interface CalendarUpcoming {
+  configured: boolean;
+  events: CalendarEvent[];
+  error?: string;
+}
+
 export interface CalendarProvider {
   readonly name: string;
   readonly configured: boolean;
+  // Найближчі події календаря організації (best-effort, ніколи не кидає).
+  listUpcoming(): Promise<CalendarUpcoming>;
 }
 
 export interface ResolvedProviders {

--- a/tests/external-calendar.test.mjs
+++ b/tests/external-calendar.test.mjs
@@ -19,14 +19,25 @@ test("ICS parser reads VEVENTs and formats Kyiv time", async () => {
   assert.match(lib, /DTSTART/);
 });
 
-test("external-calendar endpoint fetches the configured feed for staff", async () => {
+test("external-calendar endpoint serves the tenant feed via the calendar provider", async () => {
   const route = await read("app/api/staff/external-calendar/route.ts");
-  assert.match(route, /requireStaff\(/);
-  assert.match(route, /getSetting\(db, "external_ics_url"\)/);
-  assert.match(route, /parseIcs\(/);
-  assert.match(route, /safeOutboundUrl\(url\)/);
-  assert.match(route, /fetchLimited\(safeUrl/);
-  assert.match(route, /canAccessAllBookings\(member\.role\)/);
+  // Маршрут тонкий: tenant-контекст + провайдер календаря.
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /canAccessAllBookings\(ctx\.member\.role\)/);
+  assert.match(route, /resolveProviders\(db, ctx\)/);
+  assert.match(route, /calendar\.listUpcoming\(\)/);
+
+  // Реальна доставка живе у провайдері, через політику вихідних зʼєднань.
+  const provider = await read("lib/providers/calendar.ts");
+  assert.match(provider, /export function createCalendarProvider/);
+  assert.match(provider, /parseIcs\(/);
+  assert.match(provider, /safeOutboundUrl\(url\)/);
+  assert.match(provider, /fetchLimited\(safeUrl/);
+
+  // Резолвер добирає джерело (external_ics_url) у tenant-контексті.
+  const resolver = await read("lib/providers/index.ts");
+  assert.match(resolver, /external_ics_url/);
+  assert.match(resolver, /createCalendarProvider\(icsUrl\)/);
 });
 
 test("settings expose the external calendar URL and the dashboard shows events", async () => {


### PR DESCRIPTION
Друга реальна реалізація провайдер-адаптерів (після messaging). Виносить читання зовнішнього календаря у `CalendarProvider` і робить дашборд-віджет tenant-aware. Поведінка **не змінюється**.

## Що зроблено

**`lib/providers/types.ts`** — `CalendarProvider.listUpcoming() → { configured, events, error? }` + типи `CalendarEvent` / `CalendarUpcoming`.

**`lib/providers/calendar.ts`** — `createCalendarProvider(icsUrl)`: читає iCal через `safeOutboundUrl` + `fetchLimited`, парсить `parseIcs`; best-effort, ніколи не кидає.

**`lib/providers/index.ts`** — `resolveProviders` добирає календар через `createCalendarProvider(icsUrl)` (джерело `external_ics_url` — у tenant-контексті).

**`app/api/staff/external-calendar/route.ts`** — тонкий маршрут: `requireOrgContext` + `canAccessAllBookings`, далі `providers.calendar.listUpcoming()`. Логіка fetch/parse тепер у провайдері.

## Перевірки

- `lint` — 0; `tsc --noEmit` — 0; `build` ✓
- Тести: **120/120** зелені. Оновлено `external-calendar`: провайдер читає фід через outbound-політику, маршрут іде через провайдер у tenant-контексті, резолвер добирає джерело.

## Далі

За планом автономного продовження: кабінет пацієнта під tenant, потім окремі UI профілів. Публічні сторінки не змінюються; деплой не виконується.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_