### PR TITLE
Бічна панель: акордеон — менше кнопок одразу

### DIFF
--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -21,7 +21,7 @@ type StaffWorkspaceShellProps = {
 type NavChild = { label:string; href:string };
 type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
 // section — головний розділ модуля; sections — усі розділи, що його підсвічують.
-type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; defaultOpen?:boolean; items:NavChild[] };
+type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
 // Швидкий доступ: найчастіші екрани реєстратури — угорі, з піктограмами.
 const overview: NavLink[] = [
@@ -50,14 +50,13 @@ const systemModules: NavModule[] = [
     { label:"Звіти відділення", href:"/staff/reports" },
     { label:"Тарифи", href:"/staff/tariffs" },
   ]},
-  { label:"Адміністрування", href:"/staff/settings", sections:["settings","structure","organization","whatsapp","audit"], icon:"⚙️", defaultOpen:false, items:[
+  { label:"Адміністрування", href:"/staff/settings", sections:["settings","structure","organization","whatsapp","audit"], icon:"⚙️", items:[
+    { label:"Налаштування", href:"/staff/settings" },
     { label:"Сайт і структура відділення", href:"/staff/structure" },
     { label:"Організація та профіль", href:"/staff/organization" },
     { label:"Персонал і ролі", href:"/staff#staff-admin" },
-    { label:"WhatsApp", href:"/staff/whatsapp" },
+    { label:"WhatsApp і чат-бот", href:"/staff/whatsapp" },
     { label:"Журнал дій", href:"/staff/audit" },
-    { label:"Реєстрація працівника", href:"/staff/register" },
-    { label:"Налаштування", href:"/staff/settings" },
   ]},
 ];
 
@@ -141,7 +140,9 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = item.sections.includes(active);
-          const isOpen = openModules[item.href] ?? item.defaultOpen ?? true;
+          // Акордеон: типово розгорнутий лише модуль поточного розділу, решта
+          // згорнуті в один рядок. Користувач може розгортати вручну.
+          const isOpen = openModules[item.href] ?? isActive;
           return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">
               <Link


### PR DESCRIPTION
За зауваженням «на бічній панелі забагато кнопок, об'єднай».

## Що змінено
- **Акордеон замість усіх розгорнутих модулів.** Раніше всі 5 модулів були розгорнуті одночасно — на панелі одразу висіло ~25 пунктів. Тепер модулі згорнуті в один рядок, а розгортається **лише той модуль, у якому ти зараз** (решта — за кліком по стрілці). Видимих кнопок стало ~11 замість ~25.
- **Прибрано зайвий пункт** «Реєстрація працівника» — він вів на глухий екран (самостійну реєстрацію вимкнено, акаунти створює адміністратор у «Персонал і ролі»). Об'єднано підписи в «Адмініструванні» (WhatsApp → «WhatsApp і чат-бот»).
- Уся функціональність збережена — жодного розділу не втрачено, лише згорнуто.

## Перевірено
Рендер-мок бічної панелі (headless Chromium): активний модуль розгорнутий, решта в один рядок. `tsc --noEmit`, `eslint`, `next build` — чисто; 272 тести зелені.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_