### PR TITLE
Робочі екрани: на всю ширину + Календар у стилі TickTick + ієрархія

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -402,7 +402,7 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .themeDark .dashCalActions a,.themeDark .dashAgendaCount{color:#7fd4dc}
 .themeDark .dashAgendaCount{background:#0e151a;border-color:#22303a}
 /* Дошка прийому заявок */
-.intakeBoard{display:grid;grid-template-columns:360px 1fr;gap:16px;max-width:1500px;margin:0 auto;align-items:start}
+.intakeBoard{display:grid;grid-template-columns:380px 1fr;gap:16px;max-width:var(--dash-w);margin:0 auto;align-items:start}
 .intakeQueue{background:#fff;border:1px solid #e7ece9;border-radius:14px;overflow:hidden;position:sticky;top:12px}
 .intakeQueueTop{display:flex;flex-direction:column;gap:8px;padding:12px;border-bottom:1px solid #eef2f0}
 .intakeSeg{display:flex;background:#f4f8f7;border-radius:8px;padding:3px}
@@ -644,7 +644,7 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 @media(max-width:880px){.storefrontEditorToolbar{align-items:flex-start;flex-wrap:wrap}.storefrontEditorToolbar>div{flex-basis:100%}.sfStats{grid-template-columns:1fr 1fr}.sfStat:nth-child(2){border-right:0}.sfStat:nth-child(-n+2){border-bottom:1px solid #dbe3e8}.sfRoomEditor,.sfFieldGrid,.sfHowSteps,.sfHowSteps.civilian{grid-template-columns:1fr}.sfHowException,.sfHowResult,.sfAccessNotice{grid-template-columns:1fr}.sfManagedSection{align-items:flex-start;flex-direction:column}.sfManagedLink{width:100%;justify-content:space-between}}
 @media(max-width:620px){.storefrontCanvas{padding:10px;border-radius:16px}.sfEditHeader{min-height:108px;padding:17px 18px;border-radius:18px}.sfAudienceCard{min-height:126px;padding:19px 18px;border-radius:18px;gap:12px}.sfAudienceIcon{width:47px;height:47px;border-radius:13px;font-size:23px}.sfAudienceArrow{font-size:32px}.sfAboutCard,.sfManagedSection,.sfHowCard{padding:20px 17px;border-radius:18px}.sfContactRow{grid-template-columns:82px minmax(0,1fr) auto;min-height:58px;padding:11px 14px}.sfContactRow.hours{grid-template-columns:1fr;gap:2px}.sfContactValue{font-size:12.5px}.sfStat{padding:12px 8px}.sfDeviceRow,.sfPersonnelRow{grid-template-columns:1fr}.sfOpenSite,.sfResetButton,.sfSaveButton{flex:1}}
 /* Календар записів */
-.apptCal{max-width:1100px;margin:0 auto;display:flex;flex-direction:column;gap:14px}
+.apptCal{max-width:var(--dash-w);margin:0 auto;display:flex;flex-direction:column;gap:14px}
 .apptCalBar{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
 .apptCalBar input[type="date"]{padding:10px 12px;border:1px solid #cbd8d6;border-radius:8px;font:inherit;color:var(--ink)}
 .apptCalBar input[type="search"]{flex:1;min-width:180px;padding:10px 12px;border:1px solid #cbd8d6;border-radius:8px;font:inherit}
@@ -1228,13 +1228,13 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 @media(max-width:820px){.workspaceSubList,.workspaceSubToggle{display:none}.workspaceCollapsed .workspaceSubList,.workspaceCollapsed .workspaceSubToggle{display:none}}
 
 /* ================= «Записи» — таби, групи по днях, керування ================= */
-.apptTabs{max-width:1500px;margin:0 auto 12px;display:flex;flex-wrap:wrap;gap:6px}
+.apptTabs{max-width:var(--dash-w);margin:0 auto 12px;display:flex;flex-wrap:wrap;gap:6px}
 .apptTab{display:inline-flex;align-items:center;gap:7px;border:1px solid #dce4e3;background:#fff;color:#41544f;font:inherit;font-size:12.5px;font-weight:700;padding:7px 13px;border-radius:999px;cursor:pointer;transition:.15s}
 .apptTab:hover{border-color:var(--green);color:var(--green)}
 .apptTab.active{background:var(--green);border-color:var(--green);color:#fff}
 .apptTabCount{font-family:var(--font-sans);font-size:11px;font-weight:800;background:rgba(20,45,43,.08);border-radius:999px;padding:1px 7px;min-width:20px;text-align:center;font-variant-numeric:tabular-nums}
 .apptTab.active .apptTabCount{background:rgba(255,255,255,.24)}
-.apptDay{max-width:1500px;margin:0 auto 16px}
+.apptDay{max-width:var(--dash-w);margin:0 auto 16px}
 .apptDayHead{display:flex;justify-content:space-between;align-items:baseline;gap:12px;padding:2px 4px 8px;margin-bottom:8px;border-bottom:1px solid #e0e7ea}
 .apptDayHead b{font-size:14.5px;font-weight:750;letter-spacing:-.01em}
 .apptDayHead span{font-size:11px;font-weight:700;color:#6c7c86;text-transform:uppercase;letter-spacing:.05em}

--- a/app/globals.css
+++ b/app/globals.css
@@ -663,10 +663,23 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .apptEmpty span{font-size:34px;display:block;margin-bottom:10px;opacity:.6}
 .apptEmpty p{margin:0;font-size:14px}
 .apptListWrap{display:flex;flex-direction:column;gap:8px}
-.apptCardRow{display:flex;align-items:center;gap:14px;background:#fff;border:1px solid #dce4e3;border-radius:10px;padding:12px 16px}
+/* Список = агенда у стилі TickTick: час · кольорова смуга · велике ім'я. */
+.apptCardRow{display:flex;align-items:center;gap:16px;background:#fff;border:1px solid #dce4e3;border-left:4px solid #cdd6d2;border-radius:10px;padding:12px 16px;text-decoration:none;color:inherit;transition:border-color .12s,box-shadow .12s,transform .12s}
+.apptCardRow:hover{box-shadow:0 6px 18px rgba(23,54,52,.08);transform:translateY(-1px)}
+.apptCardRow.mod-ct{border-left-color:#2f7db0}
+.apptCardRow.mod-xray{border-left-color:#5a37a3}
+.apptCardRow.mod-fluoro{border-left-color:#b5761a}
+.apptCardRow.mod-other{border-left-color:#8a9995}
 .apptCardTime{font-weight:800;font-size:15px;color:var(--ink);min-width:52px}
-.apptCardBody{flex:1;display:flex;flex-direction:column;gap:2px;min-width:0}
-.apptCardBody b{font-size:14px}.apptCardBody span{font-size:12.5px;color:#66756f;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.apptCardBody{flex:1;display:flex;flex-direction:column;gap:3px;min-width:0}
+.apptCardName{font-size:16px;font-weight:750;color:var(--ink);line-height:1.15;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.apptCardMeta{font-size:12px;color:#7a8b88;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.apptCardTags{display:flex;gap:6px;flex-shrink:0;flex-wrap:wrap;justify-content:flex-end;max-width:230px}
+.apptTag{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.03em;padding:3px 9px;border-radius:20px;white-space:nowrap}
+.apptTag.contrast{background:#eae2fb;color:#5a37a3}
+.apptTag.mil{background:#dcefe9;color:#0e6b63}
+.apptTag.paid{background:#e2efe0;color:#2f5c2a}
+.apptTag.pay{background:#fdece0;color:#a5670f}
 .apptBadge{flex-shrink:0;padding:4px 11px;border-radius:99px;font-size:11px;font-weight:800;white-space:nowrap}
 .apptBadge.grp-planned{background:#fdf2df;color:#8a5a12}
 .apptBadge.grp-confirmed{background:#e0eef3;color:#1d5a72}
@@ -1259,6 +1272,9 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .themeDark .apptManage{border-top-color:#22303a}
 .themeDark .apptEmpty{background:#121a20!important;border-color:#22303a!important}
 .themeDark .apptEmpty p{color:#93a3ad}
+.themeDark .apptCardRow{background:#121a20;border-color:#22303a}
+.themeDark .apptCardName{color:#e6edf1}.themeDark .apptCardMeta{color:#8b98a1}
+.themeDark .apptCardRow:hover{box-shadow:0 6px 18px rgba(0,0,0,.35)}
 
 /* ================= Комерційний лендинг RadiologyOS (стиль Doctime) ================= */
 .rosLanding{--ros-bg:#f6f3ec;--ros-bg2:#ece7db;--ros-ink:#2b2621;--ros-muted:#6b655e;--ros-teal:#2e9e85;--ros-teal-deep:#256f60;--ros-orange:#e8794b;--ros-card:#fff;--ros-line:#e6e0d1;--ros-footer:#2b2621;background:var(--ros-bg);color:var(--ros-ink);font-family:var(--font-sans);line-height:1.5;letter-spacing:-.005em}

--- a/app/staff/week-calendar.tsx
+++ b/app/staff/week-calendar.tsx
@@ -156,6 +156,9 @@ export default function WeekCalendar({
 
   const hours = Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i);
   const doctorOf = (b: CalBooking) => nameByEmail[b.assignedRadiologistEmail || ""] || nameByEmail[b.assignedRadiographerEmail || ""] || "";
+  // Кольорова смужка за типом дослідження + контраст — розпізнавання за мить.
+  const modClass = (equipmentId: string) => `mod-${equipmentId || "other"}`;
+  const isContrast = (b: CalBooking) => /контраст|ангіограф/i.test(b.service || "");
 
   function eventBlock(b: CalBooking, compact: boolean, pos?: { lane: number; lanes: number }) {
     const mins = minutesOf(b.desiredTime);
@@ -276,14 +279,23 @@ export default function WeekCalendar({
           : dayItems.length === 0
             ? <div className="apptEmpty"><span aria-hidden="true">🗓</span><p>Записів на цей день немає</p></div>
             : <div className="apptListWrap">{dayItems.map(b => (
-                <div className="apptCardRow" key={b.id}>
+                <a className={`apptCardRow ${modClass(b.equipmentId)}`} key={b.id} href={`/staff?open=${b.id}#bookings`}>
                   <span className="apptCardTime">{b.desiredTime || "—"}<small>{b.desiredDate}</small></span>
                   <div className="apptCardBody">
-                    <div className="apptCardRoute"><span className={`patientRoute ${b.patientCategory}`}>{b.patientCategory==="military"?"Військовий":"Цивільний"}</span>{b.patientCategory==="civilian"&&<span className={`paymentOverview ${b.paymentStatus==="paid"?"paid":"pending"}`}>{b.paymentStatus==="paid"?"Оплату перевірено":`Перевірити оплату · ${b.paymentAmount || 0} грн`}</span>}</div><b>{b.name || "Без імені"}</b>
-                    <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctorOf(b) ? ` · ${doctorOf(b)}` : ""}</span>
+                    <b className="apptCardName">{b.name || "Без імені"}</b>
+                    <span className="apptCardMeta">{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctorOf(b) ? ` · 👨‍⚕️ ${doctorOf(b)}` : ""}</span>
                   </div>
-                  <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span><a className="apptOpenRecord" href={`/staff?open=${b.id}#bookings`}>Відкрити</a>
-                </div>
+                  <div className="apptCardTags">
+                    {isContrast(b) && <span className="apptTag contrast">Контраст</span>}
+                    {b.patientCategory==="military"
+                      ? <span className="apptTag mil">Військовий</span>
+                      : b.paymentStatus==="paid"
+                        ? <span className="apptTag paid">Оплачено</span>
+                        : <span className="apptTag pay">Перевірити оплату</span>}
+                  </div>
+                  <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
+                  <span className="apptOpenRecord" aria-hidden="true">Відкрити</span>
+                </a>
               ))}</div>}
     </div>
   );

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -121,9 +121,9 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
-  // Пульт — операційний центр: працює на всю ширину (Variant B), тому заголовок
+  // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
   // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
-  const wide = active === "dashboard";
+  const wide = active === "dashboard" || active === "appointments" || active === "intake";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <aside className="workspaceSidebar">
       <Link className="workspaceBrand" href="/staff/appointments" aria-label="RadiologyOS — календар заявок">

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -13,6 +13,13 @@ test("shared week calendar component offers list/day/week views", async () => {
   assert.match(cal, /apptWeek/); // сітка тижня
   assert.match(cal, /weekDates\(/); // тиждень від понеділка
   assert.match(cal, /stateLabel\(/); // людські підписи станів
+  // Список = агенда у стилі TickTick: велике ім'я + кольорова смуга за типом.
+  assert.match(cal, /apptCardName/); // ім'я пацієнта як головний елемент
+  assert.match(cal, /modClass\(/); // кольорова смуга за модальністю
+  assert.match(cal, /apptCardTags/); // компактні теги (контраст/оплата/військовий)
+  const css = await read("app/globals.css");
+  assert.match(css, /\.apptCardRow\.mod-ct\b/); // смуга КТ
+  assert.match(css, /\.apptCardName\{[^}]*font-size:16px/); // ім'я більше за мету
 });
 
 test("status filter groups map to real booking statuses", async () => {


### PR DESCRIPTION
Два кроки за вашим розбором, обидва на робочих екранах лікаря.

## 1. Ширина (проблеми №1, №4)

Ті самі «вузька колонка + порожнеча», що на Пульті (#111), тепер і на **Календарі** та **Дошці прийому**. Причина на Календарі була конкретна: сам календар обмежений **`max-width:1100px`** (на 2560px це ~43%), Дошка — 1500px.

- **Календар:** `.apptCal` 1100px → `var(--dash-w)`; `.apptTabs`, `.apptDay` 1500px → `var(--dash-w)`.
- **Дошка прийому:** `.intakeBoard` 1500px → `var(--dash-w)`; ліва черга 360→380px, права картка отримує більше місця.
- Заголовки цих екранів теж розтягнуто (`.workspaceWide`).

## 2. Календар у стилі TickTick + візуальна ієрархія (проблеми №9, №5)

Список записів тепер **агенда**, а не плаский рядок:
- **час** ліворуч, велика цифра;
- **кольорова смуга за типом дослідження** (КТ — синя, Рентген — фіолетова, Флюорографія — бурштинова) — розпізнавання за мить;
- **ім'я пацієнта — головний елемент** (16px, напівжирне); послуга, апарат і лікар — дрібним сірим нижче;
- категорія / оплата / **контраст** — компактними тегами збоку, а не нарівні з ім'ям (це і був дефект «усе одного розміру, очі не знають, куди дивитись»);
- увесь рядок — одне посилання на картку заявки.

## Чого свідомо ще НЕ чіпав
Це п.№9 і №5. Решта розбору (єдиний Workspace, пацієнт як центр, меню за процесом, Notion-Дошка, менше аналітики на Пульті) — окремі кроки, які узгодимо далі.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test` (appointments + intake + booking) — 7/7; додано перевірки `apptCardName`, `modClass`, `apptCardRow.mod-ct`
- Візуально звірив рендер агенди (велике ім'я, кольорові смуги, компактні теги)

🤖 Generated with [Claude Code](https://claude.com/claude-code)