### PR TITLE
Аудит: виправлення дефектів (дошка прийому, аудит-CSV, пульт)

### DIFF
--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -41,6 +41,7 @@ export async function POST(request: Request) {
   const phone = clean(body.phone, 40);
   const phoneNormalized = normalizeUkrainianPhone(phone);
   const dob = normalizeDob(body.dob);
+  const email = clean(body.email, 254);
   const serviceCode = clean(body.serviceCode, 12);
   const service = serviceByCode(serviceCode);
   const desiredDate = clean(body.date, 10);
@@ -85,14 +86,14 @@ export async function POST(request: Request) {
     `INSERT INTO bookings (
       organization_id, code, name, phone, phone_normalized, service, service_code, equipment_id,
       duration_minutes, desired_date, desired_time, referral, patient_category, referral_type,
-      payment_status, payment_amount, nszu_status, comment, date_of_birth,
+      payment_status, payment_amount, nszu_status, comment, date_of_birth, patient_email,
       assigned_radiologist_email, assigned_radiographer_email, status,
       consent_at, consent_version, consent_source
-    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'confirmed',CURRENT_TIMESTAMP,?,?)`
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'confirmed',CURRENT_TIMESTAMP,?,?)`
   ).bind(
     ctx.organizationId, code, name, phone, phoneNormalized, service.title, service.code, service.equipmentId,
     service.durationMinutes, desiredDate, desiredTime, referral, category, referralType,
-    paymentStatus, price, nszuStatus, comment, dob,
+    paymentStatus, price, nszuStatus, comment, dob, email,
     radiologist, radiographer, "2026-07-29", "staff",
   ).run();
 
@@ -227,8 +228,12 @@ export async function PATCH(request: Request) {
       return Response.json({ error: "Редагувати заявку може реєстратор або адміністратор" }, { status: 403 });
     }
     const cur = await db.prepare(
-      "SELECT desired_date AS d, desired_time AS t, equipment_id AS eq, payment_status AS ps FROM bookings WHERE id = ?"
-    ).bind(body.id!).first<{ d: string; t: string; eq: string; ps: string }>();
+      "SELECT desired_date AS d, desired_time AS t, equipment_id AS eq, payment_status AS ps, status AS st FROM bookings WHERE id = ?"
+    ).bind(body.id!).first<{ d: string; t: string; eq: string; ps: string; st: string }>();
+    // Закриті заявки не редагуються (як і в гілці підтвердження).
+    if (cur && (cur.st === "cancelled" || cur.st === "completed")) {
+      return Response.json({ error: "Скасовану або завершену заявку редагувати не можна" }, { status: 409 });
+    }
     // Фінанси не перезаписуємо, якщо оплату вже внесено/не потрібна.
     const financeLocked = !!cur && ["paid", "not_required"].includes(cur.ps);
     const e = body.edit;
@@ -241,7 +246,11 @@ export async function PATCH(request: Request) {
       if (!norm) return Response.json({ error: "Некоректний номер телефону" }, { status: 400 });
       sets.push("phone = ?", "phone_normalized = ?"); binds.push(ph, norm);
     }
-    if (typeof e.email === "string") { sets.push("patient_email = ?"); binds.push(e.email.trim().slice(0, 254)); }
+    if (typeof e.email === "string") {
+      const em = e.email.trim().slice(0, 254);
+      if (em && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(em)) return Response.json({ error: "Некоректний email" }, { status: 400 });
+      sets.push("patient_email = ?"); binds.push(em);
+    }
     if (typeof e.dob === "string") { sets.push("date_of_birth = ?"); binds.push(normalizeDob(e.dob)); }
     if (typeof e.patientCategory === "string") {
       const cat = e.patientCategory === "military" ? "military" : "civilian";
@@ -252,15 +261,25 @@ export async function PATCH(request: Request) {
     if (typeof e.serviceCode === "string") {
       const svc = serviceByCode(e.serviceCode.trim().slice(0, 12));
       if (!svc) return Response.json({ error: "Невідома послуга" }, { status: 400 });
-      // Зміна апарата: поточний слот має бути вільним на новому апараті.
-      if (cur && svc.equipmentId !== cur.eq) {
+      // Нова послуга може змінити апарат І/АБО тривалість — повністю
+      // перевіряємо поточний слот для неї: сітка/робочий день/блокування/
+      // накладання (виключаючи саму заявку). Інакше просимо перенести.
+      if (cur) {
+        const rSchedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+        const validTimes = candidateTimesFor(hoursFor(rSchedule, svc.equipmentId), svc.durationMinutes);
         const endTime = addMinutes(cur.t, svc.durationMinutes);
+        const rejectReschedule = Response.json({ error: "Поточний час не підходить для нової послуги (апарат / тривалість / зайнятість) — спершу перенесіть заявку" }, { status: 409 });
+        if (!isBookableDate(cur.d) || !isEquipmentDayOpen(cur.d, rSchedule, svc.equipmentId) || !validTimes.includes(cur.t)) return rejectReschedule;
         const clash = await db.prepare(
           `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ? AND id != ?
            AND status IN ('confirmed','rescheduled') AND desired_time < ?
            AND strftime('%H:%M', desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
         ).bind(svc.equipmentId, cur.d, body.id!, endTime, cur.t).first();
-        if (clash) return Response.json({ error: "Час зайнятий на апараті нової послуги — спершу перенесіть заявку" }, { status: 409 });
+        if (clash) return rejectReschedule;
+        const blocked = await db.prepare(
+          "SELECT id FROM equipment_blocks WHERE equipment_id = ? AND blocked_date = ? AND start_time < ? AND end_time > ? LIMIT 1"
+        ).bind(svc.equipmentId, cur.d, endTime, cur.t).first();
+        if (blocked) return rejectReschedule;
       }
       sets.push("service = ?", "service_code = ?", "equipment_id = ?", "duration_minutes = ?");
       binds.push(svc.title, svc.code, svc.equipmentId, svc.durationMinutes);

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -170,7 +170,7 @@ export default function DashboardPage() {
           const days:string[] = [];
           for (let i = 6; i >= 0; i--) { const dt = new Date(`${data.today}T12:00:00Z`); dt.setUTCDate(dt.getUTCDate() - i); days.push(dt.toISOString().slice(0,10)); }
           const at = (id:string, d:string) => data.equipmentWeek.find((e)=>e.id===id && e.d===d)?.c || 0;
-          const peak = Math.max(1, ...data.equipmentWeek.map((e)=>e.c));
+          const peak = Math.max(1, ...data.equipmentWeek.filter((e)=>["ct","xray","fluoro"].includes(e.id)).map((e)=>e.c));
           const dow = (d:string) => ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"][new Date(`${d}T12:00:00Z`).getUTCDay()];
           return <div className="dashLoadGrid" style={{ gridTemplateColumns:`120px repeat(${days.length}, 1fr)` }}>
             <span className="dashLoadCorner" />

--- a/app/staff/intake/page.tsx
+++ b/app/staff/intake/page.tsx
@@ -39,16 +39,22 @@ export default function IntakePage() {
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState("");
 
+  function flash(msg:string) { setToast(msg); window.setTimeout(()=>setToast(""), 2600); }
+
   async function load(keepSelection = true) {
     const res = await fetch("/api/staff/bookings", { cache:"no-store" });
     if (res.status === 401 || res.status === 403) { setForbidden(true); setLoaded(true); return; }
-    const payload = await res.json().catch(()=>({})) as Data;
+    const payload = await res.json().catch(()=>null) as (Data & { error?:string }) | null;
+    // Помилки (503/500 тощо) не кладемо в data — інакше далі впаде data.staff.
+    if (!res.ok || !payload || !Array.isArray(payload.bookings) || !payload.staff) {
+      flash(payload?.error || "Не вдалося завантажити заявки"); setLoaded(true); return;
+    }
     setData(payload); setLoaded(true);
     if (!keepSelection) setSelectedId(null);
   }
+  // Одноразове завантаження на монтуванні (load стабільний за задумом).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { const t = window.setTimeout(() => { void load(); }, 0); return () => window.clearTimeout(t); }, []);
-
-  function flash(msg:string) { setToast(msg); window.setTimeout(()=>setToast(""), 2600); }
 
   const sourceOf = useMemo(() => {
     const m = new Map<number,"site"|"staff">();

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -92,9 +92,13 @@ export async function listAuditEvents(db: D1Database, organizationId: number, q:
   return rows.results;
 }
 
-// Екранування значення для CSV (RFC 4180): лапки, коми й переноси — у лапках.
+// Екранування значення для CSV (RFC 4180) + нейтралізація формул: клітинку,
+// що починається з = + - @ (або tab/CR), префіксуємо апострофом, щоб Excel/
+// LibreOffice не виконали її як формулу (CSV injection). Лапки від цього не
+// рятують — редактор їх знімає перед обчисленням.
 function csvCell(value: unknown): string {
-  const s = String(value ?? "");
+  let s = String(value ?? "");
+  if (/^[=+\-@\t\r]/.test(s)) s = "'" + s;
   return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -54,6 +54,18 @@ test("toAuditCsv builds an Excel-friendly CSV with a BOM and escaped fields", as
   assert.match(lines[2], /"\{""a"":""b, c""\}"/);
 });
 
+test("toAuditCsv neutralizes formula-injection cells", async () => {
+  const { toAuditCsv } = await import("../lib/audit.ts");
+  const csv = toAuditCsv([
+    { id: 1, actorEmail: "=HYPERLINK(\"http://evil\")", action: "login_failed", resource: "auth", targetId: "+1", detailsJson: "@x", createdAt: "2026-08-03 10:00:00" },
+  ]);
+  const row = csv.slice(1).split("\r\n")[1];
+  // Небезпечні клітинки префіксуються апострофом (і беруться в лапки через ").
+  assert.match(row, /"'=HYPERLINK/);
+  assert.match(row, /'\+1/);
+  assert.match(row, /'@x/);
+});
+
 test("audit API is admin-only and org-scoped", async () => {
   const route = await read("app/api/staff/audit/route.ts");
   assert.match(route, /requireOrgContext/);

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -24,8 +24,15 @@ test("bookings PATCH supports full booking correction (edit branch)", async () =
   assert.match(route, /"paid", "not_required"/);
   assert.match(route, /payment_amount = \?/);
   assert.match(route, /effectivePrice\(db, svc\.code\)/);
-  assert.match(route, /svc\.equipmentId !== cur\.eq/);
-  assert.match(route, /Час зайнятий на апараті нової послуги/);
+  // Виправлено (аудит): повна перевірка слоту при зміні послуги (сітка/день/
+  // блокування/накладання), а не лише конфлікт апарата.
+  assert.match(route, /candidateTimesFor\(hoursFor\(rSchedule/);
+  assert.match(route, /isEquipmentDayOpen\(cur\.d, rSchedule/);
+  assert.match(route, /equipment_blocks/);
+  // Закриті заявки не редагуються; email валідується; email зберігається при створенні.
+  assert.match(route, /cur\.st === "cancelled"/);
+  assert.match(route, /Некоректний email/);
+  assert.match(route, /date_of_birth, patient_email,/); // POST зберігає email
 });
 
 test("intake board page is a two-pane queue + editable detail, wired into the shell", async () => {
@@ -41,6 +48,8 @@ test("intake board page is a two-pane queue + editable detail, wired into the sh
   assert.match(page, /created_by_staff|Нова заявка/); // ручне створення
   assert.match(page, /🌐|✍️/);        // позначка джерела (сайт/вручну)
   assert.match(page, /guardUnsaved/); // попередження про незбережені зміни (D4)
+  // Виправлено (аудит): помилки завантаження не кладуться в data (не білий екран).
+  assert.match(page, /!Array\.isArray\(payload\.bookings\) \|\| !payload\.staff/);
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /href:"\/staff\/intake"/);
   assert.match(shell, /Дошка прийому/);


### PR DESCRIPTION
Адверсарне рев'ю сьогоднішнього коду (3 незалежні агенти) — виправлено знайдені реальні дефекти.

## Виправлено
**Записи / дошка прийому**
- 🔴 **Подвійне бронювання / невалідний слот при зміні послуги.** Тепер зміна послуги повністю перевіряє слот для нової послуги: сітка (`candidateTimesFor`), робочий день (`isEquipmentDayOpen`), блокування (`equipment_blocks`), накладання (з виключенням самої заявки). Раніше перевірявся лише конфлікт і лише при зміні апарата — тож збільшення тривалості на тому ж апараті (напр. 201→203) могло накласти сусідній слот.
- 🟠 **Втрата email при ручному створенні** — POST тепер зберігає `patient_email`.
- 🟠 **Крах сторінки при 503/500** — відповідь-помилку більше не кладемо в `data` (не було білого екрана від `data.staff`).
- 🟡 Закриті (скасовані/завершені) заявки не редагуються; email валідується форматом.

**Аудит**
- 🟠 **CSV-ін'єкція формул** — клітинки, що починаються з `= + - @` / tab / CR, префіксуються апострофом (Excel/LibreOffice не виконають як формулу). Вектор: неавтентифікований зловмисник через email на `/api/staff/login` → `login_failed` у журналі → адмін відкриває CSV.

**Пульт**
- 🟡 Пік 7-денної завантаженості рахується лише по показаних апаратах (ct/xray/fluoro).

## Перевірено рев'ю як коректне (без змін)
SQL-параметризація (без ін'єкцій), порядок перевірки прав (`canAccessBooking` перед edit), XSS (React екранує, `wa.me` тільки цифри), дати/часові пояси на пульті, admin-гейт CSV, межі обідньої перерви, валідність обох JSON-LD, відсутність битих посилань/дублікатів ID, редирект `/` без циклу.

## Відомий незакритий пункт (крос-сесійний)
🟡 Навігація (`workspace-shell.tsx`) все ще робить запит до видаленого `/api/staff/org-profile` (залишок feature-flags, повернутий паралельною сесією) — 404 ковтається, функціонал не ламається. Лишив, щоб не конфліктувати з паралельною роботою; варто узгодити окремо.

## Перевірка
264 тести зелені (нові — на кожне виправлення); `eslint`, `tsc --noEmit`, `next build` — чисті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_