### PR TITLE
Календар записів (Список / День) із фільтрами за станом

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -253,6 +253,51 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .settingsCard .switch input{width:auto}
 .settingsActions{display:flex;align-items:center;gap:16px;margin-top:4px}
 .settingsActions button{min-height:44px;padding:0 20px;border:0;border-radius:7px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.settingsActions button:hover:not(:disabled){background:#0a4b42}.settingsActions button:disabled{opacity:.5;cursor:not-allowed}
+/* Календар записів */
+.apptCal{max-width:1100px;margin:0 auto;display:flex;flex-direction:column;gap:14px}
+.apptCalBar{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+.apptCalBar input[type="date"]{padding:10px 12px;border:1px solid #cbd8d6;border-radius:8px;font:inherit;color:var(--ink)}
+.apptCalBar input[type="search"]{flex:1;min-width:180px;padding:10px 12px;border:1px solid #cbd8d6;border-radius:8px;font:inherit}
+.apptCalBar input:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+.apptViewToggle{display:inline-flex;background:#eef2f0;border-radius:8px;padding:3px}
+.apptViewToggle button{border:0;background:none;padding:8px 16px;border-radius:6px;font:inherit;font-weight:700;font-size:13px;color:#5c6c78;cursor:pointer}
+.apptViewToggle button.active{background:var(--green);color:#fff}
+.apptStatusRow{display:flex;flex-wrap:wrap;gap:8px}
+.apptStatusTab{display:inline-flex;align-items:center;gap:7px;border:1px solid #dce4e3;background:#fff;border-radius:99px;padding:7px 13px;font:inherit;font-size:13px;font-weight:700;color:#41544f;cursor:pointer}
+.apptStatusTab:hover{border-color:#b7c9c5}
+.apptStatusTab.active{background:var(--green);border-color:var(--green);color:#fff}
+.apptStatusCount{display:inline-grid;place-items:center;min-width:20px;height:20px;padding:0 6px;border-radius:99px;background:#eef2f0;color:#41544f;font-size:11px;font-weight:800}
+.apptStatusTab.active .apptStatusCount{background:rgba(255,255,255,.28);color:#fff}
+.apptEmpty{background:#fff;border:1px solid #dce4e3;border-radius:10px;padding:56px 20px;text-align:center;color:#7a8b88}
+.apptEmpty span{font-size:34px;display:block;margin-bottom:10px;opacity:.6}
+.apptEmpty p{margin:0;font-size:14px}
+.apptListWrap{display:flex;flex-direction:column;gap:8px}
+.apptCardRow{display:flex;align-items:center;gap:14px;background:#fff;border:1px solid #dce4e3;border-radius:10px;padding:12px 16px}
+.apptCardTime{font-weight:800;font-size:15px;color:var(--ink);min-width:52px}
+.apptCardBody{flex:1;display:flex;flex-direction:column;gap:2px;min-width:0}
+.apptCardBody b{font-size:14px}.apptCardBody span{font-size:12.5px;color:#66756f;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.apptBadge{flex-shrink:0;padding:4px 11px;border-radius:99px;font-size:11px;font-weight:800;white-space:nowrap}
+.apptBadge.grp-planned{background:#fdf2df;color:#8a5a12}
+.apptBadge.grp-confirmed{background:#e0eef3;color:#1d5a72}
+.apptBadge.grp-arrived{background:#efe6fa;color:#5b3a99}
+.apptBadge.grp-inroom{background:#e2efe0;color:#2f5c2a}
+.apptBadge.grp-done{background:#e8ece9;color:#48584f}
+.apptBadge.grp-cancelled{background:#fdece7;color:#a23c1d}
+.apptTimeline{position:relative;background:#fff;border:1px solid #dce4e3;border-radius:10px;overflow:hidden}
+.apptHours{position:absolute;top:0;left:0;width:56px;height:100%}
+.apptHour{position:relative;border-bottom:1px solid #eef2f0}
+.apptHour span{position:absolute;top:-8px;left:8px;font-size:11px;font-weight:700;color:#98a6a2;background:#fff;padding:0 3px}
+.apptLane{position:absolute;top:0;left:56px;right:8px;height:100%}
+.apptLaneLine{position:absolute;left:0;right:0;height:1px;background:#eef2f0}
+.apptEvent{position:absolute;left:0;right:0;border-radius:8px;padding:6px 10px;overflow:hidden;border-left:4px solid #b7c9c5;background:#f4f8f6;box-shadow:0 1px 3px rgba(23,54,52,.06)}
+.apptEvent b{display:block;font-size:12.5px;line-height:1.2;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.apptEvent span{font-size:11px;color:#5c6c78;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block}
+.apptEvent.grp-planned{background:#fdf7ec;border-left-color:#e0a638}
+.apptEvent.grp-confirmed{background:#eef5f8;border-left-color:#2f7d99}
+.apptEvent.grp-arrived{background:#f3edfb;border-left-color:#7a53c0}
+.apptEvent.grp-inroom{background:#eef5ec;border-left-color:#3f8a37}
+.apptEvent.grp-done{background:#eef1ef;border-left-color:#7a8b88}
+.apptEvent.grp-cancelled{background:#fdefeb;border-left-color:#c85a38}
 .settingsCard .notice{margin:0;padding:11px 13px;border-radius:7px;font-size:13px}.settingsCard .notice.success{background:#eef4e6;color:#33632c}.settingsCard .notice.error{background:#fdf1ee;color:#a23c1d}
 .dashLists{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .dashList{padding:0;background:#fff;border:1px solid #e7ece9;border-radius:18px;box-shadow:0 1px 2px rgba(24,40,30,.04),0 8px 24px rgba(24,40,30,.05);overflow:hidden}

--- a/app/staff/appointments/page.tsx
+++ b/app/staff/appointments/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { stateLabel } from "../../../lib/study-state";
+
+type Booking = {
+  id: number; code: string; name: string; phone: string; service: string;
+  equipmentId: string; durationMinutes: number; desiredDate: string; desiredTime: string;
+  status: string; patientCategory: string;
+  assignedRadiologistEmail: string; assignedRadiographerEmail: string;
+};
+type StaffOption = { email: string; displayName: string; role: string };
+
+// Групи станів під фільтри у стилі DocTime. Реальні дані здебільшого несуть
+// legacy-статуси (new/confirmed/rescheduled/completed/cancelled), клінічні
+// стани зʼявляються після переходів у реєстрі досліджень.
+const GROUPS: Record<string, string[]> = {
+  planned: ["new", "requested", "needs_verification", "scheduled", "rescheduled"],
+  confirmed: ["confirmed"],
+  arrived: ["arrived"],
+  inroom: ["queued", "in_progress"],
+  done: ["performed", "images_ready", "reporting", "protocol_ready", "issued", "completed"],
+  cancelled: ["cancelled", "no_show"],
+};
+const TABS: { key: string; label: string }[] = [
+  { key: "all", label: "Усі" },
+  { key: "planned", label: "Заплановані" },
+  { key: "confirmed", label: "Підтверджені" },
+  { key: "arrived", label: "Прибув" },
+  { key: "inroom", label: "У кабінеті" },
+  { key: "done", label: "Завершено" },
+  { key: "cancelled", label: "Скасовані" },
+];
+function groupOf(status: string): string {
+  for (const [group, list] of Object.entries(GROUPS)) if (list.includes(status)) return group;
+  return "planned";
+}
+const EQUIP: Record<string, string> = { ct: "КТ", xray: "Рентген", fluoro: "Флюорограф" };
+const DAY_START = 8, DAY_END = 18, HOUR_PX = 64;
+
+function todayKyiv(): string {
+  // YYYY-MM-DD у Києві без залежностей.
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
+}
+function minutesOf(time: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(time || "");
+  if (!m) return null;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
+export default function StaffAppointmentsPage() {
+  const [staff, setStaff] = useState<StaffOption | null>(null);
+  const [items, setItems] = useState<Booking[]>([]);
+  const [options, setOptions] = useState<StaffOption[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [forbidden, setForbidden] = useState(false);
+  const [date, setDate] = useState(todayKyiv());
+  const [view, setView] = useState<"list" | "day">("list");
+  const [tab, setTab] = useState("all");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const res = await fetch("/api/staff/bookings", { cache: "no-store" });
+      if (res.status === 401 || res.status === 403) { if (active) setForbidden(true); return; }
+      const data = await res.json().catch(() => ({})) as { bookings?: Booking[]; staffOptions?: StaffOption[]; staff?: StaffOption };
+      if (!active) return;
+      setItems(data.bookings || []);
+      setOptions(data.staffOptions || []);
+      if (data.staff) setStaff(data.staff);
+      setLoaded(true);
+    })();
+    return () => { active = false; };
+  }, []);
+
+  const nameByEmail = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const o of options) map[o.email] = o.displayName || o.email;
+    return map;
+  }, [options]);
+
+  const dayItems = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return items
+      .filter(b => b.desiredDate === date)
+      .filter(b => tab === "all" || GROUPS[tab]?.includes(b.status))
+      .filter(b => !q || b.name.toLowerCase().includes(q) || (b.phone || "").includes(q))
+      .sort((a, b) => (a.desiredTime || "").localeCompare(b.desiredTime || ""));
+  }, [items, date, tab, search]);
+
+  const counts = useMemo(() => {
+    const onDay = items.filter(b => b.desiredDate === date);
+    const out: Record<string, number> = { all: onDay.length };
+    for (const t of TABS) if (t.key !== "all") out[t.key] = onDay.filter(b => GROUPS[t.key].includes(b.status)).length;
+    return out;
+  }, [items, date]);
+
+  const hours = Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i);
+
+  function card(b: Booking) {
+    const doctor = nameByEmail[b.assignedRadiologistEmail] || nameByEmail[b.assignedRadiographerEmail] || "";
+    return (
+      <div className="apptCardRow" key={b.id}>
+        <span className="apptCardTime">{b.desiredTime || "—"}</span>
+        <div className="apptCardBody">
+          <b>{b.name || "Без імені"}</b>
+          <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctor ? ` · ${doctor}` : ""}</span>
+        </div>
+        <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
+      </div>
+    );
+  }
+
+  const body = forbidden
+    ? <p className="notice error" role="alert">Доступ лише для персоналу.</p>
+    : !loaded
+      ? <p className="notice">Завантаження…</p>
+      : <div className="apptCal">
+          <div className="apptCalBar">
+            <input type="date" value={date} onChange={e => setDate(e.target.value)} />
+            <input type="search" placeholder="Пошук за пацієнтом…" value={search} onChange={e => setSearch(e.target.value)} />
+            <div className="apptViewToggle">
+              <button type="button" className={view === "list" ? "active" : ""} onClick={() => setView("list")}>Список</button>
+              <button type="button" className={view === "day" ? "active" : ""} onClick={() => setView("day")}>День</button>
+            </div>
+          </div>
+          <div className="apptStatusRow">
+            {TABS.map(t => (
+              <button type="button" key={t.key} className={`apptStatusTab${tab === t.key ? " active" : ""}`} onClick={() => setTab(t.key)}>
+                {t.label}<span className="apptStatusCount">{counts[t.key] ?? 0}</span>
+              </button>
+            ))}
+          </div>
+
+          {dayItems.length === 0
+            ? <div className="apptEmpty"><span aria-hidden="true">🗓</span><p>Записів на цей день немає</p></div>
+            : view === "list"
+              ? <div className="apptListWrap">{dayItems.map(card)}</div>
+              : <div className="apptTimeline" style={{ height: (DAY_END - DAY_START) * HOUR_PX }}>
+                  <div className="apptHours">
+                    {hours.map(h => <div className="apptHour" key={h} style={{ height: HOUR_PX }}><span>{String(h).padStart(2, "0")}:00</span></div>)}
+                  </div>
+                  <div className="apptLane">
+                    {hours.map(h => <div className="apptLaneLine" key={h} style={{ top: (h - DAY_START) * HOUR_PX }} />)}
+                    {dayItems.map(b => {
+                      const mins = minutesOf(b.desiredTime);
+                      if (mins === null) return null;
+                      const top = Math.max(0, ((mins - DAY_START * 60) / 60) * HOUR_PX);
+                      const height = Math.max(24, ((b.durationMinutes || 30) / 60) * HOUR_PX - 4);
+                      const doctor = nameByEmail[b.assignedRadiologistEmail] || nameByEmail[b.assignedRadiographerEmail] || "";
+                      return (
+                        <div className={`apptEvent grp-${groupOf(b.status)}`} key={b.id} style={{ top, height }} title={`${b.desiredTime} · ${b.name} · ${b.service}`}>
+                          <b>{b.desiredTime} · {b.name || "Без імені"}</b>
+                          <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctor ? ` · ${doctor}` : ""}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>}
+        </div>;
+
+  return (
+    <StaffWorkspaceShell
+      active="appointments"
+      title="Календар записів"
+      description="Записи на день — список або таймлайн, із фільтрами за станом."
+      staffName={staff?.displayName}
+      staffRole={staff?.role}
+    >
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site" | "appointments";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -38,6 +38,7 @@ const systemModules: NavModule[] = [
     { label:"Вибір часу", href:"/staff/dashboard" },
     { label:"Кабінет пацієнта", href:"/site/cabinet.html", flag:"patient_cabinet" },
     { label:"Черга реєстратури", href:"/staff#bookings" },
+    { label:"Календар записів", href:"/staff/appointments" },
     { label:"Реєстр досліджень", href:"/staff/studies" },
     { label:"Розклад дня", href:"/staff/dashboard" },
     { label:"Нагадування", href:"/staff/settings", flag:"reminders" },
@@ -255,14 +256,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("appointments calendar page reads real bookings and offers list/day views", async () => {
+  const page = await read("app/staff/appointments/page.tsx");
+  assert.match(page, /active="appointments"/);
+  assert.match(page, /\/api\/staff\/bookings/); // реальні дані, без нового бекенду
+  assert.match(page, /view === "list"/);
+  assert.match(page, /view === "day"/);
+  assert.match(page, /apptTimeline/); // таймлайн по годинах
+  assert.match(page, /stateLabel\(/); // людські підписи станів
+});
+
+test("status filter tabs map to real booking statuses", async () => {
+  const page = await read("app/staff/appointments/page.tsx");
+  for (const s of ["planned", "confirmed", "arrived", "inroom", "done", "cancelled"]) {
+    assert.match(page, new RegExp(`${s}:`), `group ${s} present`);
+  }
+  assert.match(page, /"confirmed": \["confirmed"\]|confirmed: \["confirmed"\]/);
+  assert.match(page, /"new"|new,/); // legacy-статус у групі «Заплановані»
+});
+
+test("calendar is wired into the staff shell and nav", async () => {
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/appointments"/);
+  assert.match(shell, /"appointments"/); // у типі WorkspaceSection
+  assert.match(shell, /Календар записів/);
+});


### PR DESCRIPTION
Сторінка **`/staff/appointments`** у стилі DocTime «Записи»: перегляд записів на обраний день у двох виглядах, із фільтрами станів. Читає наявний `GET /api/staff/bookings` — **без нового бекенду й міграцій**.

## Що є
- **Дата** + **пошук за пацієнтом**.
- Перемикач **Список / День**.
- Статус-таби зі лічильниками: **Усі / Заплановані / Підтверджені / Прибув / У кабінеті / Завершено / Скасовані**.
- **Список** — картки записів дня (час, пацієнт, послуга/апарат/лікар, бейдж стану).
- **День** — таймлайн 08:00–18:00 з блоками записів за часом; колір — за групою стану; підписи станів через `stateLabel`.
- Порожній стан «Записів на цей день немає».

Групи станів охоплюють і legacy-статуси (`new/confirmed/rescheduled/completed/cancelled`), і клінічні стани реєстру досліджень (`arrived/queued/in_progress/…`).

## Поза цим кроком
Форма «Нова запис» і налаштування слотів/графіка — окремо (ви обрали саме календар-перегляд).

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **153/153** (нові `appointments-calendar`).

## Де знайти
Кабінет → **Запис і заявки → Календар записів**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_