### PR TITLE
Пульт: дія передусім, доступ для всіх ролей, менше дублювання

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -250,7 +250,7 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 @media(max-width:600px){.equipmentRegistryHead{align-items:flex-start;flex-direction:column}.equipmentFields{grid-template-columns:1fr}.equipmentFields label.wide{grid-column:auto}.equipmentCard summary{grid-template-columns:34px minmax(0,1fr)}.equipmentCard summary em{grid-column:2;justify-self:start}}
 /* Пульт — компактна стрічка показників (замість великих блоків) */
 .dashToast{max-width:1500px;margin:0 auto 12px;padding:10px 14px;background:#e6f4ec;border:1px solid #bfe0cc;border-radius:10px;color:#1f5c39;font-size:13px;font-weight:600;cursor:pointer}
-.dashKpiStrip{max-width:1500px;margin:0 auto 14px;display:grid;grid-template-columns:repeat(6,1fr);gap:8px}
+.dashKpiStrip{max-width:1500px;margin:0 auto 14px;display:grid;grid-template-columns:repeat(5,1fr);gap:8px}
 .dashStat{display:block;padding:10px 12px;background:#fff;border:1px solid #e7ece9;border-radius:12px;transition:.15s}
 a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .dashStat>b{display:block;font-size:22px;font-weight:750;line-height:1;color:#1b211e;font-variant-numeric:tabular-nums}

--- a/app/globals.css
+++ b/app/globals.css
@@ -296,6 +296,28 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .dashCalendarHead{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
 .dashCalendarHead h2{font-size:16px;font-weight:750;margin:0}
 .dashCalNew{font-size:13px;font-weight:800;color:var(--green,#0c7a85)}
+.dashCalActions{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+.dashCalActions a{font-size:13px;font-weight:700;color:var(--green,#0c7a85);text-decoration:none}
+.dashCalActions a:hover{text-decoration:underline}
+.dashAgendaCount{display:inline-block;margin-left:6px;padding:1px 9px;border-radius:99px;background:#e6f4f5;border:1px solid #bfe0e3;color:#0a5f68;font-size:12px;font-weight:800;vertical-align:middle}
+.dashAgenda{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #e7ece9;border-radius:14px;overflow:hidden}
+.dashAgendaRow{display:flex;align-items:center;gap:12px;padding:10px 14px;border-top:1px solid #f0f3f1}
+.dashAgendaRow:first-child{border-top:0}
+.dashAgendaRow time{flex:none;width:52px;font-weight:800;font-size:13.5px;color:#123d3a;font-variant-numeric:tabular-nums}
+.dashAgendaWho{flex:1;min-width:0}
+.dashAgendaWho b{display:block;font-size:13.5px;color:#1b211e}
+.dashAgendaWho small{display:block;color:#7a8b88;font-size:11.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dashAgendaStatus{flex:none;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;padding:2px 9px;border-radius:20px;white-space:nowrap}
+.dashAgendaStatus.st-new{background:#fff4e2;color:#a5670f}
+.dashAgendaStatus.st-ok{background:#e6f4f5;color:#0a5f68}
+.dashAgendaStatus.st-done{background:#eaf5ea;color:#2f7d33}
+.dashAgendaStatus.st-off{background:#f2f2f2;color:#8a8a8a}
+.themeDark .dashAgenda{background:#121a20;border-color:#22303a}
+.themeDark .dashAgendaRow{border-top-color:#1b2731}
+.themeDark .dashAgendaRow time{color:#7fd4dc}
+.themeDark .dashAgendaWho b{color:#e6edf1}.themeDark .dashAgendaWho small{color:#8b98a1}
+.themeDark .dashCalActions a,.themeDark .dashAgendaCount{color:#7fd4dc}
+.themeDark .dashAgendaCount{background:#0e151a;border-color:#22303a}
 /* Дошка прийому заявок */
 .intakeBoard{display:grid;grid-template-columns:360px 1fr;gap:16px;max-width:1500px;margin:0 auto;align-items:start}
 .intakeQueue{background:#fff;border:1px solid #e7ece9;border-radius:14px;overflow:hidden;position:sticky;top:12px}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -86,12 +86,23 @@ export default function DashboardPage() {
       fetch("/api/staff/dashboard", { cache:"no-store" }),
       fetch("/api/staff/bookings", { cache:"no-store" }),
     ]);
-    const payload = await dashRes.json() as Data & { error?:string };
-    if (!dashRes.ok) { setError(payload.error || "Немає доступу"); return; }
-    setData(payload); setStaff(payload.staff || null); setError("");
-    const bookingsData = await bookingsRes.json().catch(() => ({})) as { bookings?:CalBooking[]; staffOptions?:CalStaffOption[] };
+    // Доступ визначаємо за заявками (доступні реєстратору й лікарям), а не за
+    // зведеною аналітикою, яка лише для адміністратора. Так Пульт лишається
+    // корисним для всіх ролей, а не блокується стіною «лише адмін».
+    const bookingsData = await bookingsRes.json().catch(() => ({})) as
+      { bookings?:CalBooking[]; staffOptions?:CalStaffOption[]; staff?:StaffInfo; error?:string };
+    if (!bookingsRes.ok || !bookingsData.staff) { setError(bookingsData.error || "Немає доступу"); return; }
+    setStaff(bookingsData.staff);
     setBookings(bookingsData.bookings || []);
     setOptions(bookingsData.staffOptions || []);
+    setError("");
+    // KPI-аналітика — лише для адміністратора; 403 тут не блокує Пульт.
+    if (dashRes.ok) {
+      const payload = await dashRes.json().catch(() => null) as Data | null;
+      if (payload?.kpi) setData(payload);
+    } else {
+      setData(null);
+    }
   }
 
   useEffect(() => {
@@ -141,55 +152,17 @@ export default function DashboardPage() {
     staffRole={staff ? roleLabels[staff.role] : undefined}
   >
     {error ? <section className="accessDenied"><b>Захищений розділ</b><p>{error}. Увійдіть через дозволений робочий обліковий запис.</p><a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Fdashboard">Увійти для роботи</a></section> :
-    !k ? <p className="dashLoading">Завантаження зведення…</p> :
+    !staff ? <p className="dashLoading">Завантаження зведення…</p> :
     <>
       {toast && <p className="dashToast" role="status" onClick={()=>setToast("")}>{toast}</p>}
 
-      {/* Компактна стрічка показників замість великих блоків */}
-      <div className="dashKpiStrip">
-        <a className="dashStat hero" href="/staff"><b>{k.scheduledToday}</b><span>сьогодні у розкладі</span><small>{k.newToday} нових · {k.confirmedToday} підтв.</small></a>
-        <a className="dashStat" href="/staff/protocols"><b className={k.awaitingProtocol?"warn":""}>{k.awaitingProtocol}</b><span>потребують протоколу</span><small>{k.readyToIssue} до видачі</small></a>
-        <a className="dashStat" href="/staff/imaging"><b className={k.needImaging?"warn":""}>{k.needImaging}</b><span>без знімків</span><small>{k.pacsEnabled?"PACS on":"PACS off"}</small></a>
-        <a className="dashStat" href="/staff/reports"><b className={k.outstandingCount?"warn":""}>{k.outstandingCount}</b><span>очікують оплати</span><small>{k.outstandingSum.toLocaleString("uk-UA")} грн</small></a>
-        <a className="dashStat" href="/staff/patients"><b>{k.patients}</b><span>пацієнтів</span><small>{k.repeatPatients} повторних</small></a>
-        <div className="dashStat equip">
-          <span>апарати сьогодні</span>
-          <div className="dashStatEquip">
-            {["ct","xray","fluoro"].map((id)=>{
-              const value = data?.equipmentToday.find((e)=>e.id===id)?.c || 0;
-              return <span key={id}><b>{value}</b>{equipmentNames[id]}</span>;
-            })}
-          </div>
-        </div>
-      </div>
-
-      {/* Завантаженість апаратів за 7 днів (сьогодні та 6 попередніх) */}
-      {data && <section className="dashLoad">
-        <div className="dashListHead"><h3>Завантаженість апаратів · 7 днів</h3><span>{data.weekStart} — {data.today}</span></div>
-        {(() => {
-          const days:string[] = [];
-          for (let i = 6; i >= 0; i--) { const dt = new Date(`${data.today}T12:00:00Z`); dt.setUTCDate(dt.getUTCDate() - i); days.push(dt.toISOString().slice(0,10)); }
-          const at = (id:string, d:string) => data.equipmentWeek.find((e)=>e.id===id && e.d===d)?.c || 0;
-          const peak = Math.max(1, ...data.equipmentWeek.filter((e)=>["ct","xray","fluoro"].includes(e.id)).map((e)=>e.c));
-          const dow = (d:string) => ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"][new Date(`${d}T12:00:00Z`).getUTCDay()];
-          return <div className="dashLoadGrid" style={{ gridTemplateColumns:`120px repeat(${days.length}, 1fr)` }}>
-            <span className="dashLoadCorner" />
-            {days.map((d)=><span key={d} className={`dashLoadDay${d===data.today?" today":""}`}>{dow(d)}<small>{d.slice(8,10)}.{d.slice(5,7)}</small></span>)}
-            {["ct","xray","fluoro"].map((id)=><Fragment key={id}>
-              <span className="dashLoadRow">{equipmentNames[id]}</span>
-              {days.map((d)=>{ const v = at(id,d); return <span key={d} className="dashLoadCell" title={`${equipmentNames[id]} · ${d}: ${v}`}>
-                <i style={{ height:`${Math.round((v/peak)*100)}%` }} className={v?"":"empty"} /><b>{v||""}</b>
-              </span>; })}
-            </Fragment>)}
-          </div>;
-        })()}
-      </section>}
-
-      {/* Нові заявки: миготять, доки не підтвердять; підтвердження одним кліком */}
+      {/* Дія передусім: нові заявки миготять, доки їх не підтвердять; підтвердження одним кліком. */}
       <section className="dashPending">
         <div className="dashPendingHead">
           <h2>Нові заявки {pending.length ? <span className="dashPendingBadge">{pending.length}</span> : null}</h2>
-          <small>Натисніть «Підтвердити» — пацієнту одразу піде повідомлення у WhatsApp.</small>
+          <small>{canManage
+            ? "Натисніть «Підтвердити» — пацієнту одразу піде повідомлення у WhatsApp."
+            : "Заявки, що очікують підтвердження реєстратури."}</small>
         </div>
         {pending.length === 0
           ? <p className="dashListEmpty">Нових непідтверджених заявок немає — усе опрацьовано.</p>
@@ -212,13 +185,44 @@ export default function DashboardPage() {
             </ul>}
       </section>
 
+      {/* Зведені показники — лише для адміністратора (аналітика по відділенню). */}
+      {k && <div className="dashKpiStrip">
+        <a className="dashStat hero" href="/staff/appointments"><b>{k.scheduledToday}</b><span>сьогодні у розкладі</span><small>{k.newToday} нових · {k.confirmedToday} підтв.</small></a>
+        <a className="dashStat" href="/staff/protocols"><b className={k.awaitingProtocol?"warn":""}>{k.awaitingProtocol}</b><span>потребують протоколу</span><small>{k.readyToIssue} до видачі</small></a>
+        <a className="dashStat" href="/staff/imaging"><b className={k.needImaging?"warn":""}>{k.needImaging}</b><span>без знімків</span><small>{k.pacsEnabled?"PACS активний":"PACS вимкнено"}</small></a>
+        <a className="dashStat" href="/staff/reports"><b className={k.outstandingCount?"warn":""}>{k.outstandingCount}</b><span>очікують оплати</span><small>{k.outstandingSum.toLocaleString("uk-UA")} грн</small></a>
+        <a className="dashStat" href="/staff/patients"><b>{k.patients}</b><span>пацієнтів</span><small>{k.repeatPatients} повторних</small></a>
+      </div>}
+
       {/* Об'єднаний календар записів прямо в пульті */}
       <section className="dashCalendar">
         <div className="dashCalendarHead"><h2>Розклад</h2><a href="/staff/book" className="dashCalNew">+ Записати пацієнта</a></div>
         <WeekCalendar bookings={bookings} options={options} initialView="week" />
       </section>
 
-      {data?.clinicalQueue?.length ? <a className="dashQueue" href="/staff/studies" aria-label="Відкрити реєстр досліджень">
+      {/* Завантаженість апаратів за 7 днів (сьогодні та 6 попередніх) — адмін-аналітика */}
+      {k && data && <section className="dashLoad">
+        <div className="dashListHead"><h3>Завантаженість апаратів · 7 днів</h3><span>{data.weekStart} — {data.today}</span></div>
+        {(() => {
+          const days:string[] = [];
+          for (let i = 6; i >= 0; i--) { const dt = new Date(`${data.today}T12:00:00Z`); dt.setUTCDate(dt.getUTCDate() - i); days.push(dt.toISOString().slice(0,10)); }
+          const at = (id:string, d:string) => data.equipmentWeek.find((e)=>e.id===id && e.d===d)?.c || 0;
+          const peak = Math.max(1, ...data.equipmentWeek.filter((e)=>["ct","xray","fluoro"].includes(e.id)).map((e)=>e.c));
+          const dow = (d:string) => ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"][new Date(`${d}T12:00:00Z`).getUTCDay()];
+          return <div className="dashLoadGrid" style={{ gridTemplateColumns:`120px repeat(${days.length}, 1fr)` }}>
+            <span className="dashLoadCorner" />
+            {days.map((d)=><span key={d} className={`dashLoadDay${d===data.today?" today":""}`}>{dow(d)}<small>{d.slice(8,10)}.{d.slice(5,7)}</small></span>)}
+            {["ct","xray","fluoro"].map((id)=><Fragment key={id}>
+              <span className="dashLoadRow">{equipmentNames[id]}</span>
+              {days.map((d)=>{ const v = at(id,d); return <span key={d} className="dashLoadCell" title={`${equipmentNames[id]} · ${d}: ${v}`}>
+                <i style={{ height:`${Math.round((v/peak)*100)}%` }} className={v?"":"empty"} /><b>{v||""}</b>
+              </span>; })}
+            </Fragment>)}
+          </div>;
+        })()}
+      </section>}
+
+      {k && data?.clinicalQueue?.length ? <a className="dashQueue" href="/staff/studies" aria-label="Відкрити реєстр досліджень">
         <div className="dashQueueHead"><b>Клінічна черга</b><small>Активні стани дослідження · відкрити реєстр →</small></div>
         <div className="dashQueueRow">
           {data.clinicalQueue.map((q)=><div key={q.v} className="dashQueueCell">
@@ -227,17 +231,17 @@ export default function DashboardPage() {
         </div>
       </a> : null}
 
-      <div className="dashLists">
-        <ActionList title="Потребують протоколу" items={data!.lists.needProtocol}
+      {k && data && <div className="dashLists">
+        <ActionList title="Потребують протоколу" items={data.lists.needProtocol}
           hint="Виконані дослідження без готового висновку" empty="Усі виконані дослідження мають протокол."
           href={(item)=>`/staff/protocols?open=${item.id}`}/>
-        <ActionList title="Готові до видачі" items={data!.lists.readyToIssue}
+        <ActionList title="Готові до видачі" items={data.lists.readyToIssue}
           hint="Протокол готовий — лишилось видати пацієнту" empty="Немає протоколів, що очікують видачі."
           href={(item)=>`/staff/protocols?open=${item.id}`}/>
-        <ActionList title="Без прив’язки знімків" items={data!.lists.needImaging}
+        <ActionList title="Без прив’язки знімків" items={data.lists.needImaging}
           hint="Виконані дослідження без DICOM-студії" empty="Усі дослідження прив’язані до знімків."
           href={(item)=>`/staff/imaging?open=${item.id}`}/>
-      </div>
+      </div>}
       <ExternalCalendar/>
     </>}
   </StaffWorkspaceShell>;

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
-import WeekCalendar, { type CalBooking, type CalStaffOption } from "../week-calendar";
+import { type CalBooking } from "../week-calendar";
 
 type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer";
 type StaffInfo = { email:string; displayName:string; role:StaffRole };
@@ -30,6 +30,19 @@ const roleLabels: Record<StaffRole,string> = {
   radiologist:"Лікар-рентгенолог", radiographer:"Рентгенолаборант",
 };
 const equipmentNames: Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
+
+// Компактний статус запису для агенди «на сьогодні».
+const STATUS_UK: Record<string,string> = {
+  new:"нова", rescheduled:"перенесено", confirmed:"підтв.", queued:"у черзі",
+  in_progress:"виконується", images_ready:"є знімки", reporting:"опис",
+  protocol_ready:"протокол", completed:"завершено", performed:"виконано",
+};
+function statusGroup(s:string) {
+  if (s === "new" || s === "rescheduled") return "new";
+  if (s === "confirmed") return "ok";
+  if (s === "cancelled") return "off";
+  return "done";
+}
 
 function ActionList({ title, items, hint, href, empty }:{
   title:string; items:ListItem[]; hint:string; href:(item:ListItem)=>string; empty:string;
@@ -75,7 +88,6 @@ function ExternalCalendar() {
 export default function DashboardPage() {
   const [data,setData] = useState<Data | null>(null);
   const [bookings,setBookings] = useState<CalBooking[]>([]);
-  const [options,setOptions] = useState<CalStaffOption[]>([]);
   const [staff,setStaff] = useState<StaffInfo | null>(null);
   const [error,setError] = useState("");
   const [toast,setToast] = useState("");
@@ -90,11 +102,10 @@ export default function DashboardPage() {
     // зведеною аналітикою, яка лише для адміністратора. Так Пульт лишається
     // корисним для всіх ролей, а не блокується стіною «лише адмін».
     const bookingsData = await bookingsRes.json().catch(() => ({})) as
-      { bookings?:CalBooking[]; staffOptions?:CalStaffOption[]; staff?:StaffInfo; error?:string };
+      { bookings?:CalBooking[]; staff?:StaffInfo; error?:string };
     if (!bookingsRes.ok || !bookingsData.staff) { setError(bookingsData.error || "Немає доступу"); return; }
     setStaff(bookingsData.staff);
     setBookings(bookingsData.bookings || []);
-    setOptions(bookingsData.staffOptions || []);
     setError("");
     // KPI-аналітика — лише для адміністратора; 403 тут не блокує Пульт.
     if (dashRes.ok) {
@@ -143,6 +154,14 @@ export default function DashboardPage() {
   }
 
   const k = data?.kpi;
+
+  // Розклад на сьогодні (Київ). Пульт дає лише короткий огляд — повний
+  // тижневий календар живе в окремому розділі «Календар записів».
+  const today = data?.today || new Intl.DateTimeFormat("en-CA", { timeZone:"Europe/Kyiv" }).format(new Date());
+  const todayAgenda = useMemo(() => bookings
+    .filter(b => b.desiredDate === today && b.status !== "cancelled")
+    .sort((a, b) => (a.desiredTime || "").localeCompare(b.desiredTime || "")),
+  [bookings, today]);
 
   return <StaffWorkspaceShell
     active="dashboard"
@@ -194,10 +213,27 @@ export default function DashboardPage() {
         <a className="dashStat" href="/staff/patients"><b>{k.patients}</b><span>пацієнтів</span><small>{k.repeatPatients} повторних</small></a>
       </div>}
 
-      {/* Об'єднаний календар записів прямо в пульті */}
+      {/* Короткий розклад на сьогодні; повний тижневий — у «Календарі записів». */}
       <section className="dashCalendar">
-        <div className="dashCalendarHead"><h2>Розклад</h2><a href="/staff/book" className="dashCalNew">+ Записати пацієнта</a></div>
-        <WeekCalendar bookings={bookings} options={options} initialView="week" />
+        <div className="dashCalendarHead">
+          <h2>Розклад на сьогодні {todayAgenda.length ? <span className="dashAgendaCount">{todayAgenda.length}</span> : null}</h2>
+          <div className="dashCalActions">
+            <a href="/staff/appointments">Календар записів →</a>
+            <a href="/staff/book" className="dashCalNew">+ Записати пацієнта</a>
+          </div>
+        </div>
+        {todayAgenda.length === 0
+          ? <p className="dashListEmpty">На сьогодні записів немає.</p>
+          : <ul className="dashAgenda">
+              {todayAgenda.map(b => <li key={b.id} className="dashAgendaRow">
+                <time>{b.desiredTime || "—"}</time>
+                <div className="dashAgendaWho">
+                  <b>{b.name || "Без імені"}</b>
+                  <small>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}</small>
+                </div>
+                <span className={`dashAgendaStatus st-${statusGroup(b.status)}`}>{STATUS_UK[b.status] || b.status}</span>
+              </li>)}
+            </ul>}
       </section>
 
       {/* Завантаженість апаратів за 7 днів (сьогодні та 6 попередніх) — адмін-аналітика */}

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -33,9 +33,14 @@ test("appointments page renders the shared calendar in the staff shell", async (
   assert.match(shell, /Календар записів/);
 });
 
-test("dashboard merges the calendar and a one-click confirm queue", async () => {
+test("dashboard shows a compact today agenda and a one-click confirm queue", async () => {
   const dash = await read("app/staff/dashboard/page.tsx");
-  assert.match(dash, /WeekCalendar/); // календар вбудований у пульт
+  // Повний тижневий календар живе в окремому розділі; пульт дає короткий
+  // огляд «на сьогодні» + перехід у «Календар записів».
+  assert.doesNotMatch(dash, /WeekCalendar/);
+  assert.match(dash, /Розклад на сьогодні/);
+  assert.match(dash, /dashAgenda/);
+  assert.match(dash, /href="\/staff\/appointments"/);
   assert.match(dash, /dashKpiStrip/); // компактні картки замість великих блоків
   assert.match(dash, /dashPending/); // черга нових заявок
   assert.match(dash, /confirm:true/); // підтвердження одним кліком


### PR DESCRIPTION
Аналіз і покращення сторінки `/staff/dashboard` (Пульт) — щоб була зручною для щоденної роботи, а не лише для адміністратора.

## Знайдені недоліки → виправлення

**1. Реєстратора було заблоковано (найважливіше).** `/api/staff/dashboard` віддає `403` усім, крім адміністратора, — а «Пульт» це **перший** пункт навігації для всіх. Реєстратор (головний щоденний користувач) бачив лише стіну «Захищений розділ».
→ Доступ тепер визначає ендпоінт заявок (доступний реєстратору й лікарям). Зведена аналітика лишається адмінською, але **більше не блокує весь екран** — операційні секції показуються всім ролям.

**2. Дія стояла нижче за аналітику.** Миготливі «Нові заявки» були аж 3-ю секцією — під KPI-стрічкою і 7-денним графіком.
→ «Нові заявки» піднято на **самий верх** — це головна дія реєстратури.

**3. Апарати дублювалися.** Міні-плитка «апарати сьогодні» повторювала дані 7-денного хітмепа.
→ Дубль-плитку прибрано; KPI-стрічку вирівняно на 5 колонок.

**4. Повний календар дублював окремий розділ.** У Пульт було вбудовано весь тижневий `WeekCalendar`, що повторював розділ «Календар записів» і робив сторінку важкою.
→ Замість нього — **компактна агенда «Розклад на сьогодні»** (час · пацієнт · послуга · статус) з переходом у повний «Календар записів».

**5. Англійська в інтерфейсі.** «PACS on / PACS off» → «PACS активний / PACS вимкнено».

**6. Дрібне.** Hero-плитка «сьогодні у розкладі» вела на стару чергу `/staff` → тепер на `/staff/appointments`.

## Порядок секцій тепер
Нові заявки (дія) → показники (адмін) → Розклад на сьогодні → навантаження апаратів / клінічна черга / списки дій (адмін) → зовнішній календар.

## Перевірено
Рендер-моки (headless Chromium) — дія-першою розкладка + компактна агенда. `tsc --noEmit`, `eslint`, `next build` — чисто; 264 тести зелені (тест пульта оновлено під нову агенду).