### PR TITLE
Структура: реальний штат за посадами й кількістю (без ПІБ)

### DIFF
--- a/lib/department-structure.ts
+++ b/lib/department-structure.ts
@@ -100,11 +100,13 @@ export const DEPARTMENT_STRUCTURE_DEFAULTS: DepartmentStructure = {
       { name: "Флюорограф 12Ф7Ц", kind: "Демонтовано", details: "На зберіганні", status: "stored" },
     ] },
   ],
+  // Штат за посадами й кількістю (без ПІБ/адрес/дат народження/телефонів).
   personnel: [
-    { position: "Начальник відділення променевої діагностики", note: "Відповідальна особа з радіаційної безпеки" },
-    { position: "Начальник ПРК", note: "" },
-    { position: "Лікарі-рентгенологи", note: "" },
-    { position: "Рентгенолаборанти", note: "" },
+    { position: "Начальник відділення променевої діагностики", note: "1 · відповідальна особа з радіаційної безпеки" },
+    { position: "Начальник ПРК", note: "1" },
+    { position: "Рентгенолаборанти", note: "5 (у т.ч. пересувного рентгенівського кабінету)" },
+    { position: "Молодша медична сестра", note: "1" },
+    { position: "Водій-електрик ПРК", note: "1" },
   ],
   hours: {
     outpatient: {
@@ -174,10 +176,18 @@ export function sanitizeDepartmentStructure(input: unknown): DepartmentStructure
     };
   }) : defaults.rooms;
 
-  const personnel = Array.isArray(src.personnel) ? src.personnel.slice(0, 30).map((item, index) => {
+  const personnelRaw = Array.isArray(src.personnel) ? src.personnel.slice(0, 30).map((item, index) => {
     const fallback = defaults.personnel[index] ?? { position: "Посада", note: "" };
     return { position: text(item?.position, fallback.position, 160), note: text(item?.note, fallback.note, 220) };
   }) : defaults.personnel;
+  // Одноразова міграція попереднього узагальненого переліку (4 посади) до
+  // фактичної штатної картини за посадами й кількістю. Власні зміни адміна не
+  // чіпаємо — оновлюємо лише якщо перелік точно збігається з колишнім типовим.
+  const legacyPersonnel = ["Начальник відділення променевої діагностики", "Начальник ПРК", "Лікарі-рентгенологи", "Рентгенолаборанти"];
+  const personnel = (personnelRaw.length === legacyPersonnel.length
+    && personnelRaw.every((p, i) => p.position === legacyPersonnel[i]))
+    ? defaults.personnel
+    : personnelRaw;
 
   const sanitizeHours = (block: unknown, fallback: DepartmentStructure["hours"]["outpatient"]) => {
     const source = block && typeof block === "object" ? block as typeof fallback : fallback;

--- a/tests/department-structure.test.mjs
+++ b/tests/department-structure.test.mjs
@@ -85,6 +85,33 @@ test("structure carries NO personal data (no names/addresses/DOB/phones)", async
   assert.doesNotMatch(raw, /\b0\d{9}\b/); // телефони персоналу
   assert.doesNotMatch(raw, /вул\. Бєлова|вул\. Гагаріна|Лук['’]яненка/); // домашні адреси
   for (const p of S.personnel) assert.ok(p.position && !/[А-ЯІЇЄ]{4,}\s+[А-ЯІЇЄ][а-яіїє]/.test(p.position));
+  // Ще й додаткові прізвища/адреси з відомості 2024 — теж відсутні.
+  assert.doesNotMatch(raw, /БЕНДІК|ВОВКУШЕВСЬКИЙ|КРИВЦОВ|КОВАЛЕНКО/);
+  assert.doesNotMatch(raw, /Незалежності 25|Савчук|Масанівська|П['’]ятницька/);
+});
+
+test("personnel roster is posts-and-headcount only (real posts, 9 people)", () => {
+  const positions = S.personnel.map((p) => p.position);
+  assert.ok(positions.includes("Молодша медична сестра"));
+  assert.ok(positions.includes("Водій-електрик ПРК"));
+  assert.ok(!positions.includes("Лікарі-рентгенологи")); // немає у фактичній відомості
+  const total = S.personnel.reduce((n, p) => n + (Number((p.note.match(/^\d+/) || [])[0]) || 0), 0);
+  assert.equal(total, 9);
+});
+
+test("legacy generic personnel list migrates to the real posts; custom lists untouched", () => {
+  const migrated = sanitizeDepartmentStructure({
+    personnel: [
+      { position: "Начальник відділення променевої діагностики", note: "Відповідальна особа з радіаційної безпеки" },
+      { position: "Начальник ПРК", note: "" },
+      { position: "Лікарі-рентгенологи", note: "" },
+      { position: "Рентгенолаборанти", note: "" },
+    ],
+  });
+  assert.deepEqual(migrated.personnel, S.personnel);
+  const custom = sanitizeDepartmentStructure({ personnel: [{ position: "Фізик-дозиметрист", note: "1" }] });
+  assert.equal(custom.personnel.length, 1);
+  assert.equal(custom.personnel[0].position, "Фізик-дозиметрист");
 });
 
 test("structure page is staff-gated and wired into the shell nav", async () => {


### PR DESCRIPTION
Оновлює блок «Персонал» у структурі відділення до фактичної штатної картини — **за посадами й кількістю, без жодних персональних даних**.

## Що змінилось
Штат (з відомості 2024, разом 9 осіб):

| Посада | К-сть |
|---|---|
| Начальник відділення променевої діагностики | 1 |
| Начальник ПРК | 1 |
| Рентгенолаборанти (вкл. пересувного рентгенкабінету) | 5 |
| Молодша медична сестра | 1 |
| Водій-електрик ПРК | 1 |

Прибрано узагальнену позицію «Лікарі-рентгенологи» (окремо у відомості її немає).

## Безпека даних
**Свідомо без ПІБ, звань пофамільно, дат народження, домашніх адрес і телефонів** — це військовий особовий склад в/ч, і таким даним не місце в коді чи на (частково публічній) сторінці структури. Тест окремо перевіряє відсутність цих полів. Поіменний реєстр, якщо колись знадобиться, має жити виключно в захищеному адмін-модулі з обмеженим доступом.

## Без ручного введення
Додано **одноразову міграцію**: попередній узагальнений перелік (4 посади) автоматично оновлюється до нового навіть якщо структуру вже збережено в БД. Власний перелік адміністратора не чіпається.

## Перевірка
260 тестів зелені (нові: склад штату 9 осіб, міграція зі старого переліку, відсутність нових прізвищ/адрес); `eslint`, `tsc --noEmit`, `next build` — чисті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_