### PR TITLE
Дошка прийому: виправлення дефектів корекції заявки (D1–D4)

### DIFF
--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -219,11 +219,18 @@ export async function PATCH(request: Request) {
 
   // Повна корекція заявки: ПІБ, телефон, email, ДН, категорія, послуга,
   // коментар. Лише реєстратор/адміністратор. Зміна послуги переобчислює
-  // апарат і тривалість (слот за потреби перенести окремо).
+  // апарат, тривалість і суму; зміна категорії — статус оплати (окрім уже
+  // оплачених). Якщо нова послуга змінює апарат — перевіряємо, що поточний
+  // слот вільний на новому апараті.
   if (body.edit && typeof body.edit === "object") {
     if (!canManageBookings(member.role)) {
       return Response.json({ error: "Редагувати заявку може реєстратор або адміністратор" }, { status: 403 });
     }
+    const cur = await db.prepare(
+      "SELECT desired_date AS d, desired_time AS t, equipment_id AS eq, payment_status AS ps FROM bookings WHERE id = ?"
+    ).bind(body.id!).first<{ d: string; t: string; eq: string; ps: string }>();
+    // Фінанси не перезаписуємо, якщо оплату вже внесено/не потрібна.
+    const financeLocked = !!cur && ["paid", "not_required"].includes(cur.ps);
     const e = body.edit;
     const sets: string[] = [];
     const binds: (string | number)[] = [];
@@ -236,13 +243,28 @@ export async function PATCH(request: Request) {
     }
     if (typeof e.email === "string") { sets.push("patient_email = ?"); binds.push(e.email.trim().slice(0, 254)); }
     if (typeof e.dob === "string") { sets.push("date_of_birth = ?"); binds.push(normalizeDob(e.dob)); }
-    if (typeof e.patientCategory === "string") { sets.push("patient_category = ?"); binds.push(e.patientCategory === "military" ? "military" : "civilian"); }
+    if (typeof e.patientCategory === "string") {
+      const cat = e.patientCategory === "military" ? "military" : "civilian";
+      sets.push("patient_category = ?"); binds.push(cat);
+      if (!financeLocked) { sets.push("payment_status = ?"); binds.push(cat === "civilian" ? "pending" : "verification_required"); }
+    }
     if (typeof e.comment === "string") { sets.push("comment = ?"); binds.push(e.comment.trim().slice(0, 700)); }
     if (typeof e.serviceCode === "string") {
       const svc = serviceByCode(e.serviceCode.trim().slice(0, 12));
       if (!svc) return Response.json({ error: "Невідома послуга" }, { status: 400 });
+      // Зміна апарата: поточний слот має бути вільним на новому апараті.
+      if (cur && svc.equipmentId !== cur.eq) {
+        const endTime = addMinutes(cur.t, svc.durationMinutes);
+        const clash = await db.prepare(
+          `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ? AND id != ?
+           AND status IN ('confirmed','rescheduled') AND desired_time < ?
+           AND strftime('%H:%M', desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
+        ).bind(svc.equipmentId, cur.d, body.id!, endTime, cur.t).first();
+        if (clash) return Response.json({ error: "Час зайнятий на апараті нової послуги — спершу перенесіть заявку" }, { status: 409 });
+      }
       sets.push("service = ?", "service_code = ?", "equipment_id = ?", "duration_minutes = ?");
       binds.push(svc.title, svc.code, svc.equipmentId, svc.durationMinutes);
+      if (!financeLocked) { sets.push("payment_amount = ?"); binds.push(await effectivePrice(db, svc.code)); }
     }
     if (!sets.length) return Response.json({ error: "Немає змін для збереження" }, { status: 400 });
     binds.push(body.id!);

--- a/app/staff/intake/page.tsx
+++ b/app/staff/intake/page.tsx
@@ -61,8 +61,20 @@ export default function IntakePage() {
 
   const selected = data?.bookings.find(b => b.id === selectedId) || null;
 
+  // Чи форма розходиться зі збереженою заявкою (лише поля корекції).
+  function formMatchesSelected() {
+    if (!selected) return true;
+    return form.name===(selected.name||"") && form.phone===(selected.phone||"") && form.email===(selected.patientEmail||"")
+      && form.dob===(selected.dateOfBirth||"") && form.patientCategory===(selected.patientCategory||"civilian")
+      && form.serviceCode===(selected.serviceCode||SERVICES[0].code) && form.comment===(selected.comment||"");
+  }
+  function guardUnsaved() {
+    return !(selected && !creating && !formMatchesSelected()) || window.confirm("Незбережені зміни буде втрачено. Продовжити?");
+  }
+
   // Вибір заявки заповнює форму (режим редагування) — без ефекту, у обробнику.
   function selectBooking(b:Booking) {
+    if (!guardUnsaved()) return;
     setCreating(false);
     setSelectedId(b.id);
     setForm({
@@ -124,7 +136,7 @@ export default function IntakePage() {
     } finally { setBusy(false); }
   }
 
-  function startCreate() { setCreating(true); setSelectedId(null); setForm({ ...emptyForm, date:todayInKyiv() }); }
+  function startCreate() { if (!guardUnsaved()) return; setCreating(true); setSelectedId(null); setForm({ ...emptyForm, date:todayInKyiv() }); }
 
   const readOnly = !!data && !["admin","registrar"].includes(data.staff.role);
 

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -18,6 +18,14 @@ test("bookings PATCH supports full booking correction (edit branch)", async () =
   assert.match(route, /duration_minutes = \?/);
   // GET віддає дату народження для форми корекції.
   assert.match(route, /date_of_birth AS dateOfBirth/);
+  // Виправлено: зміна послуги оновлює суму; категорії — статус оплати;
+  // фінанси не чіпаємо на оплачених; зміна апарата перевіряє слот.
+  assert.match(route, /financeLocked/);
+  assert.match(route, /"paid", "not_required"/);
+  assert.match(route, /payment_amount = \?/);
+  assert.match(route, /effectivePrice\(db, svc\.code\)/);
+  assert.match(route, /svc\.equipmentId !== cur\.eq/);
+  assert.match(route, /Час зайнятий на апараті нової послуги/);
 });
 
 test("intake board page is a two-pane queue + editable detail, wired into the shell", async () => {
@@ -32,6 +40,7 @@ test("intake board page is a two-pane queue + editable detail, wired into the sh
   assert.match(page, /status:"cancelled"/);     // скасування
   assert.match(page, /created_by_staff|Нова заявка/); // ручне створення
   assert.match(page, /🌐|✍️/);        // позначка джерела (сайт/вручну)
+  assert.match(page, /guardUnsaved/); // попередження про незбережені зміни (D4)
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /href:"\/staff\/intake"/);
   assert.match(shell, /Дошка прийому/);


### PR DESCRIPTION
Ревʼю дошки прийому виявило дефекти в корекції заявки — виправлено.

## Виправлено
- **D1 (🔴 гроші):** зміна послуги тепер **оновлює суму** (`payment_amount` = ціна нової послуги за `effectivePrice`). Раніше сума лишалася від старої послуги.
- **D2 (🟠):** зміна категорії коригує **статус оплати** (цивільний → `pending`, військовий → `verification_required`).
- **Гард фінансів:** сума й статус **не перезаписуються**, якщо оплату вже внесено / не потрібна (`paid`/`not_required`).
- **D3 (🟠 цілісність):** зміна послуги, що міняє **апарат**, перевіряє, що поточний слот вільний на новому апараті; інакше `409` з проханням спершу перенести (запобігає накладанню).
- **D4 (🟡 UX):** попередження про **незбережені зміни** при переході на іншу заявку чи створенні нової.

## Перевірено як коректне (без змін)
Перенесення виключає саму заявку (немає хибного накладання), позначка джерела 🌐/✍️ правильна, клієнтський `readOnly` збігається з серверним `canManageBookings` (admin/registrar).

## Перевірка
262 тести зелені (тест корекції розширено під нову поведінку); `eslint`, `tsc --noEmit`, `next build` — чисті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_