### PR TITLE
Підказка на вході: номер телефону без +38

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,6 +37,7 @@ a { color:inherit; text-decoration:none; }
 .passwordEye:hover{background:#eef4f2;color:var(--green)}.passwordEye:focus-visible{outline:2px solid var(--green);outline-offset:1px}
 .passwordEye svg{width:20px;height:20px;fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
 .passwordEye[aria-pressed="true"]{color:var(--green)}
+.fieldHint{display:block;margin:6px 0 0;font-size:12px;font-weight:500;text-transform:none;letter-spacing:0;color:#66756f}
 .loginAlt{margin:16px 0 0!important;text-align:center;color:#66756f;font-size:13px}.loginAlt a{color:var(--green);font-weight:700}.loginAlt a:hover{text-decoration:underline}
 .loginPrimaryLink{margin-top:8px;min-height:48px;display:flex;align-items:center;justify-content:center;border-radius:8px;background:var(--green);color:#fff;font-weight:800;font-size:14px}.loginPrimaryLink:hover{background:#0a4b42}
 

--- a/app/staff/login/page.tsx
+++ b/app/staff/login/page.tsx
@@ -36,7 +36,11 @@ export default function StaffLoginPage() {
       <span className="loginMark">R</span>
       <h1>RadiologyOS</h1>
       <p>Кабінет персоналу відділення променевої діагностики</p>
-      <label><span>Номер телефону</span><input name="phone" type="tel" required autoComplete="username" inputMode="tel" placeholder="+380..." autoFocus /></label>
+      <label>
+        <span>Номер телефону</span>
+        <input name="phone" type="tel" required autoComplete="username" inputMode="tel" placeholder="0XX XXX XX XX" autoFocus />
+        <span className="fieldHint">Просто ваш номер — без +38. Напр.: 0972808899</span>
+      </label>
       <label>
         <span className="labelRow">PIN-код</span>
         <PasswordInput name="password" autoComplete="current-password" placeholder="6-значний PIN" inputMode="numeric" maxLength={6} />

--- a/app/staff/page.tsx
+++ b/app/staff/page.tsx
@@ -421,7 +421,7 @@ export default function StaffPage() {
           <p>Додавайте реєстраторів, лікарів і лаборантів без зміни програмного коду.</p>
         </div>
         <form className="staffMemberAdd" onSubmit={event=>{event.preventDefault();void saveStaffMember(event.currentTarget);}}>
-          <label><span>Номер телефону</span><input name="phone" type="tel" inputMode="tel" required placeholder="+380..."/></label>
+          <label><span>Номер телефону</span><input name="phone" type="tel" inputMode="tel" required placeholder="0XX XXX XX XX"/><span className="fieldHint">Без +38, напр.: 0972808899</span></label>
           <label><span>Ім’я працівника</span><input name="displayName" maxLength={120} placeholder="ПІБ або посада"/></label>
           <label><span>Роль</span><select name="role" defaultValue="registrar">{Object.entries(roleLabels).map(([value,label])=><option key={value} value={value}>{label}</option>)}</select></label>
           <label><span>PIN-код для входу</span><input name="password" type="password" inputMode="numeric" minLength={6} maxLength={6} autoComplete="new-password" placeholder="6 цифр"/></label>


### PR DESCRIPTION
Щоб персоналу було відразу зрозуміло, що `+38` набирати **не треба**.

- Плейсхолдер поля → `0XX XXX XX XX` (замість `+380...`).
- Пояснення під полем: «Просто ваш номер — без +38. Напр.: 0972808899» — на сторінці входу і у формі додавання працівника.
- Новий клас `.fieldHint` (звичайний, не uppercase — щоб не зливався з підписом поля).

Нормалізація номера вже приймає `0XX…`, `380…` і `+380…`, тож зміни суто візуальні. `tsc` 0, `lint` 0, тести **139/139**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_