### PR TITLE
fix: восстановить Cloudflare custom-domain routes

### DIFF
--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -101,3 +101,13 @@ test("production deployment refuses to migrate without a secure active administr
   assert.match(workflow, /secure_admins/);
   assert.match(workflow, /count < 1/);
 });
+
+test("Cloudflare custom domains remain root-level before the triggers table", async () => {
+  const config = await read("wrangler.cloudflare.toml");
+  const routes = config.indexOf("\nroutes = [");
+  const triggers = config.indexOf("\n[triggers]");
+  const crons = config.indexOf("\ncrons = [\"*/15 * * * *\"]");
+  assert.ok(routes > -1, "custom-domain routes are configured");
+  assert.ok(triggers > routes, "routes must be declared before [triggers] to stay root-level");
+  assert.ok(crons > triggers, "cron schedule must remain inside [triggers]");
+});

--- a/wrangler.cloudflare.toml
+++ b/wrangler.cloudflare.toml
@@ -11,12 +11,6 @@ main = "dist/server/index.js"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Cron-тригер планових нагадувань пацієнтам (за N годин до візиту). Кожні
-# 15 хв worker.scheduled перевіряє записи на сьогодні й надсилає WhatsApp.
-# Доступно на безкоштовному плані Cloudflare Workers.
-[triggers]
-crons = ["*/15 * * * *"]
-
 # Custom domains. The radiologyos.tech zone is already on Cloudflare (its
 # nameservers point to Cloudflare), so `wrangler deploy` provisions these
 # domains and their TLS certificates automatically — no manual DNS needed.
@@ -24,6 +18,12 @@ routes = [
   { pattern = "radiologyos.tech", custom_domain = true },
   { pattern = "www.radiologyos.tech", custom_domain = true },
 ]
+
+# Cron-тригер планових нагадувань пацієнтам (за N годин до візиту). Кожні
+# 15 хв worker.scheduled перевіряє записи на сьогодні й надсилає WhatsApp.
+# Доступно на безкоштовному плані Cloudflare Workers.
+[triggers]
+crons = ["*/15 * * * *"]
 
 # Static client bundle (JS/CSS, self-hosted fonts, favicon). Served directly by
 # Cloudflare; the Worker handles every dynamic / server-rendered route.


### PR DESCRIPTION
## Причина

`routes` были объявлены после `[triggers]`, поэтому TOML относил их к таблице `triggers`. Wrangler игнорировал поле, затем пытался публиковать Worker через `workers.dev` и завершал production-деплой ошибкой.

Падение подтверждено в Deploy #31 и #32 на шаге `Deploy Worker and assets`; сборка, проверка администратора и миграции D1 до этого проходили успешно.

## Исправление

- `routes` перенесены в корневую часть `wrangler.cloudflare.toml` перед `[triggers]`;
- cron `*/15 * * * *` оставлен внутри `[triggers]`;
- добавлен регрессионный тест порядка секций.

## Ожидаемый результат

Wrangler привяжет Worker к `radiologyos.tech` и `www.radiologyos.tech`, после чего выполнится smoke-тест production.