### PR TITLE
Перебудова бічної навігації: Огляд + згруповані модулі з піктограмами

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1097,7 +1097,7 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .themeDark .protocolActions button,.themeDark .pacsFormActions button.ghost{background:#0e151a;border-color:#26333d;color:#cdd8de}
 
 /* Пункти-модулі «Карти системи» в бічній панелі — номерні бейджі */
-.workspaceNavigation a.workspaceModuleLink>span{display:grid;place-items:center;width:20px;height:20px;flex:0 0 20px;border-radius:6px;background:rgba(37,180,192,.16);color:#7fd4dc;font-size:11px;font-weight:700}
+.workspaceNavigation a.workspaceModuleLink>span{display:grid;place-items:center;width:24px;height:24px;flex:0 0 24px;border-radius:7px;background:rgba(37,180,192,.14);font-size:14px;line-height:1}
 .workspaceNavigation a.workspaceModuleLink.active>span,.workspaceNavigation a.workspaceModuleLink:hover>span{background:rgba(37,180,192,.28);color:#bff0f5}
 /* Зручність: повний підпис модуля (перенос замість обрізання) + читабельний
    активний бейдж-номер (на білому боксі — суцільний teal з білою цифрою). */

--- a/app/globals.css
+++ b/app/globals.css
@@ -1099,6 +1099,11 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 /* Пункти-модулі «Карти системи» в бічній панелі — номерні бейджі */
 .workspaceNavigation a.workspaceModuleLink>span{display:grid;place-items:center;width:20px;height:20px;flex:0 0 20px;border-radius:6px;background:rgba(37,180,192,.16);color:#7fd4dc;font-size:11px;font-weight:700}
 .workspaceNavigation a.workspaceModuleLink.active>span,.workspaceNavigation a.workspaceModuleLink:hover>span{background:rgba(37,180,192,.28);color:#bff0f5}
+/* Зручність: повний підпис модуля (перенос замість обрізання) + читабельний
+   активний бейдж-номер (на білому боксі — суцільний teal з білою цифрою). */
+.workspaceNavigation a.workspaceModuleLink{gap:9px;padding-top:6px;padding-bottom:6px;align-items:center}
+.workspaceNavigation a.workspaceModuleLink>b{white-space:normal;overflow:visible;line-height:1.16}
+.workspaceNavigation a.workspaceModuleLink.active>span{background:#0c7a85;color:#fff}
 
 /* Розгортувані модулі з підпунктами в бічній панелі */
 .workspaceModuleGroup{display:block}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -15,41 +15,49 @@ type StaffWorkspaceShellProps = {
   children: ReactNode;
 };
 
-// Бічна панель = модулі цільової структури (у порядку «Карти системи»).
-// Кожен модуль веде на робочу сторінку й розгортається у підпункти-екрани;
-// кожен підпункт — на свою сторінку (нереалізовані ведуть у блок карти).
-// Підпункт може залежати від feature flag профілю організації: якщо
-// відповідну можливість вимкнено, пункт ховається (конструктор).
-type NavChild = { label:string; href:string; flag?:string };
-type NavModule = { n:string; label:string; href:string; section?:WorkspaceSection; defaultOpen?:boolean; items:NavChild[] };
+// Бічна панель: угорі «Огляд» — найчастіші екрани реєстратури; нижче
+// «Модулі» — робочі напрями, згруповані за призначенням. Кожен модуль
+// веде на головну сторінку напряму й розгортається у підпункти-екрани.
+type NavChild = { label:string; href:string };
+type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
+// section — головний розділ модуля; sections — усі розділи, що його підсвічують.
+type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; defaultOpen?:boolean; items:NavChild[] };
+
+// Швидкий доступ: найчастіші екрани реєстратури — угорі, з піктограмами.
+const overview: NavLink[] = [
+  { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
+  { label:"Дошка прийому", href:"/staff/intake", section:"intake", icon:"📋" },
+  { label:"Календар записів", href:"/staff/appointments", section:"appointments", icon:"🗓️" },
+];
+
+// Модулі — згруповані за напрямом роботи, з піктограмами й підпунктами.
 const systemModules: NavModule[] = [
-  { n:"1", label:"Записи і слоти", href:"/staff/appointments", section:"appointments", items:[
-    { label:"Дошка прийому", href:"/staff/intake" },
-    { label:"Календар записів", href:"/staff/appointments" },
+  { label:"Пацієнти", href:"/staff/patients", sections:["patients","chat"], icon:"👥", items:[
+    { label:"Картки пацієнтів", href:"/staff/patients" },
+    { label:"Чат із пацієнтами", href:"/staff/chat" },
   ]},
-  { n:"2", label:"Кабінети й обладнання", href:"/staff/schedule", section:"schedule", items:[
+  { label:"Дослідження", href:"/staff/studies", sections:["studies","protocols","imaging"], icon:"🩻", items:[
+    { label:"Реєстр досліджень", href:"/staff/studies" },
+    { label:"Протоколи", href:"/staff/protocols" },
+    { label:"Знімки DICOM", href:"/staff/imaging" },
+  ]},
+  { label:"Кабінети й обладнання", href:"/staff/schedule", sections:["schedule","equipment","services"], icon:"🛠️", items:[
     { label:"Графік і слоти кабінетів", href:"/staff/schedule" },
     { label:"Обладнання", href:"/staff/equipment" },
     { label:"Послуги кабінетів", href:"/staff/services" },
   ]},
-  { n:"3", label:"Дослідження", href:"/staff/studies", section:"studies", items:[
-    { label:"Реєстр досліджень", href:"/staff/studies" },
-    { label:"Протоколи", href:"/staff/protocols" },
-    { label:"Знімки DICOM", href:"/staff/imaging", flag:"dicom_pacs" },
-  ]},
-  { n:"4", label:"Фінанси і звіти", href:"/staff/reports", section:"reports", items:[
+  { label:"Фінанси і звіти", href:"/staff/reports", sections:["reports","tariffs"], icon:"💳", items:[
     { label:"Звіти відділення", href:"/staff/reports" },
     { label:"Тарифи", href:"/staff/tariffs" },
   ]},
-  { n:"5", label:"Адміністрування", href:"/staff/settings", section:"settings", defaultOpen:false, items:[
-    { label:"Редактор публічного сайту", href:"/staff/structure" },
+  { label:"Адміністрування", href:"/staff/settings", sections:["settings","structure","organization","whatsapp","audit"], icon:"⚙️", defaultOpen:false, items:[
+    { label:"Сайт і структура відділення", href:"/staff/structure" },
     { label:"Організація та профіль", href:"/staff/organization" },
     { label:"Персонал і ролі", href:"/staff#staff-admin" },
-    { label:"Чат із пацієнтами", href:"/staff/chat" },
     { label:"WhatsApp", href:"/staff/whatsapp" },
+    { label:"Журнал дій", href:"/staff/audit" },
     { label:"Реєстрація працівника", href:"/staff/register" },
     { label:"Налаштування", href:"/staff/settings" },
-    { label:"Журнал дій", href:"/staff/audit" },
   ]},
 ];
 
@@ -81,29 +89,10 @@ export default function StaffWorkspaceShell({
   const [now,setNow] = useState<Date | null>(null);
   const [dark,setDark] = useState(false);
   const [openModules,setOpenModules] = useState<Record<string,boolean>>({});
-  // Ефективні feature flags організації; null — ще не завантажено (показуємо все).
-  const [flags,setFlags] = useState<Record<string,boolean> | null>(null);
 
-  function toggleModule(n:string) {
-    setOpenModules((current)=>({ ...current, [n]:!current[n] }));
+  function toggleModule(key:string) {
+    setOpenModules((current)=>({ ...current, [key]:!current[key] }));
   }
-
-  // Пункт видимий, доки прапорці не завантажені; після — лише якщо його
-  // можливість увімкнена (пункти без flag завжди видимі).
-  function childVisible(child:NavChild) {
-    if (!child.flag) return true;
-    if (!flags) return true;
-    return flags[child.flag] !== false;
-  }
-
-  useEffect(()=>{
-    let active = true;
-    fetch("/api/staff/org-profile", { cache:"no-store" })
-      .then((r)=>r.ok ? r.json() : null)
-      .then((d)=>{ if (active && d?.flags) setFlags(d.flags as Record<string,boolean>); })
-      .catch(()=>{});
-    return ()=>{ active = false; };
-  },[]);
 
   useEffect(()=>{
     const timer = window.setInterval(()=>setNow(new Date()),1000);
@@ -142,34 +131,35 @@ export default function StaffWorkspaceShell({
 
       <nav className="workspaceNavigation" aria-label="Модулі системи">
         <p>Огляд</p>
-        <Link
-          href="/staff/structure"
-          className={`workspaceModuleLink${active === "structure" ? " active":""}`}
-          aria-current={active === "structure" ? "page":undefined}
-          title={collapsed ? "Публічна вітрина":undefined}
-        ><span aria-hidden="true">▤</span><b>Редактор сайту</b></Link>
+        {overview.map((o)=><Link
+          key={o.href}
+          href={o.href}
+          className={`workspaceModuleLink${active === o.section ? " active":""}`}
+          aria-current={active === o.section ? "page":undefined}
+          title={collapsed ? o.label:undefined}
+        ><span aria-hidden="true">{o.icon}</span><b>{o.label}</b></Link>)}
         <p>Модулі</p>
         {systemModules.map((item)=>{
-          const isActive = (!!item.section && item.section === active) || (item.n === "2" && ["schedule", "equipment", "services"].includes(active));
-          const isOpen = openModules[item.n] ?? item.defaultOpen ?? true;
-          return <div className="workspaceModuleGroup" key={item.n}>
+          const isActive = item.sections.includes(active);
+          const isOpen = openModules[item.href] ?? item.defaultOpen ?? true;
+          return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">
               <Link
                 href={item.href}
                 className={`workspaceModuleLink${isActive ? " active":""}`}
                 aria-current={isActive ? "page":undefined}
                 title={collapsed ? item.label:undefined}
-              ><span aria-hidden="true">{item.n}</span><b>{item.label}</b></Link>
+              ><span aria-hidden="true">{item.icon}</span><b>{item.label}</b></Link>
               {item.items.length > 0 && <button
                 type="button"
                 className="workspaceSubToggle"
                 aria-label={isOpen ? "Згорнути підпункти":"Розгорнути підпункти"}
                 aria-expanded={isOpen}
-                onClick={()=>toggleModule(item.n)}
+                onClick={()=>toggleModule(item.href)}
               >▾</button>}
             </div>
             {isOpen && item.items.length > 0 && <div className="workspaceSubList">
-              {item.items.filter(childVisible).map((sub,i)=><Link key={i} href={sub.href} className="workspaceSubLink">{sub.label}</Link>)}
+              {item.items.map((sub,i)=><Link key={i} href={sub.href} className="workspaceSubLink">{sub.label}</Link>)}
             </div>}
           </div>;
         })}

--- a/tests/department-structure.test.mjs
+++ b/tests/department-structure.test.mjs
@@ -125,6 +125,6 @@ test("structure page is staff-gated and wired into the shell nav", async () => {
   assert.match(page, /href="\/staff\/tariffs"/);
   assert.doesNotMatch(page, /type="file"|onLogoFile/);
   const shell = await read("app/staff/workspace-shell.tsx");
-  assert.match(shell, /href="\/staff\/structure"/);
-  assert.match(shell, /Публічна вітрина/);
+  assert.match(shell, /href:"\/staff\/structure"/);
+  assert.match(shell, /Сайт і структура відділення/);
 });

--- a/tests/site-content.test.mjs
+++ b/tests/site-content.test.mjs
@@ -104,8 +104,7 @@ test("site content editor is a visual storefront with dedicated tariff navigatio
   assert.match(page, /Редагувати тарифи/);
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /href:"\/staff\/structure"/);
-  assert.match(shell, /Публічна вітрина/);
-  assert.match(shell, /Редактор публічного сайту/);
+  assert.match(shell, /Сайт і структура відділення/);
 });
 
 test("landing pulls storefront config from the API and gates on published", async () => {
@@ -182,5 +181,5 @@ test("visual storefront editor keeps appearance fixed and structure available be
   assert.doesNotMatch(page, /storefrontType/);
   assert.doesNotMatch(page, /type="color"|logoUrl|onLogoFile|type="file"/);
   const shell = await read("app/staff/workspace-shell.tsx");
-  assert.match(shell, /Редактор публічного сайту/);
+  assert.match(shell, /Сайт і структура відділення/);
 });


### PR DESCRIPTION
Повна перебудова бічної панелі робочого кабінету (за запитом «бери навігацію повністю на себе»), плюс виправлення двох видимих дефектів зі скріншота.

## Що змінено
- **Блок «Огляд» угорі** — найчастіші екрани реєстратури одразу під рукою: Пульт 🏠, Дошка прийому 📋, Календар записів 🗓️.
- **Модулі згруповано за напрямом роботи** з емодзі-піктограмами замість номерів: Пацієнти 👥, Дослідження 🩻, Кабінети й обладнання 🛠️, Фінанси і звіти 💳, Адміністрування ⚙️. Кожен модуль підсвічується для всіх своїх підрозділів (`sections`).
- **Редактор сайту + структуру** перенесено в модуль «Адміністрування» під підпис «Сайт і структура відділення».

## Виправлені дефекти (зі скріншота)
- **Обрізання підпису.** «Кабінети й обладнання» жорстко відрізалося (`a>b` мав `white-space:nowrap; overflow:hidden`). → Підпис модуля тепер переноситься в кілька рядків і видно повністю.
- **Активний бейдж невидимий.** На білому активному боксі бейдж лишався світло-teal → виглядав порожнім. → Активний бейдж тепер суцільний teal; піктограми-емодзі збільшено (24 px, 14 px) і читабельні.

## Чистка коду
- Прибрано мертвий код feature-flags: `flags`-стан, `childVisible`, fetch `/api/staff/org-profile` (залишок SaaS-конфігуратора, який ми прибрали раніше).

## Перевірено
- Рендер бічної панелі (headless Chromium): секції «Огляд»/«Модулі», емодзі чіткі, підписи повні, активний стан читається.
- 264 тести зелені; `next build`, `eslint`, `tsc --noEmit` — чисто. Тести навігації оновлено під нові підписи.