### PR TITLE
Інтеграція WhatsApp (green-api): підключення, вихідні, чат, бот-меню

### DIFF
--- a/app/api/staff/chat/route.ts
+++ b/app/api/staff/chat/route.ts
@@ -1,0 +1,70 @@
+// Чат з пацієнтами (WhatsApp-листування). Реєстратор/адмін бачать діалоги і
+// відповідають прямо з кабінету. Історія — у patient_communications
+// (channel='whatsapp').
+
+import { canViewPatientRegistry, requireStaff } from "../../../../lib/staff-auth";
+import { normalizeUkrainianPhone } from "../../../../lib/phone";
+import { sendWhatsApp } from "../../../../lib/whatsapp";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Чат доступний реєстратору або адміністратору" }, { status: 403 });
+
+  const phone = normalizeUkrainianPhone(new URL(request.url).searchParams.get("phone") || "");
+  if (phone) {
+    const rows = await db.prepare(
+      `SELECT id, direction, summary AS text, actor, created_at AS createdAt
+       FROM patient_communications WHERE phone_normalized = ? AND channel = 'whatsapp'
+       ORDER BY created_at ASC, id ASC LIMIT 300`
+    ).bind(phone).all();
+    const name = await db.prepare(
+      `SELECT COALESCE(
+         (SELECT display_name FROM patient_profiles WHERE phone_normalized = ?),
+         (SELECT name FROM bookings WHERE phone_normalized = ? ORDER BY id DESC LIMIT 1), '') AS name`
+    ).bind(phone, phone).first<{ name: string }>();
+    return Response.json({ phone, name: name?.name || "", messages: rows.results, staff: member }, { headers: { "cache-control": "no-store" } });
+  }
+
+  const conversations = await db.prepare(
+    `SELECT c.phone_normalized AS phone, c.summary AS lastText, c.direction AS lastDirection,
+       c.created_at AS lastAt,
+       COALESCE(
+         (SELECT display_name FROM patient_profiles p WHERE p.phone_normalized = c.phone_normalized),
+         (SELECT name FROM bookings b WHERE b.phone_normalized = c.phone_normalized ORDER BY id DESC LIMIT 1), '') AS name
+     FROM patient_communications c
+     JOIN (SELECT phone_normalized, MAX(id) AS maxId FROM patient_communications
+           WHERE channel = 'whatsapp' GROUP BY phone_normalized) m
+       ON m.phone_normalized = c.phone_normalized AND m.maxId = c.id
+     ORDER BY c.created_at DESC LIMIT 100`
+  ).all();
+  return Response.json({ conversations: conversations.results, staff: member }, { headers: { "cache-control": "no-store" } });
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Відповідати може реєстратор або адміністратор" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as { phone?: string; text?: string };
+  const phone = normalizeUkrainianPhone(String(body.phone || ""));
+  const text = String(body.text || "").trim().slice(0, 2000);
+  if (!phone || !text) return Response.json({ error: "Вкажіть номер і текст повідомлення" }, { status: 400 });
+
+  const result = await sendWhatsApp(db, phone, text);
+  if (!result.ok) return Response.json({ error: result.error || "Не вдалося надіслати" }, { status: 400 });
+
+  await db.prepare(
+    `INSERT INTO patient_communications (phone_normalized, channel, direction, summary, actor, external_id)
+     VALUES (?, 'whatsapp', 'outbound', ?, ?, ?)`
+  ).bind(phone, text, member.email, result.idMessage || "").run();
+  return Response.json({ ok: true, message: { direction: "outbound", text, actor: member.email, createdAt: new Date().toISOString() } });
+}

--- a/app/api/staff/whatsapp/route.ts
+++ b/app/api/staff/whatsapp/route.ts
@@ -1,0 +1,76 @@
+// Підключення WhatsApp (green-api) — лише адміністратор. Зберігає idInstance,
+// apiToken (секрет) і прапорець enabled у app_settings; видає токен вебхука
+// й готову URL, яку треба вписати в green-api.
+
+import { requireStaff } from "../../../../lib/staff-auth";
+import { getSetting, getSettings, setSetting } from "../../../../lib/settings";
+import { whatsappConfig, whatsappConfigured } from "../../../../lib/whatsapp";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+function clean(value: unknown, max: number) {
+  return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+async function ensureWebhookToken(db: D1Database): Promise<string> {
+  const existing = await getSetting(db, "whatsapp_webhook_token");
+  if (existing) return existing;
+  const token = crypto.randomUUID().replace(/-/g, "");
+  await setSetting(db, "whatsapp_webhook_token", token);
+  return token;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "WhatsApp налаштовує лише адміністратор" }, { status: 403 });
+
+  const cfg = await whatsappConfig(db);
+  const token = await ensureWebhookToken(db);
+  const origin = new URL(request.url).origin;
+  return Response.json({
+    settings: {
+      idInstance: cfg.idInstance,
+      apiTokenSet: Boolean(cfg.apiToken),
+      enabled: cfg.enabled,
+      connected: whatsappConfigured(cfg),
+      webhookUrl: `${origin}/api/whatsapp/webhook?token=${token}`,
+    },
+    staff: member,
+  }, { headers: { "cache-control": "no-store" } });
+}
+
+export async function PUT(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Змінювати WhatsApp може лише адміністратор" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as { idInstance?: string; apiToken?: string; enabled?: boolean };
+  const idInstance = clean(body.idInstance, 40);
+  const apiToken = clean(body.apiToken, 200);
+  // Порожнє поле лишає збережене; "-" очищає (як з іншими секретами).
+  if (idInstance === "-") await setSetting(db, "whatsapp_id_instance", "");
+  else if (idInstance) await setSetting(db, "whatsapp_id_instance", idInstance);
+  if (apiToken === "-") await setSetting(db, "whatsapp_api_token_instance", "");
+  else if (apiToken) await setSetting(db, "whatsapp_api_token_instance", apiToken);
+  await setSetting(db, "whatsapp_enabled", body.enabled ? "1" : "");
+
+  const cfg = await whatsappConfig(db);
+  const { whatsapp_webhook_token: token } = await getSettings(db, ["whatsapp_webhook_token"]);
+  const origin = new URL(request.url).origin;
+  return Response.json({
+    ok: true,
+    settings: {
+      idInstance: cfg.idInstance,
+      apiTokenSet: Boolean(cfg.apiToken),
+      enabled: cfg.enabled,
+      connected: whatsappConfigured(cfg),
+      webhookUrl: `${origin}/api/whatsapp/webhook?token=${token}`,
+    },
+  }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/api/staff/whatsapp/test/route.ts
+++ b/app/api/staff/whatsapp/test/route.ts
@@ -1,0 +1,21 @@
+// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест») — лише адміністратор.
+import { requireStaff } from "../../../../../lib/staff-auth";
+import { normalizeUkrainianPhone } from "../../../../../lib/phone";
+import { sendWhatsApp } from "../../../../../lib/whatsapp";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member || member.role !== "admin") return Response.json({ error: "Лише адміністратор" }, { status: 403 });
+  const body = await request.json().catch(() => ({})) as { phone?: string };
+  const phone = normalizeUkrainianPhone(String(body.phone || ""));
+  if (!phone) return Response.json({ error: "Вкажіть коректний номер для тесту" }, { status: 400 });
+  const result = await sendWhatsApp(db, phone, "Тестове повідомлення від відділення променевої діагностики. WhatsApp підключено ✅");
+  if (!result.ok) return Response.json({ error: result.error || "Не вдалося надіслати" }, { status: 400 });
+  return Response.json({ ok: true });
+}

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,0 +1,72 @@
+// Публічний вебхук green-api для вхідних WhatsApp-повідомлень. Захищений
+// секретним ?token=. Зберігає повідомлення в patient_communications, дедуплікує
+// за idMessage і за потреби відповідає бот-меню.
+
+import { getSetting } from "../../../../lib/settings";
+import { isRateLimited } from "../../../../lib/rate-limit";
+import { parseSiteContent, SITE_CONTENT_KEY } from "../../../../lib/site-content";
+import { interpretBotCommand, menuText, parseIncomingWebhook, sendWhatsApp } from "../../../../lib/whatsapp";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+function todayKyiv(): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
+}
+
+async function botReply(db: D1Database, phone: string, text: string, origin: string): Promise<string | null> {
+  const action = interpretBotCommand(text);
+  if (action === "menu") return menuText();
+  if (action === "human") return "Передав ваше звернення адміністратору — незабаром звʼяжемося.";
+  if (action === "booking") return `Записатися можна тут: ${origin}\nОберіть послугу й натисніть «Записатися».`;
+  if (action === "info") {
+    const content = parseSiteContent(await getSetting(db, SITE_CONTENT_KEY));
+    return [content.brandTitle, `📍 ${content.address}`, `🕒 ${content.workHours}`, `📞 ${content.phone}`, `Ціни: ${origin}`].filter(Boolean).join("\n");
+  }
+  if (action === "appointments") {
+    const rows = await db.prepare(
+      `SELECT service, desired_date AS d, desired_time AS t, status FROM bookings
+       WHERE phone_normalized = ? AND desired_date >= ? AND status NOT IN ('cancelled','completed')
+       ORDER BY desired_date, desired_time LIMIT 5`
+    ).bind(phone, todayKyiv()).all();
+    const list = (rows.results || []) as Array<{ service: string; d: string; t: string }>;
+    if (!list.length) return "У вас немає найближчих записів. Надішліть 2, щоб записатися.";
+    return ["Ваші найближчі записи:", ...list.map((r) => `• ${r.d}${r.t ? ` ${r.t}` : ""} — ${r.service}`)].join("\n");
+  }
+  return null; // не з меню — лишаємо персоналу, без автовідповіді
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ ok: false }, { status: 503 });
+
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token") || "";
+  const expected = await getSetting(db, "whatsapp_webhook_token");
+  if (!expected || token !== expected) return Response.json({ ok: false }, { status: 401 });
+  if (await isRateLimited(db, request, "whatsapp-webhook", 120, 15)) return Response.json({ ok: true });
+
+  const body = await request.json().catch(() => null);
+  const msg = parseIncomingWebhook(body);
+  if (!msg) return Response.json({ ok: true }); // не текстове/не вхідне — ігноруємо
+
+  // Дедуплікація повторних вебхуків за idMessage.
+  const inserted = await db.prepare(
+    `INSERT OR IGNORE INTO patient_communications (phone_normalized, channel, direction, summary, actor, external_id)
+     VALUES (?, 'whatsapp', 'inbound', ?, 'patient', ?)`
+  ).bind(msg.phoneNormalized, msg.text || "(без тексту)", msg.idMessage || `${msg.phoneNormalized}-${msg.text.slice(0, 40)}`).run();
+  if (!inserted.meta.changes) return Response.json({ ok: true }); // вже опрацьовано
+
+  const reply = await botReply(db, msg.phoneNormalized, msg.text, url.origin);
+  if (reply) {
+    const sent = await sendWhatsApp(db, msg.phoneNormalized, reply);
+    if (sent.ok) {
+      await db.prepare(
+        `INSERT INTO patient_communications (phone_normalized, channel, direction, summary, actor, external_id)
+         VALUES (?, 'whatsapp', 'outbound', ?, 'bot', ?)`
+      ).bind(msg.phoneNormalized, reply, sent.idMessage || "").run();
+    }
+  }
+  return Response.json({ ok: true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -309,6 +309,33 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .apptEvent.grp-inroom{background:#eef5ec;border-left-color:#3f8a37}
 .apptEvent.grp-done{background:#eef1ef;border-left-color:#7a8b88}
 .apptEvent.grp-cancelled{background:#fdefeb;border-left-color:#c85a38}
+/* WhatsApp сторінка */
+.waSteps{margin:6px 0 0;padding-left:20px;color:#41544f;font-size:13px;line-height:1.6}.waSteps li{margin-bottom:6px}
+.waBotList{margin:6px 0 10px;padding-left:18px;color:#41544f;font-size:13px;line-height:1.7}
+.settingsCard input[readonly]{background:#f4f8f6}
+/* Чат з пацієнтами */
+.chatShell{display:grid;grid-template-columns:320px 1fr;gap:14px;max-width:1100px;margin:0 auto;height:calc(100vh - 220px);min-height:440px}
+.chatList{background:#fff;border:1px solid #dce4e3;border-radius:10px;overflow-y:auto;padding:6px}
+.chatList .empty{padding:20px;color:#7a8b88;font-size:13px;text-align:center}
+.chatListItem{display:block;width:100%;text-align:left;border:0;background:none;border-radius:8px;padding:11px 12px;cursor:pointer;position:relative}
+.chatListItem:hover{background:#f2f6f4}.chatListItem.active{background:#e6f0ec}
+.chatListItem b{display:block;font-size:13.5px;color:var(--ink);margin-bottom:2px}
+.chatListItem small{display:block;font-size:12px;color:#66756f;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:230px}
+.chatListTime{position:absolute;top:11px;right:12px;font-size:10.5px;color:#98a6a2}
+.chatThread{background:#fff;border:1px solid #dce4e3;border-radius:10px;display:flex;flex-direction:column;overflow:hidden}
+.chatEmpty{margin:auto;text-align:center;color:#7a8b88}.chatEmpty span{font-size:34px;display:block;margin-bottom:8px;opacity:.6}
+.chatThreadHead{padding:14px 16px;border-bottom:1px solid #eef2f0}.chatThreadHead b{display:block;font-size:14px}.chatThreadHead small{color:#7a8b88;font-size:12px}
+.chatMessages{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:8px;background:#f7faf9}
+.chatMessages .empty{margin:auto;color:#98a6a2;font-size:13px}
+.chatMsg{max-width:76%;padding:8px 12px;border-radius:12px;font-size:13.5px;line-height:1.45}
+.chatMsg p{margin:0;white-space:pre-wrap;word-break:break-word}
+.chatMsg span{display:block;margin-top:3px;font-size:10.5px;opacity:.7}
+.chatMsg.in{align-self:flex-start;background:#fff;border:1px solid #e4e9e6;border-bottom-left-radius:3px}
+.chatMsg.out{align-self:flex-end;background:#d6f0dd;border-bottom-right-radius:3px}
+.chatReply{display:flex;gap:8px;padding:12px 14px;border-top:1px solid #eef2f0}
+.chatReply input{flex:1;padding:11px 13px;border:1px solid #cbd8d6;border-radius:8px;font:inherit}.chatReply input:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+.chatReply button{padding:0 18px;border:0;border-radius:8px;background:var(--green);color:#fff;font-weight:800;font-size:13px;cursor:pointer}.chatReply button:disabled{opacity:.5;cursor:not-allowed}
+@media(max-width:720px){.chatShell{grid-template-columns:1fr;height:auto}.chatThread{min-height:420px}}
 .settingsCard .notice{margin:0;padding:11px 13px;border-radius:7px;font-size:13px}.settingsCard .notice.success{background:#eef4e6;color:#33632c}.settingsCard .notice.error{background:#fdf1ee;color:#a23c1d}
 .dashLists{max-width:1500px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .dashList{padding:0;background:#fff;border:1px solid #e7ece9;border-radius:18px;box-shadow:0 1px 2px rgba(24,40,30,.04),0 8px 24px rgba(24,40,30,.05);overflow:hidden}

--- a/app/staff/chat/page.tsx
+++ b/app/staff/chat/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+type Conversation = { phone: string; name: string; lastText: string; lastDirection: string; lastAt: string };
+type Message = { id?: number; direction: string; text: string; actor: string; createdAt: string };
+
+function displayPhone(phone: string) {
+  return /^380\d{9}$/.test(phone) ? `+${phone.slice(0, 3)} ${phone.slice(3, 5)} ${phone.slice(5, 8)} ${phone.slice(8, 10)} ${phone.slice(10)}` : phone;
+}
+function shortTime(value: string) {
+  const d = new Date((value || "").replace(" ", "T") + (value && !value.includes("Z") ? "Z" : ""));
+  return Number.isNaN(d.getTime()) ? "" : new Intl.DateTimeFormat("uk-UA", { timeZone: "Europe/Kyiv", day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" }).format(d);
+}
+
+export default function StaffChatPage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [active, setActive] = useState<string | null>(null);
+  const [activeName, setActiveName] = useState("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState("");
+
+  async function loadConversations() {
+    const res = await fetch("/api/staff/chat", { cache: "no-store" });
+    if (res.status === 403) { setForbidden(true); return; }
+    const data = await res.json().catch(() => ({})) as { conversations?: Conversation[]; staff?: StaffInfo };
+    setConversations(data.conversations || []);
+    if (data.staff) setStaff(data.staff);
+    setLoaded(true);
+  }
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void loadConversations(); }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  async function openConversation(phone: string) {
+    setActive(phone); setError(""); setMessages([]);
+    const res = await fetch(`/api/staff/chat?phone=${encodeURIComponent(phone)}`, { cache: "no-store" });
+    const data = await res.json().catch(() => ({})) as { messages?: Message[]; name?: string };
+    setMessages(data.messages || []);
+    setActiveName(data.name || "");
+  }
+
+  async function reply(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!active || !draft.trim()) return;
+    setSending(true); setError("");
+    const text = draft.trim();
+    const res = await fetch("/api/staff/chat", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: active, text }),
+    });
+    const data = await res.json().catch(() => ({})) as { ok?: boolean; message?: Message; error?: string };
+    setSending(false);
+    if (!res.ok || !data.ok) { setError(data.error || "Не вдалося надіслати"); return; }
+    setDraft("");
+    if (data.message) setMessages(m => [...m, data.message as Message]);
+    void loadConversations();
+  }
+
+  const body = forbidden
+    ? <p className="notice error" role="alert">Чат доступний реєстратору або адміністратору.</p>
+    : <div className="chatShell">
+        <aside className="chatList">
+          {!loaded ? <p className="empty">Завантаження…</p>
+            : conversations.length === 0 ? <p className="empty">Поки немає повідомлень. Тут з’явиться листування, коли пацієнт напише у WhatsApp клініки.</p>
+              : conversations.map(c => (
+                <button key={c.phone} className={`chatListItem${active === c.phone ? " active" : ""}`} onClick={() => void openConversation(c.phone)}>
+                  <b>{c.name || displayPhone(c.phone)}</b>
+                  <small>{c.lastDirection === "inbound" ? "" : "Ви: "}{c.lastText}</small>
+                  <span className="chatListTime">{shortTime(c.lastAt)}</span>
+                </button>
+              ))}
+        </aside>
+        <section className="chatThread">
+          {!active ? <div className="chatEmpty"><span aria-hidden="true">💬</span><p>Оберіть діалог зліва</p></div>
+            : <>
+                <header className="chatThreadHead"><b>{activeName || displayPhone(active)}</b><small>{displayPhone(active)}</small></header>
+                <div className="chatMessages">
+                  {messages.map((m, i) => (
+                    <div key={m.id ?? i} className={`chatMsg ${m.direction === "inbound" ? "in" : "out"}`}>
+                      <p>{m.text}</p>
+                      <span>{m.direction === "inbound" ? "" : m.actor === "bot" ? "Бот · " : ""}{shortTime(m.createdAt)}</span>
+                    </div>
+                  ))}
+                  {messages.length === 0 && <p className="empty">Повідомлень ще немає.</p>}
+                </div>
+                {error && <p className="notice error" role="alert">{error}</p>}
+                <form className="chatReply" onSubmit={reply}>
+                  <input value={draft} onChange={e => setDraft(e.target.value)} placeholder="Ваша відповідь…" />
+                  <button type="submit" disabled={sending || !draft.trim()}>{sending ? "…" : "Надіслати"}</button>
+                </form>
+              </>}
+        </section>
+      </div>;
+
+  return (
+    <StaffWorkspaceShell active="chat" title="Чат з пацієнтами" description="WhatsApp-листування — відповідайте прямо звідси." staffName={staff?.displayName} staffRole={staff?.role}>
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/whatsapp/page.tsx
+++ b/app/staff/whatsapp/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+type Settings = { idInstance: string; apiTokenSet: boolean; enabled: boolean; connected: boolean; webhookUrl: string };
+
+export default function StaffWhatsAppPage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [idInstance, setIdInstance] = useState("");
+  const [apiToken, setApiToken] = useState("");
+  const [enabled, setEnabled] = useState(false);
+  const [testPhone, setTestPhone] = useState("");
+  const [status, setStatus] = useState<"idle" | "saving" | "testing">("idle");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const res = await fetch("/api/staff/whatsapp", { cache: "no-store" });
+      if (res.status === 403) { if (active) setForbidden(true); return; }
+      const data = await res.json().catch(() => ({})) as { settings?: Settings; staff?: StaffInfo };
+      if (!active) return;
+      if (data.settings) { setSettings(data.settings); setIdInstance(data.settings.idInstance); setEnabled(data.settings.enabled); }
+      if (data.staff) setStaff(data.staff);
+    })();
+    return () => { active = false; };
+  }, []);
+
+  async function save(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("saving"); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/whatsapp", {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ idInstance, apiToken, enabled }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; settings?: Settings; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
+      if (data.settings) { setSettings(data.settings); setApiToken(""); }
+      setNotice("Збережено.");
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося зберегти"); }
+    finally { setStatus("idle"); }
+  }
+
+  async function sendTest() {
+    setStatus("testing"); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/whatsapp/test", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ phone: testPhone }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося надіслати");
+      setNotice("Тестове повідомлення надіслано ✅");
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося надіслати"); }
+    finally { setStatus("idle"); }
+  }
+
+  const body = forbidden
+    ? <p className="notice error" role="alert">WhatsApp налаштовує лише адміністратор.</p>
+    : !settings
+      ? <p className="notice">Завантаження…</p>
+      : <div className="settingsCard">
+          <section className="settingsBlock">
+            <span className={`settingsState ${settings.connected ? "on" : "off"}`}>{settings.connected ? "Підключено" : "Не підключено"}</span>
+            <h3>Як підключити</h3>
+            <ol className="waSteps">
+              <li>Зареєструйтеся на <b>green-api.com</b> — це сервіс, через який WhatsApp з’єднується з програмами.</li>
+              <li>Натисніть «Створити інстанс» і відскануйте QR-код робочим WhatsApp клініки (як у WhatsApp Web).</li>
+              <li>Скопіюйте звідти <b>idInstance</b> (число) і <b>apiTokenInstance</b> (довгий код) у поля нижче.</li>
+              <li>Впишіть URL вебхука (нижче) у налаштуваннях інстансу green-api — щоб вхідні повідомлення надходили в чат.</li>
+            </ol>
+          </section>
+
+          <form className="settingsBlock" onSubmit={save}>
+            <h3>Ключі green-api</h3>
+            <label><span>idInstance (число)</span><input value={idInstance} onChange={e => setIdInstance(e.target.value)} placeholder="напр. 1101000001" /></label>
+            <label><span>apiTokenInstance (код)</span><input type="password" value={apiToken} onChange={e => setApiToken(e.target.value)} placeholder={settings.apiTokenSet ? "•••••••• (збережено)" : "Довгий код із green-api"} autoComplete="off" /><small>Порожньо — лишити збережений; «-» — очистити.</small></label>
+            <label className="crmCheck"><input type="checkbox" checked={enabled} onChange={e => setEnabled(e.target.checked)} /><span>Надсилати пацієнтам підтвердження/нагадування у WhatsApp</span></label>
+            {notice && <p className="notice success" role="status">{notice}</p>}
+            {error && <p className="notice error" role="alert">{error}</p>}
+            <button className="button" type="submit" disabled={status === "saving"}>{status === "saving" ? "Зберігаємо…" : "Підключити WhatsApp"}</button>
+          </form>
+
+          <section className="settingsBlock">
+            <h3>URL вебхука (впишіть у green-api)</h3>
+            <label><span>Webhook URL</span><input readOnly value={settings.webhookUrl} onFocus={e => e.target.select()} /></label>
+            <button type="button" className="button secondary" onClick={() => { void navigator.clipboard?.writeText(settings.webhookUrl); setCopied(true); }}>{copied ? "Скопійовано ✓" : "Скопіювати URL"}</button>
+          </section>
+
+          <section className="settingsBlock">
+            <h3>Тест</h3>
+            <label><span>Номер для тесту</span><input value={testPhone} onChange={e => setTestPhone(e.target.value)} placeholder="+380 97 000 00 00" /></label>
+            <button type="button" className="button secondary" onClick={() => void sendTest()} disabled={status === "testing" || !settings.connected}>{status === "testing" ? "Надсилаємо…" : "Надіслати тест"}</button>
+          </section>
+
+          <section className="settingsBlock">
+            <h3>Що вміє бот</h3>
+            <p className="settingsHint">Пацієнт надсилає цифру — бот відповідає:</p>
+            <ul className="waBotList">
+              <li>1 — показати найближчі записи</li>
+              <li>2 — як записатися на дослідження</li>
+              <li>3 — адреса, години роботи та ціни</li>
+              <li>4 — передати звернення адміністратору</li>
+            </ul>
+            <p className="settingsHint">Будь-який інший текст потрапляє в розділ «Чат з пацієнтами» — відповідаєте вручну.</p>
+          </section>
+        </div>;
+
+  return (
+    <StaffWorkspaceShell active="whatsapp" title="WhatsApp" description="Підключення номера, автонагадування та бот — керує адміністратор." staffName={staff?.displayName} staffRole={staff?.role}>
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site" | "appointments";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site" | "appointments" | "whatsapp" | "chat";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -46,6 +46,7 @@ const systemModules: NavModule[] = [
   ]},
   { n:"3", label:"CRM (пацієнти/клієнти)", href:"/staff/patients", section:"patients", items:[
     { label:"Картка пацієнта", href:"/staff/patients" },
+    { label:"Чат з пацієнтами", href:"/staff/chat" },
     { label:"Комунікації", href:"/staff/patients" },
     { label:"Сегменти", href:"/staff/patients" },
     { label:"Експорт контактів", href:"/staff/patients" },
@@ -84,6 +85,7 @@ const systemModules: NavModule[] = [
   { n:"7", label:"Адмін / Наскрізне", href:"/staff/dashboard", section:"dashboard", items:[
     { label:"Пульт відділення", href:"/staff/dashboard" },
     { label:"Організація та профіль", href:"/staff/organization" },
+    { label:"WhatsApp", href:"/staff/whatsapp" },
     { label:"Налаштування", href:"/staff/settings" },
     { label:"Ролі й права", href:"/staff#staff-admin" },
     { label:"Календар", href:"/staff/settings" },
@@ -256,14 +258,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "whatsapp" || active === "chat"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -246,6 +246,7 @@ export const patientCommunications = sqliteTable("patient_communications", {
   direction: text("direction").notNull().default("outbound"),
   summary: text("summary").notNull().default(""),
   actor: text("actor").notNull(),
+  externalId: text("external_id").notNull().default(""),
   createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
 }, table => [index("patient_communications_phone_idx").on(table.phoneNormalized, table.createdAt)]);
 

--- a/drizzle/0021_whatsapp.sql
+++ b/drizzle/0021_whatsapp.sql
@@ -1,0 +1,5 @@
+-- WhatsApp-листування зберігається в patient_communications (channel='whatsapp').
+-- external_id = idMessage від green-api, щоб дедуплікувати повторні вебхуки.
+ALTER TABLE `patient_communications` ADD COLUMN `external_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `patient_comm_external_idx` ON `patient_communications` (`external_id`) WHERE `external_id` != '';

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -8,6 +8,7 @@
 
 import { getSettings } from "./settings";
 import { createMessagingProvider } from "./providers/messaging";
+import { sendWhatsApp, whatsappConfig, whatsappConfigured } from "./whatsapp";
 
 export type ReminderKind = "confirmed" | "rescheduled";
 
@@ -46,7 +47,7 @@ async function record(
   db: D1Database,
   booking: ReminderBooking,
   kind: ReminderKind,
-  channel: "sms" | "email",
+  channel: "sms" | "email" | "whatsapp",
   recipient: string,
   body: string,
   status: "sent" | "skipped" | "failed",
@@ -99,7 +100,14 @@ export async function sendPatientReminder(
     }
   }
 
-  const channels: Array<{ channel: "sms" | "email"; recipient: string; url: string; send: () => Promise<void> }> = [];
+  const channels: Array<{ channel: "sms" | "email" | "whatsapp"; recipient: string; url: string; send: () => Promise<void> }> = [];
+  const wa = await whatsappConfig(db);
+  if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
+    channels.push({
+      channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
+      send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
+    });
+  }
   if (booking.phone) {
     channels.push({
       channel: "sms", recipient: booking.phone, url: cfg.sms_gateway_url || "",

--- a/lib/whatsapp-bot.ts
+++ b/lib/whatsapp-bot.ts
@@ -1,0 +1,54 @@
+// Чисті (без залежностей) функції бота й розбору вебхука green-api —
+// винесено окремо, щоб бути напряму тестованими.
+
+export type BotAction = "menu" | "appointments" | "booking" | "info" | "human" | null;
+
+export function interpretBotCommand(text: string): BotAction {
+  const t = String(text || "").trim().toLowerCase();
+  if (!t) return "menu";
+  if (["меню", "menu", "привіт", "привет", "hi", "hello", "старт", "start", "0"].includes(t)) return "menu";
+  if (t === "1") return "appointments";
+  if (t === "2") return "booking";
+  if (t === "3") return "info";
+  if (t === "4") return "human";
+  return null; // не з меню — передаємо персоналу, автовідповіді немає
+}
+
+export function menuText(): string {
+  return [
+    "Вітаємо! Оберіть дію, надіславши цифру:",
+    "1 — Мої найближчі записи",
+    "2 — Записатися на дослідження",
+    "3 — Адреса, години роботи та ціни",
+    "4 — Звʼязатися з адміністратором",
+  ].join("\n");
+}
+
+type IncomingWebhook = {
+  typeWebhook?: string;
+  idMessage?: string;
+  senderData?: { chatId?: string; senderName?: string };
+  messageData?: {
+    textMessageData?: { textMessage?: string };
+    extendedTextMessageData?: { text?: string };
+  };
+};
+
+export type IncomingMessage = { phoneNormalized: string; text: string; idMessage: string; senderName: string };
+
+export function parseIncomingWebhook(body: unknown): IncomingMessage | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as IncomingWebhook;
+  if (b.typeWebhook !== "incomingMessageReceived") return null;
+  const phoneNormalized = String(b.senderData?.chatId || "").replace(/@c\.us$/, "").replace(/\D/g, "");
+  if (!/^380\d{9}$/.test(phoneNormalized)) return null;
+  const text = String(
+    b.messageData?.textMessageData?.textMessage ?? b.messageData?.extendedTextMessageData?.text ?? "",
+  ).trim().slice(0, 2000);
+  return {
+    phoneNormalized,
+    text,
+    idMessage: String(b.idMessage || "").slice(0, 120),
+    senderName: String(b.senderData?.senderName || "").slice(0, 120),
+  };
+}

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -1,0 +1,58 @@
+// Best-effort WhatsApp через green-api.com. Тихий no-op, поки адміністратор
+// не збереже idInstance + apiToken на сторінці «WhatsApp» у кабінеті.
+// Дзеркалить lib/telegram.ts: прямий fetch до сталого хоста green-api.
+
+import { getSettings } from "./settings";
+
+// Чисті функції бота/розбору — у окремому модулі (тестовані без залежностей).
+export { interpretBotCommand, menuText, parseIncomingWebhook } from "./whatsapp-bot";
+export type { BotAction, IncomingMessage } from "./whatsapp-bot";
+
+const GREEN_API_HOST = "https://api.green-api.com";
+
+export type WhatsAppConfig = { idInstance: string; apiToken: string; enabled: boolean };
+
+export async function whatsappConfig(db: D1Database): Promise<WhatsAppConfig> {
+  const s = await getSettings(db, ["whatsapp_id_instance", "whatsapp_api_token_instance", "whatsapp_enabled"]);
+  const enabled = ["1", "true", "on", "yes"].includes((s.whatsapp_enabled || "").trim().toLowerCase());
+  return { idInstance: s.whatsapp_id_instance || "", apiToken: s.whatsapp_api_token_instance || "", enabled };
+}
+
+export function whatsappConfigured(cfg: WhatsAppConfig): boolean {
+  return Boolean(cfg.idInstance && cfg.apiToken);
+}
+
+// Надсилає повідомлення пацієнту. Нічого не записує — облік лишається за
+// викликачем (нагадування / чат / вебхук).
+export async function sendWhatsApp(
+  db: D1Database,
+  phoneNormalized: string,
+  text: string,
+): Promise<{ ok: boolean; error?: string; idMessage?: string }> {
+  const cfg = await whatsappConfig(db);
+  if (!whatsappConfigured(cfg)) return { ok: false, error: "WhatsApp не підключено (немає idInstance / apiToken)" };
+  const phone = String(phoneNormalized || "").replace(/\D/g, "");
+  if (!phone) return { ok: false, error: "Некоректний номер отримувача" };
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const response = await fetch(
+      `${GREEN_API_HOST}/waInstance${encodeURIComponent(cfg.idInstance)}/sendMessage/${encodeURIComponent(cfg.apiToken)}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ chatId: `${phone}@c.us`, message: text }),
+        signal: controller.signal,
+      },
+    );
+    clearTimeout(timer);
+    if (response.ok) {
+      const data = await response.json().catch(() => ({})) as { idMessage?: string };
+      return { ok: true, idMessage: data.idMessage };
+    }
+    const data = await response.json().catch(() => ({})) as { message?: string };
+    return { ok: false, error: data.message || `green-api відповів помилкою (${response.status})` };
+  } catch {
+    return { ok: false, error: "Не вдалося з'єднатися з green-api" };
+  }
+}

--- a/tests/whatsapp.test.mjs
+++ b/tests/whatsapp.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { interpretBotCommand, menuText, parseIncomingWebhook } from "../lib/whatsapp-bot.ts";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("bot menu maps digits to actions and unknown text to human staff", () => {
+  assert.equal(interpretBotCommand(""), "menu");
+  assert.equal(interpretBotCommand("Меню"), "menu");
+  assert.equal(interpretBotCommand("1"), "appointments");
+  assert.equal(interpretBotCommand("2"), "booking");
+  assert.equal(interpretBotCommand("3"), "info");
+  assert.equal(interpretBotCommand("4"), "human");
+  assert.equal(interpretBotCommand("боли в спине"), null); // не з меню → персонал
+  assert.match(menuText(), /1 —/);
+});
+
+test("green-api incoming webhook parses text messages and rejects noise", () => {
+  const ok = parseIncomingWebhook({
+    typeWebhook: "incomingMessageReceived",
+    idMessage: "ABC123",
+    senderData: { chatId: "380971234567@c.us", senderName: "Іван" },
+    messageData: { typeMessage: "textMessage", textMessageData: { textMessage: "1" } },
+  });
+  assert.deepEqual(ok, { phoneNormalized: "380971234567", text: "1", idMessage: "ABC123", senderName: "Іван" });
+  assert.equal(parseIncomingWebhook({ typeWebhook: "outgoingMessageStatus" }), null); // не вхідне
+  assert.equal(parseIncomingWebhook({ typeWebhook: "incomingMessageReceived", senderData: { chatId: "not-a-phone@c.us" } }), null);
+});
+
+test("migration 0021 adds external_id and dedupes by unique index", async () => {
+  const dir = new URL("../drizzle/", import.meta.url);
+  const files = (await readdir(dir)).filter(f => f.endsWith(".sql")).sort();
+  const db = new DatabaseSync(":memory:");
+  for (const f of files) {
+    const sql = await readFile(new URL(f, dir), "utf8");
+    for (const s of sql.split(/-->\s*statement-breakpoint/).map(x => x.trim()).filter(Boolean)) db.exec(s);
+  }
+  const cols = db.prepare("PRAGMA table_info(patient_communications)").all().map(c => c.name);
+  assert.ok(cols.includes("external_id"));
+  const ins = () => db.prepare("INSERT OR IGNORE INTO patient_communications (phone_normalized, channel, direction, summary, actor, external_id) VALUES (?,?,?,?,?,?)")
+    .run("380971234567", "whatsapp", "inbound", "1", "patient", "MSG-1");
+  assert.equal(ins().changes, 1); // перший запис
+  assert.equal(ins().changes, 0); // повторний вебхук — ігнорується
+});
+
+test("whatsapp send is a guarded no-op until configured", async () => {
+  const lib = await read("lib/whatsapp.ts");
+  assert.match(lib, /WhatsApp не підключено/);
+  assert.match(lib, /waInstance\$\{encodeURIComponent\(cfg\.idInstance\)\}\/sendMessage/);
+  assert.match(lib, /@c\.us/);
+});
+
+test("webhook route is token-guarded, deduped and rate-limited", async () => {
+  const route = await read("app/api/whatsapp/webhook/route.ts");
+  assert.match(route, /token !== expected/);
+  assert.match(route, /isRateLimited\(db, request, "whatsapp-webhook"/);
+  assert.match(route, /INSERT OR IGNORE INTO patient_communications/);
+  assert.match(route, /interpretBotCommand|botReply/);
+});
+
+test("staff whatsapp + chat routes are permission-guarded", async () => {
+  const wa = await read("app/api/staff/whatsapp/route.ts");
+  assert.match(wa, /member\.role !== "admin"/);
+  assert.match(wa, /whatsapp_api_token_instance/);
+  const chat = await read("app/api/staff/chat/route.ts");
+  assert.match(chat, /canViewPatientRegistry\(member\.role\)/);
+  assert.match(chat, /channel = 'whatsapp'/);
+  assert.match(chat, /sendWhatsApp\(/);
+});
+
+test("whatsapp is wired as a reminder channel and into the nav", async () => {
+  const notify = await read("lib/notify.ts");
+  assert.match(notify, /channel: "whatsapp"/);
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/whatsapp"/);
+  assert.match(shell, /href:"\/staff\/chat"/);
+});


### PR DESCRIPTION
Повний конвеєр WhatsApp через **green-api.com**, як у DocTime. Кожна частина **захищена**: без ключів усе тихо no-op (як Telegram) — наявний сайт/логіка не ламаються.

## 1. Підключення
- `lib/whatsapp.ts` (+ standalone `lib/whatsapp-bot.ts` для чистих функцій) — `sendWhatsApp` через green-api `sendMessage`, конфіг з `app_settings`, гард «не налаштовано».
- `/api/staff/whatsapp` — admin `GET/PUT` (`idInstance`, `apiToken`-секрет, `enabled`) + автогенерація токена вебхука і готова **webhook-URL**.
- `/staff/whatsapp` — сторінка підключення: інструкція green-api, поля ключів, URL вебхука для копіювання, тест-надсилання, «що вміє бот». Пункт у модулі 7.

## 2. Вихідні
- `lib/notify.ts` — **WhatsApp як ще один канал автонагадувань** (підтвердження/перенесення) поряд із SMS/e-mail, з повагою до «не турбувати». Роут `bookings` не змінювався.

## 3. Вхідні + чат
- `/api/whatsapp/webhook` — **публічний** вебхук green-api, захищений секретним `?token=`, з rate-limit і **дедуплікацією за `idMessage`** (`INSERT OR IGNORE`). Зберігає у `patient_communications`.
- `/staff/chat` + `/api/staff/chat` — інбокс діалогів і відповідь із кабінету (`canViewPatientRegistry`). Пункт у модулі 3 (CRM).
- `drizzle/0021` + schema — `external_id` у `patient_communications` + частковий унікальний індекс.

## 4. Бот-меню
`interpretBotCommand`: **1** мої записи (з БД) · **2** записатися · **3** адреса/години/ціни (із `site_content`) · **4** передати адміну. Будь-який інший текст — у «Чат з пацієнтами» до персоналу.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **165/165** (нові `whatsapp`).

## Після мерджу — як увімкнути
1. Деплой `main` (міграція 0021 застосується сама).
2. Кабінет → **WhatsApp**: зареєструйтесь на green-api.com, створіть інстанс, відскануйте QR, впишіть `idInstance` + `apiToken`, увімкніть, **скопіюйте webhook-URL у green-api**.
3. Далі: пацієнти пишуть у ваш WhatsApp → бот відповідає, а листування — у розділі **Чат з пацієнтами**.

⚠️ Без акаунта green-api інтеграція просто мовчить; тестувати проти живого green-api з мого боку неможливо — тому надійність забезпечено тестами логіки (бот, розбір вебхука, дедуп) і гардами.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_