### PR TITLE
Вітрина: завантаження логотипа файлом

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -271,6 +271,9 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .colorSwatches{display:inline-flex;gap:8px;flex-wrap:wrap}
 .colorSwatch{width:28px;height:28px;border-radius:50%;border:2px solid #fff;box-shadow:0 0 0 1px #cbd8d6;cursor:pointer;padding:0}
 .colorSwatch.active{box-shadow:0 0 0 2px var(--green)}
+.logoPreview{display:flex;align-items:center;gap:12px;margin:6px 0 8px}
+.logoPreview img{height:46px;width:auto;max-width:160px;border-radius:8px;border:1px solid #dce4e3;background:#fff;padding:3px;object-fit:contain}
+.logoPreview button{border:1px solid #d5ddd9;background:#fff;color:#a23c1d;border-radius:6px;padding:6px 12px;font:inherit;font-size:12px;font-weight:700;cursor:pointer}
 @media(max-width:600px){.siteSchema .ssRow{flex-direction:column}}
 .settingsCard .siteToggleRow{display:flex;align-items:center;justify-content:space-between;gap:16px}
 .settingsCard .siteToggleRow>div{margin:0}.settingsCard .siteToggleRow b{font-size:14px}.settingsCard .siteToggleRow p{margin:4px 0 0;color:#66756f;font-size:12px}

--- a/app/staff/site/page.tsx
+++ b/app/staff/site/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type CSSProperties, FormEvent, useEffect, useState } from "react";
+import Image from "next/image";
 import StaffWorkspaceShell from "../workspace-shell";
 import { SITE_CONTENT_DEFAULTS, type SiteContent } from "../../../lib/site-content";
 
@@ -71,6 +72,36 @@ export default function StaffSitePage() {
 
   function update(key: keyof SiteContent, value: string | boolean) {
     setContent(prev => ({ ...prev, [key]: value }));
+  }
+
+  // Логотип: SVG беремо як є, растр зменшуємо в браузері до висоти 200px і
+  // зберігаємо як компактний data-URI (без бекенду й сховища).
+  async function onLogoFile(file: File | null) {
+    setError("");
+    if (!file) return;
+    if (!file.type.startsWith("image/")) { setError("Оберіть файл зображення."); return; }
+    try {
+      if (file.type === "image/svg+xml") {
+        const uri = await new Promise<string>((res, rej) => { const fr = new FileReader(); fr.onload = () => res(String(fr.result)); fr.onerror = rej; fr.readAsDataURL(file); });
+        if (uri.length > 300000) { setError("SVG завеликий — спростіть логотип."); return; }
+        update("logoUrl", uri); return;
+      }
+      const url = URL.createObjectURL(file);
+      const img = new window.Image();
+      await new Promise<void>((res, rej) => { img.onload = () => res(); img.onerror = () => rej(new Error("read")); img.src = url; });
+      const scale = Math.min(1, 200 / img.height);
+      const w = Math.max(1, Math.round(img.width * scale)), h = Math.max(1, Math.round(img.height * scale));
+      const canvas = document.createElement("canvas"); canvas.width = w; canvas.height = h;
+      canvas.getContext("2d")?.drawImage(img, 0, 0, w, h);
+      URL.revokeObjectURL(url);
+      let uri = canvas.toDataURL("image/webp", 0.85);
+      if (!uri.startsWith("data:image/webp")) uri = canvas.toDataURL("image/png");
+      if (uri.length > 300000) uri = canvas.toDataURL("image/jpeg", 0.7);
+      if (uri.length > 300000) { setError("Логотип завеликий — оберіть менше зображення."); return; }
+      update("logoUrl", uri);
+    } catch {
+      setError("Не вдалося прочитати зображення.");
+    }
   }
 
   async function save(event: FormEvent<HTMLFormElement>) {
@@ -153,9 +184,11 @@ export default function StaffSitePage() {
               <small className="settingsHint">Колір застосовується до шапки, кнопок і карток вітрини.</small>
             </label>
             <label className="settingsField">
-              <span>Логотип (посилання на зображення)</span>
-              <input type="url" value={content.logoUrl} onChange={e => update("logoUrl", e.target.value)} placeholder="https://…/logo.png" />
-              <small className="settingsHint">Необовʼязково. Посилання на PNG/JPG/SVG (https). Зʼявиться у шапці.</small>
+              <span>Логотип</span>
+              {content.logoUrl && <span className="logoPreview"><Image src={content.logoUrl} alt="Логотип" width={120} height={46} unoptimized /><button type="button" onClick={() => update("logoUrl", "")}>Прибрати</button></span>}
+              <input type="file" accept="image/*" onChange={e => void onLogoFile(e.target.files?.[0] || null)} />
+              <small className="settingsHint">Завантажте PNG/JPG/SVG — зображення зменшиться автоматично. Або вставте посилання (https):</small>
+              <input type="url" value={/^https:\/\//.test(content.logoUrl) ? content.logoUrl : ""} onChange={e => update("logoUrl", e.target.value)} placeholder="https://…/logo.png" />
             </label>
           </section>
 

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -89,9 +89,11 @@ export function sanitizeSiteContent(input: unknown): SiteContent {
   // Фірмовий колір — лише валідний HEX (#RRGGBB), інакше типовий.
   const color = String(src.brandColor ?? "").trim();
   out.brandColor = /^#[0-9a-fA-F]{6}$/.test(color) ? color.toLowerCase() : SITE_CONTENT_DEFAULTS.brandColor;
-  // Логотип — лише безпечне посилання (https або data:image), інакше порожньо.
-  const logo = String(src.logoUrl ?? "").trim().slice(0, 500);
-  out.logoUrl = /^(https:\/\/|data:image\/)/.test(logo) ? logo : "";
+  // Логотип — https-посилання або data:image (файл, зменшений у браузері).
+  // Обмежуємо розмір, щоб не роздувати конфіг у базі.
+  const logo = String(src.logoUrl ?? "").trim();
+  const logoOk = (/^https:\/\//.test(logo) || /^data:image\/(png|jpe?g|webp|gif|svg\+xml);/.test(logo)) && logo.length <= 300000;
+  out.logoUrl = logoOk ? logo : "";
   // Вид вітрини.
   out.storefrontType = src.storefrontType === "paid_only" ? "paid_only" : "paid_and_free";
   out.published = src.published === undefined ? SITE_CONTENT_DEFAULTS.published : Boolean(src.published);

--- a/tests/site-content.test.mjs
+++ b/tests/site-content.test.mjs
@@ -82,6 +82,22 @@ test("landing themes via CSS variable and honors storefront type + logo", async 
   assert.ok((html.match(/#0c7a85/g) || []).length <= 2);
 });
 
+test("logo accepts a data:image URI within the size cap, rejects oversized/unsafe", () => {
+  const small = "data:image/png;base64," + "A".repeat(1000);
+  assert.equal(sanitizeSiteContent({ logoUrl: small }).logoUrl, small);
+  assert.equal(sanitizeSiteContent({ logoUrl: "https://x.co/l.svg" }).logoUrl, "https://x.co/l.svg");
+  assert.equal(sanitizeSiteContent({ logoUrl: "data:text/html;base64,xxx" }).logoUrl, ""); // не зображення
+  const huge = "data:image/png;base64," + "A".repeat(300001);
+  assert.equal(sanitizeSiteContent({ logoUrl: huge }).logoUrl, ""); // завеликий
+});
+
+test("editor uploads a logo file (browser-side resize to data URI)", async () => {
+  const page = await read("app/staff/site/page.tsx");
+  assert.match(page, /type="file"/);
+  assert.match(page, /onLogoFile/);
+  assert.match(page, /toDataURL/); // зменшення в canvas
+});
+
 test("editor is renamed to Вітрина with a schema and design controls", async () => {
   const page = await read("app/staff/site/page.tsx");
   assert.match(page, /title="Вітрина"/);


### PR DESCRIPTION
У редакторі **Вітрина** логотип тепер можна **завантажити файлом** (а не лише посиланням). Без нового бекенду/сховища R2: зображення **зменшується у браузері** і зберігається як компактний `data:` URI в наявному полі `logoUrl`.

## Що додано
- **`/staff/site`** — файловий інпут + прев’ю з кнопкою «Прибрати»; `onLogoFile`: SVG беремо як є, растр малюється в `canvas` до висоти 200px і експортується у webp/png/jpeg із контролем розміру. Поле-посилання (https) лишилось як альтернатива.
- **`lib/site-content.ts`** — `logoUrl` приймає `https://` або `data:image/(png|jpg|webp|gif|svg)` з обмеженням довжини **300000** символів (щоб не роздувати конфіг у базі), інакше — порожньо.

## Чому так, а не R2
Повноцінне сховище (R2) вимагає бінду бакета + окремого API й серверного завантаження, яке я не можу перевірити без вашого середовища. Зменшений data-URI працює одразу, безпечно і без інфраструктури. Якщо захочете великі логотипи/багато файлів — зробимо R2 окремо.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **180/180**. Без міграцій.

## Як користуватись
Кабінет → **Вітрина → Оформлення → Логотип → «Вибрати файл»**. Зʼявиться прев’ю; «Зберегти зміни» → логотип у шапці сайту.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_