### PR TITLE
Форма «Нова запис»: створення запису персоналом із кабінету

### DIFF
--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -1,5 +1,8 @@
 import { addMinutes, serviceByCode } from "../../../../lib/catalog";
 import { isBookableDate, isTimeForService } from "../../../../lib/booking-rules";
+import { normalizeUkrainianPhone } from "../../../../lib/phone";
+import { normalizeDob } from "../../../../lib/dob";
+import { effectivePrice } from "../../../../lib/tariffs";
 import { sendPatientReminder, type ReminderBooking } from "../../../../lib/notify";
 import { canTransition, isStudyState, stateLabel } from "../../../../lib/study-state";
 import {
@@ -14,6 +17,89 @@ import { requireOrgContext } from "../../../../lib/tenant";
 
 function dbBinding() {
   return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+function clean(value: unknown, max: number) {
+  return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+const REFERRAL_TYPES = ["military_referral", "eh_referral", "paper_referral", "none", "other"];
+
+// Ручне створення запису персоналом («Нова запис»). Реєстратор/адмін.
+// Запис одразу підтверджений (status='confirmed'), тож займає слот на апараті.
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
+  if (!canManageBookings(member.role)) {
+    return Response.json({ error: "Створювати записи може реєстратор або адміністратор" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const name = clean(body.name, 120);
+  const phone = clean(body.phone, 40);
+  const phoneNormalized = normalizeUkrainianPhone(phone);
+  const dob = normalizeDob(body.dob);
+  const serviceCode = clean(body.serviceCode, 12);
+  const service = serviceByCode(serviceCode);
+  const desiredDate = clean(body.date, 10);
+  const desiredTime = clean(body.time, 5);
+  const category = clean(body.patientCategory, 20) === "military" ? "military" : "civilian";
+  let referralType = clean(body.referralType, 30);
+  if (!REFERRAL_TYPES.includes(referralType)) referralType = "none";
+  const comment = clean(body.comment, 700);
+  const radiologist = clean(body.assignedRadiologistEmail, 254).toLowerCase();
+  const radiographer = clean(body.assignedRadiographerEmail, 254).toLowerCase();
+
+  if (!name || !phoneNormalized || !service) {
+    return Response.json({ error: "Вкажіть імʼя, телефон і послугу" }, { status: 400 });
+  }
+  if (!isBookableDate(desiredDate) || !isTimeForService(desiredTime, serviceCode)) {
+    return Response.json({ error: "Оберіть доступні дату та час" }, { status: 400 });
+  }
+
+  const endTime = addMinutes(desiredTime, service.durationMinutes);
+  const conflict = await db.prepare(
+    `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ?
+     AND status IN ('confirmed','rescheduled') AND desired_time < ?
+     AND time(desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
+  ).bind(service.equipmentId, desiredDate, endTime, desiredTime).first();
+  if (conflict) return Response.json({ error: "Цей час уже зайнятий на обраному апараті" }, { status: 409 });
+  const blocked = await db.prepare(
+    "SELECT id FROM equipment_blocks WHERE equipment_id = ? AND blocked_date = ? AND start_time < ? AND end_time > ? LIMIT 1"
+  ).bind(service.equipmentId, desiredDate, endTime, desiredTime).first();
+  if (blocked) return Response.json({ error: "Апарат недоступний у цей період" }, { status: 409 });
+
+  const code = `RD-${crypto.randomUUID().replace(/-/g, "").slice(0, 16).toUpperCase()}`;
+  const price = await effectivePrice(db, service.code);
+  const paymentStatus = category === "civilian" ? "pending" : "verification_required";
+  const nszuStatus = referralType === "eh_referral" ? "pending" : "not_applicable";
+  const referral = referralType === "none" ? "Немає направлення" : referralType;
+
+  const result = await db.prepare(
+    `INSERT INTO bookings (
+      organization_id, code, name, phone, phone_normalized, service, service_code, equipment_id,
+      duration_minutes, desired_date, desired_time, referral, patient_category, referral_type,
+      payment_status, payment_amount, nszu_status, comment, date_of_birth,
+      assigned_radiologist_email, assigned_radiographer_email, status,
+      consent_at, consent_version, consent_source
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'confirmed',CURRENT_TIMESTAMP,?,?)`
+  ).bind(
+    ctx.organizationId, code, name, phone, phoneNormalized, service.title, service.code, service.equipmentId,
+    service.durationMinutes, desiredDate, desiredTime, referral, category, referralType,
+    paymentStatus, price, nszuStatus, comment, dob,
+    radiologist, radiographer, "2026-07-29", "staff",
+  ).run();
+
+  const bookingId = result.meta.last_row_id;
+  if (bookingId) {
+    await db.prepare(
+      "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'created', ?, ?)"
+    ).bind(bookingId, `${service.code} ${desiredDate} ${desiredTime}`, member.email).run();
+  }
+  return Response.json({ ok: true, code }, { status: 201 });
 }
 
 // Область видимості заявок: спершу tenant (organization_id зі серверного

--- a/app/globals.css
+++ b/app/globals.css
@@ -287,6 +287,7 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .apptViewToggle{display:inline-flex;background:#eef2f0;border-radius:8px;padding:3px}
 .apptViewToggle button{border:0;background:none;padding:8px 16px;border-radius:6px;font:inherit;font-weight:700;font-size:13px;color:#5c6c78;cursor:pointer}
 .apptViewToggle button.active{background:var(--green);color:#fff}
+.apptNewBtn{margin-left:auto;display:inline-flex;align-items:center;padding:9px 16px;border-radius:8px;background:var(--green);color:#fff;font-weight:800;font-size:13px;text-decoration:none}.apptNewBtn:hover{background:#0a4b42}
 .apptStatusRow{display:flex;flex-wrap:wrap;gap:8px}
 .apptStatusTab{display:inline-flex;align-items:center;gap:7px;border:1px solid #dce4e3;background:#fff;border-radius:99px;padding:7px 13px;font:inherit;font-size:13px;font-weight:700;color:#41544f;cursor:pointer}
 .apptStatusTab:hover{border-color:#b7c9c5}

--- a/app/staff/appointments/page.tsx
+++ b/app/staff/appointments/page.tsx
@@ -125,6 +125,7 @@ export default function StaffAppointmentsPage() {
               <button type="button" className={view === "list" ? "active" : ""} onClick={() => setView("list")}>Список</button>
               <button type="button" className={view === "day" ? "active" : ""} onClick={() => setView("day")}>День</button>
             </div>
+            <a className="apptNewBtn" href="/staff/book">+ Нова запис</a>
           </div>
           <div className="apptStatusRow">
             {TABS.map(t => (

--- a/app/staff/book/page.tsx
+++ b/app/staff/book/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { groupedServices, serviceByCode } from "../../../lib/catalog";
+import { todayInKyiv } from "../../../lib/booking-rules";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+type StaffOption = { email: string; displayName: string; role: string };
+
+const money = new Intl.NumberFormat("uk-UA");
+const REFERRALS: [string, string][] = [
+  ["none", "Немає направлення"],
+  ["military_referral", "Направлення військової частини/закладу"],
+  ["eh_referral", "Електронне направлення"],
+  ["paper_referral", "Паперове направлення"],
+  ["other", "Інше"],
+];
+
+export default function StaffBookPage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [options, setOptions] = useState<StaffOption[]>([]);
+  const [serviceCode, setServiceCode] = useState("");
+  const [date, setDate] = useState("");
+  const [time, setTime] = useState("");
+  const [times, setTimes] = useState<string[]>([]);
+  const [slotsLoading, setSlotsLoading] = useState(false);
+  const [status, setStatus] = useState<"idle" | "saving">("idle");
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+
+  const serviceGroups = useMemo(() => groupedServices(), []);
+  const radiologists = useMemo(() => options.filter(o => o.role === "radiologist"), [options]);
+  const radiographers = useMemo(() => options.filter(o => o.role === "radiographer"), [options]);
+
+  useEffect(() => {
+    let active = true;
+    const t = window.setTimeout(async () => {
+      const res = await fetch("/api/staff/bookings", { cache: "no-store" });
+      if (res.status === 403) { if (active) setForbidden(true); return; }
+      const data = await res.json().catch(() => ({})) as { staffOptions?: StaffOption[]; staff?: StaffInfo };
+      if (!active) return;
+      setOptions(data.staffOptions || []);
+      if (data.staff) setStaff(data.staff);
+    }, 0);
+    return () => { active = false; window.clearTimeout(t); };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const t = window.setTimeout(() => {
+      if (!date || !serviceCode) { setTimes([]); setSlotsLoading(false); return; }
+      setSlotsLoading(true); setTime("");
+      fetch(`/api/availability?date=${encodeURIComponent(date)}&serviceCode=${encodeURIComponent(serviceCode)}`, { cache: "no-store" })
+        .then(r => r.json()).then((d: { times?: string[] }) => { if (active) setTimes(d.times || []); })
+        .catch(() => { if (active) setTimes([]); })
+        .finally(() => { if (active) setSlotsLoading(false); });
+    }, 0);
+    return () => { active = false; window.clearTimeout(t); };
+  }, [date, serviceCode]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("saving"); setError(""); setCode("");
+    const data = new FormData(event.currentTarget);
+    const res = await fetch("/api/staff/bookings", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: String(data.get("name") || ""),
+        phone: String(data.get("phone") || ""),
+        dob: String(data.get("dob") || ""),
+        patientCategory: String(data.get("patientCategory") || "civilian"),
+        serviceCode, date, time,
+        referralType: String(data.get("referralType") || "none"),
+        comment: String(data.get("comment") || ""),
+        assignedRadiologistEmail: String(data.get("radiologist") || ""),
+        assignedRadiographerEmail: String(data.get("radiographer") || ""),
+      }),
+    });
+    const result = await res.json().catch(() => ({})) as { ok?: boolean; code?: string; error?: string };
+    setStatus("idle");
+    if (!res.ok || !result.ok) { setError(result.error || "Не вдалося створити запис"); return; }
+    setCode(result.code || "");
+    (event.target as HTMLFormElement).reset();
+    setServiceCode(""); setDate(""); setTime(""); setTimes([]);
+  }
+
+  const price = serviceByCode(serviceCode)?.price;
+
+  const body = forbidden
+    ? <p className="notice error" role="alert">Створювати записи може реєстратор або адміністратор.</p>
+    : <form className="settingsCard" onSubmit={submit}>
+        {code && <p className="notice success" role="status">Запис створено. Код: <b>{code}</b>. <a className="textLink" href="/staff/appointments">До календаря →</a></p>}
+        <section className="settingsBlock">
+          <h3>Пацієнт</h3>
+          <label className="settingsField"><span>Імʼя та прізвище *</span><input name="name" required maxLength={120} placeholder="Іван Іваненко" /></label>
+          <label className="settingsField"><span>Телефон *</span><input name="phone" required inputMode="tel" placeholder="+380 97 000 00 00" /></label>
+          <label className="settingsField"><span>Дата народження</span><input name="dob" type="date" max="2100-12-31" min="1920-01-01" /></label>
+          <label className="settingsField"><span>Категорія</span>
+            <select name="patientCategory" defaultValue="civilian">
+              <option value="civilian">Цивільний пацієнт</option>
+              <option value="military">Військовослужбовець</option>
+            </select>
+          </label>
+        </section>
+
+        <section className="settingsBlock">
+          <h3>Послуга й час</h3>
+          <label className="settingsField"><span>Послуга *</span>
+            <select value={serviceCode} onChange={e => setServiceCode(e.target.value)} required>
+              <option value="" disabled>Оберіть послугу</option>
+              {Object.entries(serviceGroups).map(([group, items]) => (
+                <optgroup label={group} key={group}>
+                  {items.map(s => <option value={s.code} key={s.code}>{s.code} · {s.title} · {money.format(s.price)} грн</option>)}
+                </optgroup>
+              ))}
+            </select>
+            {price !== undefined && <small className="settingsHint">Орієнтовна вартість: {money.format(price)} грн</small>}
+          </label>
+          <label className="settingsField"><span>Дата *</span><input type="date" required min={todayInKyiv()} value={date} onChange={e => setDate(e.target.value)} /></label>
+          <label className="settingsField"><span>Час *</span>
+            <select value={time} onChange={e => setTime(e.target.value)} required disabled={!date || !serviceCode || slotsLoading}>
+              <option value="" disabled>{!serviceCode ? "Спершу оберіть послугу" : !date ? "Оберіть дату" : slotsLoading ? "Перевіряємо…" : times.length ? "Оберіть час" : "Вільного часу немає"}</option>
+              {times.map(t => <option key={t}>{t}</option>)}
+            </select>
+          </label>
+        </section>
+
+        <section className="settingsBlock">
+          <h3>Призначення та деталі</h3>
+          <label className="settingsField"><span>Лікар-рентгенолог</span>
+            <select name="radiologist" defaultValue="">
+              <option value="">— Не призначено</option>
+              {radiologists.map(o => <option value={o.email} key={o.email}>{o.displayName || o.email}</option>)}
+            </select>
+          </label>
+          <label className="settingsField"><span>Лаборант</span>
+            <select name="radiographer" defaultValue="">
+              <option value="">— Не призначено</option>
+              {radiographers.map(o => <option value={o.email} key={o.email}>{o.displayName || o.email}</option>)}
+            </select>
+          </label>
+          <label className="settingsField"><span>Тип направлення</span>
+            <select name="referralType" defaultValue="none">
+              {REFERRALS.map(([v, l]) => <option value={v} key={v}>{l}</option>)}
+            </select>
+          </label>
+          <label className="settingsField"><span>Причина звернення / коментар</span><textarea name="comment" rows={3} maxLength={700} placeholder="Скарги, важливі деталі" /></label>
+        </section>
+
+        {error && <p className="notice error" role="alert">{error}</p>}
+        <div className="settingsActions">
+          <button type="submit" disabled={status === "saving"}>{status === "saving" ? "Створюємо…" : "Створити запис"}</button>
+          <a className="textLink" href="/staff/appointments">До календаря</a>
+        </div>
+      </form>;
+
+  return (
+    <StaffWorkspaceShell active="appointments" title="Нова запис" description="Створення запису вручну: пацієнт, послуга, час, лікар." staffName={staff?.displayName} staffRole={staff?.role}>
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -38,6 +38,7 @@ const systemModules: NavModule[] = [
     { label:"Вибір часу", href:"/staff/dashboard" },
     { label:"Кабінет пацієнта", href:"/site/cabinet.html", flag:"patient_cabinet" },
     { label:"Черга реєстратури", href:"/staff#bookings" },
+    { label:"Нова запис", href:"/staff/book" },
     { label:"Календар записів", href:"/staff/appointments" },
     { label:"Реєстр досліджень", href:"/staff/studies" },
     { label:"Розклад дня", href:"/staff/dashboard" },

--- a/tests/staff-booking-create.test.mjs
+++ b/tests/staff-booking-create.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("staff can create a booking via POST, guarded and conflict-checked", async () => {
+  const route = await read("app/api/staff/bookings/route.ts");
+  assert.match(route, /export async function POST/);
+  assert.match(route, /canManageBookings\(member\.role\)/);
+  assert.match(route, /normalizeUkrainianPhone\(/);
+  assert.match(route, /isBookableDate\(desiredDate\) \|\| !isTimeForService/);
+  assert.match(route, /Цей час уже зайнятий/); // перевірка конфлікту слота
+  assert.match(route, /INSERT INTO bookings/);
+  assert.match(route, /'confirmed',CURRENT_TIMESTAMP/); // персональний запис одразу підтверджений
+  assert.match(route, /assigned_radiologist_email, assigned_radiographer_email/);
+  assert.match(route, /booking_events .* 'created'/s);
+});
+
+test("new-booking form gathers patient, service, slot and staff, and posts", async () => {
+  const page = await read("app/staff/book/page.tsx");
+  assert.match(page, /title="Нова запис"/);
+  assert.match(page, /\/api\/availability\?date=/); // вільні слоти
+  assert.match(page, /method: "POST"[\s\S]*\/api\/staff\/bookings|\/api\/staff\/bookings[\s\S]*method: "POST"/);
+  assert.match(page, /name="name"/);
+  assert.match(page, /name="phone"/);
+  assert.match(page, /assignedRadiologistEmail/);
+  assert.match(page, /groupedServices\(\)/);
+});
+
+test("new-booking is reachable from nav and the calendar", async () => {
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/book"/);
+  const cal = await read("app/staff/appointments/page.tsx");
+  assert.match(cal, /apptNewBtn/);
+  assert.match(cal, /\/staff\/book/);
+});


### PR DESCRIPTION
Реєстратор/адмін створює запис **вручну** з кабінету — пацієнт, послуга, дата/час зі вільних слотів, лікар, причина. Як у DocTime «Новая запись».

## Що додано
- **`POST /api/staff/bookings`** — створення заявки (`canManageBookings`): нормалізація телефону й дати народження, перевірка дати/часу та **конфлікту слота** на апараті, ціна з тарифів. Статус одразу **`confirmed`** (запис займає слот), призначення радіолога/лаборанта, подія `created`.
- **`/staff/book`** — форма: пацієнт (ПІБ, телефон, дата народження, категорія), послуга + дата + **час зі вільних слотів** (`/api/availability`), лікар-рентгенолог і лаборант, тип направлення, причина; після створення показує код заявки.
- **Навігація:** пункт «Нова запис» у модулі 2; кнопка **«+ Нова запис»** у календарі записів.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **171/171** (нові `staff-booking-create`). Без міграцій.

## Де знайти
Кабінет → **Запис і заявки → Нова запис** (або кнопка «+ Нова запис» у календарі). Створений запис одразу видно в **Календарі записів** і в черзі.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_