### PR TITLE
Налаштування графіка і слотів прийому

### DIFF
--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,5 +1,7 @@
-import { addMinutes, candidateTimes, EQUIPMENT, serviceByCode } from "../../../lib/catalog";
+import { addMinutes, EQUIPMENT, serviceByCode } from "../../../lib/catalog";
 import { isBookableDate } from "../../../lib/booking-rules";
+import { getSetting } from "../../../lib/settings";
+import { candidateTimesFor, hoursFor, isDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -8,6 +10,9 @@ export async function GET(request: Request) {
   if (!isBookableDate(date) || !service) return Response.json({ times: [] });
   const db = (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+  // Налаштовуваний графік: робочі дні й години прийому.
+  const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+  if (!isDayOpen(date, schedule)) return Response.json({ times: [], durationMinutes: service.durationMinutes, equipment: EQUIPMENT[service.equipmentId].name });
 
   const [bookings, blocks] = await Promise.all([
     db.prepare(
@@ -23,7 +28,7 @@ export async function GET(request: Request) {
 
   const overlaps = (start:string, end:string, otherStart:string, otherEnd:string) =>
     start < otherEnd && end > otherStart;
-  const times = candidateTimes(service).filter(start => {
+  const times = candidateTimesFor(hoursFor(schedule, service.equipmentId), service.durationMinutes).filter(start => {
     const end = addMinutes(start, service.durationMinutes);
     const bookingConflict = bookings.results.some((row:{startTime:string;durationMinutes:number}) =>
       overlaps(start, end, row.startTime, addMinutes(row.startTime, row.durationMinutes)));

--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -1,5 +1,7 @@
 import { addMinutes, serviceByCode } from "../../../../lib/catalog";
-import { isBookableDate, isTimeForService } from "../../../../lib/booking-rules";
+import { isBookableDate } from "../../../../lib/booking-rules";
+import { candidateTimesFor, hoursFor, isDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../../lib/schedule";
+import { getSetting } from "../../../../lib/settings";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
 import { normalizeDob } from "../../../../lib/dob";
 import { effectivePrice } from "../../../../lib/tariffs";
@@ -56,7 +58,9 @@ export async function POST(request: Request) {
   if (!name || !phoneNormalized || !service) {
     return Response.json({ error: "Вкажіть імʼя, телефон і послугу" }, { status: 400 });
   }
-  if (!isBookableDate(desiredDate) || !isTimeForService(desiredTime, serviceCode)) {
+  const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+  const validTimes = candidateTimesFor(hoursFor(schedule, service.equipmentId), service.durationMinutes);
+  if (!isBookableDate(desiredDate) || !isDayOpen(desiredDate, schedule) || !validTimes.includes(desiredTime)) {
     return Response.json({ error: "Оберіть доступні дату та час" }, { status: 400 });
   }
 
@@ -412,7 +416,9 @@ export async function PATCH(request: Request) {
        FROM bookings WHERE id = ?`
     ).bind(body.id).first<{serviceCode:string;equipmentId:string;durationMinutes:number;name:string;phone:string;phoneNormalized:string;patientEmail:string;service:string}>();
     const service = booking && serviceByCode(booking.serviceCode);
-    if (!booking || !service || !isBookableDate(body.desiredDate) || !isTimeForService(body.desiredTime, booking.serviceCode)) {
+    const rSched = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+    if (!booking || !service || !isBookableDate(body.desiredDate) || !isDayOpen(body.desiredDate, rSched)
+        || !candidateTimesFor(hoursFor(rSched, service.equipmentId), booking.durationMinutes).includes(body.desiredTime)) {
       return Response.json({ error: "Некоректні дата або час" }, { status: 400 });
     }
     const endTime = addMinutes(body.desiredTime, booking.durationMinutes);
@@ -454,7 +460,9 @@ export async function PATCH(request: Request) {
       return Response.json({ error: "Заявку вже закрито — підтвердження недоступне" }, { status: 400 });
     }
     const service = serviceByCode(booking.serviceCode);
-    if (!service || !isBookableDate(booking.desiredDate) || !isTimeForService(booking.desiredTime, booking.serviceCode)) {
+    const cSched = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+    if (!service || !isBookableDate(booking.desiredDate) || !isDayOpen(booking.desiredDate, cSched)
+        || !candidateTimesFor(hoursFor(cSched, service.equipmentId), booking.durationMinutes).includes(booking.desiredTime)) {
       return Response.json({ error: "Бажаний час поза розкладом — перенесіть запис на вільний слот" }, { status: 400 });
     }
     const endTime = addMinutes(booking.desiredTime, booking.durationMinutes);

--- a/app/api/staff/schedule/route.ts
+++ b/app/api/staff/schedule/route.ts
@@ -1,0 +1,34 @@
+// Графік прийому: години/крок слота по апаратах, робочі дні тижня та вихідні.
+// Лише адміністратор. Зберігається у app_settings (equipment_schedule).
+
+import { requireStaff } from "../../../../lib/staff-auth";
+import { getSetting, setSetting } from "../../../../lib/settings";
+import { parseSchedule, sanitizeSchedule, SCHEDULE_KEY } from "../../../../lib/schedule";
+
+function dbBinding() {
+  return (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Графік налаштовує лише адміністратор" }, { status: 403 });
+
+  const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+  return Response.json({ schedule, staff: member }, { headers: { "cache-control": "no-store" } });
+}
+
+export async function PUT(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Змінювати графік може лише адміністратор" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as { schedule?: unknown };
+  const schedule = sanitizeSchedule(body.schedule);
+  await setSetting(db, SCHEDULE_KEY, JSON.stringify(schedule));
+  return Response.json({ ok: true, schedule }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -258,6 +258,20 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .settingsCard textarea{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);resize:vertical;min-height:72px;margin-top:6px}.settingsCard textarea:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
 .settingsCard select{width:100%;padding:11px 12px;border:1px solid #cbd8d6;border-radius:7px;font:inherit;color:var(--ink);background:#fff}.settingsCard select:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
 .importErrors{margin:8px 0 0;padding-left:18px;color:#a23c1d;font-size:12.5px;line-height:1.6}
+.weekdayRow{display:flex;flex-wrap:wrap;gap:8px;margin-top:6px}
+.weekdayChip{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border:1px solid #cbd8d6;border-radius:99px;font-size:13px;font-weight:700;color:#5c6c78;cursor:pointer;background:#fff}
+.weekdayChip.on{background:var(--green);border-color:var(--green);color:#fff}
+.weekdayChip input{width:14px;height:14px;margin:0;accent-color:#fff}
+.equipHoursRow{display:flex;flex-wrap:wrap;align-items:end;gap:12px;padding:10px 0;border-top:1px solid #eef2f0}
+.equipHoursRow:first-of-type{border-top:0}
+.equipHoursRow>b{flex:1 1 100%;font-size:13.5px;margin-bottom:2px}
+.equipHoursRow label{display:flex;flex-direction:column;gap:4px}.equipHoursRow label>span{font-size:11px;font-weight:800;color:#41544f;text-transform:uppercase;letter-spacing:.05em}
+.equipHoursRow input{padding:9px 11px;border:1px solid #cbd8d6;border-radius:7px;font:inherit}.equipHoursRow input[type="number"]{width:92px}
+.dayOffAdd{display:flex;gap:10px;align-items:center;margin-top:6px}
+.dayOffAdd input{padding:9px 11px;border:1px solid #cbd8d6;border-radius:7px;font:inherit}
+.dayOffList{list-style:none;margin:12px 0 0;padding:0;display:flex;flex-wrap:wrap;gap:8px}
+.dayOffList li{display:inline-flex;align-items:center;gap:8px;background:#f2f6f4;border:1px solid #dce4e3;border-radius:8px;padding:6px 8px 6px 12px;font-size:13px}
+.dayOffList button{border:0;background:#e5ecea;color:#a23c1d;width:22px;height:22px;border-radius:50%;font-size:15px;line-height:1;cursor:pointer}
 .settingsBlock h3{font-size:15px;font-weight:700;margin:0 0 6px}
 .settingsBlock h3 .ssNum{margin-right:8px}
 .ssNum{display:inline-grid;place-items:center;width:20px;height:20px;border-radius:50%;background:var(--brand,#0c7a85);color:#fff;font-size:11px;font-weight:800;flex-shrink:0}

--- a/app/staff/schedule/page.tsx
+++ b/app/staff/schedule/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { EQUIP_KEYS, EQUIP_LABELS, SCHEDULE_DEFAULTS, type ScheduleConfig } from "../../../lib/schedule";
+
+type StaffInfo = { email: string; displayName: string; role: string };
+const WEEKDAYS: [number, string][] = [[1, "Пн"], [2, "Вт"], [3, "Ср"], [4, "Чт"], [5, "Пт"], [6, "Сб"]];
+
+export default function StaffSchedulePage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [cfg, setCfg] = useState<ScheduleConfig>(() => JSON.parse(JSON.stringify(SCHEDULE_DEFAULTS)));
+  const [newDay, setNewDay] = useState("");
+  const [status, setStatus] = useState<"idle" | "saving">("idle");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    const t = window.setTimeout(async () => {
+      const res = await fetch("/api/staff/schedule", { cache: "no-store" });
+      if (res.status === 403) { if (active) setForbidden(true); return; }
+      const data = await res.json().catch(() => ({})) as { schedule?: ScheduleConfig; staff?: StaffInfo };
+      if (!active) return;
+      if (data.schedule) setCfg({ ...JSON.parse(JSON.stringify(SCHEDULE_DEFAULTS)), ...data.schedule });
+      if (data.staff) setStaff(data.staff);
+      setLoaded(true);
+    }, 0);
+    return () => { active = false; window.clearTimeout(t); };
+  }, []);
+
+  function setHours(key: string, field: "start" | "end" | "slotMinutes", value: string) {
+    setCfg(prev => ({ ...prev, equipment: { ...prev.equipment, [key]: { ...prev.equipment[key], [field]: field === "slotMinutes" ? Number(value) : value } } }));
+  }
+  function toggleWeekday(d: number) {
+    setCfg(prev => ({ ...prev, weekdays: prev.weekdays.includes(d) ? prev.weekdays.filter(x => x !== d) : [...prev.weekdays, d].sort((a, b) => a - b) }));
+  }
+  function addDayOff() {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(newDay) || cfg.daysOff.includes(newDay)) return;
+    setCfg(prev => ({ ...prev, daysOff: [...prev.daysOff, newDay].sort() }));
+    setNewDay("");
+  }
+
+  async function save(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("saving"); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/schedule", {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ schedule: cfg }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; schedule?: ScheduleConfig; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
+      if (data.schedule) setCfg({ ...JSON.parse(JSON.stringify(SCHEDULE_DEFAULTS)), ...data.schedule });
+      setNotice("Графік збережено. Слоти на записі оновляться відповідно.");
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося зберегти"); }
+    finally { setStatus("idle"); }
+  }
+
+  const body = forbidden
+    ? <p className="notice error" role="alert">Графік налаштовує лише адміністратор.</p>
+    : !loaded
+      ? <p className="notice">Завантаження…</p>
+      : <form className="settingsCard" onSubmit={save}>
+          <section className="settingsBlock">
+            <h3>Робочі дні тижня</h3>
+            <p className="settingsHint">Неділя завжди закрита. Зніміть галочку, щоб закрити ще якийсь день.</p>
+            <div className="weekdayRow">
+              {WEEKDAYS.map(([d, label]) => (
+                <label key={d} className={`weekdayChip${cfg.weekdays.includes(d) ? " on" : ""}`}>
+                  <input type="checkbox" checked={cfg.weekdays.includes(d)} onChange={() => toggleWeekday(d)} />{label}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="settingsBlock">
+            <h3>Години прийому та крок слота</h3>
+            <p className="settingsHint">Для кожного апарата окремо. Крок — інтервал між слотами у хвилинах.</p>
+            {EQUIP_KEYS.map(key => (
+              <div className="equipHoursRow" key={key}>
+                <b>{EQUIP_LABELS[key]}</b>
+                <label><span>З</span><input type="time" value={cfg.equipment[key].start} onChange={e => setHours(key, "start", e.target.value)} /></label>
+                <label><span>До</span><input type="time" value={cfg.equipment[key].end} onChange={e => setHours(key, "end", e.target.value)} /></label>
+                <label><span>Крок, хв</span><input type="number" min={5} max={240} step={5} value={cfg.equipment[key].slotMinutes} onChange={e => setHours(key, "slotMinutes", e.target.value)} /></label>
+              </div>
+            ))}
+          </section>
+
+          <section className="settingsBlock">
+            <h3>Вихідні та свята</h3>
+            <p className="settingsHint">Конкретні дати, коли запис недоступний.</p>
+            <div className="dayOffAdd">
+              <input type="date" value={newDay} onChange={e => setNewDay(e.target.value)} />
+              <button type="button" className="button secondary" onClick={addDayOff}>Додати</button>
+            </div>
+            {cfg.daysOff.length > 0 && <ul className="dayOffList">{cfg.daysOff.map(d => (
+              <li key={d}>{d}<button type="button" onClick={() => setCfg(prev => ({ ...prev, daysOff: prev.daysOff.filter(x => x !== d) }))}>×</button></li>
+            ))}</ul>}
+          </section>
+
+          {notice && <p className="notice success" role="status">{notice}</p>}
+          {error && <p className="notice error" role="alert">{error}</p>}
+          <div className="settingsActions">
+            <button type="submit" disabled={status === "saving"}>{status === "saving" ? "Зберігаємо…" : "Зберегти графік"}</button>
+            <a className="textLink" href="/staff/appointments">До календаря</a>
+          </div>
+        </form>;
+
+  return (
+    <StaffWorkspaceShell active="schedule" title="Графік і слоти" description="Години прийому, крок слота, робочі дні та вихідні — керує адміністратор." staffName={staff?.displayName} staffRole={staff?.role}>
+      {body}
+    </StaffWorkspaceShell>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site" | "appointments" | "whatsapp" | "chat";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "system-map" | "site" | "appointments" | "whatsapp" | "chat" | "schedule";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -77,6 +77,7 @@ const systemModules: NavModule[] = [
   ]},
   { n:"6", label:"Обладнання", href:"/staff/imaging", section:"imaging", items:[
     { label:"Реєстр апаратів", href:"/staff#equipment" },
+    { label:"Графік і слоти", href:"/staff/schedule" },
     { label:"Завантаженість", href:"/staff/dashboard" },
     { label:"Знімки / PACS", href:"/staff/imaging", flag:"dicom_pacs" },
     { label:"Обслуговування (ТО)", href:"/staff/system-map#mod-6" },
@@ -259,14 +260,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Вітрина":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Вітрина":active === "schedule" ? "Графік і слоти":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "system-map" ? "Карта системи":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "whatsapp" || active === "chat"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "whatsapp" || active === "chat" || active === "schedule"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -1,0 +1,80 @@
+// Налаштовуваний графік прийому: години й крок слота по апаратах, робочі дні
+// тижня та конкретні вихідні (свята). Зберігається у app_settings (ключ
+// equipment_schedule). Читається /api/availability і «Новою записом».
+// Типові значення дублюють EQUIPMENT з lib/catalog, тож без конфігу поведінка
+// не змінюється. Чистий модуль без залежностей (тестований).
+
+export type EquipHours = { start: string; end: string; slotMinutes: number };
+export type ScheduleConfig = {
+  equipment: Record<string, EquipHours>;
+  weekdays: number[]; // відкриті дні тижня, 1=Пн … 6=Сб (неділя завжди закрита)
+  daysOff: string[];  // конкретні закриті дати YYYY-MM-DD
+};
+
+export const SCHEDULE_KEY = "equipment_schedule";
+export const EQUIP_KEYS = ["ct", "xray", "fluoro"] as const;
+export const EQUIP_LABELS: Record<string, string> = {
+  ct: "Комп’ютерний томограф", xray: "Цифровий рентген", fluoro: "Флюорограф",
+};
+
+export const SCHEDULE_DEFAULTS: ScheduleConfig = {
+  equipment: {
+    ct: { start: "08:00", end: "17:00", slotMinutes: 30 },
+    xray: { start: "08:00", end: "17:00", slotMinutes: 15 },
+    fluoro: { start: "08:00", end: "17:00", slotMinutes: 15 },
+  },
+  weekdays: [1, 2, 3, 4, 5, 6],
+  daysOff: [],
+};
+
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+function toMin(t: string): number { const m = /^(\d{2}):(\d{2})$/.exec(t); return m ? Number(m[1]) * 60 + Number(m[2]) : 0; }
+function fromMin(n: number): string { return `${String(Math.floor(n / 60)).padStart(2, "0")}:${String(n % 60).padStart(2, "0")}`; }
+
+// Слоти для апарата з урахуванням тривалості дослідження.
+export function candidateTimesFor(hours: EquipHours, durationMinutes: number): string[] {
+  const out: string[] = [];
+  const end = toMin(hours.end);
+  const step = hours.slotMinutes > 0 ? hours.slotMinutes : 15;
+  for (let t = toMin(hours.start); t + durationMinutes <= end; t += step) out.push(fromMin(t));
+  return out;
+}
+
+// Чи відкритий заклад у цю дату (робочий день тижня і не вихідний/свято).
+export function isDayOpen(date: string, cfg: ScheduleConfig): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  if (cfg.daysOff.includes(date)) return false;
+  const d = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return false;
+  return cfg.weekdays.includes(d.getUTCDay());
+}
+
+export function hoursFor(cfg: ScheduleConfig, equipmentId: string): EquipHours {
+  return cfg.equipment[equipmentId] || SCHEDULE_DEFAULTS.equipment[equipmentId] || SCHEDULE_DEFAULTS.equipment.ct;
+}
+
+export function sanitizeSchedule(input: unknown): ScheduleConfig {
+  const src = (input && typeof input === "object") ? input as Record<string, unknown> : {};
+  const srcEquip = (src.equipment && typeof src.equipment === "object") ? src.equipment as Record<string, { start?: unknown; end?: unknown; slotMinutes?: unknown }> : {};
+  const equipment: Record<string, EquipHours> = {};
+  for (const key of EQUIP_KEYS) {
+    const d = SCHEDULE_DEFAULTS.equipment[key];
+    const e = srcEquip[key] || {};
+    const start = typeof e.start === "string" && HHMM.test(e.start) ? e.start : d.start;
+    const end = typeof e.end === "string" && HHMM.test(e.end) ? e.end : d.end;
+    let step = Number(e.slotMinutes);
+    if (!Number.isInteger(step) || step < 5 || step > 240) step = d.slotMinutes;
+    equipment[key] = toMin(end) > toMin(start) ? { start, end, slotMinutes: step } : { ...d };
+  }
+  const rawWk = Array.isArray(src.weekdays) ? src.weekdays.map(Number).filter(n => Number.isInteger(n) && n >= 1 && n <= 6) : [];
+  const weekdays = rawWk.length ? Array.from(new Set(rawWk)).sort((a, b) => a - b) : [...SCHEDULE_DEFAULTS.weekdays];
+  const daysOff = Array.isArray(src.daysOff)
+    ? Array.from(new Set(src.daysOff.filter((x): x is string => typeof x === "string" && /^\d{4}-\d{2}-\d{2}$/.test(x)))).slice(0, 200)
+    : [];
+  return { equipment, weekdays, daysOff };
+}
+
+export function parseSchedule(stored: string): ScheduleConfig {
+  if (!stored) return sanitizeSchedule({});
+  try { return sanitizeSchedule(JSON.parse(stored)); } catch { return sanitizeSchedule({}); }
+}

--- a/tests/schedule.test.mjs
+++ b/tests/schedule.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  candidateTimesFor, isDayOpen, parseSchedule, sanitizeSchedule, SCHEDULE_DEFAULTS,
+} from "../lib/schedule.ts";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("candidateTimesFor honours start/end/step and study duration", () => {
+  const t = candidateTimesFor({ start: "08:00", end: "09:00", slotMinutes: 30 }, 30);
+  assert.deepEqual(t, ["08:00", "08:30"]); // 09:00 не влазить (30 хв)
+  const t2 = candidateTimesFor({ start: "08:00", end: "09:00", slotMinutes: 15 }, 60);
+  assert.deepEqual(t2, ["08:00"]); // лише один слот на 60 хв
+});
+
+test("isDayOpen respects weekdays and specific days-off", () => {
+  const cfg = sanitizeSchedule({ weekdays: [1, 2, 3, 4, 5], daysOff: ["2026-08-04"] });
+  assert.equal(isDayOpen("2026-08-02", cfg), false); // неділя
+  assert.equal(isDayOpen("2026-08-01", cfg), false); // субота вимкнена (лише 1-5)
+  assert.equal(isDayOpen("2026-08-03", cfg), true);  // понеділок
+  assert.equal(isDayOpen("2026-08-04", cfg), false); // вихідний зі списку
+});
+
+test("sanitizeSchedule clamps invalid input to safe defaults", () => {
+  const c = sanitizeSchedule({ equipment: { ct: { start: "25:99", end: "08:00", slotMinutes: 9999 } }, weekdays: [0, 9], daysOff: ["bad", "2026-01-01"] });
+  assert.deepEqual(c.equipment.ct, SCHEDULE_DEFAULTS.equipment.ct); // некоректні години → типові
+  assert.deepEqual(c.weekdays, SCHEDULE_DEFAULTS.weekdays); // 0/9 відкинуто → типові
+  assert.deepEqual(c.daysOff, ["2026-01-01"]); // лишилась лише валідна дата
+});
+
+test("parseSchedule returns defaults for empty/invalid JSON", () => {
+  assert.deepEqual(parseSchedule(""), sanitizeSchedule({}));
+  assert.deepEqual(parseSchedule("{oops"), sanitizeSchedule({}));
+});
+
+test("availability and staff booking read the configurable schedule", async () => {
+  const avail = await read("app/api/availability/route.ts");
+  assert.match(avail, /parseSchedule\(await getSetting\(db, SCHEDULE_KEY\)\)/);
+  assert.match(avail, /isDayOpen\(date, schedule\)/);
+  assert.match(avail, /candidateTimesFor\(hoursFor\(schedule/);
+  assert.match(avail, /equipment_blocks/); // збережено фільтр блокувань
+  assert.match(avail, /status IN \('confirmed','rescheduled'\)/);
+  const book = await read("app/api/staff/bookings/route.ts");
+  assert.match(book, /candidateTimesFor\(hoursFor\(schedule/);
+  assert.match(book, /isDayOpen\(desiredDate, schedule\)/);
+});
+
+test("schedule editor and admin API are wired and guarded", async () => {
+  const route = await read("app/api/staff/schedule/route.ts");
+  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /sanitizeSchedule\(body\.schedule\)/);
+  assert.match(route, /setSetting\(db, SCHEDULE_KEY/);
+  const page = await read("app/staff/schedule/page.tsx");
+  assert.match(page, /active="schedule"/);
+  assert.match(page, /Робочі дні тижня/);
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /href:"\/staff\/schedule"/);
+});

--- a/tests/staff-booking-create.test.mjs
+++ b/tests/staff-booking-create.test.mjs
@@ -9,7 +9,7 @@ test("staff can create a booking via POST, guarded and conflict-checked", async 
   assert.match(route, /export async function POST/);
   assert.match(route, /canManageBookings\(member\.role\)/);
   assert.match(route, /normalizeUkrainianPhone\(/);
-  assert.match(route, /isBookableDate\(desiredDate\) \|\| !isTimeForService/);
+  assert.match(route, /isBookableDate\(desiredDate\) \|\| !isDayOpen\(desiredDate, schedule\) \|\| !validTimes\.includes/);
   assert.match(route, /Цей час уже зайнятий/); // перевірка конфлікту слота
   assert.match(route, /INSERT INTO bookings/);
   assert.match(route, /'confirmed',CURRENT_TIMESTAMP/); // персональний запис одразу підтверджений


### PR DESCRIPTION
Адмін керує **годинами прийому, кроком слота** (по апаратах), **робочими днями тижня** та **вихідними/святами**. Раніше це було зашито в коді (`08:00–17:00`, крім неділі) — тепер конфігурується. **Без міграцій** (конфіг у `app_settings`).

## Що додано
- **`lib/schedule.ts`** (standalone) — модель графіка + типові значення (дублюють `EQUIPMENT`), `sanitize`/`parse`, `candidateTimesFor` (слоти з годин+кроку+тривалості), `isDayOpen` (робочий день тижня і не вихідний).
- **`/api/availability`** — читає графік: робочий день і слоти з нього (фільтр `bookings`/`equipment_blocks` збережено). Керує **і публічним записом**, і «Новою записом».
- **`/api/staff/bookings`** — створення й перенесення/підтвердження перевіряють дату й час за налаштованим графіком (замість зашитих годин).
- **`/api/staff/schedule`** — admin `GET`/`PUT`.
- **`/staff/schedule`** — редактор: робочі дні тижня, години й крок по апаратах (КТ/рентген/флюорограф), список вихідних. Пункт **«Графік і слоти»** у модулі «Обладнання».

## Безпечно за замовчуванням
Типові значення **ідентичні поточним** (08:00–17:00, крок 30/15, крім неділі) — без конфігу нічого не змінюється. Неділя лишається завжди закрита (стеля з `isBookableDate`); додаткові дні можна закрити.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **186/186** (нові `schedule`).

## Де
Кабінет → **Обладнання → «Графік і слоти»**. Зміни одразу впливають на вільні слоти в записі (і публічному, і в «Новій записі»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_