### PR TITLE
fix(ci): підняти nanoid до ≥3.3.17 — розблокувати CI й деплой

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7991,9 +7991,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "wrangler": "4.92.0"
   },
   "overrides": {
+    "nanoid": "^3.3.17",
     "next": {
       "postcss": "8.5.25",
       "sharp": "0.35.3"


### PR DESCRIPTION
## Проблема
Після мержу #107 **CI (#343) і Deploy (#68) на `main` впали** на кроці `npm audit --omit=dev --audit-level=high`:

```
nanoid  <3.3.17
Severity: high
GHSA-2v37-7h3g-55p8 — custom generators can loop indefinitely when size is zero
```

Це **не пов'язано з кодом #107** — нова advisory для `nanoid` опублікована після того, як CI на гілці був зелений. `nanoid` приходить транзитивно через `postcss`. Деплой падав на цьому ж кроці й **не доходив до Cloudflare**.

## Виправлення
Додано top-level override `"nanoid": "^3.3.17"` → у lock тепер **3.3.18**.
- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities**
- Зміна мінімальна: `package.json` +1 рядок, `package-lock.json` 3 рядки; жодних побічних апгрейдів (next/react/postcss/vite без змін).

## Перевірено
`next build`, `eslint` — чисто; **274 тести** зелені.

Після мержу цього PR деплой (Actions → Deploy → `DEPLOY`) пройде крок audit і викотить накопичене (#106 акордеон-панель, #107 шаблони + маркетинг прайсу).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_