### PR TITLE
Пульт: завантаженість апаратів за 7 днів

### DIFF
--- a/app/api/staff/dashboard/route.ts
+++ b/app/api/staff/dashboard/route.ts
@@ -26,6 +26,8 @@ export async function GET(request: Request) {
   const orgId = ctx?.organizationId ?? 1;
 
   const today = todayInKyiv();
+  // Початок 7-денного вікна завантаженості (сьогодні та 6 попередніх днів).
+  const weekStart = (() => { const d = new Date(`${today}T12:00:00Z`); d.setUTCDate(d.getUTCDate() - 6); return d.toISOString().slice(0, 10); })();
   const one = (sql: string, ...bind: unknown[]) => db.prepare(sql).bind(...bind).first<Record<string, unknown>>();
   const many = (sql: string, ...bind: unknown[]) => db.prepare(sql).bind(...bind).all();
 
@@ -38,6 +40,7 @@ export async function GET(request: Request) {
     equipmentToday,
     needProtocolList, readyList, needImagingList, confirmList,
     clinicalQueueRows,
+    equipmentWeekRows,
   ] = await Promise.all([
     one("SELECT COUNT(*) AS c FROM bookings WHERE desired_date = ? AND status != 'cancelled'", today),
     one("SELECT SUM(status='new') AS newc, SUM(status='confirmed') AS confirmedc FROM bookings WHERE desired_date = ? AND status != 'cancelled'", today),
@@ -64,6 +67,13 @@ export async function GET(request: Request) {
        WHERE organization_id = ? AND status IN ('queued','in_progress','images_ready','reporting','protocol_ready')
        GROUP BY status`,
       orgId,
+    ),
+    // Завантаженість апаратів за 7 днів: кількість досліджень на день і апарат.
+    many(
+      `SELECT desired_date AS d, equipment_id AS id, COUNT(*) AS c FROM bookings
+       WHERE desired_date BETWEEN ? AND ? AND status != 'cancelled'
+       GROUP BY desired_date, equipment_id`,
+      weekStart, today,
     ),
   ]);
 
@@ -98,6 +108,8 @@ export async function GET(request: Request) {
       doNotContact: num(doNotContact),
     },
     equipmentToday: (equipmentToday as { results?: Array<Record<string, unknown>> }).results || [],
+    equipmentWeek: (equipmentWeekRows as { results?: Array<Record<string, unknown>> }).results || [],
+    weekStart,
     clinicalQueue,
     lists: {
       needProtocol: withTitle(needProtocolList),

--- a/app/globals.css
+++ b/app/globals.css
@@ -262,6 +262,18 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 @media(max-width:1000px){.dashKpiStrip{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:620px){.dashKpiStrip{grid-template-columns:repeat(2,1fr)}}
 /* Пульт — нові заявки з миготінням і підтвердженням у 1 клік */
+.dashLoad{max-width:1500px;margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:14px;padding:16px}
+.dashLoadGrid{display:grid;gap:6px 8px;align-items:end;margin-top:12px}
+.dashLoadCorner{grid-row:1}
+.dashLoadDay{grid-row:1;text-align:center;font-size:11px;font-weight:800;color:#8a9995;display:flex;flex-direction:column;gap:1px}
+.dashLoadDay small{font-weight:600;color:#aab6b2}
+.dashLoadDay.today{color:#0c7a85}.dashLoadDay.today small{color:#0c7a85}
+.dashLoadRow{align-self:center;font-size:12.5px;font-weight:650;color:#25332f}
+.dashLoadCell{position:relative;display:flex;flex-direction:column;justify-content:flex-end;align-items:center;height:52px;background:#f4f8f7;border-radius:6px;overflow:hidden}
+.dashLoadCell i{width:100%;background:linear-gradient(180deg,#2aa198,#0c7a85);min-height:2px;transition:height .2s}
+.dashLoadCell i.empty{background:transparent;min-height:0}
+.dashLoadCell b{position:absolute;top:3px;font-size:11px;font-weight:800;color:#25332f}
+@media(max-width:640px){.dashLoadRow{font-size:11px}.dashLoadCell{height:40px}}
 .dashPending{max-width:1500px;margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:14px;padding:16px}
 .dashPendingHead{display:flex;flex-wrap:wrap;align-items:baseline;gap:10px;margin-bottom:10px}
 .dashPendingHead h2{font-size:16px;font-weight:750;margin:0}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
 import WeekCalendar, { type CalBooking, type CalStaffOption } from "../week-calendar";
 
@@ -18,6 +18,8 @@ type QueueState = { v:string; l:string; count:number };
 type Data = {
   today:string; kpi:Kpi;
   equipmentToday:Array<{ id:string; c:number }>;
+  equipmentWeek:Array<{ d:string; id:string; c:number }>;
+  weekStart:string;
   clinicalQueue:QueueState[];
   lists:{ needProtocol:ListItem[]; readyToIssue:ListItem[]; needImaging:ListItem[]; confirmQueue:ListItem[] };
   staff:StaffInfo;
@@ -160,6 +162,28 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+
+      {/* Завантаженість апаратів за 7 днів (сьогодні та 6 попередніх) */}
+      {data && <section className="dashLoad">
+        <div className="dashListHead"><h3>Завантаженість апаратів · 7 днів</h3><span>{data.weekStart} — {data.today}</span></div>
+        {(() => {
+          const days:string[] = [];
+          for (let i = 6; i >= 0; i--) { const dt = new Date(`${data.today}T12:00:00Z`); dt.setUTCDate(dt.getUTCDate() - i); days.push(dt.toISOString().slice(0,10)); }
+          const at = (id:string, d:string) => data.equipmentWeek.find((e)=>e.id===id && e.d===d)?.c || 0;
+          const peak = Math.max(1, ...data.equipmentWeek.map((e)=>e.c));
+          const dow = (d:string) => ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"][new Date(`${d}T12:00:00Z`).getUTCDay()];
+          return <div className="dashLoadGrid" style={{ gridTemplateColumns:`120px repeat(${days.length}, 1fr)` }}>
+            <span className="dashLoadCorner" />
+            {days.map((d)=><span key={d} className={`dashLoadDay${d===data.today?" today":""}`}>{dow(d)}<small>{d.slice(8,10)}.{d.slice(5,7)}</small></span>)}
+            {["ct","xray","fluoro"].map((id)=><Fragment key={id}>
+              <span className="dashLoadRow">{equipmentNames[id]}</span>
+              {days.map((d)=>{ const v = at(id,d); return <span key={d} className="dashLoadCell" title={`${equipmentNames[id]} · ${d}: ${v}`}>
+                <i style={{ height:`${Math.round((v/peak)*100)}%` }} className={v?"":"empty"} /><b>{v||""}</b>
+              </span>; })}
+            </Fragment>)}
+          </div>;
+        })()}
+      </section>}
 
       {/* Нові заявки: миготять, доки не підтвердять; підтвердження одним кліком */}
       <section className="dashPending">

--- a/tests/dashboard.test.mjs
+++ b/tests/dashboard.test.mjs
@@ -17,6 +17,19 @@ test("dashboard API aggregates across pillars and never mutates schema", async (
   assert.doesNotMatch(route, /UPDATE\s+bookings/i);
 });
 
+test("dashboard exposes a 7-day per-equipment workload", async () => {
+  const route = await read("app/api/staff/dashboard/route.ts");
+  // 7-денне вікно: сьогодні та 6 попередніх днів.
+  assert.match(route, /setUTCDate\(d\.getUTCDate\(\) - 6\)/);
+  assert.match(route, /desired_date BETWEEN \? AND \?/);
+  assert.match(route, /GROUP BY desired_date, equipment_id/);
+  assert.match(route, /equipmentWeek:/);
+  assert.match(route, /weekStart,/);
+  const page = await read("app/staff/dashboard/page.tsx");
+  assert.match(page, /Завантаженість апаратів · 7 днів/);
+  assert.match(page, /equipmentWeek/);
+});
+
 test("dashboard exposes a tenant-scoped clinical queue by machine state", async () => {
   const route = await read("app/api/staff/dashboard/route.ts");
   // Черга рахує активні стани єдиної state machine.


### PR DESCRIPTION
Доповнює блок «Завантаженість» на пульті: крім лічильника «сьогодні» тепер видно **розподіл досліджень по КТ / рентгену / флюорографу за 7 днів** (сьогодні та 6 попередніх).

## Що додано
- **`/api/staff/dashboard`** — `equipmentWeek`: `GROUP BY desired_date, equipment_id` за 7-денне вікно + `weekStart`. Схему **не змінює** (лише `SELECT`, без CREATE/ALTER/INSERT/UPDATE).
- **`/staff/dashboard`** — секція «Завантаженість апаратів · 7 днів»: компактна стовпчикова сітка (висота = частка від піку тижня), підпис дня тижня й дати, підсвітка поточного дня.

## Навіщо
Адміністратор одразу бачить, який апарат недо-/перевантажений протягом тижня — для планування слотів і змін.

## Перевірка
258 тестів зелені (нові: 7-денне вікно, `GROUP BY`, вивід `equipmentWeek`/`weekStart`, секція в UI); `eslint`, `tsc --noEmit`, `next build` — чисті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_