### PR TITLE
Календар: тижневий вигляд (як Google) + перехід після підтвердження

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -342,6 +342,28 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 .apptEvent.grp-inroom{background:#eef5ec;border-left-color:#3f8a37}
 .apptEvent.grp-done{background:#eef1ef;border-left-color:#7a8b88}
 .apptEvent.grp-cancelled{background:#fdefeb;border-left-color:#c85a38}
+/* Календар: навігація і тижневий вигляд (як Google Calendar) */
+.apptNav{display:inline-flex;align-items:center;gap:6px}
+.apptNav button{border:1px solid #cbd8d6;background:#fff;border-radius:7px;min-width:34px;height:38px;font-size:18px;line-height:1;cursor:pointer;color:#41544f;padding:0 10px}
+.apptNav button:hover{background:#f2f6f4}
+.apptNav .apptToday{font-size:13px;font-weight:700}
+.apptRange{font-weight:800;font-size:14px;color:var(--ink);margin-left:4px;white-space:nowrap}
+.apptWeek{display:flex;flex-direction:column}
+.apptWeekHead{display:grid;grid-template-columns:56px repeat(7,1fr);background:#fff;border:1px solid #dce4e3;border-radius:10px 10px 0 0}
+.apptWeekCorner{border-right:1px solid #eef2f0}
+.apptWeekHeadCell{border:0;border-left:1px solid #eef2f0;background:none;padding:9px 4px;text-align:center;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:3px}
+.apptWeekHeadCell small{font-size:10.5px;color:#98a6a2;text-transform:uppercase;font-weight:800}
+.apptWeekHeadCell b{font-size:15px;color:var(--ink)}
+.apptWeekHeadCell:hover{background:#f2f6f4}
+.apptWeekHeadCell.sel{background:#eef5f2}
+.apptWeekHeadCell.today b{background:var(--green);color:#fff;border-radius:50%;width:26px;height:26px;display:inline-grid;place-items:center}
+.apptWeekBody{position:relative;display:grid;grid-template-columns:56px repeat(7,1fr);background:#fff;border:1px solid #dce4e3;border-top:0;border-radius:0 0 10px 10px;overflow:hidden}
+.apptWeek .apptHours{position:relative;top:auto;left:auto;width:auto;height:auto;border-right:1px solid #eef2f0}
+.apptWeekCol{position:relative;border-left:1px solid #eef2f0}
+.apptWeek .apptEvent{left:2px;right:2px;padding:3px 6px;border-left-width:3px}
+.apptWeek .apptEvent b{font-size:10.5px}
+.apptWeek .apptEvent span{font-size:9.5px}
+@media(max-width:820px){.apptWeekHeadCell b{font-size:13px}.apptWeek .apptEvent b{font-size:9px}.apptWeek .apptEvent span{display:none}}
 /* WhatsApp сторінка */
 .waSteps{margin:6px 0 0;padding-left:20px;color:#41544f;font-size:13px;line-height:1.6}.waSteps li{margin-bottom:6px}
 .waBotList{margin:6px 0 10px;padding-left:18px;color:#41544f;font-size:13px;line-height:1.7}

--- a/app/staff/appointments/page.tsx
+++ b/app/staff/appointments/page.tsx
@@ -11,10 +11,8 @@ type Booking = {
   assignedRadiologistEmail: string; assignedRadiographerEmail: string;
 };
 type StaffOption = { email: string; displayName: string; role: string };
+type View = "list" | "day" | "week";
 
-// Групи станів під фільтри у стилі DocTime. Реальні дані здебільшого несуть
-// legacy-статуси (new/confirmed/rescheduled/completed/cancelled), клінічні
-// стани зʼявляються після переходів у реєстрі досліджень.
 const GROUPS: Record<string, string[]> = {
   planned: ["new", "requested", "needs_verification", "scheduled", "rescheduled"],
   confirmed: ["confirmed"],
@@ -37,16 +35,25 @@ function groupOf(status: string): string {
   return "planned";
 }
 const EQUIP: Record<string, string> = { ct: "КТ", xray: "Рентген", fluoro: "Флюорограф" };
-const DAY_START = 8, DAY_END = 18, HOUR_PX = 64;
+const WEEKDAY = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
+const DAY_START = 8, DAY_END = 19, HOUR_PX = 56;
 
 function todayKyiv(): string {
-  // YYYY-MM-DD у Києві без залежностей.
   return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
 }
 function minutesOf(time: string): number | null {
   const m = /^(\d{1,2}):(\d{2})$/.exec(time || "");
-  if (!m) return null;
-  return Number(m[1]) * 60 + Number(m[2]);
+  return m ? Number(m[1]) * 60 + Number(m[2]) : null;
+}
+function fmtDate(d: Date): string { return d.toISOString().slice(0, 10); }
+function addDays(dateStr: string, delta: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`); d.setUTCDate(d.getUTCDate() + delta); return fmtDate(d);
+}
+function weekDates(dateStr: string): string[] {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  const dow = d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() + (dow === 0 ? -6 : 1 - dow)); // → понеділок
+  return Array.from({ length: 7 }, (_, i) => { const x = new Date(d); x.setUTCDate(d.getUTCDate() + i); return fmtDate(x); });
 }
 
 export default function StaffAppointmentsPage() {
@@ -56,7 +63,7 @@ export default function StaffAppointmentsPage() {
   const [loaded, setLoaded] = useState(false);
   const [forbidden, setForbidden] = useState(false);
   const [date, setDate] = useState(todayKyiv());
-  const [view, setView] = useState<"list" | "day">("list");
+  const [view, setView] = useState<View>("week");
   const [tab, setTab] = useState("all");
   const [search, setSearch] = useState("");
 
@@ -75,43 +82,63 @@ export default function StaffAppointmentsPage() {
     return () => { active = false; };
   }, []);
 
+  // Дозволяємо відкрити календар на конкретній даті/вигляді (напр. після
+  // підтвердження запису: /staff/appointments?date=…&view=week).
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      const p = new URLSearchParams(window.location.search);
+      const v = p.get("view"); const d = p.get("date");
+      if (v === "day" || v === "week" || v === "list") setView(v);
+      if (d && /^\d{4}-\d{2}-\d{2}$/.test(d)) setDate(d);
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, []);
+
   const nameByEmail = useMemo(() => {
     const map: Record<string, string> = {};
     for (const o of options) map[o.email] = o.displayName || o.email;
     return map;
   }, [options]);
 
-  const dayItems = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return items
-      .filter(b => b.desiredDate === date)
-      .filter(b => tab === "all" || GROUPS[tab]?.includes(b.status))
-      .filter(b => !q || b.name.toLowerCase().includes(q) || (b.phone || "").includes(q))
-      .sort((a, b) => (a.desiredTime || "").localeCompare(b.desiredTime || ""));
-  }, [items, date, tab, search]);
+  const q = search.trim().toLowerCase();
+
+  const dayItems = useMemo(() => items
+    .filter(b => b.desiredDate === date && ((tab === "all" || GROUPS[tab]?.includes(b.status)) && (!q || b.name.toLowerCase().includes(q) || (b.phone || "").includes(q))))
+    .sort((a, b) => (a.desiredTime || "").localeCompare(b.desiredTime || "")),
+  [items, date, tab, q]);
+
+  const week = useMemo(() => weekDates(date), [date]);
+  const weekItems = useMemo(() => items.filter(b => week.includes(b.desiredDate)
+    && ((tab === "all" || GROUPS[tab]?.includes(b.status)) && (!q || b.name.toLowerCase().includes(q) || (b.phone || "").includes(q)))),
+  [items, week, tab, q]);
 
   const counts = useMemo(() => {
-    const onDay = items.filter(b => b.desiredDate === date);
-    const out: Record<string, number> = { all: onDay.length };
-    for (const t of TABS) if (t.key !== "all") out[t.key] = onDay.filter(b => GROUPS[t.key].includes(b.status)).length;
+    const scope = view === "week" ? items.filter(b => week.includes(b.desiredDate)) : items.filter(b => b.desiredDate === date);
+    const out: Record<string, number> = { all: scope.length };
+    for (const t of TABS) if (t.key !== "all") out[t.key] = scope.filter(b => GROUPS[t.key].includes(b.status)).length;
     return out;
-  }, [items, date]);
+  }, [items, date, week, view]);
 
   const hours = Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i);
+  const doctorOf = (b: Booking) => nameByEmail[b.assignedRadiologistEmail] || nameByEmail[b.assignedRadiographerEmail] || "";
 
-  function card(b: Booking) {
-    const doctor = nameByEmail[b.assignedRadiologistEmail] || nameByEmail[b.assignedRadiographerEmail] || "";
+  function eventBlock(b: Booking, compact: boolean) {
+    const mins = minutesOf(b.desiredTime);
+    if (mins === null) return null;
+    const top = Math.max(0, ((mins - DAY_START * 60) / 60) * HOUR_PX);
+    const height = Math.max(compact ? 20 : 24, ((b.durationMinutes || 30) / 60) * HOUR_PX - 3);
     return (
-      <div className="apptCardRow" key={b.id}>
-        <span className="apptCardTime">{b.desiredTime || "—"}</span>
-        <div className="apptCardBody">
-          <b>{b.name || "Без імені"}</b>
-          <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctor ? ` · ${doctor}` : ""}</span>
-        </div>
-        <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
+      <div className={`apptEvent grp-${groupOf(b.status)}`} key={b.id} style={{ top, height }} title={`${b.desiredTime} · ${b.name} · ${b.service}`}>
+        <b>{b.desiredTime} {b.name || "Без імені"}</b>
+        {!compact && <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctorOf(b) ? ` · ${doctorOf(b)}` : ""}</span>}
+        {compact && <span>{EQUIP[b.equipmentId] || b.service}</span>}
       </div>
     );
   }
+
+  const rangeLabel = view === "week"
+    ? `${week[0].slice(8)}–${week[6].slice(8)}.${week[0].slice(5, 7)}`
+    : date;
 
   const body = forbidden
     ? <p className="notice error" role="alert">Доступ лише для персоналу.</p>
@@ -119,11 +146,18 @@ export default function StaffAppointmentsPage() {
       ? <p className="notice">Завантаження…</p>
       : <div className="apptCal">
           <div className="apptCalBar">
+            <div className="apptNav">
+              <button type="button" onClick={() => setDate(addDays(date, view === "week" ? -7 : -1))} aria-label="Назад">‹</button>
+              <button type="button" className="apptToday" onClick={() => setDate(todayKyiv())}>Сьогодні</button>
+              <button type="button" onClick={() => setDate(addDays(date, view === "week" ? 7 : 1))} aria-label="Вперед">›</button>
+              <span className="apptRange">{rangeLabel}</span>
+            </div>
             <input type="date" value={date} onChange={e => setDate(e.target.value)} />
             <input type="search" placeholder="Пошук за пацієнтом…" value={search} onChange={e => setSearch(e.target.value)} />
             <div className="apptViewToggle">
-              <button type="button" className={view === "list" ? "active" : ""} onClick={() => setView("list")}>Список</button>
+              <button type="button" className={view === "week" ? "active" : ""} onClick={() => setView("week")}>Тиждень</button>
               <button type="button" className={view === "day" ? "active" : ""} onClick={() => setView("day")}>День</button>
+              <button type="button" className={view === "list" ? "active" : ""} onClick={() => setView("list")}>Список</button>
             </div>
             <a className="apptNewBtn" href="/staff/book">+ Нова запис</a>
           </div>
@@ -135,38 +169,58 @@ export default function StaffAppointmentsPage() {
             ))}
           </div>
 
-          {dayItems.length === 0
-            ? <div className="apptEmpty"><span aria-hidden="true">🗓</span><p>Записів на цей день немає</p></div>
-            : view === "list"
-              ? <div className="apptListWrap">{dayItems.map(card)}</div>
-              : <div className="apptTimeline" style={{ height: (DAY_END - DAY_START) * HOUR_PX }}>
+          {view === "week"
+            ? <div className="apptWeek">
+                <div className="apptWeekHead">
+                  <span className="apptWeekCorner" />
+                  {week.map(d => {
+                    const dow = new Date(`${d}T00:00:00Z`).getUTCDay();
+                    return <button type="button" key={d} className={`apptWeekHeadCell${d === date ? " sel" : ""}${d === todayKyiv() ? " today" : ""}`} onClick={() => { setDate(d); setView("day"); }}>
+                      <small>{WEEKDAY[dow]}</small><b>{d.slice(8)}</b>
+                    </button>;
+                  })}
+                </div>
+                <div className="apptWeekBody" style={{ height: (DAY_END - DAY_START) * HOUR_PX }}>
                   <div className="apptHours">
                     {hours.map(h => <div className="apptHour" key={h} style={{ height: HOUR_PX }}><span>{String(h).padStart(2, "0")}:00</span></div>)}
                   </div>
-                  <div className="apptLane">
-                    {hours.map(h => <div className="apptLaneLine" key={h} style={{ top: (h - DAY_START) * HOUR_PX }} />)}
-                    {dayItems.map(b => {
-                      const mins = minutesOf(b.desiredTime);
-                      if (mins === null) return null;
-                      const top = Math.max(0, ((mins - DAY_START * 60) / 60) * HOUR_PX);
-                      const height = Math.max(24, ((b.durationMinutes || 30) / 60) * HOUR_PX - 4);
-                      const doctor = nameByEmail[b.assignedRadiologistEmail] || nameByEmail[b.assignedRadiographerEmail] || "";
-                      return (
-                        <div className={`apptEvent grp-${groupOf(b.status)}`} key={b.id} style={{ top, height }} title={`${b.desiredTime} · ${b.name} · ${b.service}`}>
-                          <b>{b.desiredTime} · {b.name || "Без імені"}</b>
-                          <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctor ? ` · ${doctor}` : ""}</span>
-                        </div>
-                      );
-                    })}
+                  {week.map(d => (
+                    <div className="apptWeekCol" key={d}>
+                      {hours.map(h => <div className="apptLaneLine" key={h} style={{ top: (h - DAY_START) * HOUR_PX }} />)}
+                      {weekItems.filter(b => b.desiredDate === d).map(b => eventBlock(b, true))}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            : (view === "day" ? dayItems : dayItems).length === 0
+              ? <div className="apptEmpty"><span aria-hidden="true">🗓</span><p>Записів на цей день немає</p></div>
+              : view === "day"
+                ? <div className="apptTimeline" style={{ height: (DAY_END - DAY_START) * HOUR_PX }}>
+                    <div className="apptHours">
+                      {hours.map(h => <div className="apptHour" key={h} style={{ height: HOUR_PX }}><span>{String(h).padStart(2, "0")}:00</span></div>)}
+                    </div>
+                    <div className="apptLane">
+                      {hours.map(h => <div className="apptLaneLine" key={h} style={{ top: (h - DAY_START) * HOUR_PX }} />)}
+                      {dayItems.map(b => eventBlock(b, false))}
+                    </div>
                   </div>
-                </div>}
+                : <div className="apptListWrap">{dayItems.map(b => (
+                    <div className="apptCardRow" key={b.id}>
+                      <span className="apptCardTime">{b.desiredTime || "—"}</span>
+                      <div className="apptCardBody">
+                        <b>{b.name || "Без імені"}</b>
+                        <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctorOf(b) ? ` · ${doctorOf(b)}` : ""}</span>
+                      </div>
+                      <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
+                    </div>
+                  ))}</div>}
         </div>;
 
   return (
     <StaffWorkspaceShell
       active="appointments"
       title="Календар записів"
-      description="Записи на день — список або таймлайн, із фільтрами за станом."
+      description="Тиждень, день або список — із фільтрами за станом."
       staffName={staff?.displayName}
       staffRole={staff?.role}
     >

--- a/app/staff/page.tsx
+++ b/app/staff/page.tsx
@@ -259,8 +259,9 @@ export default function StaffPage() {
     const data = await response.json() as { error?:string; reminder?:ReminderResult };
     if (!response.ok) { setActionError(data.error || "Не вдалося підтвердити запис"); return; }
     setItems(current => current.map(item => item.id === id ? {...item,status:"confirmed"} : item));
-    setActionSuccess(`Запис підтверджено та поставлено в розклад.${reminderNote(data.reminder)}`);
-    void load();
+    // Одразу відкриваємо розклад (тиждень) на даті цього запису.
+    const target = items.find(item => item.id === id)?.desiredDate;
+    window.location.assign(`/staff/appointments?view=week&date=${target || ""}`);
   }
 
   async function saveNote(id:number,note:string) {

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -23,6 +23,20 @@ test("status filter tabs map to real booking statuses", async () => {
   assert.match(page, /"new"|new,/); // legacy-статус у групі «Заплановані»
 });
 
+test("calendar offers a Google-style week grid with navigation", async () => {
+  const page = await read("app/staff/appointments/page.tsx");
+  assert.match(page, /view === "week"/);
+  assert.match(page, /apptWeek/); // сітка тижня
+  assert.match(page, /weekDates\(/); // тиждень від понеділка
+  assert.match(page, /Тиждень/);
+  assert.match(page, /Сьогодні/); // навігація
+});
+
+test("confirming a booking opens the week schedule on its date", async () => {
+  const page = await read("app/staff/page.tsx");
+  assert.match(page, /\/staff\/appointments\?view=week&date=/);
+});
+
 test("calendar is wired into the staff shell and nav", async () => {
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /href:"\/staff\/appointments"/);


### PR DESCRIPTION
На прохання: після **«Підтвердити й у розклад»** одразу відкривається розклад, а сам розклад має наочний **тижневий вигляд у стилі Google Calendar**.

## Що додано
- **Вигляд «Тиждень»** у `/staff/appointments` — сітка **7 днів × години** (08:00–19:00) із блоками записів за днем і часом, колір за станом. Тиждень — тепер типовий вигляд.
- **Навігація** `‹ Сьогодні ›` (±тиждень / ±день), заголовки днів; клік по дню відкриває «День».
- **Deep-link** `?view=&date=` — календар можна відкрити на потрібній даті.
- Лічильники станів рахуються по тижню (або дню).
- **«Підтвердити й у розклад»** тепер після підтвердження веде на `/staff/appointments?view=week&date=<дата запису>` — одразу бачите запис у розкладі.

Види **«День»** (таймлайн) і **«Список»** лишились.

## Перевірки
- `tsc` 0; `lint` 0; `build` ✓; тести **192/192**. Без міграцій.

## Де
Кабінет → **Запис і заявки → Календар записів** (типово — Тиждень). Або підтвердіть заявку в черзі — відкриється розклад на її даті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_