### PR TITLE
Реєстр досліджень: пошук, фільтр за апаратом, інлайн-помилки

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1327,6 +1327,18 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .studiesOrgBar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;max-width:1500px;margin:0 auto 16px}
 .studiesOrgBadge{display:inline-flex;align-items:center;gap:8px;padding:7px 13px;border-radius:999px;background:var(--ws-soft);color:var(--ws-deep);font-size:12px;font-weight:800;border:1px solid rgba(12,122,133,.28)}
 .studiesOrgBar small{color:#5f716d;font-size:12px}
+.studiesToolbar{display:flex;flex-wrap:wrap;align-items:center;gap:10px;max-width:1500px;margin:0 auto 14px}
+.studiesToolbar .studiesSearch{flex:1;min-width:220px;padding:10px 13px;border:1px solid #cbd8d6;border-radius:9px;font:inherit}
+.studiesToolbar select{padding:10px 12px;border:1px solid #cbd8d6;border-radius:9px;font:inherit;color:var(--ink)}
+.studiesToolbar input:focus,.studiesToolbar select:focus{outline:2px solid var(--ws-accent,#0c7a85);outline-offset:1px;border-color:var(--ws-accent,#0c7a85)}
+.studiesClear{padding:9px 13px;border:1px solid #d6ded9;border-radius:9px;background:#f7faf9;color:#41544f;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
+.studiesClear:hover{border-color:var(--ws-accent,#0c7a85);color:var(--ws-accent,#0c7a85)}
+.studiesResultCount{margin-left:auto;color:#5f716d;font-size:12px;font-weight:700;font-variant-numeric:tabular-nums}
+.studiesTrunc{max-width:1500px;margin:12px auto 0;padding:10px 14px;background:#fff7ec;border:1px solid #f0dcb6;border-radius:10px;color:#8a5a12;font-size:12px}
+.themeDark .studiesToolbar .studiesSearch,.themeDark .studiesToolbar select{background:#0e151a;border-color:#22303a;color:#e6edf1}
+.themeDark .studiesClear{background:#0e151a;border-color:#22303a;color:#9fb0bb}
+.themeDark .studiesResultCount{color:#8b98a1}
+.themeDark .studiesTrunc{background:#22190e;border-color:#3a2c15;color:#e0b877}
 .studiesTabs{display:flex;flex-wrap:wrap;gap:8px;max-width:1500px;margin:0 auto 16px}
 .studiesTabs button{display:inline-flex;align-items:center;gap:7px;padding:8px 13px;border:1px solid #d6ded9;border-radius:999px;background:#f7faf9;color:#41544f;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer;transition:border-color .12s,background .12s,color .12s}
 .studiesTabs button:hover{border-color:var(--ws-accent);color:var(--ws-accent)}

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -44,6 +44,9 @@ export default function StudiesPage() {
   const [staff,setStaff] = useState<StaffInfo|null>(null);
   const [error,setError] = useState("");
   const [filter,setFilter] = useState("all");
+  const [equipment,setEquipment] = useState("all");
+  const [query,setQuery] = useState("");
+  const [notice,setNotice] = useState("");
   const [busy,setBusy] = useState(0);
 
   async function load() {
@@ -62,7 +65,7 @@ export default function StudiesPage() {
 
   async function transition(id:number, status:string) {
     if (!status) return;
-    setBusy(id);
+    setBusy(id); setNotice("");
     try {
       const response = await fetch("/api/staff/bookings", {
         method:"PATCH", headers:{"content-type":"application/json"},
@@ -70,10 +73,12 @@ export default function StudiesPage() {
       });
       if (!response.ok) {
         const payload = await response.json().catch(()=>({})) as { error?:string };
-        window.alert(payload.error || "Не вдалося змінити стан");
+        setNotice(payload.error || "Не вдалося змінити стан");
       } else {
         await load();
       }
+    } catch {
+      setNotice("Помилка мережі — спробуйте ще раз");
     } finally {
       setBusy(0);
     }
@@ -82,7 +87,7 @@ export default function StudiesPage() {
   // Призначення виконавця: reg/admin шлють оновлення на той самий PATCH
   // /api/staff/bookings, що валідує роль виконавця й фіксує подію.
   async function assign(study:Study, field:"radiologist"|"radiographer", email:string) {
-    setBusy(study.id);
+    setBusy(study.id); setNotice("");
     try {
       const body = field === "radiologist"
         ? { id:study.id, assignedRadiologistEmail:email, assignedRadiographerEmail:study.assignedRadiographerEmail }
@@ -93,10 +98,12 @@ export default function StudiesPage() {
       });
       if (!response.ok) {
         const payload = await response.json().catch(()=>({})) as { error?:string };
-        window.alert(payload.error || "Не вдалося призначити виконавця");
+        setNotice(payload.error || "Не вдалося призначити виконавця");
       } else {
         await load();
       }
+    } catch {
+      setNotice("Помилка мережі — спробуйте ще раз");
     } finally {
       setBusy(0);
     }
@@ -104,8 +111,13 @@ export default function StudiesPage() {
 
   const visible = useMemo(() => {
     if (!data) return [];
-    return filter === "all" ? data.studies : data.studies.filter((s)=>s.status===filter);
-  }, [data, filter]);
+    const q = query.trim().toLowerCase();
+    return data.studies.filter((s)=>
+      (filter === "all" || s.status === filter)
+      && (equipment === "all" || s.equipmentId === equipment)
+      && (!q || `${s.code} ${s.name} ${s.service}`.toLowerCase().includes(q)),
+    );
+  }, [data, filter, equipment, query]);
 
   const activeStates = useMemo(
     () => (data?.states || []).filter((s)=>s.count > 0),
@@ -131,6 +143,18 @@ export default function StudiesPage() {
         <small>{data.profile?.label ? `${data.profile.label} · ` : ""}{data.studies.length} досліджень · роль: {roleLabels[data.role]}{data.canManage ? "" : " · лише перегляд"}</small>
       </div>
 
+      {notice && <p className="staffError" role="alert" onClick={()=>setNotice("")}>{notice}</p>}
+
+      <div className="studiesToolbar">
+        <input type="search" className="studiesSearch" value={query} onChange={(e)=>setQuery(e.target.value)} placeholder="Пошук: код, пацієнт, дослідження" aria-label="Пошук досліджень"/>
+        <select value={equipment} onChange={(e)=>setEquipment(e.target.value)} aria-label="Апарат">
+          <option value="all">Усі апарати</option>
+          <option value="ct">КТ</option><option value="xray">Рентген</option><option value="fluoro">Флюорограф</option>
+        </select>
+        {(query || equipment!=="all" || filter!=="all") && <button type="button" className="studiesClear" onClick={()=>{setQuery("");setEquipment("all");setFilter("all");}}>Скинути</button>}
+        <span className="studiesResultCount">Показано: {visible.length}</span>
+      </div>
+
       <div className="studiesTabs" role="tablist" aria-label="Фільтр за станом">
         <button type="button" role="tab" aria-selected={filter==="all"}
           className={filter==="all"?"active":""} onClick={()=>setFilter("all")}>
@@ -142,7 +166,7 @@ export default function StudiesPage() {
         </button>)}
       </div>
 
-      {visible.length === 0 ? <p className="dashListEmpty">У цьому стані досліджень немає.</p> :
+      {visible.length === 0 ? <p className="dashListEmpty">{query || equipment!=="all" ? "За цим запитом досліджень не знайдено." : "У цьому стані досліджень немає."}</p> :
       <div className="studiesTableWrap">
         <table className="studiesTable">
           <thead><tr>
@@ -193,6 +217,8 @@ export default function StudiesPage() {
           </tbody>
         </table>
       </div>}
+
+      {data.studies.length >= 500 && <p className="studiesTrunc">Показано найновіші 500 досліджень. Старіші поки не відображаються — уточніть пошук або стан.</p>}
     </>}
   </StaffWorkspaceShell>;
 }

--- a/tests/studies-registry.test.mjs
+++ b/tests/studies-registry.test.mjs
@@ -67,6 +67,20 @@ test("studies page renders a transition-aware, tenant-scoped registry", async ()
   assert.match(page, /data\.canManage/);
 });
 
+test("studies registry has search, equipment filter and inline errors (no alert)", async () => {
+  const page = await read("app/staff/studies/page.tsx");
+  // Пошук за кодом/пацієнтом/послугою.
+  assert.match(page, /studiesSearch/);
+  assert.match(page, /`\$\{s\.code\} \$\{s\.name\} \$\{s\.service\}`\.toLowerCase\(\)\.includes/);
+  // Фільтр за апаратом.
+  assert.match(page, /equipment === "all" \|\| s\.equipmentId === equipment/);
+  // Помилки — інлайн, а не системний alert.
+  assert.doesNotMatch(page, /window\.alert/);
+  assert.match(page, /setNotice/);
+  // Позначка обрізання на межі 500.
+  assert.match(page, /studies\.length >= 500/);
+});
+
 // Робочий shell інтегрує реєстр досліджень.
 test("workspace shell wires the studies registry", async () => {
   const shell = await read("app/staff/workspace-shell.tsx");


### PR DESCRIPTION
Аналіз і функціональні покращення сторінки `/staff/studies` (Реєстр досліджень).

## Знайдені недоліки → виправлення

**1. Немає пошуку (найбільша прогалина).** Реєстр показував до 500 досліджень із фільтром лише за станом — знайти конкретного пацієнта/код/послугу можна було тільки гортанням.
→ Додано **пошук** за кодом, ПІБ пацієнта і назвою дослідження.

**2. Немає фільтра за апаратом.**
→ Додано **фільтр КТ / Рентген / Флюорограф**, який комбінується з фільтром стану, + кнопка **«Скинути»** і лічильник **«Показано: N»**.

**3. Помилки через `window.alert`.** Невдалий перехід стану чи призначення виконавця показувалися системним попапом.
→ Тепер помилки — **інлайн-банер** у сторінці (плюс обробка помилок мережі).

**4. Тихе обрізання на 500.** Якщо досліджень більше — старіші зникали без жодної позначки.
→ Додано **чесну позначку** «Показано найновіші 500 досліджень…» на межі.

## Перевірено
Рендер-мок реєстру (headless Chromium): панель пошуку/фільтра/лічильника над вкладками станів. `tsc --noEmit`, `eslint`, `next build` — чисто; 267 тестів зелені (додано покриття пошуку/фільтра/інлайн-помилок).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_