### PR TITLE
Пульт як Mission Control — «хто наступний», а не інфопанель

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -275,6 +275,55 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .dashStat.equip>span{margin-bottom:6px}.dashStatEquip{display:flex;gap:6px}.dashStatEquip>span{flex:1;text-align:center;font-size:9.5px;font-weight:800;text-transform:uppercase;color:#71807c}.dashStatEquip b{display:block;font-size:16px;color:#123d3a;font-weight:750}
 @media(max-width:1000px){.dashKpiStrip{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:620px){.dashKpiStrip{grid-template-columns:repeat(2,1fr)}}
+/* Пульт як «місія»: головні числа дня в один рядок */
+.dashMc{max-width:1500px;margin:0 auto 16px;display:grid;grid-template-columns:repeat(5,1fr);gap:10px}
+.dashMcItem{display:flex;flex-direction:column;gap:2px;padding:12px 14px;border-radius:14px;text-decoration:none;background:#fff;border:1px solid #e7ece9;border-left:5px solid #cbd5d1;transition:.15s}
+.dashMcItem:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(20,40,35,.08)}
+.dashMcItem b{font-size:26px;font-weight:800;line-height:1;color:#1b211e;font-variant-numeric:tabular-nums}
+.dashMcItem span{font-size:12px;font-weight:750;color:#697873;text-transform:uppercase;letter-spacing:.03em}
+.dashMcItem.red{border-left-color:#dc4b3e}.dashMcItem.red b{color:#c33a2e}
+.dashMcItem.orange{border-left-color:#e08a1e}.dashMcItem.orange b{color:#b5761a}
+.dashMcItem.green{border-left-color:#2f9e44}.dashMcItem.green b{color:#2f7d33}
+.dashMcItem.blue{border-left-color:#2f7db0}.dashMcItem.blue b{color:#256291}
+.dashMcItem.violet{border-left-color:#7048c4}.dashMcItem.violet b{color:#5a37a3}
+@media(max-width:1000px){.dashMc{grid-template-columns:repeat(3,1fr)}}
+@media(max-width:620px){.dashMc{grid-template-columns:repeat(2,1fr)}.dashMcItem b{font-size:22px}}
+/* Нові заявки — картки (TickTick-стиль) */
+.dashCards{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:10px}
+.dashCard{display:flex;flex-direction:column;gap:5px;padding:12px 13px;border:1px solid #f0d9b6;background:#fffaf1;border-radius:12px;animation:dashBlink 1.8s ease-in-out infinite}
+.dashCard:hover{animation-play-state:paused}
+.dashCard.rescheduled{border-color:#c4dcef;background:#f4f9fd}
+.dashCardTop{display:flex;flex-wrap:wrap;gap:6px;align-items:center}
+.dashCardTag{font-size:10.5px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;padding:2px 9px;border-radius:20px;background:#f7e4c4;color:#a5670f}
+.dashCardTag.rescheduled{background:#d8ebfa;color:#256291}
+.dashCardFlag{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.03em;padding:2px 8px;border-radius:20px;background:#eae2fb;color:#5a37a3}
+.dashCardFlag.pay{background:#fde3e0;color:#b5352a}
+.dashCardName{font-size:15px;font-weight:750;color:#1b211e}
+.dashCardSvc{font-size:12.5px;color:#5c6b67}
+.dashCardWhen{font-size:12px;font-weight:700;color:#123d3a;font-variant-numeric:tabular-nums}
+.dashCardActions{display:flex;gap:6px;margin-top:6px;flex-wrap:wrap}
+.dashCardBtn{flex:none;min-height:36px;display:inline-flex;align-items:center;justify-content:center;padding:0 12px;border:1px solid #d8e0dd;border-radius:8px;background:#fff;color:#25332f;font-weight:800;font-size:12.5px;text-decoration:none;cursor:pointer;white-space:nowrap}
+.dashCardBtn:hover{border-color:#bcc9c4}
+.dashCardBtn.wa{background:#e8f6ec;border-color:#bfe3c9;color:#1c7a3a}
+.dashCardBtn.ok{flex:1;border:0;background:var(--green,#0c7a85);color:#fff}
+.dashCardBtn.ok:hover:not(:disabled){background:#0a4b42}.dashCardBtn.ok:disabled{opacity:.55;cursor:progress}
+.dashCardBtn.wait{flex:1;background:#f2f2f2;border:0;color:#8a8a8a}
+/* Швидкі фільтри розкладу */
+.dashChips{display:flex;flex-wrap:wrap;gap:7px;margin-bottom:10px}
+.dashChip{display:inline-flex;align-items:center;gap:6px;padding:6px 13px;border:1px solid #d8e0dd;border-radius:99px;background:#fff;color:#3a4a45;font-size:12.5px;font-weight:750;cursor:pointer;transition:.12s}
+.dashChip:hover{border-color:#bcc9c4}
+.dashChip.on{background:#123d3a;border-color:#123d3a;color:#fff}
+.dashChip i{font-style:normal;font-size:11px;font-weight:800;padding:0 6px;border-radius:99px;background:#eef3f1;color:#5c6b67}
+.dashChip.on i{background:rgba(255,255,255,.22);color:#fff}
+.dashAgendaFlag{flex:none;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.03em;padding:2px 8px;border-radius:20px;background:#eae2fb;color:#5a37a3}
+.dashAgendaFlag.pay{background:#fde3e0;color:#b5352a}
+/* Аналітика — нижче агенди */
+.dashAnalytics{max-width:1500px;margin:26px auto 0;border-top:1px solid #e7ece9;padding-top:18px}
+.dashAnalyticsHead{font-size:14px;font-weight:800;text-transform:uppercase;letter-spacing:.05em;color:#8a9995;margin:0 auto 14px}
+.themeDark .dashMcItem,.themeDark .dashChip{background:#121a20;border-color:#22303a;color:#cdd9df}
+.themeDark .dashMcItem b{color:#e6edf1}
+.themeDark .dashChip.on{background:#2aa198;border-color:#2aa198;color:#08201f}
+.themeDark .dashAnalytics{border-top-color:#22303a}
 /* Пульт — нові заявки з миготінням і підтвердженням у 1 клік */
 .dashLoad{max-width:1500px;margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:14px;padding:16px}
 .dashLoadGrid{display:grid;gap:6px 8px;align-items:end;margin-top:12px}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -30,6 +30,7 @@ const roleLabels: Record<StaffRole,string> = {
   radiologist:"Лікар-рентгенолог", radiographer:"Рентгенолаборант",
 };
 const equipmentNames: Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
+const EQUIP: Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
 
 // Компактний статус запису для агенди «на сьогодні».
 const STATUS_UK: Record<string,string> = {
@@ -42,6 +43,33 @@ function statusGroup(s:string) {
   if (s === "confirmed") return "ok";
   if (s === "cancelled") return "off";
   return "done";
+}
+
+// Ознаки запису, потрібні лікарю «з першого погляду» — без окремих полів у БД.
+const isContrast = (b:CalBooking) => /контраст|ангіограф/i.test(b.service || "");
+const needsPay = (b:CalBooking) => b.patientCategory === "civilian" && b.paymentStatus !== "paid";
+// Дослідження вже зроблено, але висновку ще немає — черга опису.
+const NEEDS_REPORT = new Set(["performed", "images_ready", "reporting"]);
+const needsReport = (b:CalBooking) => NEEDS_REPORT.has(b.status);
+// Посилання «написати у WhatsApp»: лишаємо тільки цифри номера.
+const waLink = (phone:string) => `https://wa.me/${(phone || "").replace(/[^\d]/g, "")}`;
+
+// Швидкі фільтри агенди — кожен відповідає реальній ознаці запису.
+type AgendaFilter = "all" | "contrast" | "pay" | "ct" | "xray";
+const AGENDA_FILTERS: Array<{ id:AgendaFilter; label:string }> = [
+  { id:"all", label:"Усі" },
+  { id:"contrast", label:"Контраст" },
+  { id:"pay", label:"Перевірити оплату" },
+  { id:"ct", label:"КТ" },
+  { id:"xray", label:"Рентген" },
+];
+function matchFilter(b:CalBooking, f:AgendaFilter) {
+  if (f === "all") return true;
+  if (f === "contrast") return isContrast(b);
+  if (f === "pay") return needsPay(b);
+  if (f === "ct") return b.equipmentId === "ct";
+  if (f === "xray") return b.equipmentId === "xray" || b.equipmentId === "fluoro";
+  return true;
 }
 
 function ActionList({ title, items, hint, href, empty }:{
@@ -61,8 +89,6 @@ function ActionList({ title, items, hint, href, empty }:{
     </ul>}
   </section>;
 }
-
-const EQUIP: Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
 
 type ExtEvent = { display: string; summary: string };
 function ExternalCalendar() {
@@ -92,6 +118,7 @@ export default function DashboardPage() {
   const [error,setError] = useState("");
   const [toast,setToast] = useState("");
   const [busyId,setBusyId] = useState<number | null>(null);
+  const [agendaFilter,setAgendaFilter] = useState<AgendaFilter>("all");
 
   async function load() {
     const [dashRes, bookingsRes] = await Promise.all([
@@ -163,10 +190,23 @@ export default function DashboardPage() {
     .sort((a, b) => (a.desiredTime || "").localeCompare(b.desiredTime || "")),
   [bookings, today]);
 
+  // Лічильники «місії» — рахуємо із заявок, тому працюють для будь-якої ролі,
+  // а не лише для адміністратора (у якого є зведена аналітика).
+  const mc = useMemo(() => ({
+    contrastToday: todayAgenda.filter(isContrast).length,
+    payToday: todayAgenda.filter(needsPay).length,
+    toReport: bookings.filter(needsReport).length,
+  }), [todayAgenda, bookings]);
+
+  const agendaShown = useMemo(
+    () => todayAgenda.filter(b => matchFilter(b, agendaFilter)),
+    [todayAgenda, agendaFilter],
+  );
+
   return <StaffWorkspaceShell
     active="dashboard"
     title="Пульт відділення"
-    description="Нові заявки, розклад і те, що потребує уваги — в одному місці."
+    description="Хто наступний, що термінове і що потребує уваги — в одному екрані."
     staffName={staff?.displayName || staff?.email}
     staffRole={staff ? roleLabels[staff.role] : undefined}
   >
@@ -175,8 +215,27 @@ export default function DashboardPage() {
     <>
       {toast && <p className="dashToast" role="status" onClick={()=>setToast("")}>{toast}</p>}
 
-      {/* Дія передусім: нові заявки миготять, доки їх не підтвердять; підтвердження одним кліком. */}
-      <section className="dashPending">
+      {/* Панель місії: головні числа дня в один рядок. Клік веде до дії. */}
+      <nav className="dashMc" aria-label="Головні показники дня">
+        <a className="dashMcItem red" href="#dash-pending">
+          <b>{pending.length}</b><span>нових заявок</span>
+        </a>
+        <a className="dashMcItem orange" href="#dash-agenda" onClick={()=>setAgendaFilter("contrast")}>
+          <b>{mc.contrastToday}</b><span>з контрастом</span>
+        </a>
+        <a className="dashMcItem green" href="#dash-agenda" onClick={()=>setAgendaFilter("all")}>
+          <b>{todayAgenda.length}</b><span>пацієнтів сьогодні</span>
+        </a>
+        <a className="dashMcItem blue" href="/staff/protocols">
+          <b>{k ? k.awaitingProtocol : mc.toReport}</b><span>описати протокол</span>
+        </a>
+        <a className="dashMcItem violet" href="#dash-agenda" onClick={()=>setAgendaFilter("pay")}>
+          <b>{mc.payToday}</b><span>перевірити оплату</span>
+        </a>
+      </nav>
+
+      {/* Дія передусім: нові заявки — картками, з телефоном, WhatsApp і підтвердженням. */}
+      <section className="dashPending" id="dash-pending">
         <div className="dashPendingHead">
           <h2>Нові заявки {pending.length ? <span className="dashPendingBadge">{pending.length}</span> : null}</h2>
           <small>{canManage
@@ -185,99 +244,121 @@ export default function DashboardPage() {
         </div>
         {pending.length === 0
           ? <p className="dashListEmpty">Нових непідтверджених заявок немає — усе опрацьовано.</p>
-          : <ul className="dashPendingList">
+          : <div className="dashCards">
               {pending.map(b => (
-                <li key={b.id} className="dashPendingRow">
-                  <span className={`dashPendingDot ${b.status}`} aria-hidden="true" />
-                  <div className="dashPendingWho">
-                    <b>{b.name || "Без імені"}</b>
-                    <small>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""} · {b.desiredDate} {b.desiredTime}</small>
+                <article key={b.id} className={`dashCard ${b.status}`}>
+                  <div className="dashCardTop">
+                    <span className={`dashCardTag ${b.status}`}>{b.status === "rescheduled" ? "Перенесено" : "Нова"}</span>
+                    {isContrast(b) && <span className="dashCardFlag">Контраст</span>}
+                    {needsPay(b) && <span className="dashCardFlag pay">Оплата</span>}
                   </div>
-                  <a className="dashPendingPhone" href={`tel:${b.phone}`}>{b.phone}</a>
-                  {canManage
-                    ? <button type="button" className="dashConfirmBtn" disabled={busyId===b.id} onClick={()=>void confirmBooking(b.id)}>
-                        {busyId===b.id ? "…" : "✓ Підтвердити"}
-                      </button>
-                    : <span className="dashPendingTag">очікує</span>}
-                </li>
+                  <b className="dashCardName">{b.name || "Без імені"}</b>
+                  <span className="dashCardSvc">{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}</span>
+                  <span className="dashCardWhen">{b.desiredDate} · {b.desiredTime || "—"}</span>
+                  <div className="dashCardActions">
+                    <a className="dashCardBtn" href={`tel:${b.phone}`} title={b.phone}>📞</a>
+                    <a className="dashCardBtn wa" href={waLink(b.phone)} target="_blank" rel="noreferrer">WhatsApp</a>
+                    {canManage
+                      ? <button type="button" className="dashCardBtn ok" disabled={busyId===b.id} onClick={()=>void confirmBooking(b.id)}>
+                          {busyId===b.id ? "…" : "✓ Підтвердити"}
+                        </button>
+                      : <span className="dashCardBtn wait">очікує</span>}
+                  </div>
+                </article>
               ))}
-            </ul>}
+            </div>}
       </section>
 
-      {/* Зведені показники — лише для адміністратора (аналітика по відділенню). */}
-      {k && <div className="dashKpiStrip">
-        <a className="dashStat hero" href="/staff/appointments"><b>{k.scheduledToday}</b><span>сьогодні у розкладі</span><small>{k.newToday} нових · {k.confirmedToday} підтв.</small></a>
-        <a className="dashStat" href="/staff/protocols"><b className={k.awaitingProtocol?"warn":""}>{k.awaitingProtocol}</b><span>потребують протоколу</span><small>{k.readyToIssue} до видачі</small></a>
-        <a className="dashStat" href="/staff/imaging"><b className={k.needImaging?"warn":""}>{k.needImaging}</b><span>без знімків</span><small>{k.pacsEnabled?"PACS активний":"PACS вимкнено"}</small></a>
-        <a className="dashStat" href="/staff/reports"><b className={k.outstandingCount?"warn":""}>{k.outstandingCount}</b><span>очікують оплати</span><small>{k.outstandingSum.toLocaleString("uk-UA")} грн</small></a>
-        <a className="dashStat" href="/staff/patients"><b>{k.patients}</b><span>пацієнтів</span><small>{k.repeatPatients} повторних</small></a>
-      </div>}
-
-      {/* Короткий розклад на сьогодні; повний тижневий — у «Календарі записів». */}
-      <section className="dashCalendar">
+      {/* Центр Пульта — хто наступний. Розклад на сьогодні з швидкими фільтрами. */}
+      <section className="dashCalendar" id="dash-agenda">
         <div className="dashCalendarHead">
-          <h2>Розклад на сьогодні {todayAgenda.length ? <span className="dashAgendaCount">{todayAgenda.length}</span> : null}</h2>
+          <h2>Розклад на сьогодні {todayAgenda.length ? <span className="dashAgendaCount">{agendaShown.length}{agendaFilter!=="all"?`/${todayAgenda.length}`:""}</span> : null}</h2>
           <div className="dashCalActions">
             <a href="/staff/appointments">Календар записів →</a>
             <a href="/staff/book" className="dashCalNew">+ Записати пацієнта</a>
           </div>
         </div>
+        <div className="dashChips" role="tablist" aria-label="Фільтр розкладу">
+          {AGENDA_FILTERS.map(f => {
+            const n = f.id === "all" ? todayAgenda.length : todayAgenda.filter(b => matchFilter(b, f.id)).length;
+            return <button key={f.id} type="button" role="tab" aria-selected={agendaFilter===f.id}
+              className={`dashChip${agendaFilter===f.id?" on":""}`} onClick={()=>setAgendaFilter(f.id)}>
+              {f.label}{n ? <i>{n}</i> : null}
+            </button>;
+          })}
+        </div>
         {todayAgenda.length === 0
           ? <p className="dashListEmpty">На сьогодні записів немає.</p>
+          : agendaShown.length === 0
+          ? <p className="dashListEmpty">За фільтром «{AGENDA_FILTERS.find(f=>f.id===agendaFilter)?.label}» записів немає.</p>
           : <ul className="dashAgenda">
-              {todayAgenda.map(b => <li key={b.id} className="dashAgendaRow">
+              {agendaShown.map(b => <li key={b.id} className="dashAgendaRow">
                 <time>{b.desiredTime || "—"}</time>
                 <div className="dashAgendaWho">
                   <b>{b.name || "Без імені"}</b>
                   <small>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}</small>
                 </div>
+                {isContrast(b) && <span className="dashAgendaFlag">Контраст</span>}
+                {needsPay(b) && <span className="dashAgendaFlag pay">Оплата</span>}
                 <span className={`dashAgendaStatus st-${statusGroup(b.status)}`}>{STATUS_UK[b.status] || b.status}</span>
               </li>)}
             </ul>}
       </section>
 
-      {/* Завантаженість апаратів за 7 днів (сьогодні та 6 попередніх) — адмін-аналітика */}
-      {k && data && <section className="dashLoad">
-        <div className="dashListHead"><h3>Завантаженість апаратів · 7 днів</h3><span>{data.weekStart} — {data.today}</span></div>
-        {(() => {
-          const days:string[] = [];
-          for (let i = 6; i >= 0; i--) { const dt = new Date(`${data.today}T12:00:00Z`); dt.setUTCDate(dt.getUTCDate() - i); days.push(dt.toISOString().slice(0,10)); }
-          const at = (id:string, d:string) => data.equipmentWeek.find((e)=>e.id===id && e.d===d)?.c || 0;
-          const peak = Math.max(1, ...data.equipmentWeek.filter((e)=>["ct","xray","fluoro"].includes(e.id)).map((e)=>e.c));
-          const dow = (d:string) => ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"][new Date(`${d}T12:00:00Z`).getUTCDay()];
-          return <div className="dashLoadGrid" style={{ gridTemplateColumns:`120px repeat(${days.length}, 1fr)` }}>
-            <span className="dashLoadCorner" />
-            {days.map((d)=><span key={d} className={`dashLoadDay${d===data.today?" today":""}`}>{dow(d)}<small>{d.slice(8,10)}.{d.slice(5,7)}</small></span>)}
-            {["ct","xray","fluoro"].map((id)=><Fragment key={id}>
-              <span className="dashLoadRow">{equipmentNames[id]}</span>
-              {days.map((d)=>{ const v = at(id,d); return <span key={d} className="dashLoadCell" title={`${equipmentNames[id]} · ${d}: ${v}`}>
-                <i style={{ height:`${Math.round((v/peak)*100)}%` }} className={v?"":"empty"} /><b>{v||""}</b>
-              </span>; })}
-            </Fragment>)}
-          </div>;
-        })()}
-      </section>}
+      {/* Аналітика — нижче: потрібна рідше, ніж «хто наступний». Лише адмін. */}
+      {k && data && <section className="dashAnalytics">
+        <h2 className="dashAnalyticsHead">Аналітика відділення</h2>
 
-      {k && data?.clinicalQueue?.length ? <a className="dashQueue" href="/staff/studies" aria-label="Відкрити реєстр досліджень">
-        <div className="dashQueueHead"><b>Клінічна черга</b><small>Активні стани дослідження · відкрити реєстр →</small></div>
-        <div className="dashQueueRow">
-          {data.clinicalQueue.map((q)=><div key={q.v} className="dashQueueCell">
-            <b className={q.count?"":"muted"}>{q.count}</b><span>{q.l}</span>
-          </div>)}
+        <div className="dashKpiStrip">
+          <a className="dashStat hero" href="/staff/appointments"><b>{k.scheduledToday}</b><span>сьогодні у розкладі</span><small>{k.newToday} нових · {k.confirmedToday} підтв.</small></a>
+          <a className="dashStat" href="/staff/protocols"><b className={k.awaitingProtocol?"warn":""}>{k.awaitingProtocol}</b><span>потребують протоколу</span><small>{k.readyToIssue} до видачі</small></a>
+          <a className="dashStat" href="/staff/imaging"><b className={k.needImaging?"warn":""}>{k.needImaging}</b><span>без знімків</span><small>{k.pacsEnabled?"PACS активний":"PACS вимкнено"}</small></a>
+          <a className="dashStat" href="/staff/reports"><b className={k.outstandingCount?"warn":""}>{k.outstandingCount}</b><span>очікують оплати</span><small>{k.outstandingSum.toLocaleString("uk-UA")} грн</small></a>
+          <a className="dashStat" href="/staff/patients"><b>{k.patients}</b><span>пацієнтів</span><small>{k.repeatPatients} повторних</small></a>
         </div>
-      </a> : null}
 
-      {k && data && <div className="dashLists">
-        <ActionList title="Потребують протоколу" items={data.lists.needProtocol}
-          hint="Виконані дослідження без готового висновку" empty="Усі виконані дослідження мають протокол."
-          href={(item)=>`/staff/protocols?open=${item.id}`}/>
-        <ActionList title="Готові до видачі" items={data.lists.readyToIssue}
-          hint="Протокол готовий — лишилось видати пацієнту" empty="Немає протоколів, що очікують видачі."
-          href={(item)=>`/staff/protocols?open=${item.id}`}/>
-        <ActionList title="Без прив’язки знімків" items={data.lists.needImaging}
-          hint="Виконані дослідження без DICOM-студії" empty="Усі дослідження прив’язані до знімків."
-          href={(item)=>`/staff/imaging?open=${item.id}`}/>
-      </div>}
+        <div className="dashLoad">
+          <div className="dashListHead"><h3>Завантаженість апаратів · 7 днів</h3><span>{data.weekStart} — {data.today}</span></div>
+          {(() => {
+            const days:string[] = [];
+            for (let i = 6; i >= 0; i--) { const dt = new Date(`${data.today}T12:00:00Z`); dt.setUTCDate(dt.getUTCDate() - i); days.push(dt.toISOString().slice(0,10)); }
+            const at = (id:string, d:string) => data.equipmentWeek.find((e)=>e.id===id && e.d===d)?.c || 0;
+            const peak = Math.max(1, ...data.equipmentWeek.filter((e)=>["ct","xray","fluoro"].includes(e.id)).map((e)=>e.c));
+            const dow = (d:string) => ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"][new Date(`${d}T12:00:00Z`).getUTCDay()];
+            return <div className="dashLoadGrid" style={{ gridTemplateColumns:`120px repeat(${days.length}, 1fr)` }}>
+              <span className="dashLoadCorner" />
+              {days.map((d)=><span key={d} className={`dashLoadDay${d===data.today?" today":""}`}>{dow(d)}<small>{d.slice(8,10)}.{d.slice(5,7)}</small></span>)}
+              {["ct","xray","fluoro"].map((id)=><Fragment key={id}>
+                <span className="dashLoadRow">{equipmentNames[id]}</span>
+                {days.map((d)=>{ const v = at(id,d); return <span key={d} className="dashLoadCell" title={`${equipmentNames[id]} · ${d}: ${v}`}>
+                  <i style={{ height:`${Math.round((v/peak)*100)}%` }} className={v?"":"empty"} /><b>{v||""}</b>
+                </span>; })}
+              </Fragment>)}
+            </div>;
+          })()}
+        </div>
+
+        {data.clinicalQueue?.length ? <a className="dashQueue" href="/staff/studies" aria-label="Відкрити реєстр досліджень">
+          <div className="dashQueueHead"><b>Клінічна черга</b><small>Активні стани дослідження · відкрити реєстр →</small></div>
+          <div className="dashQueueRow">
+            {data.clinicalQueue.map((q)=><div key={q.v} className="dashQueueCell">
+              <b className={q.count?"":"muted"}>{q.count}</b><span>{q.l}</span>
+            </div>)}
+          </div>
+        </a> : null}
+
+        <div className="dashLists">
+          <ActionList title="Потребують протоколу" items={data.lists.needProtocol}
+            hint="Виконані дослідження без готового висновку" empty="Усі виконані дослідження мають протокол."
+            href={(item)=>`/staff/protocols?open=${item.id}`}/>
+          <ActionList title="Готові до видачі" items={data.lists.readyToIssue}
+            hint="Протокол готовий — лишилось видати пацієнту" empty="Немає протоколів, що очікують видачі."
+            href={(item)=>`/staff/protocols?open=${item.id}`}/>
+          <ActionList title="Без прив’язки знімків" items={data.lists.needImaging}
+            hint="Виконані дослідження без DICOM-студії" empty="Усі дослідження прив’язані до знімків."
+            href={(item)=>`/staff/imaging?open=${item.id}`}/>
+        </div>
+      </section>}
       <ExternalCalendar/>
     </>}
   </StaffWorkspaceShell>;

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -45,6 +45,14 @@ test("dashboard shows a compact today agenda and a one-click confirm queue", asy
   assert.match(dash, /dashPending/); // черга нових заявок
   assert.match(dash, /confirm:true/); // підтвердження одним кліком
   assert.match(dash, /WhatsApp/); // повідомлення пацієнту
+  // Пульт як «місія»: рядок головних чисел дня + фільтри розкладу + аналітика внизу.
+  assert.match(dash, /dashMc/); // панель головних показників дня
+  assert.match(dash, /нових заявок/);
+  assert.match(dash, /dashCards/); // нові заявки картками
+  assert.match(dash, /dashChips/); // швидкі фільтри розкладу
+  assert.match(dash, /dashAnalytics/); // аналітика — нижче агенди
   const css = await read("app/globals.css");
   assert.match(css, /@keyframes dashBlink/); // миготіння нових заявок
+  assert.match(css, /\.dashMc\{/); // стилі панелі місії
+  assert.match(css, /\.dashChip\b/); // стилі фільтрів
 });


### PR DESCRIPTION
## Навіщо

Пульт був **інформаційною панеллю**, а не робочим місцем: багато статистики зверху («потребують протоколу», «без знімків», «завантаження за 7 днів»), великі порожні блоки при 0 записів, і користувач сам мав вирішувати, куди дивитися. Лікар приходить не читати статистику — він думає **«хто наступний?»**. Ця зміна перебудовує екран під це питання.

## Що змінилося

**1. Панель місії (верх, один рядок, для всіх ролей)**
`нових заявок · з контрастом · пацієнтів сьогодні · описати протокол · перевірити оплату`. Числа рахуються **із заявок**, тож панель працює й для реєстратора/лаборанта, а не лише для адміністратора. Клік веде до дії (скрол до заявок / фільтр розкладу / протоколи).

**2. Нові заявки — картками** (замість вузького списку)
Кожна картка: статус (Нова/Перенесено), прапорці «Контраст»/«Оплата», ПІБ, дослідження, дата й час, а внизу — 📞 телефон, WhatsApp, **✓ Підтвердити** в один клік (пацієнту одразу йде повідомлення).

**3. Розклад на сьогодні — центр екрана**
Зі швидкими фільтрами `Усі / Контраст / Перевірити оплату / КТ / Рентген` (кожен із лічильником) і прапорцями просто в рядках. Це і є «хто наступний».

**4. Аналітика — вниз**
KPI-стрічка, завантаженість апаратів за 7 днів, клінічна черга та робочі списки зібрані під окремий заголовок **«Аналітика відділення»** наприкінці — вона потрібна рідше, ніж черга дня.

## Технічні дрібниці
- Ознаки записів виводяться з наявних даних без нових полів у БД: `Контраст` — з назви послуги (`/контраст|ангіограф/`), `Оплата` — цивільний із `paymentStatus !== "paid"`, «описати» — статуси `performed/images_ready/reporting`.
- WhatsApp-посилання: `https://wa.me/<цифри номера>`.
- Адмін-аналітика лишається під `k && data` (403 на зведенні не блокує Пульт).

## Перевірка
- `npx tsc --noEmit` — чисто
- `npm run lint` — чисто
- `npm run build` — успішно
- `node --test tests/appointments-calendar.test.mjs` — 4/4 (додано перевірки `dashMc`/`dashCards`/`dashChips`/`dashAnalytics` та відповідних стилів)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_