### PR TITLE
Disable workers.dev and cron deployment

### DIFF
--- a/tests/reminders.test.mjs
+++ b/tests/reminders.test.mjs
@@ -52,14 +52,15 @@ test("kyivNow converts a UTC instant to Kyiv date and minutes", () => {
   assert.equal(minutes, 15 * 60);
 });
 
-test("worker runs due reminders on a cron schedule", async () => {
+test("worker retains reminder support while production cron is disabled", async () => {
   const worker = await read("worker/index.ts");
   assert.match(worker, /async scheduled\(/);
   assert.match(worker, /runDueReminders\(env\.DB, Date\.now\(\)\)/);
   assert.match(worker, /ctx\.waitUntil/);
   const wrangler = await read("wrangler.cloudflare.toml");
-  assert.match(wrangler, /\[triggers\]/);
-  assert.match(wrangler, /crons = \[/);
+  assert.match(wrangler, /workers_dev = false/);
+  assert.doesNotMatch(wrangler, /\[triggers\]/);
+  assert.doesNotMatch(wrangler, /crons = \[/);
 });
 
 test("runner sends WhatsApp, dedupes by kind and respects do-not-contact", async () => {

--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -102,12 +102,11 @@ test("production deployment refuses to migrate without a secure active administr
   assert.match(workflow, /count < 1/);
 });
 
-test("Cloudflare custom domains remain root-level before the triggers table", async () => {
+test("Cloudflare deployment uses custom domains only", async () => {
   const config = await read("wrangler.cloudflare.toml");
-  const routes = config.indexOf("\nroutes = [");
-  const triggers = config.indexOf("\n[triggers]");
-  const crons = config.indexOf("\ncrons = [\"*/15 * * * *\"]");
-  assert.ok(routes > -1, "custom-domain routes are configured");
-  assert.ok(triggers > routes, "routes must be declared before [triggers] to stay root-level");
-  assert.ok(crons > triggers, "cron schedule must remain inside [triggers]");
+  assert.match(config, /\nworkers_dev = false\n/);
+  assert.match(config, /pattern = "radiologyos\\.tech", custom_domain = true/);
+  assert.match(config, /pattern = "www\\.radiologyos\\.tech", custom_domain = true/);
+  assert.doesNotMatch(config, /\n\[triggers\]\n/);
+  assert.doesNotMatch(config, /\ncrons\s*=/);
 });

--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -105,8 +105,8 @@ test("production deployment refuses to migrate without a secure active administr
 test("Cloudflare deployment uses custom domains only", async () => {
   const config = await read("wrangler.cloudflare.toml");
   assert.match(config, /\nworkers_dev = false\n/);
-  assert.match(config, /pattern = "radiologyos\\.tech", custom_domain = true/);
-  assert.match(config, /pattern = "www\\.radiologyos\\.tech", custom_domain = true/);
+  assert.match(config, /pattern = "radiologyos\.tech", custom_domain = true/);
+  assert.match(config, /pattern = "www\.radiologyos\.tech", custom_domain = true/);
   assert.doesNotMatch(config, /\n\[triggers\]\n/);
   assert.doesNotMatch(config, /\ncrons\s*=/);
 });

--- a/wrangler.cloudflare.toml
+++ b/wrangler.cloudflare.toml
@@ -10,6 +10,7 @@ name = "radiologyos"
 main = "dist/server/index.js"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
+workers_dev = false
 
 # Custom domains. The radiologyos.tech zone is already on Cloudflare (its
 # nameservers point to Cloudflare), so `wrangler deploy` provisions these
@@ -18,12 +19,6 @@ routes = [
   { pattern = "radiologyos.tech", custom_domain = true },
   { pattern = "www.radiologyos.tech", custom_domain = true },
 ]
-
-# Cron-тригер планових нагадувань пацієнтам (за N годин до візиту). Кожні
-# 15 хв worker.scheduled перевіряє записи на сьогодні й надсилає WhatsApp.
-# Доступно на безкоштовному плані Cloudflare Workers.
-[triggers]
-crons = ["*/15 * * * *"]
 
 # Static client bundle (JS/CSS, self-hosted fonts, favicon). Served directly by
 # Cloudflare; the Worker handles every dynamic / server-rendered route.


### PR DESCRIPTION
## Summary
- disable the `workers.dev` route explicitly
- remove the scheduled cron trigger that requires a Workers subdomain
- keep deployment only on `radiologyos.tech` and `www.radiologyos.tech`
- add a regression test for custom-domain-only deployment

## Context
Production run #35 uploaded the Worker but Cloudflare rejected schedule creation with API error 10063 because the account has no `workers.dev` subdomain.