### PR TITLE
Редактор вітрини «Сайт клініки»: тексти, контакти й публікація (етап 1)

### DIFF
--- a/app/api/site-content/route.ts
+++ b/app/api/site-content/route.ts
@@ -1,0 +1,19 @@
+// Публічне читання контенту вітрини для статичного лендинга (/site/*).
+// Повертає повний SiteContent (усі поля — публічні тексти).
+
+import { getSetting } from "../../../lib/settings";
+import { SITE_CONTENT_KEY, parseSiteContent } from "../../../lib/site-content";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET() {
+  const db = dbBinding();
+  // Без бази — типові значення, щоб сайт лишався робочим.
+  const content = db ? parseSiteContent(await getSetting(db, SITE_CONTENT_KEY)) : undefined;
+  return Response.json(
+    { content: content ?? null },
+    { headers: { "cache-control": "no-store", "access-control-allow-origin": "*" } },
+  );
+}

--- a/app/api/staff/site/route.ts
+++ b/app/api/staff/site/route.ts
@@ -1,0 +1,34 @@
+// Редактор вітрини (сайту клініки) — лише адміністратор. Читає й зберігає
+// налаштовуваний контент публічної сторінки у app_settings (ключ site_content).
+
+import { requireStaff } from "../../../../lib/staff-auth";
+import { getSetting, setSetting } from "../../../../lib/settings";
+import { SITE_CONTENT_KEY, parseSiteContent, sanitizeSiteContent } from "../../../../lib/site-content";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Сайт клініки редагує лише адміністратор" }, { status: 403 });
+
+  const content = parseSiteContent(await getSetting(db, SITE_CONTENT_KEY));
+  return Response.json({ content, staff: member }, { headers: { "cache-control": "no-store" } });
+}
+
+export async function PUT(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Змінювати сайт може лише адміністратор" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as { content?: unknown };
+  const content = sanitizeSiteContent(body.content);
+  await setSetting(db, SITE_CONTENT_KEY, JSON.stringify(content));
+  return Response.json({ ok: true, content }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -244,6 +244,15 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .settingsHint{display:block;margin-top:8px;color:#7a8b88;font-size:11px}
 .settingsCard .linkBtn{border:0;background:none;color:var(--green);font:inherit;font-weight:700;cursor:pointer;padding:0;text-decoration:underline}.settingsCard .linkBtn:hover{color:#0a4b42}
 .settingsCard input[readonly]{background:#f4f8f6;color:#41544f}
+.settingsCard textarea{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);resize:vertical;min-height:72px;margin-top:6px}.settingsCard textarea:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+.settingsBlock h3{font-size:15px;font-weight:700;margin:0 0 6px}
+.settingsCard .siteToggleRow{display:flex;align-items:center;justify-content:space-between;gap:16px}
+.settingsCard .siteToggleRow>div{margin:0}.settingsCard .siteToggleRow b{font-size:14px}.settingsCard .siteToggleRow p{margin:4px 0 0;color:#66756f;font-size:12px}
+.settingsCard .switch{display:inline-flex;align-items:center;gap:8px;margin:0;white-space:nowrap}
+.settingsCard .switch>span{display:inline;margin:0;font-size:12px;font-weight:700;text-transform:none;letter-spacing:0;color:#41544f}
+.settingsCard .switch input{width:auto}
+.settingsActions{display:flex;align-items:center;gap:16px;margin-top:4px}
+.settingsActions button{min-height:44px;padding:0 20px;border:0;border-radius:7px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.settingsActions button:hover:not(:disabled){background:#0a4b42}.settingsActions button:disabled{opacity:.5;cursor:not-allowed}
 .settingsCard .notice{margin:0;padding:11px 13px;border-radius:7px;font-size:13px}.settingsCard .notice.success{background:#eef4e6;color:#33632c}.settingsCard .notice.error{background:#fdf1ee;color:#a23c1d}
 .dashLists{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .dashList{padding:0;background:#fff;border:1px solid #e7ece9;border-radius:18px;box-shadow:0 1px 2px rgba(24,40,30,.04),0 8px 24px rgba(24,40,30,.05);overflow:hidden}

--- a/app/staff/site/page.tsx
+++ b/app/staff/site/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { SITE_CONTENT_DEFAULTS, type SiteContent } from "../../../lib/site-content";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+type Field = { key: keyof SiteContent; label: string; area?: boolean; hint?: string };
+
+const GROUPS: { title: string; fields: Field[] }[] = [
+  { title: "Бренд і шапка", fields: [
+    { key: "brandTitle", label: "Назва закладу" },
+    { key: "brandSubtitle", label: "Підзаголовок" },
+    { key: "slogan", label: "Слоган", hint: "Необовʼязково — показується під підзаголовком" },
+  ] },
+  { title: "Картки авдиторій (головна)", fields: [
+    { key: "milTitle", label: "Військовим — заголовок" },
+    { key: "milSub", label: "Військовим — підпис" },
+    { key: "civTitle", label: "Цивільним — заголовок" },
+    { key: "civSub", label: "Цивільним — підпис" },
+  ] },
+  { title: "Контакти", fields: [
+    { key: "phone", label: "Телефон" },
+    { key: "address", label: "Адреса" },
+    { key: "workHours", label: "Години роботи" },
+  ] },
+  { title: "Про клініку", fields: [
+    { key: "about", label: "Опис", area: true, hint: "Необовʼязково — короткий блок на головній" },
+  ] },
+  { title: "Сторінка цивільних (прайс)", fields: [
+    { key: "pricePageTitle", label: "Заголовок сторінки" },
+    { key: "pricePageSub", label: "Підзаголовок" },
+    { key: "priceIntro", label: "Вступний текст", area: true },
+    { key: "priceListTitle", label: "Заголовок прайсу" },
+    { key: "priceLead", label: "Підпис під прайсом" },
+  ] },
+  { title: "Сторінка військових", fields: [
+    { key: "milPageTitle", label: "Заголовок сторінки" },
+    { key: "milPageSub", label: "Підзаголовок" },
+    { key: "milNotice", label: "Примітка", area: true },
+    { key: "milLead", label: "Підпис" },
+  ] },
+];
+
+export default function StaffSitePage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [content, setContent] = useState<SiteContent>({ ...SITE_CONTENT_DEFAULTS });
+  const [loaded, setLoaded] = useState(false);
+  const [status, setStatus] = useState<"idle" | "saving">("idle");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const res = await fetch("/api/staff/site", { cache: "no-store" });
+      if (res.status === 403) { if (active) setForbidden(true); return; }
+      const data = await res.json().catch(() => ({})) as { content?: SiteContent; staff?: StaffInfo };
+      if (!active) return;
+      if (data.content) setContent({ ...SITE_CONTENT_DEFAULTS, ...data.content });
+      if (data.staff) setStaff(data.staff);
+      setLoaded(true);
+    })();
+    return () => { active = false; };
+  }, []);
+
+  function update(key: keyof SiteContent, value: string | boolean) {
+    setContent(prev => ({ ...prev, [key]: value }));
+  }
+
+  async function save(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("saving"); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/site", {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; content?: SiteContent; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
+      if (data.content) setContent({ ...SITE_CONTENT_DEFAULTS, ...data.content });
+      setNotice("Збережено. Оновіть публічний сайт, щоб побачити зміни.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося зберегти");
+    } finally {
+      setStatus("idle");
+    }
+  }
+
+  const body = forbidden
+    ? <p className="notice error" role="alert">Сайт клініки редагує лише адміністратор.</p>
+    : !loaded
+      ? <p className="notice">Завантаження…</p>
+      : <form className="settingsCard" onSubmit={save}>
+          <section className="settingsBlock">
+            <div className="siteToggleRow">
+              <div>
+                <b>{content.published ? "Сайт опубліковано" : "Сайт у чернетці"}</b>
+                <p className="settingsHint">Коли вимкнено — відвідувачі бачать заглушку замість вітрини.</p>
+              </div>
+              <label className="switch">
+                <input type="checkbox" checked={content.published} onChange={e => update("published", e.target.checked)} />
+                <span>{content.published ? "Опубліковано" : "Чернетка"}</span>
+              </label>
+            </div>
+          </section>
+          {GROUPS.map(group => (
+            <section className="settingsBlock" key={group.title}>
+              <h3>{group.title}</h3>
+              {group.fields.map(field => (
+                <label className="settingsField" key={String(field.key)}>
+                  <span>{field.label}</span>
+                  {field.area
+                    ? <textarea rows={3} value={String(content[field.key] ?? "")} onChange={e => update(field.key, e.target.value)} />
+                    : <input type="text" value={String(content[field.key] ?? "")} onChange={e => update(field.key, e.target.value)} />}
+                  {field.hint && <small className="settingsHint">{field.hint}</small>}
+                </label>
+              ))}
+            </section>
+          ))}
+          {notice && <p className="notice success" role="status">{notice}</p>}
+          {error && <p className="notice error" role="alert">{error}</p>}
+          <div className="settingsActions">
+            <button type="submit" disabled={status === "saving"}>{status === "saving" ? "Зберігаємо…" : "Зберегти зміни"}</button>
+            <a className="textLink" href="/" target="_blank" rel="noopener">Відкрити сайт ↗</a>
+          </div>
+        </form>;
+
+  return (
+    <StaffWorkspaceShell
+      active="site"
+      title="Сайт клініки"
+      description="Публічна вітрина: тексти, контакти та публікація — керує адміністратор."
+      staffName={staff?.displayName}
+      staffRole={staff?.role}
+    >
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -23,7 +23,8 @@ type StaffWorkspaceShellProps = {
 type NavChild = { label:string; href:string; flag?:string };
 type NavModule = { n:string; label:string; href:string; section?:WorkspaceSection; items:NavChild[] };
 const systemModules: NavModule[] = [
-  { n:"1", label:"Головна / Продаж послуг", href:"/", items:[
+  { n:"1", label:"Головна / Продаж послуг", href:"/staff/site", section:"site", items:[
+    { label:"Сайт клініки (редактор)", href:"/staff/site" },
     { label:"Вітрина послуг", href:"/" },
     { label:"Онлайн-запис", href:"/" },
     { label:"Тарифи", href:"/staff/tariffs" },

--- a/drizzle/0019_site_content.sql
+++ b/drizzle/0019_site_content.sql
@@ -1,0 +1,3 @@
+-- Налаштовуваний контент публічної вітрини (сайту клініки). Один JSON у
+-- app_settings; порожнє значення означає «типові тексти з коду/HTML».
+INSERT OR IGNORE INTO `app_settings` (`key`, `value`) VALUES ('site_content', '');

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -1,0 +1,90 @@
+// Налаштовуваний контент публічної вітрини (сайту клініки). Редагується
+// адміністратором у кабінеті (/staff/site), зберігається у app_settings під
+// ключем `site_content` (єдиний JSON), застосовується на статичному лендингу
+// через /api/site-content. Порожнє текстове поле означає «лишити типове
+// значення з HTML» — застосування на сторінці ставить текст лише коли він є.
+
+export type SiteContent = {
+  brandTitle: string;
+  brandSubtitle: string;
+  slogan: string;
+  milTitle: string;
+  milSub: string;
+  civTitle: string;
+  civSub: string;
+  phone: string;
+  address: string;
+  workHours: string;
+  about: string;
+  pricePageTitle: string;
+  pricePageSub: string;
+  priceIntro: string;
+  priceListTitle: string;
+  priceLead: string;
+  milPageTitle: string;
+  milPageSub: string;
+  milNotice: string;
+  milLead: string;
+  published: boolean;
+};
+
+export const SITE_CONTENT_KEY = "site_content";
+
+// Обмеження довжини для кожного текстового поля.
+const FIELD_MAX: Record<Exclude<keyof SiteContent, "published">, number> = {
+  brandTitle: 120, brandSubtitle: 160, slogan: 160,
+  milTitle: 80, milSub: 200, civTitle: 80, civSub: 200,
+  phone: 40, address: 200, workHours: 120, about: 800,
+  pricePageTitle: 120, pricePageSub: 200, priceIntro: 800, priceListTitle: 160, priceLead: 300,
+  milPageTitle: 120, milPageSub: 200, milNotice: 800, milLead: 300,
+};
+
+export const SITE_CONTENT_DEFAULTS: SiteContent = {
+  brandTitle: "Чернігівський військовий госпіталь",
+  brandSubtitle: "Відділення променевої діагностики",
+  slogan: "",
+  milTitle: "Військовослужбовцям",
+  milSub: "Безоплатні дослідження за направленням",
+  civTitle: "Цивільним особам",
+  civSub: "Платні дослідження — повний прайс і запис",
+  phone: "+380 97 280 88 99",
+  address: "м. Чернігів, вул. Полуботка, 40",
+  workHours: "Пн–Сб · 08:00–17:00",
+  about: "",
+  pricePageTitle: "Платні дослідження",
+  pricePageSub: "Вартість указана відповідно до чинних тарифів.",
+  priceIntro: "Цивільним особам — платні послуги. Оберіть потрібне дослідження, натисніть «Записатися» та введіть свої дані.",
+  priceListTitle: "Тарифи на платні медичні послуги",
+  priceLead: "Відділення променевої діагностики Чернігівського військового госпіталю.",
+  milPageTitle: "Дослідження для військовослужбовців",
+  milPageSub: "За направленням лікаря та відповідно до чинного законодавства України.",
+  milNotice: "Оберіть потрібний розділ. Для військовослужбовців дослідження виконуються безоплатно за направленням.",
+  milLead: "Відділення променевої діагностики Чернігівського військового госпіталю.",
+  published: true,
+};
+
+const TEXT_FIELDS = Object.keys(FIELD_MAX) as Array<Exclude<keyof SiteContent, "published">>;
+
+// Приводить довільний ввід до валідного SiteContent: обрізає тексти за
+// довжиною, published — булеве. Відсутні поля беруться з типових значень.
+export function sanitizeSiteContent(input: unknown): SiteContent {
+  const src = (input && typeof input === "object") ? input as Record<string, unknown> : {};
+  const out = { ...SITE_CONTENT_DEFAULTS };
+  for (const field of TEXT_FIELDS) {
+    if (typeof src[field] === "string") {
+      out[field] = (src[field] as string).trim().slice(0, FIELD_MAX[field]);
+    }
+  }
+  out.published = src.published === undefined ? SITE_CONTENT_DEFAULTS.published : Boolean(src.published);
+  return out;
+}
+
+// Читання збереженого JSON зі стовпця app_settings у повний SiteContent.
+export function parseSiteContent(stored: string): SiteContent {
+  if (!stored) return { ...SITE_CONTENT_DEFAULTS };
+  try {
+    return sanitizeSiteContent(JSON.parse(stored));
+  } catch {
+    return { ...SITE_CONTENT_DEFAULTS };
+  }
+}

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -36,6 +36,8 @@ header{position:sticky;top:10px;z-index:50;padding:0 14px}
 .hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
 .hospital-brand-title{font-size:clamp(20px,3vw,27px);font-weight:700;line-height:1.08;color:#fff;overflow-wrap:anywhere}
 .hospital-brand-subtitle{font-size:clamp(13px,1.8vw,17px);line-height:1.25;color:#e5ecf0;margin-top:5px}
+.hospital-brand-slogan{font-size:clamp(12px,1.6vw,15px);line-height:1.3;color:#cfe0e6;margin-top:6px;font-style:italic}
+.about-clinic{padding:22px 0 0}.about-clinic-text{margin:0;color:var(--muted);line-height:1.6;font-size:15px}
 nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font-weight:800;font-size:14px}
 
 /* ===== Меню «Вхід» ===== */
@@ -236,6 +238,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
       <div class="hospital-brand-text">
         <div class="hospital-brand-title" id="scBrandTitle">Чернігівський військовий госпіталь</div>
         <div class="hospital-brand-subtitle" id="scBrandSubtitle">Відділення променевої діагностики</div>
+        <div class="hospital-brand-slogan" id="scSlogan" style="display:none"></div>
       </div>
     </a>
     <nav>
@@ -284,6 +287,10 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
     </div>
   </section>
 
+  <section class="about-clinic" id="scAboutWrap" style="display:none">
+    <div class="wrap"><p class="about-clinic-text" id="scAbout"></p></div>
+  </section>
+
   <section class="tariffs-home" id="tariffs">
     <div class="wrap">
       <div class="tariffs-head">
@@ -307,6 +314,10 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
         <span class="address-text" id="scAddress">м. Чернігів, вул. Полуботка, 40</span>
         <span class="address-arrow" aria-hidden="true">›</span>
       </a>
+      <div class="contact-card address-row" id="scHoursRow" style="display:none;margin-top:14px">
+        <span class="address-label">Години</span>
+        <span class="address-text" id="scHours"></span>
+      </div>
     </div>
   </section>
 </main>
@@ -422,19 +433,32 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 
 <script src="/site/assets/department.js"></script>
 <script>
-/* Застосовуємо збережені редагування головної (якщо персонал щось змінив) */
+/* Вітрина керується з кабінету (Сайт клініки) — тексти й публікація
+   зберігаються в базі та віддаються через /api/site-content. Спершу
+   застосовуємо локальний кеш (миттєво), потім свіже значення з сервера. */
 (function(){
-  try{
-    if(!localStorage.getItem(SITECONTENT_STORE)) return; /* стандартний HTML і так актуальний */
-    const c=getSiteContent();
-    const set=(id,v)=>{const el=document.getElementById(id);if(el&&v)el.textContent=v};
+  var set=function(id,v){var el=document.getElementById(id); if(el&&v){el.textContent=v;}};
+  var show=function(id){var el=document.getElementById(id); if(el){el.style.display='';}};
+  function apply(c){
+    if(!c||typeof c!=='object') return;
     set('scBrandTitle',c.brandTitle); set('scBrandSubtitle',c.brandSubtitle);
     set('scMilTitle',c.milTitle);     set('scMilSub',c.milSub);
     set('scCivTitle',c.civTitle);     set('scCivSub',c.civSub);
     set('scAddress',c.address);
-    const ph=document.getElementById('scPhone');
-    if(ph&&c.phone){ph.textContent=c.phone;ph.closest('a').href='tel:'+c.phone.replace(/[^+\d]/g,'');}
-  }catch(e){}
+    var ph=document.getElementById('scPhone');
+    if(ph&&c.phone){ph.textContent=c.phone; var a=ph.closest('a'); if(a){a.href='tel:'+c.phone.replace(/[^+\d]/g,'');}}
+    if(c.slogan){ set('scSlogan',c.slogan); show('scSlogan'); }
+    if(c.workHours){ set('scHours',c.workHours); show('scHoursRow'); }
+    if(c.about){ set('scAbout',c.about); show('scAboutWrap'); }
+    if(c.published===false){
+      var m=document.querySelector('main');
+      if(m){ m.innerHTML='<section class="hero"><div class="wrap"><div class="promo-card" style="cursor:default"><span class="promo-text"><strong>Сайт тимчасово недоступний</strong><span>Онлайн-запис буде відновлено найближчим часом.</span></span></div></div></section>'; }
+    }
+  }
+  try{ if(typeof getSiteContent==='function' && localStorage.getItem(SITECONTENT_STORE)){ apply(getSiteContent()); } }catch(e){}
+  fetch('/api/site-content',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
+    if(d&&d.content){ apply(d.content); try{ localStorage.setItem(SITECONTENT_STORE, JSON.stringify(d.content)); }catch(e){} }
+  }).catch(function(){});
 })();
 </script>
 <script src="/site/assets/qrgen.js"></script>

--- a/tests/site-content.test.mjs
+++ b/tests/site-content.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  SITE_CONTENT_DEFAULTS,
+  parseSiteContent,
+  sanitizeSiteContent,
+} from "../lib/site-content.ts";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("sanitizeSiteContent clamps text, coerces published and keeps defaults", () => {
+  const out = sanitizeSiteContent({ brandTitle: "  Нова назва  ", published: 0, unknown: "x" });
+  assert.equal(out.brandTitle, "Нова назва"); // trimmed
+  assert.equal(out.published, false); // coerced from falsy
+  assert.equal(out.brandSubtitle, SITE_CONTENT_DEFAULTS.brandSubtitle); // missing → default
+  assert.ok(!("unknown" in out)); // unknown fields dropped
+  const long = sanitizeSiteContent({ brandTitle: "x".repeat(500) });
+  assert.ok(long.brandTitle.length <= 120); // max length enforced
+});
+
+test("published defaults to true when unset", () => {
+  assert.equal(sanitizeSiteContent({}).published, true);
+});
+
+test("parseSiteContent returns defaults for empty or invalid JSON", () => {
+  assert.deepEqual(parseSiteContent(""), SITE_CONTENT_DEFAULTS);
+  assert.deepEqual(parseSiteContent("{bad json"), SITE_CONTENT_DEFAULTS);
+  assert.equal(parseSiteContent(JSON.stringify({ phone: "+380 44 000" })).phone, "+380 44 000");
+});
+
+test("admin site route is admin-only and persists to app_settings", async () => {
+  const route = await read("app/api/staff/site/route.ts");
+  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /setSetting\(db, SITE_CONTENT_KEY/);
+  assert.match(route, /sanitizeSiteContent\(body\.content\)/);
+});
+
+test("public site-content endpoint returns merged content", async () => {
+  const route = await read("app/api/site-content/route.ts");
+  assert.match(route, /parseSiteContent\(/);
+  assert.match(route, /cache-control.*no-store/);
+});
+
+test("editor page and nav item exist", async () => {
+  const page = await read("app/staff/site/page.tsx");
+  assert.match(page, /\/api\/staff\/site/);
+  assert.match(page, /active="site"/);
+  assert.match(page, /published/);
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/site"/);
+  assert.match(shell, /"site"/); // section in the union
+});
+
+test("landing pulls storefront config from the API and gates on published", async () => {
+  const html = await read("public/site/index.html");
+  assert.match(html, /fetch\('\/api\/site-content'/);
+  assert.match(html, /c\.published===false/); // draft → placeholder
+  assert.match(html, /id="scSlogan"/);
+  assert.match(html, /id="scAbout"/);
+});


### PR DESCRIPTION
Перший етап **конфігурованої вітрини** — як розділ «Сайт клініки» у DocTime. Адміністратор керує публічною сторінкою з кабінету, замість жорстко зашитого HTML.

## Що додано
- **`lib/site-content.ts`** — модель `SiteContent` + типові значення, `sanitize` (обрізання за довжиною, `published` як булеве), `parse` збереженого JSON.
- **`/api/staff/site`** — admin-only `GET`/`PUT`; зберігає єдиний JSON у `app_settings` (ключ `site_content`). `drizzle/0019` сідить ключ.
- **`/api/site-content`** — публічне читання для лендинга (повертає типові значення, якщо база порожня — сайт завжди робочий).
- **`/staff/site`** (нова сторінка) — редактор: назва/підзаголовок/слоган, картки «Військовим/Цивільним», телефон/адреса/години, опис, тексти сторінок цін і військових, **перемикач Опубліковано/Чернетка**. Пункт «Сайт клініки (редактор)» у модулі 1 бічної панелі.
- **`public/site/index.html`** — тягне конфіг із `/api/site-content` (локальний кеш миттєво → потім свіже з сервера), застосовує тексти за id-елементами, показує слоган/години/опис, а на «Чернетка» — заглушку. + невеликий CSS.

## Поза цим етапом
Колір/тема/логотип/вмикання-вимикання розділів — **етап 2** (потребує рефакторингу ~97 захардкоджених місць кольору й сховища логотипа).

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **150/150** (нові `site-content`).

## Після мерджу
Деплой `main` (Actions → Deploy to Cloudflare → `DEPLOY`) — міграція 0019 застосується автоматично. Далі: кабінет → **Головна / Продаж послуг → Сайт клініки** → редагуєте тексти, тиснете «Зберегти», оновлюєте публічний сайт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_