### PR TITLE
Пацієнт як центр (P2) + Єдиний Workspace: drawer у Календарі (P3)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -352,6 +352,10 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .dashAgendaWhen{display:block;margin-top:3px;font-style:normal;font-size:10px;font-weight:800;letter-spacing:.01em;color:#8a9995}
 .dashAgendaWhen.now{color:#c33a2e}.dashAgendaWhen.soon{color:#b5761a}.dashAgendaWhen.past{color:#b3bdb9}
 .themeDark .dashTier{color:#8b98a1}
+/* Імʼя пацієнта як вхід у картку (пацієнт як центр) */
+.patLink{color:inherit;text-decoration:none}
+.patLink:hover{text-decoration:underline;text-underline-offset:2px;color:#0c7a85}
+.themeDark .patLink:hover{color:#7fd4dc}
 .themeDark .dashMcItem,.themeDark .dashChip{background:#121a20;border-color:#22303a;color:#cdd9df}
 .themeDark .dashMcItem b{color:#e6edf1}
 .themeDark .dashChip.on{background:#2aa198;border-color:#2aa198;color:#08201f}
@@ -456,6 +460,11 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .intakeToast{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#25332f;color:#fff;padding:11px 18px;border-radius:10px;font-size:13px;z-index:50;box-shadow:0 6px 24px rgba(0,0,0,.2)}
 .intakeHeadActions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
 .intakeCall{color:#0c7a85;font-weight:800;font-size:13px;text-decoration:none;white-space:nowrap}
+.intakePatientLink{color:#0c7a85;font-weight:800;font-size:12.5px;text-decoration:none;white-space:nowrap;border:1px solid #bfe0dd;background:#eef7f6;padding:6px 11px;border-radius:8px}
+.intakePatientLink:hover{background:#e2f1ef}
+.intakeHistoryAll{color:#0c7a85;font-weight:800;font-size:11.5px;text-decoration:none;white-space:nowrap}
+.intakeHistoryAll:hover{text-decoration:underline}
+.themeDark .intakePatientLink{background:#0e2b2e;border-color:#1c4a4d;color:#7fd4dc}
 .intakeConfirm{border:0;background:#0c7a85;color:#fff;border-radius:8px;padding:8px 13px;font:inherit;font-weight:800;cursor:pointer;white-space:nowrap}
 .intakeConfirm:disabled{opacity:.55;cursor:progress}
 /* Notion-стиль: контекст пацієнта у правій картці */

--- a/app/globals.css
+++ b/app/globals.css
@@ -745,6 +745,44 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .apptTag.mil{background:#dcefe9;color:#0e6b63}
 .apptTag.paid{background:#e2efe0;color:#2f5c2a}
 .apptTag.pay{background:#fdece0;color:#a5670f}
+/* Клікабельні записи — тепер кнопки (відкривають drawer): скидання UA-стилів */
+button.apptCardRow,button.apptEvent,button.roomSlot{font:inherit;cursor:pointer;text-align:left;-webkit-appearance:none;appearance:none;color:inherit}
+button.apptEvent{border-top:0;border-right:0;border-bottom:0}
+/* Єдиний Workspace: права панель-drawer із контекстом запису */
+.apptDrawer{position:fixed;inset:0;z-index:60;display:flex;justify-content:flex-end}
+.apptDrawerBackdrop{position:absolute;inset:0;background:rgba(16,32,30,.28);animation:apptDrawerFade .15s ease}
+.apptDrawerPanel{position:relative;width:min(440px,92vw);height:100%;overflow-y:auto;background:#fff;border-left:1px solid #e0e7e4;box-shadow:-12px 0 40px rgba(16,32,30,.16);padding:18px;display:flex;flex-direction:column;gap:14px;animation:apptDrawerIn .18s ease}
+@keyframes apptDrawerFade{from{opacity:0}to{opacity:1}}
+@keyframes apptDrawerIn{from{transform:translateX(24px);opacity:.4}to{transform:none;opacity:1}}
+.apptDrawerHead{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}
+.apptDrawerHead h3{margin:0;font-size:18px;font-weight:750}
+.apptDrawerHead small{color:#5b6a66;font-size:12px}
+.apptDrawerClose{border:0;background:#f2f6f4;border-radius:8px;width:32px;height:32px;cursor:pointer;font-size:14px;flex:none}
+.apptDrawerChips{display:flex;flex-wrap:wrap;gap:7px;align-items:center}
+.apptDrawerFacts{display:grid;grid-template-columns:1fr 1fr;gap:1px;margin:0;background:#eef2f0;border:1px solid #eef2f0;border-radius:12px;overflow:hidden}
+.apptDrawerFacts>div{background:#fff;padding:9px 12px}
+.apptDrawerFacts dt{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:#8a9995;margin:0 0 3px}
+.apptDrawerFacts dd{margin:0;font-size:13px;font-weight:650;color:#25332f}
+.apptDrawerNote{margin:0;padding:10px 12px;border-radius:10px;background:#f4efff;border:1px solid #e0d5f7;color:#5a37a3;font-size:12px;line-height:1.5}
+.apptDrawerHistory{border:1px solid #e7ece9;border-radius:12px;overflow:hidden}
+.apptDrawerHistoryHead{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;background:#f7faf9;border-bottom:1px solid #eef2f0}
+.apptDrawerHistoryHead b{font-size:13px}.apptDrawerHistoryHead span{font-size:11px;font-weight:800;color:#5b6a66;background:#fff;border:1px solid #e0e7e4;padding:1px 9px;border-radius:20px}
+.apptDrawerHistoryEmpty{margin:0;padding:11px 12px;color:#8a9995;font-size:12px}
+.apptDrawerHistory ul{list-style:none;margin:0;padding:4px}
+.apptDrawerHistory li button{display:grid;grid-template-columns:80px 1fr auto;align-items:center;gap:10px;width:100%;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;font:inherit;text-align:left;color:inherit}
+.apptDrawerHistory li button:hover{background:#f4f8f7}
+.apptDrawerActions{display:flex;flex-wrap:wrap;gap:8px;margin-top:auto;padding-top:6px}
+.apptDrawerBtn{display:inline-flex;align-items:center;justify-content:center;min-height:38px;padding:0 13px;border:1px solid #d8e0dd;border-radius:8px;background:#fff;color:#25332f;font-size:12.5px;font-weight:800;text-decoration:none;white-space:nowrap;cursor:pointer}
+.apptDrawerBtn:hover{border-color:#bcc9c4}
+.apptDrawerBtn.wa{background:#e8f6ec;border-color:#bfe3c9;color:#1c7a3a}
+.apptDrawerBtn.primary{background:#0c7a85;border-color:#0c7a85;color:#fff}
+@media(max-width:560px){.apptDrawerFacts{grid-template-columns:1fr}.apptDrawerPanel{width:100vw}}
+.themeDark .apptDrawerPanel{background:#121a20;border-left-color:#22303a}
+.themeDark .apptDrawerHead h3{color:#e6edf1}.themeDark .apptDrawerHead small{color:#8b98a1}
+.themeDark .apptDrawerFacts{background:#1b2731;border-color:#22303a}.themeDark .apptDrawerFacts>div{background:#121a20}.themeDark .apptDrawerFacts dd{color:#e6edf1}
+.themeDark .apptDrawerHistory{border-color:#22303a}.themeDark .apptDrawerHistoryHead{background:#0e151a;border-bottom-color:#22303a}.themeDark .apptDrawerHistoryHead b{color:#e6edf1}
+.themeDark .apptDrawerClose{background:#1b2731;color:#cdd9df}
+.themeDark .apptDrawerBtn{background:#161d24;border-color:#2a3843;color:#cdd8de}
 .apptBadge{flex-shrink:0;padding:4px 11px;border-radius:99px;font-size:11px;font-weight:800;white-space:nowrap}
 .apptBadge.grp-planned{background:#fdf2df;color:#8a5a12}
 .apptBadge.grp-confirmed{background:#e0eef3;color:#1d5a72}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -53,6 +53,8 @@ const NEEDS_REPORT = new Set(["performed", "images_ready", "reporting"]);
 const needsReport = (b:CalBooking) => NEEDS_REPORT.has(b.status);
 // Посилання «написати у WhatsApp»: лишаємо тільки цифри номера.
 const waLink = (phone:string) => `https://wa.me/${(phone || "").replace(/[^\d]/g, "")}`;
+// Пацієнт як центр: імʼя веде в єдину картку пацієнта (CRM за номером).
+const patientHref = (phone:string) => `/staff/patients?phone=${(phone || "").replace(/[^\d]/g, "")}`;
 // Кольорова смужка за типом дослідження — розпізнавання за частку секунди.
 const modClass = (equipmentId:string) => `mod-${equipmentId || "other"}`;
 // Лікар: маємо лише email — показуємо частину до «@» з великої літери.
@@ -291,7 +293,7 @@ export default function DashboardPage() {
                     {isContrast(b) && <span className="dashCardFlag">Контраст</span>}
                     {needsPay(b) && <span className="dashCardFlag pay">Оплата</span>}
                   </div>
-                  <b className="dashCardName">{b.name || "Без імені"}</b>
+                  <b className="dashCardName">{b.phone ? <a className="patLink" href={patientHref(b.phone)}>{b.name || "Без імені"}</a> : (b.name || "Без імені")}</b>
                   <span className="dashCardSvc">{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}</span>
                   <span className="dashCardWhen">{b.desiredDate} · {b.desiredTime || "—"}{doctorShort(b.assignedRadiologistEmail) ? ` · 👨‍⚕️ ${doctorShort(b.assignedRadiologistEmail)}` : ""}</span>
                   <div className="dashCardActions">
@@ -338,7 +340,7 @@ export default function DashboardPage() {
                 return <li key={b.id} className={`dashAgendaRow ${modClass(b.equipmentId)}`}>
                   <time>{b.desiredTime || "—"}{when ? <em className={`dashAgendaWhen ${when.cls}`}>{when.text}</em> : null}</time>
                   <div className="dashAgendaWho">
-                    <b>{b.name || "Без імені"}</b>
+                    <b>{b.phone ? <a className="patLink" href={patientHref(b.phone)}>{b.name || "Без імені"}</a> : (b.name || "Без імені")}</b>
                     <small>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doc ? ` · 👨‍⚕️ ${doc}` : ""}</small>
                   </div>
                   {isContrast(b) && <span className="dashAgendaFlag">Контраст</span>}

--- a/app/staff/intake/page.tsx
+++ b/app/staff/intake/page.tsx
@@ -225,6 +225,7 @@ export default function IntakePage() {
               </div>
               <div className="intakeHeadActions">
                 <a className="intakeCall" href={`tel:${selected.phone}`}>{selected.phone || "—"}</a>
+                {digits(selected.phone) && <a className="intakePatientLink" href={`/staff/patients?phone=${digits(selected.phone)}`}>Картка пацієнта →</a>}
                 <a className="intakeWa" href={`https://wa.me/${digits(selected.phone)}`} target="_blank" rel="noreferrer">WhatsApp</a>
                 {!readOnly && (selected.status==="new"||selected.status==="rescheduled") && <button className="intakeConfirm" disabled={busy} onClick={confirmBooking}>✓ Підтвердити</button>}
               </div>
@@ -251,7 +252,7 @@ export default function IntakePage() {
               {selected.comment && <div className="intakeCtxComment"><b>Коментар</b><p>{selected.comment}</p></div>}
 
               <div className="intakeHistory">
-                <div className="intakeHistoryHead"><b>Попередні дослідження</b><span>{history.length}</span></div>
+                <div className="intakeHistoryHead"><b>Попередні дослідження</b>{digits(selected.phone) ? <a className="intakeHistoryAll" href={`/staff/patients?phone=${digits(selected.phone)}`}>уся картка →</a> : <span>{history.length}</span>}</div>
                 {history.length === 0
                   ? <p className="intakeHistoryEmpty">Перше звернення цього пацієнта (за номером телефону).</p>
                   : <ul>{history.slice(0,8).map(h => <li key={h.id}>

--- a/app/staff/week-calendar.tsx
+++ b/app/staff/week-calendar.tsx
@@ -5,7 +5,7 @@
 // презентаційний: дані (bookings, staffOptions) приходять пропсами, а стан
 // вигляду/дати/фільтра — локальний.
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { stateLabel } from "../../lib/study-state";
 import { candidateTimesFor, EQUIP_KEYS, EQUIP_LABELS, isEquipmentDayOpen, SCHEDULE_DEFAULTS, type ScheduleConfig } from "../../lib/schedule";
 
@@ -154,6 +154,25 @@ export default function WeekCalendar({
   // кабінетів) вони не застосовуються — тому там їх не показуємо.
   const filtersApply = view === "week" || view === "list";
 
+  // Єдиний Workspace: клік по запису відкриває контекст у правій панелі, без
+  // переходу на іншу сторінку. Дані вже є у пропсі bookings — без бекенду.
+  const [openId, setOpenId] = useState<number | null>(null);
+  const openBooking = useMemo(() => bookings.find(b => b.id === openId) || null, [bookings, openId]);
+  const openHistory = useMemo(() => {
+    if (!openBooking) return [] as CalBooking[];
+    const ph = (openBooking.phone || "").replace(/[^\d]/g, "");
+    if (!ph) return [];
+    return bookings
+      .filter(b => b.id !== openBooking.id && (b.phone || "").replace(/[^\d]/g, "") === ph)
+      .sort((a, b) => (b.desiredDate + b.desiredTime).localeCompare(a.desiredDate + a.desiredTime));
+  }, [bookings, openBooking]);
+  useEffect(() => {
+    if (openId === null) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpenId(null); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [openId]);
+
   const hours = Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i);
   const doctorOf = (b: CalBooking) => nameByEmail[b.assignedRadiologistEmail || ""] || nameByEmail[b.assignedRadiographerEmail || ""] || "";
   // Кольорова смужка за типом дослідження + контраст — розпізнавання за мить.
@@ -171,12 +190,12 @@ export default function WeekCalendar({
       ? { left: `calc(${(pos!.lane * 100) / lanes}% + 2px)`, width: `calc(${100 / lanes}% - 4px)`, right: "auto" as const }
       : {};
     return (
-      <a href={`/staff?open=${b.id}#bookings`} className={`apptEvent grp-${groupOf(b.status)} route-${b.patientCategory || "unknown"} ${b.paymentStatus==="paid"?"paid":"unpaid"}`} key={b.id} style={{ top, height, ...laneStyle }} title={`${b.desiredTime} · ${b.name} · ${b.service}`}>
+      <button type="button" onClick={()=>setOpenId(b.id)} className={`apptEvent grp-${groupOf(b.status)} route-${b.patientCategory || "unknown"} ${b.paymentStatus==="paid"?"paid":"unpaid"}`} key={b.id} style={{ top, height, ...laneStyle }} title={`${b.desiredTime} · ${b.name} · ${b.service}`}>
         <b>{b.desiredTime} {b.name || "Без імені"}</b>
         {!compact && <span>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doctorOf(b) ? ` · ${doctorOf(b)}` : ""}</span>}
         {compact && <span>{EQUIP[b.equipmentId] || b.service}</span>}
         <em>{b.patientCategory==="military"?"Військовий":b.paymentStatus==="paid"?"Оплачено":"Цивільний · перевірити оплату"}</em>
-      </a>
+      </button>
     );
   }
 
@@ -269,7 +288,7 @@ export default function WeekCalendar({
                     ? <p className="roomClosed">Кабінет цього дня не працює</p>
                     : <div className="roomSlots">{candidateTimesFor(schedule.equipment[equipmentId] || SCHEDULE_DEFAULTS.equipment[equipmentId], schedule.equipment[equipmentId]?.slotMinutes || 15).map(time => {
                         const state=roomSlot(equipmentId,time);
-                        if(state.occupied) return <a href={`/staff?open=${state.occupied.id}#bookings`} className={`roomSlot occupied route-${state.occupied.patientCategory || "unknown"}`} key={time}><strong>{time}</strong><span>{state.occupied.name}</span><small>{state.occupied.service}</small></a>;
+                        if(state.occupied) { const occ = state.occupied; return <button type="button" onClick={()=>setOpenId(occ.id)} className={`roomSlot occupied route-${occ.patientCategory || "unknown"}`} key={time}><strong>{time}</strong><span>{occ.name}</span><small>{occ.service}</small></button>; }
                         if(state.blocked) return <span className="roomSlot blocked" key={time} title={state.blocked.reason}><strong>{time}</strong><span>Недоступно</span><small>{state.blocked.reason || "Технічне вікно"}</small></span>;
                         return <a className="roomSlot free" href={`/staff/book?date=${date}&time=${time}&equipment=${equipmentId}`} key={time}><strong>{time}</strong><span>Вільний слот</span></a>;
                       })}</div>}
@@ -279,7 +298,7 @@ export default function WeekCalendar({
           : dayItems.length === 0
             ? <div className="apptEmpty"><span aria-hidden="true">🗓</span><p>Записів на цей день немає</p></div>
             : <div className="apptListWrap">{dayItems.map(b => (
-                <a className={`apptCardRow ${modClass(b.equipmentId)}`} key={b.id} href={`/staff?open=${b.id}#bookings`}>
+                <button type="button" className={`apptCardRow ${modClass(b.equipmentId)}`} key={b.id} onClick={()=>setOpenId(b.id)}>
                   <span className="apptCardTime">{b.desiredTime || "—"}<small>{b.desiredDate}</small></span>
                   <div className="apptCardBody">
                     <b className="apptCardName">{b.name || "Без імені"}</b>
@@ -295,8 +314,63 @@ export default function WeekCalendar({
                   </div>
                   <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
                   <span className="apptOpenRecord" aria-hidden="true">Відкрити</span>
-                </a>
+                </button>
               ))}</div>}
+
+      {openBooking && (() => {
+        const b = openBooking;
+        const ph = (b.phone || "").replace(/[^\d]/g, "");
+        const doc = doctorOf(b);
+        return <div className="apptDrawer" role="dialog" aria-modal="false" aria-label={`Заявка ${b.name || ""}`}>
+          <div className="apptDrawerBackdrop" onClick={()=>setOpenId(null)} />
+          <aside className="apptDrawerPanel">
+            <div className="apptDrawerHead">
+              <div>
+                <h3>{ph ? <a className="patLink" href={`/staff/patients?phone=${ph}`}>{b.name || "Без імені"}</a> : (b.name || "Без імені")}</h3>
+                <small>{b.code} · {b.desiredDate} · {b.desiredTime || "—"}{doc ? ` · 👨‍⚕️ ${doc}` : ""}</small>
+              </div>
+              <button type="button" className="apptDrawerClose" onClick={()=>setOpenId(null)} aria-label="Закрити">✕</button>
+            </div>
+
+            <div className="apptDrawerChips">
+              <span className={`apptTag ${b.patientCategory==="military"?"mil":"paid"}`}>{b.patientCategory==="military"?"Військовий":"Цивільний"}</span>
+              {isContrast(b) && <span className="apptTag contrast">Контраст</span>}
+              {b.patientCategory==="civilian" && <span className={`apptTag ${b.paymentStatus==="paid"?"paid":"pay"}`}>{b.paymentStatus==="paid"?`Оплачено${b.paymentAmount?` · ${b.paymentAmount} грн`:""}`:`Перевірити оплату${b.paymentAmount?` · ${b.paymentAmount} грн`:""}`}</span>}
+              <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
+            </div>
+
+            <dl className="apptDrawerFacts">
+              <div><dt>Дослідження</dt><dd>{b.service}{b.equipmentId?` · ${EQUIP[b.equipmentId]||b.equipmentId}`:""}</dd></div>
+              <div><dt>Дата й час</dt><dd>{b.desiredDate} · {b.desiredTime || "—"}</dd></div>
+              {doc && <div><dt>Лікар</dt><dd>{doc}</dd></div>}
+              <div><dt>Телефон</dt><dd>{b.phone || "—"}</dd></div>
+            </dl>
+
+            {isContrast(b) && <p className="apptDrawerNote">Дослідження з контрастуванням — попередьте про підготовку (креатинін, алергоанамнез, натще).</p>}
+
+            <div className="apptDrawerHistory">
+              <div className="apptDrawerHistoryHead"><b>Попередні дослідження</b><span>{openHistory.length}</span></div>
+              {openHistory.length === 0
+                ? <p className="apptDrawerHistoryEmpty">Перше звернення (за номером телефону).</p>
+                : <ul>{openHistory.slice(0,8).map(h => <li key={h.id}>
+                    <button type="button" onClick={()=>setOpenId(h.id)}>
+                      <span className="ihDate">{h.desiredDate}</span>
+                      <span className="ihSvc">{h.service}{h.equipmentId?` · ${EQUIP[h.equipmentId]||h.equipmentId}`:""}</span>
+                      <span className="ihStatus">{stateLabel(h.status)}</span>
+                    </button></li>)}
+                  {openHistory.length>8 && <li className="ihMore">…і ще {openHistory.length-8}</li>}
+                </ul>}
+            </div>
+
+            <div className="apptDrawerActions">
+              {ph && <a className="apptDrawerBtn" href={`tel:${b.phone}`}>📞 Подзвонити</a>}
+              {ph && <a className="apptDrawerBtn wa" href={`https://wa.me/${ph}`} target="_blank" rel="noreferrer">WhatsApp</a>}
+              {ph && <a className="apptDrawerBtn" href={`/staff/patients?phone=${ph}`}>Картка пацієнта →</a>}
+              <a className="apptDrawerBtn primary" href={`/staff?open=${b.id}#bookings`}>Відкрити повну заявку →</a>
+            </div>
+          </aside>
+        </div>;
+      })()}
     </div>
   );
 }

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -20,6 +20,13 @@ test("shared week calendar component offers list/day/week views", async () => {
   const css = await read("app/globals.css");
   assert.match(css, /\.apptCardRow\.mod-ct\b/); // смуга КТ
   assert.match(css, /\.apptCardName\{[^}]*font-size:16px/); // ім'я більше за мету
+  // Єдиний Workspace: клік по запису відкриває drawer, а не перехід на сторінку.
+  assert.match(cal, /setOpenId\(/); // клік відкриває панель
+  assert.match(cal, /apptDrawer/); // права панель
+  assert.match(cal, /openHistory/); // історія пацієнта в панелі
+  assert.match(cal, /Escape/); // закриття по ESC
+  assert.match(css, /\.apptDrawerPanel\b/);
+  assert.match(css, /button\.apptCardRow/); // скидання UA-стилів кнопки-рядка
 });
 
 test("status filter groups map to real booking statuses", async () => {

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -85,4 +85,8 @@ test("dashboard shows a compact today agenda and a one-click confirm queue", asy
   assert.match(dash, /<details className="dashAnalytics"/); // аналітика у details (згорнута)
   assert.match(dash, /filter\(l => l\.items\.length > 0\)/); // порожні списки ховаємо
   assert.match(css, /details\.dashAnalytics\[open\]/); // стилі згорнутого стану
+  // Пацієнт як центр: імʼя веде в картку пацієнта (CRM за телефоном).
+  assert.match(dash, /patientHref/);
+  assert.match(dash, /\/staff\/patients\?phone=/);
+  assert.match(css, /\.patLink\b/);
 });

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -56,6 +56,9 @@ test("intake board page is a two-pane queue + editable detail, wired into the sh
   assert.match(page, /REFERRAL_UK/); // направлення людською мовою
   assert.match(page, /intakeEdit/); // форма корекції — згорнута
   assert.match(page, /digits\(b\.phone\) === ph/); // історія за номером телефону
+  // Пацієнт як центр: із Дошки — перехід у повну картку пацієнта (CRM).
+  assert.match(page, /Картка пацієнта/);
+  assert.match(page, /\/staff\/patients\?phone=/);
   const css = await read("app/globals.css");
   assert.match(css, /\.intakeHistory\b/); // стилі історії
   assert.match(css, /\.intakeFacts\b/);   // сітка фактів


### PR DESCRIPTION
Два фінальні кроки архітектурного блоку.

## P2 — Пацієнт як центр (№3)
Повна картка пацієнта вже існує (`/staff/patients`, вся історія, відкривається за `?phone=`) — додано **зв'язки** звідусіль:
- **Пульт:** імʼя в нових заявках і в розкладі на сьогодні → картка пацієнта.
- **Дошка прийому:** «Картка пацієнта →» у шапці + «уся картка →» над попередніми дослідженнями.

## P3 — Єдиний Workspace: drawer у Календарі (№8, крок 1)
Клік по запису в календарі (**список, тиждень, зайнятий слот**) відкриває **праву панель-drawer** із контекстом — **без переходу** на іншу сторінку:
- пацієнт (імʼя → картка), статус, дата/час, лікар;
- чипи: категорія, **контраст**, оплата (+сума);
- факти: дослідження + апарат, дата/час, лікар, телефон;
- нагадування про підготовку до контрасту;
- **«Попередні дослідження»** пацієнта (за телефоном) — клік перемикає панель на інший запис;
- дії: 📞 Подзвонити, WhatsApp, **Картка пацієнта →**, **Відкрити повну заявку →**;
- закриття по **ESC** або кліку на тлі.

Дані вже є у пропсі `bookings` — без нового бекенду. Клікабельні записи стали кнопками (скинуто UA-стилі).

## Далі (P3, крок 2)
Той самий drawer можна ввімкнути на Пульті й у списках — коли скажете.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test` — усі зелені; додано перевірки `patientHref`, `apptDrawer`, `openHistory`, ESC-закриття, скидання стилів кнопки-рядка
- Візуально звірив drawer і патієнт-лінки (прев'ю в чаті)

🤖 Generated with [Claude Code](https://claude.com/claude-code)