### PR TITLE
Вітрина: SEO-пакет — заголовок, соцпрев'ю, geo, FAQ-розмітка

### DIFF
--- a/public/site/index.html
+++ b/public/site/index.html
@@ -321,7 +321,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
   <section class="experience" id="experience">
     <div class="wrap">
       <details class="experience-card experience-fold">
-        <summary><span><span class="experience-kicker">Про відділення</span><strong class="experience-summary-title">Досвід, підтверджений щоденною практикою</strong></span></summary>
+        <summary><span><span class="experience-kicker">Про відділення</span><strong class="experience-summary-title">Флюорографія, рентгенографія та КТ у Чернігові</strong></span></summary>
         <div class="experience-body">
         <p class="experience-lead" id="scAbout">Екстрені дослідження для військовослужбовців проводяться цілодобово — 24/7. Планові дослідження проводяться відповідно до режиму роботи відділення: 08:30–17:30. Цивільні пацієнти можуть пройти платні дослідження за попереднім записом.</p>
         <p class="experience-seo">У відділенні доступні КТ у Чернігові, КТ з внутрішньовенним контрастуванням, цифрова рентгенографія та флюорографія. Цивільні пацієнти можуть обрати дослідження й подати онлайн-заявку на вільний час.</p>

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -9,11 +9,27 @@
 <meta property="og:title" content="КТ, рентген і флюорографія у Чернігові | RadiologyOS"/>
 <meta property="og:description" content="Відділення променевої діагностики у Чернігові: КТ, цифровий рентген, флюорографія та онлайн-запис."/>
 <meta property="og:url" content="https://radiologyos.tech/"/>
+<meta property="og:type" content="website"/>
+<meta property="og:image" content="https://radiologyos.tech/hospital-emblem.jpg"/>
+<meta property="og:locale" content="uk_UA"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="КТ, рентген і флюорографія у Чернігові"/>
+<meta name="twitter:description" content="Відділення променевої діагностики у Чернігові: КТ, рентген, флюорографія, онлайн-запис."/>
+<meta name="twitter:image" content="https://radiologyos.tech/hospital-emblem.jpg"/>
 <link rel="canonical" href="https://radiologyos.tech/"/>
 <meta name="theme-color" content="#0c7a85"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"MedicalClinic","@id":"https://radiologyos.tech/#clinic","name":"Відділення променевої діагностики Чернігівського військового госпіталю","url":"https://radiologyos.tech/","telephone":"+380972808899","description":"КТ, КТ з контрастуванням, цифрова рентгенографія та флюорографія у Чернігові.","medicalSpecialty":"Radiologic","address":{"@type":"PostalAddress","streetAddress":"вул. Гетьмана Полуботка, 40","addressLocality":"Чернігів","postalCode":"14013","addressCountry":"UA"},"areaServed":{"@type":"City","name":"Чернігів"},"openingHoursSpecification":[{"@type":"OpeningHoursSpecification","dayOfWeek":["Monday","Tuesday","Wednesday","Thursday","Friday"],"opens":"08:30","closes":"17:30"}]}
+{"@context":"https://schema.org","@type":"MedicalClinic","@id":"https://radiologyos.tech/#clinic","name":"Відділення променевої діагностики Чернігівського військового госпіталю","url":"https://radiologyos.tech/","telephone":"+380972808899","description":"КТ, КТ з контрастуванням, цифрова рентгенографія та флюорографія у Чернігові.","medicalSpecialty":"Radiologic","address":{"@type":"PostalAddress","streetAddress":"вул. Гетьмана Полуботка, 40","addressLocality":"Чернігів","postalCode":"14013","addressCountry":"UA"},"geo":{"@type":"GeoCoordinates","latitude":51.4978508,"longitude":31.3094428},"hasMap":"https://www.google.com/maps?q=51.4978508,31.3094428","areaServed":{"@type":"City","name":"Чернігів"},"openingHoursSpecification":[{"@type":"OpeningHoursSpecification","dayOfWeek":["Monday","Tuesday","Wednesday","Thursday","Friday"],"opens":"08:30","closes":"17:30"}]}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"Чи потрібне направлення на дослідження?","acceptedAnswer":{"@type":"Answer","text":"Військовослужбовцям дослідження виконуються безоплатно за направленням. Цивільні пацієнти проходять платні дослідження за попереднім записом — направлення не обов'язкове."}},
+{"@type":"Question","name":"Скільки коштує КТ у Чернігові?","acceptedAnswer":{"@type":"Answer","text":"Вартість КТ залежить від анатомічної ділянки та наявності контрастування. Актуальні ціни — на сторінці тарифів; там же можна одразу подати онлайн-заявку."}},
+{"@type":"Question","name":"Чи роблять КТ з контрастуванням?","acceptedAnswer":{"@type":"Answer","text":"Так, доступне КТ з внутрішньовенним контрастуванням за медичними показаннями."}},
+{"@type":"Question","name":"Як записатися на дослідження?","acceptedAnswer":{"@type":"Answer","text":"Онлайн на сайті: оберіть дослідження, вкажіть дані та зручний час. Або зателефонуйте в реєстратуру за номером +380 97 280 88 99."}},
+{"@type":"Question","name":"Де розташоване відділення променевої діагностики?","acceptedAnswer":{"@type":"Answer","text":"м. Чернігів, вул. Гетьмана Полуботка, 40 (Чернігівський військовий госпіталь)."}}
+]}
 </script>
 <style>
 /* ===== Токени ===== */
@@ -390,6 +406,16 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
           </div></div>
         </details>
       </div>
+    </div>
+  </section>
+
+  <section class="experience" id="faq" aria-label="Часті питання">
+    <div class="wrap">
+      <details class="experience-card experience-fold"><summary><span><span class="experience-kicker">Часті питання</span><strong class="experience-summary-title" style="font-size:clamp(16px,2vw,19px)">Чи потрібне направлення на дослідження?</strong></span></summary><div class="experience-body"><p class="experience-seo">Військовослужбовцям — безоплатно за направленням. Цивільні пацієнти проходять платні дослідження за попереднім записом; направлення не обов'язкове.</p></div></details>
+      <details class="experience-card experience-fold" style="margin-top:10px"><summary><span><strong class="experience-summary-title" style="font-size:clamp(16px,2vw,19px)">Скільки коштує КТ у Чернігові?</strong></span></summary><div class="experience-body"><p class="experience-seo">Вартість КТ залежить від ділянки та контрастування. Актуальні ціни — на <a href="/site/price.html">сторінці тарифів</a>, там же можна одразу записатися.</p></div></details>
+      <details class="experience-card experience-fold" style="margin-top:10px"><summary><span><strong class="experience-summary-title" style="font-size:clamp(16px,2vw,19px)">Чи роблять КТ з контрастуванням?</strong></span></summary><div class="experience-body"><p class="experience-seo">Так, доступне КТ з внутрішньовенним контрастуванням за медичними показаннями.</p></div></details>
+      <details class="experience-card experience-fold" style="margin-top:10px"><summary><span><strong class="experience-summary-title" style="font-size:clamp(16px,2vw,19px)">Як записатися на дослідження?</strong></span></summary><div class="experience-body"><p class="experience-seo">Онлайн на сайті: оберіть дослідження, вкажіть дані та зручний час. Або за телефоном реєстратури +380 97 280 88 99.</p></div></details>
+      <p class="experience-seo" style="margin:12px 4px 0">Види досліджень у Чернігові: КТ головного мозку, КТ органів грудної клітки, КТ черевної порожнини, КТ з контрастуванням, цифрова рентгенографія, флюорографія ОГК. <a href="/site/price.html">Переглянути ціни й записатися →</a></p>
     </div>
   </section>
 

--- a/tests/public-hospital-home.test.mjs
+++ b/tests/public-hospital-home.test.mjs
@@ -9,7 +9,7 @@ test("the public homepage combines hospital information, services and booking", 
   for (const marker of [
     "scSlogan",
     "scAbout",
-    "Досвід, підтверджений щоденною практикою",
+    "Флюорографія, рентгенографія та КТ у Чернігові",
     "29 700",
     "16 500",
     "10 400",

--- a/tests/seo-landing.test.mjs
+++ b/tests/seo-landing.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("landing has social preview + rich SEO markup", async () => {
+  const html = await read("public/site/index.html");
+  // OG / Twitter соцпрев'ю.
+  assert.match(html, /property="og:image" content="https:\/\/radiologyos\.tech\/hospital-emblem\.jpg"/);
+  assert.match(html, /name="twitter:card" content="summary_large_image"/);
+  // Гео-координати й карта у MedicalClinic JSON-LD.
+  assert.match(html, /"@type":"GeoCoordinates","latitude":51\.4978508,"longitude":31\.3094428/);
+  assert.match(html, /"hasMap":"https:\/\/www\.google\.com\/maps/);
+  // FAQ: розмітка + видима секція.
+  assert.match(html, /"@type":"FAQPage"/);
+  assert.match(html, /Скільки коштує КТ у Чернігові\?/);
+  assert.match(html, /id="faq"/);
+  // Довгі ключі: види досліджень + локація.
+  assert.match(html, /Види досліджень у Чернігові/);
+  assert.match(html, /КТ головного мозку/);
+});


### PR DESCRIPTION
Повний SEO-пакет головної під локальний пошук у Чернігові (усі розділи).

## Що зроблено
1. **Заголовок «Про відділення»** → «Флюорографія, рентгенографія та КТ у Чернігові» (видимий keyword+місто).
2. **Соцпрев'ю:** `og:image` (емблема госпіталю), `og:type`/`og:locale`, Twitter `summary_large_image` — гарний вигляд при поширенні у Facebook/Telegram.
3. **Гео в JSON-LD `MedicalClinic`:** `GeoCoordinates` + `hasMap` (карта вже була посиланням у контактах).
4. **FAQ:** розмітка `FAQPage` (5 питань — направлення, ціна КТ, контраст, запис, адреса) + видима секція «Часті питання» (акордеон) — Google може показувати розгортання прямо у видачі.
5. **Довгі ключі:** рядок «Види досліджень у Чернігові: КТ головного мозку, КТ ОГК…» з посиланням на прайс.

Доповнює вже наявні `title` / `meta description` / `robots.txt` / `sitemap.xml` / `MedicalClinic`.

## Що поза кодом (на вашому боці, найважливіше)
- **Google Business Profile** (Maps) — головний фактор локальної видимості.
- **Google Search Console** — підтвердити домен, надіслати `sitemap.xml`.
- **Відгуки Google** від цивільних пацієнтів.

## Перевірка
263 тести зелені (новий тест на SEO-розмітку); `next build`, `eslint` — чисті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)