### PR TITLE
Пульт для лікаря: менше аналітики, більше фокусу

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -327,6 +327,14 @@ a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}
 .dashTier:before{content:"";width:10px;height:10px;border-radius:50%;flex:none}
 .dashTier.t1:before{background:#dc4b3e}.dashTier.t2:before{background:#e0a11e}.dashTier.t3:before{background:#b7c2be}
 .dashAnalytics .dashTier{margin-top:0}
+/* Аналітика згорнута за замовчуванням — Пульт лишається фокусованим */
+details.dashAnalytics>summary{cursor:pointer;list-style:none;margin:0}
+details.dashAnalytics>summary::-webkit-details-marker{display:none}
+.dashTierToggle{margin-left:auto;font-size:0;letter-spacing:0}
+.dashTierToggle::after{content:"▾ розгорнути";font-size:11px;font-weight:800;color:#0c7a85;text-transform:none;letter-spacing:0}
+details.dashAnalytics[open]>summary>.dashTierToggle::after{content:"▴ згорнути"}
+details.dashAnalytics[open]>summary{margin-bottom:14px}
+.themeDark .dashTierToggle::after{color:#25b4c0}
 /* Кольорова смужка за типом дослідження — картки й рядки розкладу */
 .dashCard.mod-ct{border-left:4px solid #2f7db0}
 .dashCard.mod-xray{border-left:4px solid #5a37a3}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -349,25 +349,30 @@ export default function DashboardPage() {
             </ul>}
       </section>
 
-      {/* Рівень 2 — робота на сьогодні: що треба довести до кінця (лише адмін). */}
-      {k && data && <>
-      <p className="dashTier t2">Робота сьогодні</p>
-      <div className="dashLists">
-        <ActionList title="Потребують протоколу" items={data.lists.needProtocol}
-          hint="Виконані дослідження без готового висновку" empty="Усі виконані дослідження мають протокол."
-          href={(item)=>`/staff/protocols?open=${item.id}`}/>
-        <ActionList title="Готові до видачі" items={data.lists.readyToIssue}
-          hint="Протокол готовий — лишилось видати пацієнту" empty="Немає протоколів, що очікують видачі."
-          href={(item)=>`/staff/protocols?open=${item.id}`}/>
-        <ActionList title="Без прив’язки знімків" items={data.lists.needImaging}
-          hint="Виконані дослідження без DICOM-студії" empty="Усі дослідження прив’язані до знімків."
-          href={(item)=>`/staff/imaging?open=${item.id}`}/>
-      </div>
-      </>}
+      {/* Рівень 2 — робота на сьогодні: показуємо лише те, що справді потребує
+          дії. Порожні списки не малюємо — жодних карток «усе гаразд» (лише адмін). */}
+      {k && data && (() => {
+        const lists = [
+          { key:"np", title:"Потребують протоколу", items:data.lists.needProtocol,
+            hint:"Виконані дослідження без готового висновку", href:(item:ListItem)=>`/staff/protocols?open=${item.id}` },
+          { key:"ri", title:"Готові до видачі", items:data.lists.readyToIssue,
+            hint:"Протокол готовий — лишилось видати пацієнту", href:(item:ListItem)=>`/staff/protocols?open=${item.id}` },
+          { key:"ni", title:"Без прив’язки знімків", items:data.lists.needImaging,
+            hint:"Виконані дослідження без DICOM-студії", href:(item:ListItem)=>`/staff/imaging?open=${item.id}` },
+        ].filter(l => l.items.length > 0);
+        if (!lists.length) return null;
+        return <>
+          <p className="dashTier t2">Робота сьогодні</p>
+          <div className="dashLists">
+            {lists.map(l => <ActionList key={l.key} title={l.title} items={l.items} hint={l.hint} href={l.href} empty=""/>)}
+          </div>
+        </>;
+      })()}
 
-      {/* Рівень 3 — аналітика: потрібна рідше, ніж «хто наступний». Лише адмін. */}
-      {k && data && <section className="dashAnalytics">
-        <p className="dashTier t3">Аналітика</p>
+      {/* Рівень 3 — аналітика: керівникові, не лікарю. Згорнута за замовчуванням,
+          щоб Пульт лишався фокусованим; розгортається одним кліком (лише адмін). */}
+      {k && data && <details className="dashAnalytics">
+        <summary className="dashTier t3">Аналітика відділення <span className="dashTierToggle">розгорнути</span></summary>
 
         <div className="dashKpiStrip">
           <a className="dashStat hero" href="/staff/appointments"><b>{k.scheduledToday}</b><span>сьогодні у розкладі</span><small>{k.newToday} нових · {k.confirmedToday} підтв.</small></a>
@@ -406,7 +411,7 @@ export default function DashboardPage() {
             </div>)}
           </div>
         </a> : null}
-      </section>}
+      </details>}
       <ExternalCalendar/>
     </>}
   </StaffWorkspaceShell>;

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -72,4 +72,8 @@ test("dashboard shows a compact today agenda and a one-click confirm queue", asy
   assert.match(css, /\.dashMc\{max-width:var\(--dash-w\)/);
   assert.match(css, /\.dashTier\b/); // маркери рівнів пріоритету
   assert.match(css, /\.dashCard\.mod-ct\b/); // смужка за модальністю
+  // Пульт для лікаря: аналітика згорнута за замовчуванням, порожні списки не малюються.
+  assert.match(dash, /<details className="dashAnalytics"/); // аналітика у details (згорнута)
+  assert.match(dash, /filter\(l => l\.items\.length > 0\)/); // порожні списки ховаємо
+  assert.match(css, /details\.dashAnalytics\[open\]/); // стилі згорнутого стану
 });


### PR DESCRIPTION
Проблеми №2 (немає головного фокусу) і №6 (забагато карток) з вашого розбору.

## Що змінилось
- **Аналітика відділення (Рівень 3) згорнута за замовчуванням** — тепер це `<details>`, що розгортається одним кліком. KPI-стрічка, завантаженість за 7 днів і клінічна черга більше не займають пів-екрана: вони керівникові, не лікарю, тож лежать «під рукою», а не в очах.
- **Порожні списки більше не малюються.** Рівень 2 («Потребують протоколу / Готові до видачі / Без DICOM») показує лише те, де реально є діла. Ніяких високих порожніх карток «усе гаразд» — саме вони й створювали відчуття «стіни карток».

## Що бачить лікар (не адмін)
Аналітика й раніше була доступна лише адміністраторові (зведення повертає 403 для інших ролей), тож лікар-рентгенолог бачить **лише**: рядок лічильників дня → нові заявки → розклад на сьогодні. Це і є той лінійний потік пріоритету, який ви описували.

## Що бачить адмін
Сфокусований Пульт (лічильники + заявки + розклад + непорожні списки дня), а вся аналітика — за одним кліком «▾ розгорнути».

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test` — 4/4 на Пульті; додано перевірки `<details className="dashAnalytics">`, приховування порожніх списків, стилів згорнутого стану

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_