### PR TITLE
Вітрина: етап 2 (колір/тема/логотип), 2 види вітрини і схема в редакторі

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -256,7 +256,21 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .settingsCard .linkBtn{border:0;background:none;color:var(--green);font:inherit;font-weight:700;cursor:pointer;padding:0;text-decoration:underline}.settingsCard .linkBtn:hover{color:#0a4b42}
 .settingsCard input[readonly]{background:#f4f8f6;color:#41544f}
 .settingsCard textarea{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);resize:vertical;min-height:72px;margin-top:6px}.settingsCard textarea:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+.settingsCard select{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);background:#fff}.settingsCard select:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
 .settingsBlock h3{font-size:15px;font-weight:700;margin:0 0 6px}
+.settingsBlock h3 .ssNum{margin-right:8px}
+.ssNum{display:inline-grid;place-items:center;width:20px;height:20px;border-radius:50%;background:var(--brand,#0c7a85);color:#fff;font-size:11px;font-weight:800;flex-shrink:0}
+.siteSchema{--brand:#0c7a85;display:flex;flex-direction:column;gap:8px;margin-top:8px}
+.siteSchema .ssZone{display:flex;align-items:center;gap:8px;border:1px solid #dce4e3;border-radius:8px;padding:12px 14px;font-size:13px;font-weight:600;color:#41544f;background:#fff}
+.siteSchema .ssRow{display:flex;gap:8px}.siteSchema .ssRow .ssZone{flex:1}
+.siteSchema .ssHeader,.siteSchema .ssContact{background:var(--brand);border-color:var(--brand);color:#fff}
+.siteSchema .ssHeader .ssNum,.siteSchema .ssContact .ssNum{background:rgba(255,255,255,.28)}
+.colorRow{display:flex;align-items:center;gap:12px;margin-top:6px}
+.colorRow input[type="color"]{width:46px;height:38px;padding:0;border:1px solid #cbd8d6;border-radius:8px;background:none;cursor:pointer}
+.colorSwatches{display:inline-flex;gap:8px;flex-wrap:wrap}
+.colorSwatch{width:28px;height:28px;border-radius:50%;border:2px solid #fff;box-shadow:0 0 0 1px #cbd8d6;cursor:pointer;padding:0}
+.colorSwatch.active{box-shadow:0 0 0 2px var(--green)}
+@media(max-width:600px){.siteSchema .ssRow{flex-direction:column}}
 .settingsCard .siteToggleRow{display:flex;align-items:center;justify-content:space-between;gap:16px}
 .settingsCard .siteToggleRow>div{margin:0}.settingsCard .siteToggleRow b{font-size:14px}.settingsCard .siteToggleRow p{margin:4px 0 0;color:#66756f;font-size:12px}
 .settingsCard .switch{display:inline-flex;align-items:center;gap:8px;margin:0;white-space:nowrap}

--- a/app/staff/site/page.tsx
+++ b/app/staff/site/page.tsx
@@ -1,46 +1,50 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from "react";
+import { type CSSProperties, FormEvent, useEffect, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
 import { SITE_CONTENT_DEFAULTS, type SiteContent } from "../../../lib/site-content";
 
 type StaffInfo = { email: string; displayName: string; role: string };
 type Field = { key: keyof SiteContent; label: string; area?: boolean; hint?: string };
+type Group = { n: string; title: string; where: string; fields: Field[] };
 
-const GROUPS: { title: string; fields: Field[] }[] = [
-  { title: "Бренд і шапка", fields: [
+// Кожна група пронумерована так само, як зона на схемі вітрини нижче.
+const GROUPS: Group[] = [
+  { n: "1", title: "Шапка", where: "Верх сторінки", fields: [
     { key: "brandTitle", label: "Назва закладу" },
     { key: "brandSubtitle", label: "Підзаголовок" },
-    { key: "slogan", label: "Слоган", hint: "Необовʼязково — показується під підзаголовком" },
+    { key: "slogan", label: "Слоган", hint: "Необовʼязково — під підзаголовком" },
   ] },
-  { title: "Картки авдиторій (головна)", fields: [
+  { n: "3", title: "Картки авдиторій", where: "Великі кнопки на головній", fields: [
     { key: "milTitle", label: "Військовим — заголовок" },
     { key: "milSub", label: "Військовим — підпис" },
     { key: "civTitle", label: "Цивільним — заголовок" },
     { key: "civSub", label: "Цивільним — підпис" },
   ] },
-  { title: "Контакти", fields: [
+  { n: "4", title: "Про клініку", where: "Блок під картками", fields: [
+    { key: "about", label: "Опис", area: true, hint: "Необовʼязково — короткий блок на головній" },
+  ] },
+  { n: "5", title: "Контакти", where: "Блок унизу головної", fields: [
     { key: "phone", label: "Телефон" },
     { key: "address", label: "Адреса" },
     { key: "workHours", label: "Години роботи" },
   ] },
-  { title: "Про клініку", fields: [
-    { key: "about", label: "Опис", area: true, hint: "Необовʼязково — короткий блок на головній" },
-  ] },
-  { title: "Сторінка цивільних (прайс)", fields: [
+  { n: "6", title: "Сторінка цивільних (прайс)", where: "Окрема сторінка платних послуг", fields: [
     { key: "pricePageTitle", label: "Заголовок сторінки" },
     { key: "pricePageSub", label: "Підзаголовок" },
     { key: "priceIntro", label: "Вступний текст", area: true },
     { key: "priceListTitle", label: "Заголовок прайсу" },
     { key: "priceLead", label: "Підпис під прайсом" },
   ] },
-  { title: "Сторінка військових", fields: [
+  { n: "7", title: "Сторінка військових", where: "Окрема сторінка безкоштовних послуг", fields: [
     { key: "milPageTitle", label: "Заголовок сторінки" },
     { key: "milPageSub", label: "Підзаголовок" },
     { key: "milNotice", label: "Примітка", area: true },
     { key: "milLead", label: "Підпис" },
   ] },
 ];
+
+const COLOR_PRESETS = ["#0c7a85", "#2f8f46", "#2563eb", "#6d28d9", "#b91c1c", "#b45309", "#0f172a"];
 
 export default function StaffSitePage() {
   const [staff, setStaff] = useState<StaffInfo | null>(null);
@@ -80,7 +84,7 @@ export default function StaffSitePage() {
       const data = await res.json().catch(() => ({})) as { ok?: boolean; content?: SiteContent; error?: string };
       if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
       if (data.content) setContent({ ...SITE_CONTENT_DEFAULTS, ...data.content });
-      setNotice("Збережено. Оновіть публічний сайт, щоб побачити зміни.");
+      setNotice("Збережено. Оновіть публічну вітрину, щоб побачити зміни.");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не вдалося зберегти");
     } finally {
@@ -88,15 +92,34 @@ export default function StaffSitePage() {
     }
   }
 
+  const showMil = content.storefrontType !== "paid_only";
+
   const body = forbidden
-    ? <p className="notice error" role="alert">Сайт клініки редагує лише адміністратор.</p>
+    ? <p className="notice error" role="alert">Вітрину редагує лише адміністратор.</p>
     : !loaded
       ? <p className="notice">Завантаження…</p>
       : <form className="settingsCard" onSubmit={save}>
+          {/* Схема: де на вітрині опиняється кожен блок (номери збігаються з групами) */}
+          <section className="settingsBlock">
+            <h3>Схема вітрини</h3>
+            <p className="settingsHint">Номери підказують, у якій частині вітрини зʼявиться те, що ви редагуєте нижче.</p>
+            <div className="siteSchema" style={{ "--brand": content.brandColor } as CSSProperties}>
+              <div className="ssZone ssHeader"><span className="ssNum">1</span>Шапка — назва, підзаголовок, слоган{content.logoUrl ? ", логотип" : ""}</div>
+              <div className="ssRow">
+                {showMil && <div className="ssZone ssMil"><span className="ssNum">3</span>Картка «{content.milTitle || "Військовим"}»</div>}
+                <div className="ssZone ssCiv"><span className="ssNum">3</span>Картка «{content.civTitle || "Цивільним"}»</div>
+              </div>
+              {content.about && <div className="ssZone"><span className="ssNum">4</span>Про клініку</div>}
+              <div className="ssZone ssContact"><span className="ssNum">5</span>Контакти — телефон, адреса, години</div>
+            </div>
+            {!showMil && <p className="settingsHint">Вид «Тільки платні»: картку «Військовим» на вітрині приховано.</p>}
+          </section>
+
+          {/* Публікація */}
           <section className="settingsBlock">
             <div className="siteToggleRow">
               <div>
-                <b>{content.published ? "Сайт опубліковано" : "Сайт у чернетці"}</b>
+                <b>{content.published ? "Вітрину опубліковано" : "Вітрина у чернетці"}</b>
                 <p className="settingsHint">Коли вимкнено — відвідувачі бачать заглушку замість вітрини.</p>
               </div>
               <label className="switch">
@@ -105,9 +128,42 @@ export default function StaffSitePage() {
               </label>
             </div>
           </section>
+
+          {/* Оформлення: вид, колір/тема, логотип */}
+          <section className="settingsBlock">
+            <h3>Оформлення</h3>
+            <label className="settingsField">
+              <span>Вид вітрини</span>
+              <select value={content.storefrontType} onChange={e => update("storefrontType", e.target.value)}>
+                <option value="paid_and_free">Платні + безкоштовні (військовим) — як зараз</option>
+                <option value="paid_only">Тільки платні послуги</option>
+              </select>
+              <small className="settingsHint">«Тільки платні» ховає картку «Військовим» на головній.</small>
+            </label>
+            <label className="settingsField">
+              <span>Фірмовий колір (тема)</span>
+              <span className="colorRow">
+                <input type="color" value={/^#[0-9a-fA-F]{6}$/.test(content.brandColor) ? content.brandColor : "#0c7a85"} onChange={e => update("brandColor", e.target.value)} />
+                <span className="colorSwatches">
+                  {COLOR_PRESETS.map(c => (
+                    <button type="button" key={c} className={`colorSwatch${content.brandColor.toLowerCase() === c ? " active" : ""}`} style={{ background: c }} title={c} aria-label={c} onClick={() => update("brandColor", c)} />
+                  ))}
+                </span>
+              </span>
+              <small className="settingsHint">Колір застосовується до шапки, кнопок і карток вітрини.</small>
+            </label>
+            <label className="settingsField">
+              <span>Логотип (посилання на зображення)</span>
+              <input type="url" value={content.logoUrl} onChange={e => update("logoUrl", e.target.value)} placeholder="https://…/logo.png" />
+              <small className="settingsHint">Необовʼязково. Посилання на PNG/JPG/SVG (https). Зʼявиться у шапці.</small>
+            </label>
+          </section>
+
+          {/* Тексти по зонах */}
           {GROUPS.map(group => (
             <section className="settingsBlock" key={group.title}>
-              <h3>{group.title}</h3>
+              <h3><span className="ssNum">{group.n}</span>{group.title}</h3>
+              <p className="settingsHint">{group.where}</p>
               {group.fields.map(field => (
                 <label className="settingsField" key={String(field.key)}>
                   <span>{field.label}</span>
@@ -123,15 +179,15 @@ export default function StaffSitePage() {
           {error && <p className="notice error" role="alert">{error}</p>}
           <div className="settingsActions">
             <button type="submit" disabled={status === "saving"}>{status === "saving" ? "Зберігаємо…" : "Зберегти зміни"}</button>
-            <a className="textLink" href="/" target="_blank" rel="noopener">Відкрити сайт ↗</a>
+            <a className="textLink" href="/" target="_blank" rel="noopener">Відкрити вітрину ↗</a>
           </div>
         </form>;
 
   return (
     <StaffWorkspaceShell
       active="site"
-      title="Сайт клініки"
-      description="Публічна вітрина: тексти, контакти та публікація — керує адміністратор."
+      title="Вітрина"
+      description="Публічна вітрина: вид, тексти, колір, логотип і публікація — керує адміністратор."
       staffName={staff?.displayName}
       staffRole={staff?.role}
     >

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -24,8 +24,8 @@ type NavChild = { label:string; href:string; flag?:string };
 type NavModule = { n:string; label:string; href:string; section?:WorkspaceSection; items:NavChild[] };
 const systemModules: NavModule[] = [
   { n:"1", label:"Головна / Продаж послуг", href:"/staff/site", section:"site", items:[
-    { label:"Сайт клініки (редактор)", href:"/staff/site" },
-    { label:"Вітрина послуг", href:"/" },
+    { label:"Вітрина (редактор)", href:"/staff/site" },
+    { label:"Відкрити вітрину", href:"/" },
     { label:"Онлайн-запис", href:"/" },
     { label:"Тарифи", href:"/staff/tariffs" },
     { label:"Контакти", href:"/" },
@@ -258,7 +258,7 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Вітрина":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -25,19 +25,27 @@ export type SiteContent = {
   milPageSub: string;
   milNotice: string;
   milLead: string;
+  brandColor: string;
+  logoUrl: string;
+  storefrontType: StorefrontType;
   published: boolean;
 };
 
+// Види вітрини: лише платні послуги, або платні + безкоштовні (військовим).
+export type StorefrontType = "paid_and_free" | "paid_only";
+export const STOREFRONT_TYPES: StorefrontType[] = ["paid_and_free", "paid_only"];
+
 export const SITE_CONTENT_KEY = "site_content";
 
-// Обмеження довжини для кожного текстового поля.
-const FIELD_MAX: Record<Exclude<keyof SiteContent, "published">, number> = {
+// Обмеження довжини для звичайних текстових полів (brandColor/logoUrl/
+// storefrontType валідуються окремо нижче).
+const FIELD_MAX = {
   brandTitle: 120, brandSubtitle: 160, slogan: 160,
   milTitle: 80, milSub: 200, civTitle: 80, civSub: 200,
   phone: 40, address: 200, workHours: 120, about: 800,
   pricePageTitle: 120, pricePageSub: 200, priceIntro: 800, priceListTitle: 160, priceLead: 300,
   milPageTitle: 120, milPageSub: 200, milNotice: 800, milLead: 300,
-};
+} as const;
 
 export const SITE_CONTENT_DEFAULTS: SiteContent = {
   brandTitle: "Чернігівський військовий госпіталь",
@@ -60,10 +68,13 @@ export const SITE_CONTENT_DEFAULTS: SiteContent = {
   milPageSub: "За направленням лікаря та відповідно до чинного законодавства України.",
   milNotice: "Оберіть потрібний розділ. Для військовослужбовців дослідження виконуються безоплатно за направленням.",
   milLead: "Відділення променевої діагностики Чернігівського військового госпіталю.",
+  brandColor: "#0c7a85",
+  logoUrl: "",
+  storefrontType: "paid_and_free",
   published: true,
 };
 
-const TEXT_FIELDS = Object.keys(FIELD_MAX) as Array<Exclude<keyof SiteContent, "published">>;
+const TEXT_FIELDS = Object.keys(FIELD_MAX) as Array<keyof typeof FIELD_MAX>;
 
 // Приводить довільний ввід до валідного SiteContent: обрізає тексти за
 // довжиною, published — булеве. Відсутні поля беруться з типових значень.
@@ -75,6 +86,14 @@ export function sanitizeSiteContent(input: unknown): SiteContent {
       out[field] = (src[field] as string).trim().slice(0, FIELD_MAX[field]);
     }
   }
+  // Фірмовий колір — лише валідний HEX (#RRGGBB), інакше типовий.
+  const color = String(src.brandColor ?? "").trim();
+  out.brandColor = /^#[0-9a-fA-F]{6}$/.test(color) ? color.toLowerCase() : SITE_CONTENT_DEFAULTS.brandColor;
+  // Логотип — лише безпечне посилання (https або data:image), інакше порожньо.
+  const logo = String(src.logoUrl ?? "").trim().slice(0, 500);
+  out.logoUrl = /^(https:\/\/|data:image\/)/.test(logo) ? logo : "";
+  // Вид вітрини.
+  out.storefrontType = src.storefrontType === "paid_only" ? "paid_only" : "paid_and_free";
   out.published = src.published === undefined ? SITE_CONTENT_DEFAULTS.published : Boolean(src.published);
   return out;
 }

--- a/public/site/about.html
+++ b/public/site/about.html
@@ -8,10 +8,11 @@
 <meta name="theme-color" content="#0c7a85"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
 <style>
+:root{--brand:#0c7a85;--brand-dark:#0e6b74}
 :root{
   --bg:#eef2f5;--ink:#0e161c;--muted:#5c6c78;--line:#dbe3e8;
-  --gold:#25b4c0;--olive:#0c7a85;
-  --grad:linear-gradient(135deg,#0c7a85,#0e6b74);
+  --gold:#25b4c0;--olive:var(--brand);
+  --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));
   --shadow:0 16px 42px rgba(24,34,19,.12);
 }
 *{box-sizing:border-box}
@@ -29,7 +30,7 @@ header{padding:0 14px;margin-bottom:18px}
 
 section{margin-bottom:26px}
 h2{font-size:19px;margin:0 0 12px;display:flex;align-items:center;gap:9px}
-h2 .sec-icon{width:34px;height:34px;border-radius:10px;background:#eef2f5;color:#0c7a85;display:grid;place-items:center;flex-shrink:0}
+h2 .sec-icon{width:34px;height:34px;border-radius:10px;background:#eef2f5;color:var(--brand);display:grid;place-items:center;flex-shrink:0}
 h2 .sec-icon svg{width:18px;height:18px}
 
 .card{background:#fff;border:1px solid var(--line);border-radius:16px;padding:16px 18px;box-shadow:0 8px 24px rgba(24,34,19,.05)}
@@ -58,7 +59,7 @@ h2 .sec-icon svg{width:18px;height:18px}
 /* Персонал */
 .person{display:flex;gap:13px;align-items:center}
 .person + .person{margin-top:12px;padding-top:12px;border-top:1px solid var(--line)}
-.avatar{width:46px;height:46px;border-radius:50%;background:#eef2f5;color:#0c7a85;display:grid;place-items:center;flex-shrink:0;font-weight:800}
+.avatar{width:46px;height:46px;border-radius:50%;background:#eef2f5;color:var(--brand);display:grid;place-items:center;flex-shrink:0;font-weight:800}
 .person strong{display:block;font-size:15px}
 .person small{display:block;color:var(--muted);font-size:13px}
 .p-contacts a{color:#0e454c;font-weight:600}

--- a/public/site/assets/department.js
+++ b/public/site/assets/department.js
@@ -85,8 +85,24 @@ const DEFAULT_SITECONTENT = {
   milPageTitle: 'Дослідження для військовослужбовців',
   milPageSub: 'За направленням лікаря та відповідно до чинного законодавства України.',
   milNotice: 'Оберіть потрібний розділ. Для військовослужбовців дослідження виконуються безоплатно за направленням та відповідно до законодавства України.',
-  milLead: 'Відділення променевої діагностики Чернігівського військового госпіталю військової частини А3120.'
+  milLead: 'Відділення променевої діагностики Чернігівського військового госпіталю військової частини А3120.',
+  brandColor: '#0c7a85',
+  logoUrl: '',
+  storefrontType: 'paid_and_free'
 };
+
+// Фірмовий колір застосовується на всіх сторінках вітрини (з кешу
+// localStorage; свіже значення тягне головна через /api/site-content).
+function applyBrandColor(c) {
+  if (!c || !c.brandColor) return;
+  var m = /^#([0-9a-f]{6})$/i.exec(c.brandColor);
+  var dark = c.brandColor;
+  if (m) { var n = parseInt(m[1], 16); var p = function (x) { return ('0' + Math.round(x * 0.82).toString(16)).slice(-2); }; dark = '#' + p((n >> 16) & 255) + p((n >> 8) & 255) + p(n & 255); }
+  var r = document.documentElement;
+  r.style.setProperty('--brand', c.brandColor);
+  r.style.setProperty('--brand-dark', dark);
+}
+try { applyBrandColor(getSiteContent()); } catch (e) {}
 
 function getSiteContent() {
   try {

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -9,10 +9,11 @@
 <meta name="theme-color" content="#0c7a85"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
 <style>
+:root{--brand:#0c7a85;--brand-dark:#0e6b74}
 :root{
   --bg:#eef2f5;--ink:#0e161c;--muted:#5c6c78;--line:#dbe3e8;
-  --gold:#25b4c0;--olive:#0c7a85;
-  --grad:linear-gradient(135deg,#0c7a85,#0e6b74);
+  --gold:#25b4c0;--olive:var(--brand);
+  --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));
   --shadow:0 16px 42px rgba(24,34,19,.12);
 }
 *{box-sizing:border-box}
@@ -31,7 +32,7 @@ header{padding:0 14px;margin-bottom:18px}
 .card{background:#fff;border:1px solid var(--line);border-radius:18px;padding:20px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
 .gate p{color:var(--muted);font-size:14px;margin:6px 0 14px}
 .phone-wrap{display:flex}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:#0c7a85}
+.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
 .phone-wrap input{flex:1;min-width:0;padding:12px;border:1px solid #dbe3e8;border-radius:0 11px 11px 0;font:inherit}
 .phone-wrap input:focus{outline:2px solid var(--olive);outline-offset:1px;border-color:var(--olive)}
 .code-wrap{margin-top:12px}

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -11,10 +11,10 @@
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
 <style>
 /* ===== Токени ===== */
-:root{
+:root{--brand:#0c7a85;--brand-dark:#0e6b74;
   --bg:#eef2f5;--ink:#0e161c;--muted:#5c6c78;--line:#dbe3e8;
   --gold:#25b4c0;--beige:#d9eef0;
-  --grad:linear-gradient(135deg,#0c7a85,#0e6b74);
+  --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));
   --shadow:0 16px 42px rgba(24,34,19,.12);
 }
 
@@ -33,6 +33,7 @@ header{position:sticky;top:10px;z-index:50;padding:0 14px}
   display:flex;align-items:center;gap:18px;color:#fff;
 }
 .brand{display:flex;align-items:center;gap:13px;flex:1;min-width:0}
+.brand-logo{height:46px;width:auto;max-width:120px;border-radius:8px;background:#fff;padding:3px;flex-shrink:0}
 .hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
 .hospital-brand-title{font-size:clamp(20px,3vw,27px);font-weight:700;line-height:1.08;color:#fff;overflow-wrap:anywhere}
 .hospital-brand-subtitle{font-size:clamp(13px,1.8vw,17px);line-height:1.25;color:#e5ecf0;margin-top:5px}
@@ -53,7 +54,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .login-choice{display:grid;grid-template-columns:42px 1fr auto;align-items:center;gap:11px;padding:11px;border-radius:12px;color:#0f1a20;border:0;background:transparent;width:100%;font:inherit;text-align:left;cursor:pointer}
 .login-choice + .login-choice{border-top:1px solid #e5ecf0}
 .login-choice:hover{background:#f2f6f8}
-.login-choice-icon{width:42px;height:42px;border-radius:12px;display:grid;place-items:center;background:#0c7a85;color:#fff;font-size:18px}
+.login-choice-icon{width:42px;height:42px;border-radius:12px;display:grid;place-items:center;background:var(--brand);color:#fff;font-size:18px}
 .login-choice strong{display:block;font-size:15px}
 .login-choice small{display:block;margin-top:2px;color:#6c7c86;font-size:12px}
 .login-choice-arrow{font-size:22px;color:#0a5f68}
@@ -74,7 +75,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .promo-icon{width:58px;height:58px;border-radius:16px;display:grid;place-items:center;background:rgba(255,255,255,.14)}
 .promo-icon svg{width:28px;height:28px}
 .promo-military .promo-icon{color:#f2f6f8}
-.promo-civil .promo-icon{background:rgba(79,93,62,.1);color:#0c7a85}
+.promo-civil .promo-icon{background:rgba(79,93,62,.1);color:var(--brand)}
 .promo-text{min-width:0}
 .promo-text strong{display:block;font-size:clamp(22px,3.3vw,29px);font-weight:600;line-height:1.12;letter-spacing:-.01em}
 .promo-text span{display:block;margin-top:7px;font-size:clamp(15px,2.1vw,18px)}
@@ -115,24 +116,24 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .form-step{padding:4px 0 14px}
 .form-step + .form-step{border-top:1px solid var(--line);padding-top:16px}
 .step-title{display:flex;align-items:center;gap:9px;font-weight:800;font-size:15px;margin-bottom:11px}
-.step-num{width:24px;height:24px;border-radius:50%;background:#0c7a85;color:#fff;display:grid;place-items:center;font-size:13px;font-weight:800}
+.step-num{width:24px;height:24px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:13px;font-weight:800}
 .field{margin:11px 0}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .field label{display:block;font-size:13px;font-weight:700;margin-bottom:5px}
 .req{color:#c0392b}
 .opt{font-weight:500;color:#7c8a94}
 .field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:11px;font:inherit;background:#fff}
-.field input:focus-visible,.field select:focus-visible,.field textarea:focus-visible{outline:2px solid #0c7a85;outline-offset:1px}
+.field input:focus-visible,.field select:focus-visible,.field textarea:focus-visible{outline:2px solid var(--brand);outline-offset:1px}
 .field textarea{min-height:78px;resize:vertical}
 .phone-wrap{display:flex;align-items:stretch}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:#0c7a85}
+.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
 .phone-wrap input{border-radius:0 11px 11px 0}
 .field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
 .was-validated .field input:invalid,.was-validated .field select:invalid{border-color:#d9705f;background:#fdf0ee}
 .was-validated .field input:invalid ~ .field-error,.was-validated .field:has(input:invalid) .field-error{display:block}
 .was-validated:has(#dataConsent:invalid) .consent-error{display:block}
 .btn.secondary{background:#eef2f5;color:#0e454c}
-.send-request{width:100%;border:0;background:#0c7a85;color:#fff;cursor:pointer}
+.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}
 .upload-box{border:1.5px dashed #9fb0bb;border-radius:16px;padding:14px;background:#f7fafb}
 .upload-help{font-size:13px;color:var(--muted);margin-bottom:10px}
 .file-input{width:100%;padding:11px;background:#fff;border:1px solid var(--line);border-radius:12px}
@@ -140,7 +141,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .consent{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:#3a4a52}
 .consent input{margin-top:3px;width:18px;height:18px;flex:0 0 18px}
 .success-panel{background:#fff;border:1px solid var(--line);border-radius:18px;padding:28px 20px;text-align:center}
-.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:#0c7a85;color:#fff;display:grid;place-items:center;font-size:28px}
+.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
 .success-panel h3{margin:0 0 8px}
 .success-summary{background:#f5f8fa;border:1px solid var(--line);border-radius:12px;padding:12px 14px;margin:0 0 12px;font-size:13.5px;text-align:left}
 .success-summary div{margin:3px 0}
@@ -193,20 +194,20 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
 .sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
 .sp-day{flex-shrink:0;padding:8px 11px;border-radius:10px;border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
-.sp-day.on{border-color:#0c7a85;background:#eef2f5;color:#0e454c}
+.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
 .sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
 .sp-time{padding:8px 4px;border-radius:9px;border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
-.sp-time.on{border-color:#0c7a85;background:#0c7a85;color:#fff}
+.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
 .sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
 /* ===== Тарифи на головній ===== */
 .tariffs-home{padding:22px 0 0}
 .tariffs-head{margin-bottom:14px}
 .tariffs-head h2{font-size:clamp(24px,3.2vw,32px);font-weight:700;letter-spacing:-.02em;margin:6px 0}
 .tariffs-head p{color:var(--muted);max-width:760px;margin:0}
-.tariffs-head p b{color:#0c7a85}
+.tariffs-head p b{color:var(--brand)}
 .ht-loading{padding:22px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:18px}
 .ht-group{background:#fff;border:1px solid var(--line);border-radius:18px;overflow:hidden;margin-bottom:14px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
-.ht-group>h3{margin:0;padding:15px 18px;background:linear-gradient(135deg,#0c7a85,#0e6b74);color:#fff;font-size:17px;font-weight:700}
+.ht-group>h3{margin:0;padding:15px 18px;background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:#fff;font-size:17px;font-weight:700}
 .ht-table{width:100%;border-collapse:collapse}
 .ht-table th{text-align:left;padding:10px 16px;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);border-bottom:1px solid var(--line);white-space:nowrap}
 .ht-table th.num,.ht-table td.num{text-align:right}
@@ -214,11 +215,11 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .ht-table tr:last-child td{border-bottom:0}
 .ht-title{font-weight:700;color:#0e161c}
 .ht-help{margin-top:3px;color:var(--muted);font-size:12.5px;line-height:1.35}
-.ht-mil{color:#0c7a85;font-weight:800;white-space:nowrap}
+.ht-mil{color:var(--brand);font-weight:800;white-space:nowrap}
 .ht-civ{font-weight:800;white-space:nowrap;font-variant-numeric:tabular-nums}
-.ht-book{border:0;background:#0c7a85;color:#fff;border-radius:10px;padding:9px 14px;font-weight:700;cursor:pointer;white-space:nowrap}
+.ht-book{border:0;background:var(--brand);color:#fff;border-radius:10px;padding:9px 14px;font-weight:700;cursor:pointer;white-space:nowrap}
 .ht-book:hover{background:#12444b}.ht-book.added{background:#7c8a94}
-.field-note{display:block;margin-top:6px;font-size:12px;color:#0c7a85}
+.field-note{display:block;margin-top:6px;font-size:12px;color:var(--brand)}
 @media(max-width:640px){
   .ht-table thead{display:none}
   .ht-table,.ht-table tbody,.ht-table tr,.ht-table td{display:block;width:100%}
@@ -235,6 +236,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 <header>
   <div class="wrap header-row">
     <a class="brand" href="/">
+      <img id="scLogo" class="brand-logo" alt="" style="display:none"/>
       <div class="hospital-brand-text">
         <div class="hospital-brand-title" id="scBrandTitle">Чернігівський військовий госпіталь</div>
         <div class="hospital-brand-subtitle" id="scBrandSubtitle">Відділення променевої діагностики</div>
@@ -267,7 +269,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
   <section class="hero">
     <div class="wrap">
       <div class="photo-audience">
-        <a class="promo-card promo-military" href="/site/military.html">
+        <a class="promo-card promo-military" id="scMilCard" href="/site/military.html">
           <span class="promo-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.6-3 8.6-7 10-4-1.4-7-5.4-7-10V6l7-3z"/></svg></span>
           <span class="promo-text">
             <strong id="scMilTitle">Військовослужбовцям</strong>
@@ -294,7 +296,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
   <section class="tariffs-home" id="tariffs">
     <div class="wrap">
       <div class="tariffs-head">
-        <div class="eyebrow" style="color:#0c7a85">Тарифи</div>
+        <div class="eyebrow" style="color:var(--brand)">Тарифи</div>
         <h2>Дослідження та вартість</h2>
         <p>Військовослужбовцям — <b>безоплатно</b> за направленням. Цивільним особам — за тарифом. Оберіть дослідження, натисніть «Записатися» та вкажіть категорію.</p>
       </div>
@@ -327,7 +329,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
   <aside aria-label="Моя заявка" aria-modal="true" class="cart-drawer" role="dialog">
     <div class="cart-head">
       <div>
-        <div class="eyebrow" style="color:#0c7a85">Попередній вибір</div>
+        <div class="eyebrow" style="color:var(--brand)">Попередній вибір</div>
         <h2 style="margin:5px 0">Моя заявка</h2>
       </div>
       <button class="cart-close" onclick="closeCart()" type="button" aria-label="Закрити">×</button>
@@ -439,8 +441,12 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 (function(){
   var set=function(id,v){var el=document.getElementById(id); if(el&&v){el.textContent=v;}};
   var show=function(id){var el=document.getElementById(id); if(el){el.style.display='';}};
+  var darken=function(hex){var m=/^#([0-9a-f]{6})$/i.exec(hex||'');if(!m)return hex;var n=parseInt(m[1],16);var p=function(x){return ('0'+Math.round(x*0.82).toString(16)).slice(-2);};return '#'+p((n>>16)&255)+p((n>>8)&255)+p(n&255);};
   function apply(c){
     if(!c||typeof c!=='object') return;
+    if(c.brandColor){var r=document.documentElement;r.style.setProperty('--brand',c.brandColor);r.style.setProperty('--brand-dark',darken(c.brandColor));}
+    var logo=document.getElementById('scLogo'); if(logo&&c.logoUrl){logo.src=c.logoUrl;logo.style.display='';}
+    if(c.storefrontType==='paid_only'){var mc=document.getElementById('scMilCard'); if(mc){mc.style.display='none';}}
     set('scBrandTitle',c.brandTitle); set('scBrandSubtitle',c.brandSubtitle);
     set('scMilTitle',c.milTitle);     set('scMilSub',c.milSub);
     set('scCivTitle',c.civTitle);     set('scCivSub',c.civSub);

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -5,9 +5,10 @@
 <meta name="theme-color" content="#0c7a85"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
 <style>
+:root{--brand:#0c7a85;--brand-dark:#0e6b74}
 :root{
-  --bg:#eef2f5;--paper:#fff;--ink:#0e161c;--muted:#5c6c78;--dark:#0c7a85;
-  --dark2:#0e6b74;--olive:#0a5f68;--beige:#d9eef0;--line:#dbe3e8;
+  --bg:#eef2f5;--paper:#fff;--ink:#0e161c;--muted:#5c6c78;--dark:var(--brand);
+  --dark2:var(--brand-dark);--olive:#0a5f68;--beige:#d9eef0;--line:#dbe3e8;
   --gold:#25b4c0;--shadow:0 16px 42px rgba(24,34,19,.12);--r:24px
 }
 *{box-sizing:border-box}html{scroll-behavior:smooth}
@@ -22,10 +23,10 @@ nav{margin-left:auto;display:flex;align-items:center;gap:22px;font-weight:650;fo
 .hero{padding:24px 0 0}
 .audience{display:grid;grid-template-columns:1fr 1fr;border-radius:22px;overflow:hidden;box-shadow:var(--shadow)}
 .audience>div{padding:20px 24px;min-height:120px;display:flex;gap:15px;align-items:center}
-.military{background:linear-gradient(135deg,#0c7a85,#0e6b74);color:white}.civil{background:linear-gradient(135deg,#e2f4f5,#bfe0e4)}
+.military{background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:white}.civil{background:linear-gradient(135deg,#e2f4f5,#bfe0e4)}
 .icon{width:58px;height:58px;border-radius:17px;background:rgba(255,255,255,.12);display:grid;place-items:center;font-weight:750;flex:0 0 58px}
 .civil .icon{background:rgba(26,36,20,.08)}.audience strong{display:block;font-size:21px}.audience span{font-size:14px}
-.support{margin-top:14px;border-radius:18px;padding:17px 22px;background:#0e6b74;color:white;font-size:17px;font-weight:700}
+.support{margin-top:14px;border-radius:18px;padding:17px 22px;background:var(--brand-dark);color:white;font-size:17px;font-weight:700}
 .support b{color:var(--gold)}
 .hero-main{margin-top:14px;min-height:455px;border-radius:24px;overflow:hidden;position:relative;box-shadow:var(--shadow);
  background:linear-gradient(90deg,rgba(20,27,17,.96),rgba(20,27,17,.72) 41%,rgba(20,27,17,.08) 72%),
@@ -42,16 +43,16 @@ h1{font-size:clamp(30px,4.2vw,44px);font-weight:700;line-height:1.1;letter-spaci
 .section h2{font-size:42px;line-height:1.05;letter-spacing:-.03em;margin:5px 0}.section p.lead{color:var(--muted);max-width:760px}
 .cards{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}.card{background:#fff;border:1px solid var(--line);border-radius:20px;padding:20px;box-shadow:0 10px 26px rgba(24,34,19,.07)}
 .card h3{margin:8px 0 4px;font-size:18px}.card p{color:var(--muted);font-size:14px;min-height:40px}.price{font-size:26px;font-weight:750;color:var(--olive)}
-.card .mini{font-size:12px;color:var(--muted)}.card .book{margin-top:14px;width:100%;background:#eef2f5;color:#0c7a85}
+.card .mini{font-size:12px;color:var(--muted)}.card .book{margin-top:14px;width:100%;background:#eef2f5;color:var(--brand)}
 .price-cta{margin-top:18px;display:flex;justify-content:center}
 .features{background:#eef2f5}.feature-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}.feature{background:#fff;border:1px solid var(--line);padding:20px;border-radius:18px}
 .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}.step{background:#fff;border-radius:18px;border:1px solid var(--line);padding:20px}.num{font-size:34px;font-weight:750;color:var(--olive)}
-.contact{background:linear-gradient(135deg,#0c7a85,#0e6b74);color:white;padding:52px 0}.contact-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:24px}
+.contact{background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:white;padding:52px 0}.contact-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:24px}
 .contact-box{border:1px solid rgba(255,255,255,.14);border-radius:17px;padding:17px;margin-bottom:11px}.contact-box small{display:block;color:#dbe3e8;margin-bottom:4px}
 footer{padding:26px 0 100px;color:var(--muted);font-size:13px}
 .fixed{display:none}
 .price-page{padding:34px 0 70px}.price-group{background:#fff;border:1px solid var(--line);border-radius:20px;overflow:hidden;margin-bottom:16px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
-.price-group h2{margin:0;padding:18px 20px;background:linear-gradient(135deg,#0c7a85,#0e6b74);color:#fff;font-size:23px}
+.price-group h2{margin:0;padding:18px 20px;background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:#fff;font-size:23px}
 table{width:100%;border-collapse:collapse}th,td{padding:13px 15px;border-bottom:1px solid var(--line);text-align:left}th{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
 td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}.code{color:var(--muted);width:68px}
 .note{background:#eef7f8;border:1px solid #d9eef0;border-radius:18px;padding:18px;color:#0e454c;margin-top:20px}
@@ -69,7 +70,7 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
  .fixed a{min-height:48px;border-radius:12px;display:flex;align-items:center;justify-content:center;font-weight:700}.fixed a:first-child{background:var(--dark2);color:white}.fixed a:last-child{background:var(--beige)}
 }
 
-.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:13px;background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:99px;background:#25b4c0;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:#0c7a85;color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:#0c7a85;color:#fff;border-radius:10px;padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}.cart-overlay.open{opacity:1;pointer-events:auto}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:16px;padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form{background:#fff;border:1px solid #dbe3e8;border-radius:18px;padding:16px}.request-form h3{margin-top:0}.field{margin:11px 0}.field label{display:block;font-size:13px;font-weight:650;margin-bottom:5px}.field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:11px;font:inherit;background:#fff}.field textarea{min-height:85px;resize:vertical}.send-request{width:100%;border:0;background:#0c7a85;color:#fff;cursor:pointer}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:999px;background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}.floating-cart .cart-count{display:inline-grid;margin-left:6px}
+.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:13px;background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:99px;background:#25b4c0;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:var(--brand);color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:var(--brand);color:#fff;border-radius:10px;padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}.cart-overlay.open{opacity:1;pointer-events:auto}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:16px;padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form{background:#fff;border:1px solid #dbe3e8;border-radius:18px;padding:16px}.request-form h3{margin-top:0}.field{margin:11px 0}.field label{display:block;font-size:13px;font-weight:650;margin-bottom:5px}.field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:11px;font:inherit;background:#fff}.field textarea{min-height:85px;resize:vertical}.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:999px;background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}.floating-cart .cart-count{display:inline-grid;margin-left:6px}
 @media(max-width:700px){.cart-button{padding:10px 12px}.cart-button .cart-label{display:none}.floating-cart{bottom:74px;right:12px}.price-group tr{grid-template-columns:46px 1fr auto}.row-add{grid-column:2/4;margin:0 8px 10px}.cart-drawer{padding:16px}}
 
 .upload-box{border:1.5px dashed #9fb0bb;border-radius:16px;padding:16px;background:#f7fafb}
@@ -100,7 +101,7 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
 
 .military-notice{padding:28px 0 0}
 .military-notice-card{
-  background:linear-gradient(135deg,#0c7a85,#0e6b74);color:#fff;border-radius:22px;
+  background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:#fff;border-radius:22px;
   padding:28px;display:flex;justify-content:space-between;gap:20px;align-items:center;
   box-shadow:var(--shadow)
 }
@@ -234,12 +235,12 @@ header .brand{flex:1;min-width:0}
 .form-step{padding:4px 0 14px}
 .form-step + .form-step{border-top:1px solid #dbe3e8;padding-top:16px}
 .step-title{display:flex;align-items:center;gap:9px;font-weight:650;font-size:15px;margin-bottom:11px}
-.step-num{width:24px;height:24px;border-radius:50%;background:#0c7a85;color:#fff;display:grid;place-items:center;font-size:13px;font-weight:700}
+.step-num{width:24px;height:24px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:13px;font-weight:700}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .req{color:#c0392b}
 .opt{font-weight:500;color:#7c8a94}
 .phone-wrap{display:flex;align-items:stretch}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:#0c7a85}
+.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
 .phone-wrap input{border-radius:0 11px 11px 0}
 .field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
 .was-validated .field:has(input:invalid) .field-error{display:block}
@@ -251,7 +252,7 @@ header .brand{flex:1;min-width:0}
 .success-summary{background:#f5f8fa;border:1px solid #dbe3e8;border-radius:12px;padding:12px 14px;margin:0 0 12px;font-size:13.5px;text-align:left}
 .success-summary div{margin:3px 0}
 .offline-note{background:#eef7f8;border:1px solid #c9e6ea;border-radius:11px;padding:10px 12px}
-.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:#0c7a85;color:#fff;display:grid;place-items:center;font-size:28px}
+.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
 .req-text{white-space:pre-wrap;text-align:left;font:13px/1.5 ui-monospace,Menlo,Consolas,monospace;background:#f5f8fa;border:1px solid #dbe3e8;border-radius:12px;padding:13px;max-height:220px;overflow:auto;margin:0 0 10px}
 .msg-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:10px 0 12px}
 .next-steps{text-align:left;font-size:13.5px;color:#123039;padding-left:20px;margin:0 0 12px}
@@ -267,10 +268,10 @@ header .brand{flex:1;min-width:0}
 .sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
 .sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
 .sp-day{flex-shrink:0;padding:8px 11px;border-radius:10px;border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
-.sp-day.on{border-color:#0c7a85;background:#eef2f5;color:#0e454c}
+.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
 .sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
 .sp-time{padding:8px 4px;border-radius:9px;border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
-.sp-time.on{border-color:#0c7a85;background:#0c7a85;color:#fff}
+.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
 .sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
 </style></head><body>
 <header><div class="wrap header-row"><a class="brand" href="/"><div class="hospital-brand-text"><div class="hospital-brand-title">Чернігівський військовий госпіталь</div><div class="hospital-brand-subtitle">Відділення променевої діагностики</div></div></a><nav><a href="/">Головна</a><button class="cart-button" onclick="openMilitaryCart()" type="button">
@@ -287,7 +288,7 @@ header .brand{flex:1;min-width:0}
 </div>
 </div>
 </div>
-</section><div class="wrap"><div class="price-intro" id="scMilNotice"><strong>Оберіть потрібний розділ.</strong> Для військовослужбовців дослідження виконуються безоплатно за направленням та відповідно до законодавства України.</div><div class="section-head"><div><div class="eyebrow" style="color:#0c7a85">Офіційний перелік досліджень</div><p class="lead" style="margin-top:8px" id="scMilLead">Відділення променевої діагностики Чернігівського військового госпіталю військової частини А3120.</p></div></div>
+</section><div class="wrap"><div class="price-intro" id="scMilNotice"><strong>Оберіть потрібний розділ.</strong> Для військовослужбовців дослідження виконуються безоплатно за направленням та відповідно до законодавства України.</div><div class="section-head"><div><div class="eyebrow" style="color:var(--brand)">Офіційний перелік досліджень</div><p class="lead" style="margin-top:8px" id="scMilLead">Відділення променевої діагностики Чернігівського військового госпіталю військової частини А3120.</p></div></div>
 <section class="price-group open"><h2>1. Цифрова флюорографія</h2><table><thead><tr><th>Код</th><th>Дослідження та що входить</th></tr></thead><tbody><tr>
 <td class="code">101</td>
 <td>
@@ -352,7 +353,7 @@ document.querySelectorAll('.price-group h2').forEach((heading)=>{
 <aside aria-label="Моя заявка" aria-modal="true" class="cart-drawer" role="dialog">
 <div class="cart-head">
 <div>
-<div class="eyebrow" style="color:#0c7a85">Попередній вибір</div>
+<div class="eyebrow" style="color:var(--brand)">Попередній вибір</div>
 <h2 style="margin:5px 0">Моя заявка</h2>
 </div>
 <button class="cart-close" onclick="closeMilitaryCart()" type="button">×</button>

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -5,9 +5,10 @@
 <meta name="theme-color" content="#0c7a85"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
 <style>
+:root{--brand:#0c7a85;--brand-dark:#0e6b74}
 :root{
-  --bg:#eef2f5;--paper:#fff;--ink:#0e161c;--muted:#5c6c78;--dark:#0c7a85;
-  --dark2:#0e6b74;--olive:#0a5f68;--beige:#d9eef0;--line:#dbe3e8;
+  --bg:#eef2f5;--paper:#fff;--ink:#0e161c;--muted:#5c6c78;--dark:var(--brand);
+  --dark2:var(--brand-dark);--olive:#0a5f68;--beige:#d9eef0;--line:#dbe3e8;
   --gold:#25b4c0;--shadow:0 16px 42px rgba(24,34,19,.12);--r:24px
 }
 *{box-sizing:border-box}html{scroll-behavior:smooth}
@@ -22,10 +23,10 @@ nav{margin-left:auto;display:flex;align-items:center;gap:22px;font-weight:650;fo
 .hero{padding:24px 0 0}
 .audience{display:grid;grid-template-columns:1fr 1fr;border-radius:22px;overflow:hidden;box-shadow:var(--shadow)}
 .audience>div{padding:20px 24px;min-height:120px;display:flex;gap:15px;align-items:center}
-.military{background:linear-gradient(135deg,#0c7a85,#0e6b74);color:white}.civil{background:linear-gradient(135deg,#e2f4f5,#bfe0e4)}
+.military{background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:white}.civil{background:linear-gradient(135deg,#e2f4f5,#bfe0e4)}
 .icon{width:58px;height:58px;border-radius:17px;background:rgba(255,255,255,.12);display:grid;place-items:center;font-weight:750;flex:0 0 58px}
 .civil .icon{background:rgba(26,36,20,.08)}.audience strong{display:block;font-size:21px}.audience span{font-size:14px}
-.support{margin-top:14px;border-radius:18px;padding:17px 22px;background:#0e6b74;color:white;font-size:17px;font-weight:700}
+.support{margin-top:14px;border-radius:18px;padding:17px 22px;background:var(--brand-dark);color:white;font-size:17px;font-weight:700}
 .support b{color:var(--gold)}
 .hero-main{margin-top:14px;min-height:455px;border-radius:24px;overflow:hidden;position:relative;box-shadow:var(--shadow);
  background:linear-gradient(90deg,rgba(20,27,17,.96),rgba(20,27,17,.72) 41%,rgba(20,27,17,.08) 72%),
@@ -42,16 +43,16 @@ h1{font-size:clamp(30px,4.2vw,44px);font-weight:700;line-height:1.1;letter-spaci
 .section h2{font-size:42px;line-height:1.05;letter-spacing:-.03em;margin:5px 0}.section p.lead{color:var(--muted);max-width:760px}
 .cards{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}.card{background:#fff;border:1px solid var(--line);border-radius:20px;padding:20px;box-shadow:0 10px 26px rgba(24,34,19,.07)}
 .card h3{margin:8px 0 4px;font-size:18px}.card p{color:var(--muted);font-size:14px;min-height:40px}.price{font-size:26px;font-weight:750;color:var(--olive)}
-.card .mini{font-size:12px;color:var(--muted)}.card .book{margin-top:14px;width:100%;background:#eef2f5;color:#0c7a85}
+.card .mini{font-size:12px;color:var(--muted)}.card .book{margin-top:14px;width:100%;background:#eef2f5;color:var(--brand)}
 .price-cta{margin-top:18px;display:flex;justify-content:center}
 .features{background:#eef2f5}.feature-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}.feature{background:#fff;border:1px solid var(--line);padding:20px;border-radius:18px}
 .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}.step{background:#fff;border-radius:18px;border:1px solid var(--line);padding:20px}.num{font-size:34px;font-weight:750;color:var(--olive)}
-.contact{background:linear-gradient(135deg,#0c7a85,#0e6b74);color:white;padding:52px 0}.contact-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:24px}
+.contact{background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:white;padding:52px 0}.contact-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:24px}
 .contact-box{border:1px solid rgba(255,255,255,.14);border-radius:17px;padding:17px;margin-bottom:11px}.contact-box small{display:block;color:#dbe3e8;margin-bottom:4px}
 footer{padding:26px 0 100px;color:var(--muted);font-size:13px}
 .fixed{display:none}
 .price-page{padding:34px 0 70px}.price-group{background:#fff;border:1px solid var(--line);border-radius:20px;overflow:hidden;margin-bottom:16px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
-.price-group h2{margin:0;padding:18px 20px;background:linear-gradient(135deg,#0c7a85,#0e6b74);color:#fff;font-size:23px}
+.price-group h2{margin:0;padding:18px 20px;background:linear-gradient(135deg,var(--brand),var(--brand-dark));color:#fff;font-size:23px}
 table{width:100%;border-collapse:collapse}th,td{padding:13px 15px;border-bottom:1px solid var(--line);text-align:left}th{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
 td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}.code{color:var(--muted);width:68px}
 .note{background:#eef7f8;border:1px solid #d9eef0;border-radius:18px;padding:18px;color:#0e454c;margin-top:20px}
@@ -69,7 +70,7 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
  .fixed a{min-height:48px;border-radius:12px;display:flex;align-items:center;justify-content:center;font-weight:700}.fixed a:first-child{background:var(--dark2);color:white}.fixed a:last-child{background:var(--beige)}
 }
 
-.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:13px;background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:99px;background:#25b4c0;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:#0c7a85;color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:#0c7a85;color:#fff;border-radius:10px;padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}.cart-overlay.open{opacity:1;pointer-events:auto}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:16px;padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form h3{margin-top:0}.field{margin:11px 0}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:999px;background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}.floating-cart .cart-count{display:inline-grid;margin-left:6px}
+.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:13px;background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:99px;background:#25b4c0;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:var(--brand);color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:var(--brand);color:#fff;border-radius:10px;padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}.cart-overlay.open{opacity:1;pointer-events:auto}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:16px;padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form h3{margin-top:0}.field{margin:11px 0}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:999px;background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}.floating-cart .cart-count{display:inline-grid;margin-left:6px}
 @media(max-width:700px){.cart-button{padding:10px 12px}.cart-button .cart-label{display:none}.floating-cart{bottom:74px;right:12px}.price-group tr{grid-template-columns:46px 1fr auto}.row-add{grid-column:2/4;margin:0 8px 10px}.cart-drawer{padding:16px}}
 
 
@@ -105,7 +106,7 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
 }
 .civilian-heading-card h1{font-size:42px;margin:6px 0}
 .civilian-heading-card p{margin:0;color:#5c6c78}
-.civilian-heading-card .btn{background:#0c7a85;color:#fff}
+.civilian-heading-card .btn{background:var(--brand);color:#fff}
 @media(max-width:700px){
   .civilian-heading-card{align-items:flex-start;flex-direction:column;padding:20px}
   .civilian-heading-card h1{font-size:30px}
@@ -136,24 +137,24 @@ header .brand{flex:1;min-width:0}
 .form-step{padding:4px 0 14px}
 .form-step + .form-step{border-top:1px solid var(--line);padding-top:16px}
 .step-title{display:flex;align-items:center;gap:9px;font-weight:650;font-size:15px;margin-bottom:11px}
-.step-num{width:24px;height:24px;border-radius:50%;background:#0c7a85;color:#fff;display:grid;place-items:center;font-size:13px;font-weight:650}
+.step-num{width:24px;height:24px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:13px;font-weight:650}
 .field{margin:11px 0}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .field label{display:block;font-size:13px;font-weight:700;margin-bottom:5px}
 .req{color:#c0392b}
 .opt{font-weight:500;color:#7c8a94}
 .field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:11px;font:inherit;background:#fff}
-.field input:focus-visible,.field select:focus-visible,.field textarea:focus-visible{outline:2px solid #0c7a85;outline-offset:1px}
+.field input:focus-visible,.field select:focus-visible,.field textarea:focus-visible{outline:2px solid var(--brand);outline-offset:1px}
 .field textarea{min-height:78px;resize:vertical}
 .phone-wrap{display:flex;align-items:stretch}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:#0c7a85}
+.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:11px 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
 .phone-wrap input{border-radius:0 11px 11px 0}
 .field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
 .was-validated .field input:invalid,.was-validated .field select:invalid{border-color:#d9705f;background:#fdf0ee}
 .was-validated .field input:invalid ~ .field-error,.was-validated .field:has(input:invalid) .field-error{display:block}
 .was-validated:has(#dataConsent:invalid) .consent-error{display:block}
 .btn.secondary{background:#eef2f5;color:#0e454c}
-.send-request{width:100%;border:0;background:#0c7a85;color:#fff;cursor:pointer}
+.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}
 .upload-box{border:1.5px dashed #9fb0bb;border-radius:16px;padding:14px;background:#f7fafb}
 .upload-help{font-size:13px;color:var(--muted);margin-bottom:10px}
 .file-input{width:100%;padding:11px;background:#fff;border:1px solid var(--line);border-radius:12px}
@@ -161,7 +162,7 @@ header .brand{flex:1;min-width:0}
 .consent{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:#3a4a52}
 .consent input{margin-top:3px;width:18px;height:18px;flex:0 0 18px}
 .success-panel{background:#fff;border:1px solid var(--line);border-radius:18px;padding:28px 20px;text-align:center}
-.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:#0c7a85;color:#fff;display:grid;place-items:center;font-size:28px}
+.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
 .success-panel h3{margin:0 0 8px}
 .success-summary{background:#f5f8fa;border:1px solid var(--line);border-radius:12px;padding:12px 14px;margin:0 0 12px;font-size:13.5px;text-align:left}
 .success-summary div{margin:3px 0}
@@ -176,22 +177,22 @@ header .brand{flex:1;min-width:0}
 .sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
 .sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
 .sp-day{flex-shrink:0;padding:8px 11px;border-radius:10px;border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
-.sp-day.on{border-color:#0c7a85;background:#eef2f5;color:#0e454c}
+.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
 .sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
 .sp-time{padding:8px 4px;border-radius:9px;border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
-.sp-time.on{border-color:#0c7a85;background:#0c7a85;color:#fff}
+.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
 .sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
 </style></head><body>
 <header><div class="wrap header-row"><a class="brand" href="/"><div class="hospital-brand-text"><div class="hospital-brand-title">Чернігівський військовий госпіталь</div><div class="hospital-brand-subtitle">Відділення променевої діагностики</div></div></a><nav><a href="/">Головна</a><button class="cart-button" onclick="openCart()" type="button"><span class="cart-label">Моя заявка</span><span class="cart-count" data-cart-count="">0</span></button></nav></div></header>
 <main class="price-page">
 <section class="civilian-heading"><div class="wrap">
 <div class="civilian-heading-card">
-<div><div class="eyebrow" style="color:#0c7a85">Цивільним особам</div>
+<div><div class="eyebrow" style="color:var(--brand)">Цивільним особам</div>
 <h1 id="scPriceTitle">Платні дослідження</h1>
 <p id="scPriceSub">Вартість указана відповідно до чинних тарифів.</p></div>
 </div>
 </div></section>
-<div class="wrap"><div class="price-intro" id="scPriceIntro"><strong>Цивільним особам — платні послуги.</strong> Оберіть потрібне дослідження, натисніть «Записатися» та введіть свої дані. Після опрацювання заявки з вами зв’яжуться і повідомлять дату та час проведення дослідження.</div><div class="section-head"><div><div class="eyebrow" style="color:#0c7a85">Офіційний перелік</div><h1 style="color:var(--ink);margin:10px 0" id="scPriceListTitle">Тарифи на платні медичні послуги</h1><p class="lead" id="scPriceLead">Відділення променевої діагностики Чернігівського військового госпіталю військової частини А3120.</p></div></div>
+<div class="wrap"><div class="price-intro" id="scPriceIntro"><strong>Цивільним особам — платні послуги.</strong> Оберіть потрібне дослідження, натисніть «Записатися» та введіть свої дані. Після опрацювання заявки з вами зв’яжуться і повідомлять дату та час проведення дослідження.</div><div class="section-head"><div><div class="eyebrow" style="color:var(--brand)">Офіційний перелік</div><h1 style="color:var(--ink);margin:10px 0" id="scPriceListTitle">Тарифи на платні медичні послуги</h1><p class="lead" id="scPriceLead">Відділення променевої діагностики Чернігівського військового госпіталю військової частини А3120.</p></div></div>
 <div id="priceGroups">
     <section class="price-group open">
       <h2>1. Цифрова флюорографія</h2>
@@ -430,7 +431,7 @@ header .brand{flex:1;min-width:0}
 </div></main>
 <div class="fixed"><a href="tel:+380972808899">Записатися</a><a href="https://wa.me/380972808899">WhatsApp</a></div>
 
-<div aria-hidden="true" class="cart-overlay" id="cartOverlay"><aside aria-label="Моя заявка" aria-modal="true" class="cart-drawer" role="dialog"><div class="cart-head"><div><div class="eyebrow" style="color:#0c7a85">Попередній вибір</div><h2 style="margin:5px 0">Моя заявка</h2></div><button class="cart-close" onclick="closeCart()" type="button">×</button></div><div id="cartItems"></div><div class="cart-total"><span>Орієнтовна сума</span><span id="cartTotal">0 грн</span></div><form class="request-form" id="requestForm" novalidate>
+<div aria-hidden="true" class="cart-overlay" id="cartOverlay"><aside aria-label="Моя заявка" aria-modal="true" class="cart-drawer" role="dialog"><div class="cart-head"><div><div class="eyebrow" style="color:var(--brand)">Попередній вибір</div><h2 style="margin:5px 0">Моя заявка</h2></div><button class="cart-close" onclick="closeCart()" type="button">×</button></div><div id="cartItems"></div><div class="cart-total"><span>Орієнтовна сума</span><span id="cartTotal">0 грн</span></div><form class="request-form" id="requestForm" novalidate>
       <div class="form-step">
         <div class="step-title"><span class="step-num">1</span>Контактні дані</div>
         <div class="field">

--- a/tests/site-content.test.mjs
+++ b/tests/site-content.test.mjs
@@ -59,3 +59,36 @@ test("landing pulls storefront config from the API and gates on published", asyn
   assert.match(html, /id="scSlogan"/);
   assert.match(html, /id="scAbout"/);
 });
+
+test("stage 2: color, logo and storefront type are validated", () => {
+  const ok = sanitizeSiteContent({ brandColor: "#2F8F46", logoUrl: "https://x.co/l.png", storefrontType: "paid_only" });
+  assert.equal(ok.brandColor, "#2f8f46"); // normalized lowercase
+  assert.equal(ok.logoUrl, "https://x.co/l.png");
+  assert.equal(ok.storefrontType, "paid_only");
+  const bad = sanitizeSiteContent({ brandColor: "red", logoUrl: "javascript:alert(1)", storefrontType: "weird" });
+  assert.equal(bad.brandColor, SITE_CONTENT_DEFAULTS.brandColor); // invalid hex → default
+  assert.equal(bad.logoUrl, ""); // unsafe url rejected
+  assert.equal(bad.storefrontType, "paid_and_free"); // unknown → default
+});
+
+test("landing themes via CSS variable and honors storefront type + logo", async () => {
+  const html = await read("public/site/index.html");
+  assert.match(html, /--brand:#0c7a85/); // змінна визначена
+  assert.match(html, /setProperty\('--brand',c\.brandColor\)/); // застосування кольору
+  assert.match(html, /storefrontType==='paid_only'/); // ховає картку військових
+  assert.match(html, /id="scMilCard"/);
+  assert.match(html, /id="scLogo"/);
+  // Колірні літерали замінено на var(--brand) — лишились тільки meta + визначення змінної.
+  assert.ok((html.match(/#0c7a85/g) || []).length <= 2);
+});
+
+test("editor is renamed to Вітрина with a schema and design controls", async () => {
+  const page = await read("app/staff/site/page.tsx");
+  assert.match(page, /title="Вітрина"/);
+  assert.match(page, /Схема вітрини/);
+  assert.match(page, /storefrontType/);
+  assert.match(page, /brandColor/);
+  assert.match(page, /logoUrl/);
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /Вітрина \(редактор\)/);
+});


### PR DESCRIPTION
На прохання: перейменовано **«Сайт клініки» → «Вітрина»**, додано **оформлення** (колір/тема/логотип), **вибір виду вітрини**, а редактор отримав **схему**, де видно, у якій частині вітрини опиниться кожен блок.

## Що додано
- **`lib/site-content.ts`** — поля `brandColor` (валідний HEX), `logoUrl` (лише `https`/`data:image`), `storefrontType` (`paid_and_free` | `paid_only`).
- **`/staff/site`** — заголовок **«Вітрина»**; блок **«Оформлення»**: вид вітрини, фірмовий колір (палітра-пресети + піпетка), логотип; над формою **«Схема вітрини»** з пронумерованими зонами, і кожна група текстів має той самий номер — одразу видно, де що зʼявиться.
- **Навігація:** «Сайт клініки (редактор)» → **«Вітрина (редактор)»**; хлібна крихта.
- **`public/site/index.html`** — фірмовий колір винесено в CSS-змінну `--brand` (типове значення **ідентичне** поточному), лендинг застосовує колір/логотип і **ховає картку «Військовим» у виді «Тільки платні»**.
- **`price/military/cabinet/about` + `department.js`** — колір теж через `--brand`, застосовується на всіх сторінках вітрини (з кешу).

## Два види вітрини
- **Платні + безкоштовні (військовим)** — як зараз (типово).
- **Тільки платні** — картку «Військовим» на головній приховано.

## Логотип
Поле — **посилання** на зображення (`https://…`). Завантаження файлу можна додати згодом (потрібне сховище); посилання працює одразу.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **168/168**. Кольоровий рефакторинг зроблено так, що **типовий вигляд не змінюється** — колір інший лише коли ви його оберете.

## Після мерджу
Деплой `main` (без міграцій). Кабінет → **Головна / Продаж послуг → Вітрина**: оберіть вид, колір/тему, логотип; за схемою зрозумієте, де який текст.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_