### PR TITLE
PR 14: Кабінет пацієнта — організація і людські стани дослідження

### DIFF
--- a/app/api/booking-status/route.ts
+++ b/app/api/booking-status/route.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../lib/patient-auth";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isRateLimited } from "../../../lib/rate-limit";
+import { stateLabel } from "../../../lib/study-state";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
@@ -24,14 +25,17 @@ export async function POST(request: Request) {
     return Response.json({ error: "Перевірте код і повний номер телефону" }, { status: 400 });
   }
   const result = await db.prepare(
-    `SELECT code, service, desired_date AS desiredDate, desired_time AS desiredTime,
-      status, created_at AS createdAt
-     FROM bookings WHERE code = ? AND phone_normalized = ?
+    `SELECT b.code, b.service, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
+      b.status, b.created_at AS createdAt, COALESCE(o.name, '') AS organization
+     FROM bookings b LEFT JOIN organizations o ON o.id = b.organization_id
+     WHERE b.code = ? AND b.phone_normalized = ?
      LIMIT 1`
-  ).bind(code, phoneNormalized).first();
+  ).bind(code, phoneNormalized).first<{ status: string }>();
   if (!result) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  // Людський підпис стану дослідження (єдина state machine).
+  const booking = { ...result, statusLabel: stateLabel(result.status) };
   const sessionToken = await createPatientSession(db, phoneNormalized);
-  return Response.json({ booking: result }, {
+  return Response.json({ booking }, {
     headers: {
       "cache-control": "no-store",
       "set-cookie": patientSessionCookie(sessionToken),

--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../lib/patient-auth";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isRateLimited } from "../../../lib/rate-limit";
+import { stateLabel } from "../../../lib/study-state";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
@@ -34,18 +35,22 @@ export async function POST(request: Request) {
   }
 
   const rows = await db.prepare(
-    `SELECT code, service, desired_date AS desiredDate, desired_time AS desiredTime,
-       status, created_at AS createdAt, patient_category AS category,
-       payment_status AS paymentStatus, payment_amount AS paymentAmount,
-       CASE WHEN protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol
-     FROM bookings WHERE phone_normalized = ?
-     ORDER BY created_at DESC, id DESC
+    `SELECT b.code, b.service, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
+       b.status, b.created_at AS createdAt, b.patient_category AS category,
+       b.payment_status AS paymentStatus, b.payment_amount AS paymentAmount,
+       COALESCE(o.name, '') AS organization,
+       CASE WHEN b.protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol
+     FROM bookings b LEFT JOIN organizations o ON o.id = b.organization_id
+     WHERE b.phone_normalized = ?
+     ORDER BY b.created_at DESC, b.id DESC
      LIMIT 50`
   ).bind(phoneNormalized).all();
 
   const bookings = (rows.results || []).map((row) => ({
     ...row,
     hasProtocol: Number((row as { hasProtocol: number }).hasProtocol) === 1,
+    // Людський підпис стану дослідження для пацієнта.
+    statusLabel: stateLabel(String((row as { status: string }).status)),
   }));
   const rawToken = await createPatientSession(db, phoneNormalized);
   return Response.json(

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -156,11 +156,23 @@ const STATUS_API = '/api/booking-status';
 const PROTOCOL_API = '/api/my-protocol';
 
 const statusMeta = {
-  new:         { badge: 'new',       label: 'Нова',           step: 'new' },
-  confirmed:   { badge: 'booked',    label: 'Підтверджена',   step: 'booked' },
-  rescheduled: { badge: 'booked',    label: 'Перенесена',     step: 'booked' },
-  completed:   { badge: 'done',      label: 'Виконана',       step: 'done' },
-  cancelled:   { badge: 'cancelled', label: 'Скасована',      step: 'cancelled' },
+  new:               { badge: 'new',       label: 'Нова',              step: 'new' },
+  requested:         { badge: 'new',       label: 'Заявка',            step: 'new' },
+  needs_verification:{ badge: 'new',       label: 'Потребує перевірки',step: 'new' },
+  scheduled:         { badge: 'booked',    label: 'Заплановано',       step: 'booked' },
+  confirmed:         { badge: 'booked',    label: 'Підтверджена',      step: 'booked' },
+  rescheduled:       { badge: 'booked',    label: 'Перенесена',        step: 'booked' },
+  arrived:           { badge: 'booked',    label: 'Прибуття',          step: 'booked' },
+  queued:            { badge: 'booked',    label: 'У черзі',           step: 'booked' },
+  in_progress:       { badge: 'booked',    label: 'Виконується',       step: 'booked' },
+  performed:         { badge: 'booked',    label: 'Виконано',          step: 'done' },
+  images_ready:      { badge: 'booked',    label: 'Зображення готові', step: 'done' },
+  reporting:         { badge: 'booked',    label: 'Готуємо висновок',  step: 'done' },
+  protocol_ready:    { badge: 'done',      label: 'Протокол готовий',  step: 'done' },
+  issued:            { badge: 'done',      label: 'Видано',            step: 'done' },
+  completed:         { badge: 'done',      label: 'Виконана',          step: 'done' },
+  cancelled:         { badge: 'cancelled', label: 'Скасована',         step: 'cancelled' },
+  no_show:           { badge: 'cancelled', label: 'Неявка',            step: 'cancelled' },
 };
 const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#2f5aa0;' }[m]));
 const humanDate = (iso) => (iso ? String(iso).split('-').reverse().join('.') : '');
@@ -192,6 +204,8 @@ function stepper(status) {
 
 function cardHtml(b) {
   const meta = statusMeta[b.status] || { badge: 'new', label: b.status };
+  const badgeLabel = b.statusLabel || meta.label;
+  const org = b.organization ? ' · ' + esc(b.organization) : '';
   const when = b.desiredDate ? `бажана дата: ${esc(humanDate(b.desiredDate))}${b.desiredTime ? ' о ' + esc(b.desiredTime) : ''}` : '';
   const canCancel = ['new', 'confirmed', 'rescheduled'].includes(b.status);
   const awaitingPayment = b.paymentStatus === 'pending' && Number(b.paymentAmount) > 0 && b.status !== 'cancelled' && b.status !== 'completed';
@@ -199,9 +213,9 @@ function cardHtml(b) {
     <div class="app-top">
       <div>
         <div class="app-study">${esc(b.service)}</div>
-        <div class="app-meta">Код ${esc(b.code)}${when ? ' · ' + when : ''}</div>
+        <div class="app-meta">Код ${esc(b.code)}${org}${when ? ' · ' + when : ''}</div>
       </div>
-      <span class="badge ${meta.badge}">${esc(meta.label)}</span>
+      <span class="badge ${meta.badge}">${esc(badgeLabel)}</span>
     </div>
     ${b.status !== 'cancelled' ? stepper(b.status) : ''}
     ${awaitingPayment ? `<div class="pay-row">💳 <span>Очікує оплати: <strong>${esc(money(b.paymentAmount))} грн</strong></span></div>` : ''}

--- a/tests/patient-cabinet-tenant.test.mjs
+++ b/tests/patient-cabinet-tenant.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+// Публічний статус заявки несе назву організації та людський підпис стану.
+test("booking-status returns organization and a human status label", async () => {
+  const route = await read("app/api/booking-status/route.ts");
+  assert.match(route, /LEFT JOIN organizations o ON o\.id = b\.organization_id/);
+  assert.match(route, /COALESCE\(o\.name, ''\) AS organization/);
+  assert.match(route, /stateLabel\(result\.status\)/);
+  assert.match(route, /statusLabel/);
+});
+
+// Список заявок пацієнта так само несе організацію й підпис стану.
+test("my-bookings enriches each booking with organization and status label", async () => {
+  const route = await read("app/api/my-bookings/route.ts");
+  assert.match(route, /LEFT JOIN organizations o ON o\.id = b\.organization_id/);
+  assert.match(route, /COALESCE\(o\.name, ''\) AS organization/);
+  assert.match(route, /stateLabel\(String\(\(row as \{ status: string \}\)\.status\)\)/);
+});
+
+// Кабінет пацієнта коректно показує нові стани дослідження й організацію.
+test("cabinet renders new study states, prefers server label and shows the organization", async () => {
+  const cabinet = await read("public/site/cabinet.html");
+  // Розширена мапа станів під єдину state machine.
+  for (const s of ["in_progress", "protocol_ready", "issued", "queued"]) {
+    assert.match(cabinet, new RegExp(`${s}:`), `statusMeta has ${s}`);
+  }
+  // Пріоритет — людський підпис із сервера; показуємо організацію.
+  assert.match(cabinet, /b\.statusLabel \|\| meta\.label/);
+  assert.match(cabinet, /b\.organization/);
+});

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -45,7 +45,7 @@ test("patient cabinet lists bookings by phone and reads protocols from D1", asyn
 test("my-bookings lists every booking for a full phone number", async () => {
   const route = await read("app/api/my-bookings/route.ts");
   assert.match(route, /normalizeUkrainianPhone\(/);
-  assert.match(route, /WHERE phone_normalized = \?/);
+  assert.match(route, /WHERE b\.phone_normalized = \?/);
   assert.match(route, /protocol_status = 'issued'/); // exposes hasProtocol flag
   assert.match(route, /isRateLimited\(/);
 });


### PR DESCRIPTION
Публічна перевірка статусу заявки тепер несе **назву організації** (tenant) і показує стан дослідження **людською мовою** через єдину state machine. Публічний сайт лишається офіційним і зрозумілим (без Doctime-стилю).

## Що зроблено

**`app/api/booking-status`, `app/api/my-bookings`**
- `LEFT JOIN organizations` → назва організації у відповіді (`organization`);
- `statusLabel` через `stateLabel` (`lib/study-state`) для кожної заявки — пацієнт бачить «Виконується», «Протокол готовий», «Видано» замість службових кодів.

**`public/site/cabinet.html`**
- розширено мапу станів під 15 канонічних станів (`requested`…`issued`, `no_show`) з бейджами й кроками степера;
- бейдж використовує серверний `statusLabel` (fallback на локальну мапу);
- у картці заявки показано організацію.

## Перевірки

- `lint` — 0; `tsc --noEmit` — 0; `build` ✓
- Тести: **128/128** зелені (+3 у `tests/patient-cabinet-tenant.test.mjs`): обидва публічні ендпойнти віддають `organization` + `statusLabel`; кабінет рендерить нові стани, бере серверний підпис і показує організацію. Оновлено `site-bridge` під префікс `b.` у SQL.

## Межі

Публічний онлайн-запис (`site-booking`) досі приймає заявки в початковий tenant за замовчуванням — резолвінг організації за доменом/піддоменом буде окремим кроком, коли зʼявиться друга організація. Стиль публічних сторінок не змінюється.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_