### PR TITLE
P3-крок2: спільний drawer + на Пульті + дія-мутація «Підтвердити»

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -401,7 +401,9 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .dashAgendaCount{display:inline-block;margin-left:6px;padding:1px 9px;border-radius:99px;background:#e6f4f5;border:1px solid #bfe0e3;color:#0a5f68;font-size:12px;font-weight:800;vertical-align:middle}
 .dashAgenda{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #e7ece9;border-radius:14px;overflow:hidden}
 .dashAgendaRow{display:flex;align-items:center;gap:12px;padding:10px 14px;border-top:1px solid #f0f3f1}
-.dashAgendaRow:first-child{border-top:0}
+button.dashAgendaRow{width:100%;background:transparent;border-left:0;border-right:0;border-bottom:0;font:inherit;text-align:left;cursor:pointer}
+button.dashAgendaRow:hover{background:#f7faf9}
+.dashAgenda>li:first-child .dashAgendaRow{border-top:0}
 .dashAgendaRow time{flex:none;width:52px;font-weight:800;font-size:13.5px;color:#123d3a;font-variant-numeric:tabular-nums}
 .dashAgendaWho{flex:1;min-width:0}
 .dashAgendaWho b{display:block;font-size:13.5px;color:#1b211e}
@@ -776,6 +778,8 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .apptDrawerBtn:hover{border-color:#bcc9c4}
 .apptDrawerBtn.wa{background:#e8f6ec;border-color:#bfe3c9;color:#1c7a3a}
 .apptDrawerBtn.primary{background:#0c7a85;border-color:#0c7a85;color:#fff}
+.apptDrawerBtn.confirm{flex:1 0 100%;background:#1c7a3a;border-color:#1c7a3a;color:#fff}
+.apptDrawerBtn.confirm:disabled{opacity:.6;cursor:progress}
 @media(max-width:560px){.apptDrawerFacts{grid-template-columns:1fr}.apptDrawerPanel{width:100vw}}
 .themeDark .apptDrawerPanel{background:#121a20;border-left-color:#22303a}
 .themeDark .apptDrawerHead h3{color:#e6edf1}.themeDark .apptDrawerHead small{color:#8b98a1}

--- a/app/staff/booking-drawer.tsx
+++ b/app/staff/booking-drawer.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// Спільна права панель-drawer із контекстом запису (Єдиний Workspace).
+// Використовується у Календарі та на Пульті: клік по запису відкриває контекст
+// без переходу на іншу сторінку. Дані приходять пропсами — без бекенду.
+
+import { useEffect } from "react";
+import { type CalBooking } from "./week-calendar";
+import { stateLabel } from "../../lib/study-state";
+
+const EQUIP: Record<string, string> = { ct: "КТ", xray: "Рентген", fluoro: "Флюорограф" };
+const GROUPS: Record<string, string[]> = {
+  planned: ["new", "requested", "needs_verification", "scheduled", "rescheduled"],
+  confirmed: ["confirmed"], arrived: ["arrived"], inroom: ["queued", "in_progress"],
+  done: ["performed", "images_ready", "reporting", "protocol_ready", "issued", "completed"],
+  cancelled: ["cancelled", "no_show"],
+};
+function groupOf(status: string): string {
+  for (const [group, list] of Object.entries(GROUPS)) if (list.includes(status)) return group;
+  return "planned";
+}
+const isContrast = (svc: string) => /контраст|ангіограф/i.test(svc || "");
+const digits = (p: string) => (p || "").replace(/[^\d]/g, "");
+
+export default function BookingDrawer({ booking, all, doctorName = "", onClose, onOpen, onConfirm, confirming = false }: {
+  booking: CalBooking;
+  all: CalBooking[];
+  doctorName?: string;
+  onClose: () => void;
+  onOpen: (id: number) => void;
+  onConfirm?: (id: number) => void;
+  confirming?: boolean;
+}) {
+  const b = booking;
+  const ph = digits(b.phone);
+  const history = ph
+    ? all.filter(x => x.id !== b.id && digits(x.phone) === ph)
+        .sort((a, c) => (c.desiredDate + c.desiredTime).localeCompare(a.desiredDate + a.desiredTime))
+    : [];
+  const canConfirm = !!onConfirm && (b.status === "new" || b.status === "rescheduled");
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return <div className="apptDrawer" role="dialog" aria-modal="false" aria-label={`Заявка ${b.name || ""}`}>
+    <div className="apptDrawerBackdrop" onClick={onClose} />
+    <aside className="apptDrawerPanel">
+      <div className="apptDrawerHead">
+        <div>
+          <h3>{ph ? <a className="patLink" href={`/staff/patients?phone=${ph}`}>{b.name || "Без імені"}</a> : (b.name || "Без імені")}</h3>
+          <small>{b.code} · {b.desiredDate} · {b.desiredTime || "—"}{doctorName ? ` · 👨‍⚕️ ${doctorName}` : ""}</small>
+        </div>
+        <button type="button" className="apptDrawerClose" onClick={onClose} aria-label="Закрити">✕</button>
+      </div>
+
+      <div className="apptDrawerChips">
+        <span className={`apptTag ${b.patientCategory === "military" ? "mil" : "paid"}`}>{b.patientCategory === "military" ? "Військовий" : "Цивільний"}</span>
+        {isContrast(b.service) && <span className="apptTag contrast">Контраст</span>}
+        {b.patientCategory === "civilian" && <span className={`apptTag ${b.paymentStatus === "paid" ? "paid" : "pay"}`}>{b.paymentStatus === "paid" ? `Оплачено${b.paymentAmount ? ` · ${b.paymentAmount} грн` : ""}` : `Перевірити оплату${b.paymentAmount ? ` · ${b.paymentAmount} грн` : ""}`}</span>}
+        <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
+      </div>
+
+      <dl className="apptDrawerFacts">
+        <div><dt>Дослідження</dt><dd>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}</dd></div>
+        <div><dt>Дата й час</dt><dd>{b.desiredDate} · {b.desiredTime || "—"}</dd></div>
+        {doctorName && <div><dt>Лікар</dt><dd>{doctorName}</dd></div>}
+        <div><dt>Телефон</dt><dd>{b.phone || "—"}</dd></div>
+      </dl>
+
+      {isContrast(b.service) && <p className="apptDrawerNote">Дослідження з контрастуванням — попередьте про підготовку (креатинін, алергоанамнез, натще).</p>}
+
+      <div className="apptDrawerHistory">
+        <div className="apptDrawerHistoryHead"><b>Попередні дослідження</b><span>{history.length}</span></div>
+        {history.length === 0
+          ? <p className="apptDrawerHistoryEmpty">Перше звернення (за номером телефону).</p>
+          : <ul>{history.slice(0, 8).map(h => <li key={h.id}>
+              <button type="button" onClick={() => onOpen(h.id)}>
+                <span className="ihDate">{h.desiredDate}</span>
+                <span className="ihSvc">{h.service}{h.equipmentId ? ` · ${EQUIP[h.equipmentId] || h.equipmentId}` : ""}</span>
+                <span className="ihStatus">{stateLabel(h.status)}</span>
+              </button></li>)}
+            {history.length > 8 && <li className="ihMore">…і ще {history.length - 8}</li>}
+          </ul>}
+      </div>
+
+      <div className="apptDrawerActions">
+        {canConfirm && <button type="button" className="apptDrawerBtn confirm" disabled={confirming} onClick={() => onConfirm!(b.id)}>{confirming ? "…" : "✓ Підтвердити"}</button>}
+        {ph && <a className="apptDrawerBtn" href={`tel:${b.phone}`}>📞 Подзвонити</a>}
+        {ph && <a className="apptDrawerBtn wa" href={`https://wa.me/${ph}`} target="_blank" rel="noreferrer">WhatsApp</a>}
+        {ph && <a className="apptDrawerBtn" href={`/staff/patients?phone=${ph}`}>Картка пацієнта →</a>}
+        <a className="apptDrawerBtn primary" href={`/staff?open=${b.id}#bookings`}>Відкрити повну заявку →</a>
+      </div>
+    </aside>
+  </div>;
+}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
+import BookingDrawer from "../booking-drawer";
 import { type CalBooking } from "../week-calendar";
 
 type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer";
@@ -151,6 +152,7 @@ export default function DashboardPage() {
   const [busyId,setBusyId] = useState<number | null>(null);
   const [agendaFilter,setAgendaFilter] = useState<AgendaFilter>("all");
   const [nowMin,setNowMin] = useState(() => nowMinutesKyiv());
+  const [openId,setOpenId] = useState<number | null>(null);
 
   async function load() {
     const [dashRes, bookingsRes] = await Promise.all([
@@ -337,15 +339,17 @@ export default function DashboardPage() {
                 const active = b.status !== "completed" && b.status !== "performed" && b.status !== "issued";
                 const when = active ? whenLabel(minsUntil(b.desiredTime, nowMin)) : null;
                 const doc = doctorShort(b.assignedRadiologistEmail);
-                return <li key={b.id} className={`dashAgendaRow ${modClass(b.equipmentId)}`}>
-                  <time>{b.desiredTime || "—"}{when ? <em className={`dashAgendaWhen ${when.cls}`}>{when.text}</em> : null}</time>
-                  <div className="dashAgendaWho">
-                    <b>{b.phone ? <a className="patLink" href={patientHref(b.phone)}>{b.name || "Без імені"}</a> : (b.name || "Без імені")}</b>
-                    <small>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doc ? ` · 👨‍⚕️ ${doc}` : ""}</small>
-                  </div>
-                  {isContrast(b) && <span className="dashAgendaFlag">Контраст</span>}
-                  {needsPay(b) && <span className="dashAgendaFlag pay">Оплата</span>}
-                  <span className={`dashAgendaStatus st-${statusGroup(b.status)}`}>{STATUS_UK[b.status] || b.status}</span>
+                return <li key={b.id}>
+                  <button type="button" className={`dashAgendaRow ${modClass(b.equipmentId)}`} onClick={()=>setOpenId(b.id)}>
+                    <time>{b.desiredTime || "—"}{when ? <em className={`dashAgendaWhen ${when.cls}`}>{when.text}</em> : null}</time>
+                    <div className="dashAgendaWho">
+                      <b>{b.name || "Без імені"}</b>
+                      <small>{b.service}{b.equipmentId ? ` · ${EQUIP[b.equipmentId] || b.equipmentId}` : ""}{doc ? ` · 👨‍⚕️ ${doc}` : ""}</small>
+                    </div>
+                    {isContrast(b) && <span className="dashAgendaFlag">Контраст</span>}
+                    {needsPay(b) && <span className="dashAgendaFlag pay">Оплата</span>}
+                    <span className={`dashAgendaStatus st-${statusGroup(b.status)}`}>{STATUS_UK[b.status] || b.status}</span>
+                  </button>
                 </li>;
               })}
             </ul>}
@@ -415,6 +419,20 @@ export default function DashboardPage() {
         </a> : null}
       </details>}
       <ExternalCalendar/>
+
+      {/* Єдиний Workspace на Пульті: клік по розкладу відкриває контекст + дію. */}
+      {(() => {
+        const ob = bookings.find(b => b.id === openId) || null;
+        return ob ? <BookingDrawer
+          booking={ob}
+          all={bookings}
+          doctorName={doctorShort(ob.assignedRadiologistEmail)}
+          onClose={()=>setOpenId(null)}
+          onOpen={setOpenId}
+          onConfirm={canManage ? (id)=>void confirmBooking(id) : undefined}
+          confirming={busyId===ob.id}
+        /> : null;
+      })()}
     </>}
   </StaffWorkspaceShell>;
 }

--- a/app/staff/week-calendar.tsx
+++ b/app/staff/week-calendar.tsx
@@ -5,7 +5,8 @@
 // презентаційний: дані (bookings, staffOptions) приходять пропсами, а стан
 // вигляду/дати/фільтра — локальний.
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import BookingDrawer from "./booking-drawer";
 import { stateLabel } from "../../lib/study-state";
 import { candidateTimesFor, EQUIP_KEYS, EQUIP_LABELS, isEquipmentDayOpen, SCHEDULE_DEFAULTS, type ScheduleConfig } from "../../lib/schedule";
 
@@ -155,23 +156,9 @@ export default function WeekCalendar({
   const filtersApply = view === "week" || view === "list";
 
   // Єдиний Workspace: клік по запису відкриває контекст у правій панелі, без
-  // переходу на іншу сторінку. Дані вже є у пропсі bookings — без бекенду.
+  // переходу на іншу сторінку. Спільний компонент BookingDrawer.
   const [openId, setOpenId] = useState<number | null>(null);
   const openBooking = useMemo(() => bookings.find(b => b.id === openId) || null, [bookings, openId]);
-  const openHistory = useMemo(() => {
-    if (!openBooking) return [] as CalBooking[];
-    const ph = (openBooking.phone || "").replace(/[^\d]/g, "");
-    if (!ph) return [];
-    return bookings
-      .filter(b => b.id !== openBooking.id && (b.phone || "").replace(/[^\d]/g, "") === ph)
-      .sort((a, b) => (b.desiredDate + b.desiredTime).localeCompare(a.desiredDate + a.desiredTime));
-  }, [bookings, openBooking]);
-  useEffect(() => {
-    if (openId === null) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpenId(null); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [openId]);
 
   const hours = Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i);
   const doctorOf = (b: CalBooking) => nameByEmail[b.assignedRadiologistEmail || ""] || nameByEmail[b.assignedRadiographerEmail || ""] || "";
@@ -317,60 +304,13 @@ export default function WeekCalendar({
                 </button>
               ))}</div>}
 
-      {openBooking && (() => {
-        const b = openBooking;
-        const ph = (b.phone || "").replace(/[^\d]/g, "");
-        const doc = doctorOf(b);
-        return <div className="apptDrawer" role="dialog" aria-modal="false" aria-label={`Заявка ${b.name || ""}`}>
-          <div className="apptDrawerBackdrop" onClick={()=>setOpenId(null)} />
-          <aside className="apptDrawerPanel">
-            <div className="apptDrawerHead">
-              <div>
-                <h3>{ph ? <a className="patLink" href={`/staff/patients?phone=${ph}`}>{b.name || "Без імені"}</a> : (b.name || "Без імені")}</h3>
-                <small>{b.code} · {b.desiredDate} · {b.desiredTime || "—"}{doc ? ` · 👨‍⚕️ ${doc}` : ""}</small>
-              </div>
-              <button type="button" className="apptDrawerClose" onClick={()=>setOpenId(null)} aria-label="Закрити">✕</button>
-            </div>
-
-            <div className="apptDrawerChips">
-              <span className={`apptTag ${b.patientCategory==="military"?"mil":"paid"}`}>{b.patientCategory==="military"?"Військовий":"Цивільний"}</span>
-              {isContrast(b) && <span className="apptTag contrast">Контраст</span>}
-              {b.patientCategory==="civilian" && <span className={`apptTag ${b.paymentStatus==="paid"?"paid":"pay"}`}>{b.paymentStatus==="paid"?`Оплачено${b.paymentAmount?` · ${b.paymentAmount} грн`:""}`:`Перевірити оплату${b.paymentAmount?` · ${b.paymentAmount} грн`:""}`}</span>}
-              <span className={`apptBadge grp-${groupOf(b.status)}`}>{stateLabel(b.status)}</span>
-            </div>
-
-            <dl className="apptDrawerFacts">
-              <div><dt>Дослідження</dt><dd>{b.service}{b.equipmentId?` · ${EQUIP[b.equipmentId]||b.equipmentId}`:""}</dd></div>
-              <div><dt>Дата й час</dt><dd>{b.desiredDate} · {b.desiredTime || "—"}</dd></div>
-              {doc && <div><dt>Лікар</dt><dd>{doc}</dd></div>}
-              <div><dt>Телефон</dt><dd>{b.phone || "—"}</dd></div>
-            </dl>
-
-            {isContrast(b) && <p className="apptDrawerNote">Дослідження з контрастуванням — попередьте про підготовку (креатинін, алергоанамнез, натще).</p>}
-
-            <div className="apptDrawerHistory">
-              <div className="apptDrawerHistoryHead"><b>Попередні дослідження</b><span>{openHistory.length}</span></div>
-              {openHistory.length === 0
-                ? <p className="apptDrawerHistoryEmpty">Перше звернення (за номером телефону).</p>
-                : <ul>{openHistory.slice(0,8).map(h => <li key={h.id}>
-                    <button type="button" onClick={()=>setOpenId(h.id)}>
-                      <span className="ihDate">{h.desiredDate}</span>
-                      <span className="ihSvc">{h.service}{h.equipmentId?` · ${EQUIP[h.equipmentId]||h.equipmentId}`:""}</span>
-                      <span className="ihStatus">{stateLabel(h.status)}</span>
-                    </button></li>)}
-                  {openHistory.length>8 && <li className="ihMore">…і ще {openHistory.length-8}</li>}
-                </ul>}
-            </div>
-
-            <div className="apptDrawerActions">
-              {ph && <a className="apptDrawerBtn" href={`tel:${b.phone}`}>📞 Подзвонити</a>}
-              {ph && <a className="apptDrawerBtn wa" href={`https://wa.me/${ph}`} target="_blank" rel="noreferrer">WhatsApp</a>}
-              {ph && <a className="apptDrawerBtn" href={`/staff/patients?phone=${ph}`}>Картка пацієнта →</a>}
-              <a className="apptDrawerBtn primary" href={`/staff?open=${b.id}#bookings`}>Відкрити повну заявку →</a>
-            </div>
-          </aside>
-        </div>;
-      })()}
+      {openBooking && <BookingDrawer
+        booking={openBooking}
+        all={bookings}
+        doctorName={doctorOf(openBooking)}
+        onClose={()=>setOpenId(null)}
+        onOpen={setOpenId}
+      />}
     </div>
   );
 }

--- a/tests/appointments-calendar.test.mjs
+++ b/tests/appointments-calendar.test.mjs
@@ -20,11 +20,14 @@ test("shared week calendar component offers list/day/week views", async () => {
   const css = await read("app/globals.css");
   assert.match(css, /\.apptCardRow\.mod-ct\b/); // смуга КТ
   assert.match(css, /\.apptCardName\{[^}]*font-size:16px/); // ім'я більше за мету
-  // Єдиний Workspace: клік по запису відкриває drawer, а не перехід на сторінку.
+  // Єдиний Workspace: клік по запису відкриває спільний drawer, без переходу.
   assert.match(cal, /setOpenId\(/); // клік відкриває панель
-  assert.match(cal, /apptDrawer/); // права панель
-  assert.match(cal, /openHistory/); // історія пацієнта в панелі
-  assert.match(cal, /Escape/); // закриття по ESC
+  assert.match(cal, /<BookingDrawer/); // спільний компонент панелі
+  const drawer = await read("app/staff/booking-drawer.tsx");
+  assert.match(drawer, /apptDrawer/); // права панель
+  assert.match(drawer, /Попередні дослідження/); // історія пацієнта в панелі
+  assert.match(drawer, /Escape/); // закриття по ESC
+  assert.match(drawer, /onConfirm/); // дія-мутація (Підтвердити) — опційно
   assert.match(css, /\.apptDrawerPanel\b/);
   assert.match(css, /button\.apptCardRow/); // скидання UA-стилів кнопки-рядка
 });
@@ -96,4 +99,7 @@ test("dashboard shows a compact today agenda and a one-click confirm queue", asy
   assert.match(dash, /patientHref/);
   assert.match(dash, /\/staff\/patients\?phone=/);
   assert.match(css, /\.patLink\b/);
+  // Єдиний Workspace на Пульті: клік по розкладу відкриває drawer + дію.
+  assert.match(dash, /<BookingDrawer/);
+  assert.match(dash, /onConfirm=\{canManage/); // мутація підтвердження з панелі
 });


### PR DESCRIPTION
Продовження Єдиного Workspace (№8).

## Що зроблено
- **Спільний компонент `BookingDrawer`.** Праву панель винесено з календаря в окремий компонент — тепер Календар і Пульт користуються **однаковою** панеллю (єдина поведінка: ESC-закриття, історія пацієнта за телефоном, перемикання на інший запис).
- **Drawer на Пульті.** Клік по рядку «Розкладу на сьогодні» відкриває панель із контекстом пацієнта — без переходу на іншу сторінку.
- **Дія-мутація в панелі.** Зʼявилася кнопка **«✓ Підтвердити»** (для admin/registrar) — підтверджує запис і надсилає пацієнту WhatsApp **прямо з drawer**, оновлюючи статус на місці.

## Поведінка
- Календар передає drawer без мутацій (презентаційний компонент, стан у сторінці) — там панель відкриває контекст і дає навігацію (Картка пацієнта, Відкрити повну заявку).
- Пульт передає `onConfirm` (локальний стан заявок) — тому підтвердження працює одразу з панелі.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test tests/*.test.mjs` — **273/273**; додано перевірки спільного `BookingDrawer`, `onConfirm`, drawer на Пульті

## Далі (за бажанням)
- «Перенести» прямо з панелі (дата/час + перевірка слоту).
- Той самий drawer у списках CRM/Дошки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_