### PR TITLE
Імпорт пацієнтів із CSV

### DIFF
--- a/app/api/staff/patients/import/route.ts
+++ b/app/api/staff/patients/import/route.ts
@@ -1,0 +1,65 @@
+// Пакетний імпорт пацієнтів у CRM. Клієнт розбирає CSV і надсилає рядки;
+// сервер валідує кожен через sanitizeProfile і робить upsert у
+// patient_profiles. Лише реєстратор/адмін.
+
+import { canManageBookings, requireStaff } from "../../../../../lib/staff-auth";
+import { sanitizeProfile } from "../../../../../lib/patients";
+import { logSecurityEvent } from "../../../../../lib/audit";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+const MAX_ROWS = 5000;
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canManageBookings(member.role)) {
+    return Response.json({ error: "Імпортувати пацієнтів може реєстратор або адміністратор" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as { records?: unknown };
+  const records = Array.isArray(body.records) ? body.records : [];
+  if (!records.length) return Response.json({ error: "Немає рядків для імпорту" }, { status: 400 });
+  if (records.length > MAX_ROWS) return Response.json({ error: `Забагато рядків (макс. ${MAX_ROWS})` }, { status: 400 });
+
+  const statements: D1PreparedStatement[] = [];
+  const errors: { row: number; error: string }[] = [];
+  let imported = 0;
+  records.forEach((raw, index) => {
+    const parsed = sanitizeProfile(raw);
+    if (!parsed.ok) { errors.push({ row: index + 1, error: parsed.error }); return; }
+    const p = parsed.profile;
+    imported += 1;
+    statements.push(db.prepare(
+      `INSERT INTO patient_profiles
+         (phone_normalized, display_name, birth_year, birth_date, email, address, tags, notes, do_not_contact, updated_by, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+       ON CONFLICT(phone_normalized) DO UPDATE SET
+         display_name = excluded.display_name, birth_year = excluded.birth_year,
+         birth_date = excluded.birth_date, email = excluded.email, address = excluded.address,
+         notes = CASE WHEN excluded.notes != '' THEN excluded.notes ELSE patient_profiles.notes END,
+         updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
+    ).bind(
+      p.phoneNormalized, p.displayName, p.birthYear, p.birthDate, p.email, p.address,
+      p.tags, p.notes, p.doNotContact, member.email,
+    ));
+  });
+
+  // D1 batch по частинах, щоб не впертися в ліміт кількості операцій.
+  for (let i = 0; i < statements.length; i += 50) {
+    await db.batch(statements.slice(i, i + 50));
+  }
+
+  await logSecurityEvent(db, {
+    actorEmail: member.email,
+    action: "patients_imported",
+    resource: "patient_registry",
+    details: { imported, skipped: errors.length },
+  });
+
+  return Response.json({ ok: true, imported, skipped: errors.length, errors: errors.slice(0, 50) });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -257,6 +257,7 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .settingsCard input[readonly]{background:#f4f8f6;color:#41544f}
 .settingsCard textarea{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);resize:vertical;min-height:72px;margin-top:6px}.settingsCard textarea:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
 .settingsCard select{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);background:#fff}.settingsCard select:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+.importErrors{margin:8px 0 0;padding-left:18px;color:#a23c1d;font-size:12.5px;line-height:1.6}
 .settingsBlock h3{font-size:15px;font-weight:700;margin:0 0 6px}
 .settingsBlock h3 .ssNum{margin-right:8px}
 .ssNum{display:inline-grid;place-items:center;width:20px;height:20px;border-radius:50%;background:var(--brand,#0c7a85);color:#fff;font-size:11px;font-weight:800;flex-shrink:0}

--- a/app/staff/patients/import/page.tsx
+++ b/app/staff/patients/import/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+import { mapRows, parseCsv, type ImportRecord } from "../../../../lib/patient-import";
+
+const TEMPLATE = "Прізвище,Імʼя,По батькові,Телефон,Дата народження,Email,Адреса,Нотатки\n"
+  + "Іваненко,Іван,Іванович,+380 97 000 00 00,1990-05-21,ivan@example.com,\"м. Чернігів, вул. Миру 1\",Алергія на йод\n";
+
+export default function PatientsImportPage() {
+  const [fileName, setFileName] = useState("");
+  const [records, setRecords] = useState<ImportRecord[]>([]);
+  const [parseErrors, setParseErrors] = useState<{ line: number; error: string }[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<{ imported: number; skipped: number; errors: { row: number; error: string }[] } | null>(null);
+  const [error, setError] = useState("");
+
+  async function onFile(file: File | null) {
+    setResult(null); setError(""); setRecords([]); setParseErrors([]);
+    if (!file) return;
+    setFileName(file.name);
+    try {
+      const text = await file.text();
+      const parsed = mapRows(parseCsv(text));
+      setRecords(parsed.records);
+      setParseErrors(parsed.errors);
+    } catch {
+      setError("Не вдалося прочитати файл. Переконайтеся, що це CSV.");
+    }
+  }
+
+  async function runImport() {
+    if (!records.length) return;
+    setImporting(true); setError(""); setResult(null);
+    try {
+      const res = await fetch("/api/staff/patients/import", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ records }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; imported?: number; skipped?: number; errors?: { row: number; error: string }[]; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося імпортувати");
+      setResult({ imported: data.imported || 0, skipped: data.skipped || 0, errors: data.errors || [] });
+      setRecords([]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося імпортувати");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const templateHref = "data:text/csv;charset=utf-8,%EF%BB%BF" + encodeURIComponent(TEMPLATE);
+
+  return (
+    <StaffWorkspaceShell active="patients" title="Імпорт пацієнтів" description="Завантаження списку пацієнтів із CSV.">
+      <div className="settingsCard">
+        <section className="settingsBlock">
+          <h3>Формат файлу</h3>
+          <p className="settingsHint">Завантажте <b>CSV</b>. Excel: «Файл → Зберегти як → CSV (розділювач — кома)». Перший рядок — заголовки (у будь-якому порядку). Обовʼязкові: <b>Прізвище/Імʼя</b> (або ПІБ) і <b>Телефон</b>. Дата народження: <code>РРРР-ММ-ДД</code> або <code>ДД.ММ.РРРР</code>.</p>
+          <a className="button secondary" href={templateHref} download="patients-template.csv">↧ Завантажити шаблон CSV</a>
+        </section>
+
+        <section className="settingsBlock">
+          <h3>Файл</h3>
+          <label className="settingsField"><span>CSV-файл</span><input type="file" accept=".csv,text/csv" onChange={e => void onFile(e.target.files?.[0] || null)} /></label>
+          {fileName && <p className="settingsHint">{fileName}: розпізнано <b>{records.length}</b> записів{parseErrors.length ? `, пропущено ${parseErrors.length}` : ""}.</p>}
+          {parseErrors.length > 0 && <ul className="importErrors">{parseErrors.slice(0, 10).map((e, i) => <li key={i}>Рядок {e.line}: {e.error}</li>)}</ul>}
+        </section>
+
+        {error && <p className="notice error" role="alert">{error}</p>}
+        {result && <p className="notice success" role="status">Імпортовано: <b>{result.imported}</b>{result.skipped ? `, пропущено: ${result.skipped}` : ""}. <a className="textLink" href="/staff/patients">До пацієнтів →</a></p>}
+        {result && result.errors.length > 0 && <ul className="importErrors">{result.errors.slice(0, 10).map((e, i) => <li key={i}>Рядок {e.row}: {e.error}</li>)}</ul>}
+
+        <div className="settingsActions">
+          <button type="button" onClick={() => void runImport()} disabled={importing || !records.length}>{importing ? "Імпортуємо…" : `Імпортувати ${records.length || ""}`.trim()}</button>
+          <a className="textLink" href="/staff/patients">Скасувати</a>
+        </div>
+      </div>
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/patients/page.tsx
+++ b/app/staff/patients/page.tsx
@@ -212,6 +212,7 @@ export default function PatientsPage() {
           <input type="search" value={query} onChange={(e)=>setQuery(e.target.value)} placeholder="ПІБ, телефон, тег"/>
           {canManage && <button type="button" className="crmAddBtn" onClick={()=>{setCreating(true);setSelectedPhone(null);setCard(null);setActionError("");setActionSuccess("");}}>+ Додати пацієнта</button>}
           <a className="crmExport" href="/api/staff/patients/export" download title="Завантажити CSV для імпорту в Google Контакти">↧ Експорт у Google Контакти</a>
+          {canManage && <a className="crmExport" href="/staff/patients/import" title="Імпорт пацієнтів із CSV">↥ Імпорт із CSV</a>}
         </div>
         <div className="protocolQueueList">
           {visible.length === 0 ? <p className="empty">Пацієнтів у цій категорії немає.</p> : visible.map((item)=><button

--- a/lib/patient-import.ts
+++ b/lib/patient-import.ts
@@ -1,0 +1,110 @@
+// Розбір CSV зі списком пацієнтів для імпорту в CRM. Чистий модуль без
+// залежностей (тестований). Нормалізацію телефону й фінальну валідацію
+// робить сервер через sanitizeProfile — тут лише розбір і зіставлення колонок.
+
+export type ImportRecord = {
+  displayName: string; phone: string; birthDate: string;
+  email: string; address: string; notes: string;
+};
+export type ImportParse = { records: ImportRecord[]; errors: { line: number; error: string }[] };
+
+// Гнучке зіставлення заголовків (укр / рос / англ).
+const ALIASES: Record<string, string[]> = {
+  surname: ["прізвище", "фамилия", "surname", "last name", "lastname"],
+  name: ["імʼя", "ім'я", "имя", "first name", "firstname", "name"],
+  patronymic: ["по батькові", "отчество", "patronymic", "middle name"],
+  fullname: ["піб", "фио", "повне імʼя", "повне ім'я", "full name", "пацієнт"],
+  phone: ["телефон", "phone", "номер", "мобільний", "тел", "mobile"],
+  dob: ["дата народження", "дата рождения", "birth date", "birthdate", "dob", "дн", "народження"],
+  email: ["email", "e-mail", "пошта", "почта", "емейл"],
+  address: ["адреса", "адрес", "address"],
+  notes: ["нотатки", "заметки", "примітки", "notes", "comment", "коментар"],
+};
+
+function pickDelimiter(headerLine: string): string {
+  const c = (headerLine.match(/,/g) || []).length;
+  const s = (headerLine.match(/;/g) || []).length;
+  const t = (headerLine.match(/\t/g) || []).length;
+  if (t >= c && t >= s) return "\t";
+  return s > c ? ";" : ",";
+}
+
+export function parseCsv(text: string, delimiter?: string): string[][] {
+  const s = String(text || "").replace(/^﻿/, "");
+  const delim = delimiter || pickDelimiter((s.split(/\r?\n/)[0]) || "");
+  const rows: string[][] = [];
+  let row: string[] = [], field = "", inQuotes = false, i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (s[i + 1] === '"') { field += '"'; i += 2; continue; }
+        inQuotes = false; i++; continue;
+      }
+      field += c; i++; continue;
+    }
+    if (c === '"') { inQuotes = true; i++; continue; }
+    if (c === delim) { row.push(field); field = ""; i++; continue; }
+    if (c === "\r") { i++; continue; }
+    if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; i++; continue; }
+    field += c; i++;
+  }
+  row.push(field); rows.push(row);
+  return rows.filter((r) => r.some((cell) => cell.trim() !== ""));
+}
+
+function normHeader(value: string): string {
+  return String(value || "").trim().toLowerCase().replace(/["']/g, "");
+}
+function matchColumn(header: string): string | null {
+  const h = normHeader(header);
+  for (const [field, names] of Object.entries(ALIASES)) {
+    if (names.some((n) => h === n || h.includes(n))) return field;
+  }
+  return null;
+}
+
+// Дата → YYYY-MM-DD з поширених форматів (ISO, DD.MM.YYYY, DD/MM/YYYY).
+export function normalizeImportDate(value: string): string {
+  const v = String(value || "").trim();
+  if (!v) return "";
+  let m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  m = /^(\d{1,2})[.\/](\d{1,2})[.\/](\d{4})$/.exec(v);
+  if (m) return `${m[3]}-${m[2].padStart(2, "0")}-${m[1].padStart(2, "0")}`;
+  return "";
+}
+
+export function mapRows(rows: string[][]): ImportParse {
+  const out: ImportParse = { records: [], errors: [] };
+  if (!rows.length) { out.errors.push({ line: 0, error: "Порожній файл" }); return out; }
+  const header = rows[0];
+  const col: Record<string, number> = {};
+  header.forEach((h, idx) => { const f = matchColumn(h); if (f && col[f] === undefined) col[f] = idx; });
+  const has = (f: string) => col[f] !== undefined;
+  if (!has("phone")) { out.errors.push({ line: 1, error: "Не знайдено колонку «Телефон»" }); return out; }
+  if (!has("fullname") && !has("surname") && !has("name")) {
+    out.errors.push({ line: 1, error: "Не знайдено колонку з іменем (ПІБ або Прізвище/Імʼя)" });
+    return out;
+  }
+  const at = (r: string[], f: string) => (col[f] !== undefined ? String(r[col[f]] || "").trim() : "");
+
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const displayName = (has("fullname")
+      ? at(r, "fullname")
+      : [at(r, "surname"), at(r, "name"), at(r, "patronymic")].filter(Boolean).join(" ")).slice(0, 120);
+    const phone = at(r, "phone");
+    if (!phone) { out.errors.push({ line: i + 1, error: "Порожній телефон" }); continue; }
+    if (!displayName) { out.errors.push({ line: i + 1, error: "Порожнє імʼя" }); continue; }
+    out.records.push({
+      displayName,
+      phone,
+      birthDate: normalizeImportDate(at(r, "dob")),
+      email: at(r, "email").slice(0, 254),
+      address: at(r, "address").slice(0, 200),
+      notes: at(r, "notes").slice(0, 2000),
+    });
+  }
+  return out;
+}

--- a/tests/patient-import.test.mjs
+++ b/tests/patient-import.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { mapRows, normalizeImportDate, parseCsv } from "../lib/patient-import.ts";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("parseCsv handles quotes, embedded commas and CRLF", () => {
+  const rows = parseCsv('a,b,c\r\n1,"x, y",3\r\n');
+  assert.deepEqual(rows, [["a", "b", "c"], ["1", "x, y", "3"]]);
+});
+
+test("parseCsv auto-detects a semicolon delimiter", () => {
+  const rows = parseCsv("a;b\n1;2");
+  assert.deepEqual(rows, [["a", "b"], ["1", "2"]]);
+});
+
+test("normalizeImportDate accepts ISO and DD.MM.YYYY", () => {
+  assert.equal(normalizeImportDate("1990-05-21"), "1990-05-21");
+  assert.equal(normalizeImportDate("21.05.1990"), "1990-05-21");
+  assert.equal(normalizeImportDate("garbage"), "");
+});
+
+test("mapRows maps flexible headers, builds ПІБ and flags bad rows", () => {
+  const csv = "Прізвище,Імʼя,Телефон,Дата народження,Email\n"
+    + "Іваненко,Іван,+380971112233,21.05.1990,a@b.co\n"
+    + ",,+380971112233,,\n" // без імені → помилка
+    + "Петренко,Петро,,1985-01-01,\n"; // без телефону → помилка
+  const { records, errors } = mapRows(parseCsv(csv));
+  assert.equal(records.length, 1);
+  assert.equal(records[0].displayName, "Іваненко Іван");
+  assert.equal(records[0].phone, "+380971112233");
+  assert.equal(records[0].birthDate, "1990-05-21");
+  assert.equal(errors.length, 2);
+});
+
+test("mapRows rejects a file without required columns", () => {
+  const { errors } = mapRows(parseCsv("колонка1,колонка2\nx,y"));
+  assert.ok(errors.some((e) => /Телефон|імен/i.test(e.error)));
+});
+
+test("import API validates each row and upserts, guarded", async () => {
+  const route = await read("app/api/staff/patients/import/route.ts");
+  assert.match(route, /canManageBookings\(member\.role\)/);
+  assert.match(route, /sanitizeProfile\(raw\)/);
+  assert.match(route, /INSERT INTO patient_profiles/);
+  assert.match(route, /db\.batch\(/);
+  assert.match(route, /MAX_ROWS/);
+});
+
+test("import page parses CSV client-side and offers a template", async () => {
+  const page = await read("app/staff/patients/import/page.tsx");
+  assert.match(page, /parseCsv|mapRows/);
+  assert.match(page, /patients-template\.csv/);
+  assert.match(page, /\/api\/staff\/patients\/import/);
+  const list = await read("app/staff/patients/page.tsx");
+  assert.match(list, /\/staff\/patients\/import/);
+});


### PR DESCRIPTION
Реєстратор/адмін завантажує список пацієнтів у CRM. **Excel** — через «Зберегти як CSV» (парсинг `.xlsx` на Cloudflare Worker завеликий; свідомо обрано CSV, без нових залежностей).

## Що додано
- **`lib/patient-import.ts`** — чистий парсер CSV (лапки, коми в полях, CRLF, **автовизначення роздільника** `,` `;` таб) + гнучке зіставлення заголовків (укр/рос/англ), збірка ПІБ, нормалізація дати (`РРРР-ММ-ДД` / `ДД.ММ.РРРР`).
- **`/api/staff/patients/import`** — пакетний upsert у `patient_profiles` через наявний `sanitizeProfile` (нормалізація/валідація телефону), D1 `batch` по 50, ліміт 5000 рядків, аудит. `canManageBookings`.
- **`/staff/patients/import`** — сторінка: формат, **шаблон CSV** для завантаження, вибір файлу, **клієнтський розбір із прев’ю** (скільки розпізнано / помилки по рядках), результат імпорту.
- Кнопка **«Імпорт із CSV»** поряд з експортом у CRM.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **178/178** (нові `patient-import`). Без міграцій.

## Як користуватись
Кабінет → **Пацієнти → «Імпорт із CSV»** → завантажте шаблон, заповніть (обовʼязкові: **Прізвище/Імʼя** або ПІБ, і **Телефон**), збережіть як CSV, завантажте → перевірте прев’ю → «Імпортувати». Дублікати за телефоном оновлюються.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_