### PR TITLE
Drawer у списках CRM і Дошки

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -237,7 +237,9 @@ footer { display:flex;justify-content:space-between;align-items:center;gap:25px;
 .crmCreateActions .crmCancel{background:#fff;color:#41544f;border-color:#d5ddd9}
 @media(max-width:600px){.crmCreateForm{grid-template-columns:1fr}}
 .crmColumns{display:grid;grid-template-columns:1.3fr 1fr;gap:16px;align-items:start}.crmColumns h3{font-family:var(--font-serif);font-size:20px;margin-bottom:12px;color:#20423d}
-.crmVisits ol,.crmCommList{margin:0;padding:0;list-style:none}.crmVisits li{padding:14px;margin-bottom:8px;border:1px solid #e4e9e6;border-radius:7px;background:#f8fbfa}.crmVisitHead{display:flex;flex-wrap:wrap;align-items:center;gap:8px}.crmVisitHead b{font-size:13px}.crmVisitHead small{color:#71807c;font-size:11px}.crmVisitMeta{display:flex;flex-direction:column;gap:3px;margin:8px 0}.crmVisitMeta span{color:#5b6d69;font-size:11px}.crmVisitLink{color:#0d5b50;font-size:11px;font-weight:800}.crmVisitLink:hover{text-decoration:underline}
+.crmVisits ol,.crmCommList{margin:0;padding:0;list-style:none}.crmVisits li{padding:14px;margin-bottom:8px;border:1px solid #e4e9e6;border-radius:7px;background:#f8fbfa}.crmVisitHead{display:flex;flex-wrap:wrap;align-items:center;gap:8px}
+button.crmVisitHead{width:100%;text-align:left;background:transparent;border:0;padding:0;font:inherit;cursor:pointer;color:inherit}
+button.crmVisitHead:hover b{text-decoration:underline;text-underline-offset:2px;color:#0d5b50}.crmVisitHead b{font-size:13px}.crmVisitHead small{color:#71807c;font-size:11px}.crmVisitMeta{display:flex;flex-direction:column;gap:3px;margin:8px 0}.crmVisitMeta span{color:#5b6d69;font-size:11px}.crmVisitLink{color:#0d5b50;font-size:11px;font-weight:800}.crmVisitLink:hover{text-decoration:underline}
 .crmComms .crmCommForm{padding:16px;border:1px solid #e4e9e6;border-radius:7px;background:#f8fbfa;margin-bottom:14px}.crmCommRow{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:10px}.crmComms .crmCommForm>label{margin-bottom:10px}.crmComms .crmCommForm button{width:100%}
 .crmCommList li{padding:12px 0;border-bottom:1px solid #eceeea}.crmCommList li>div{display:flex;align-items:center;gap:8px}.crmCommList b{font-size:12px}.crmCommTag{display:inline-block;padding:3px 8px;border-radius:20px;font-size:9px;font-weight:900;text-transform:uppercase;letter-spacing:.04em;background:#eef1f0;color:#5f706c}.crmCommTag.inbound{background:#e0f2ea;color:#0d6b52}.crmCommTag.outbound{background:#dcecf6;color:#155e86}.crmCommList p{margin:8px 0 5px;font-size:12px;line-height:1.5;color:#2d3f3b}.crmCommList small{color:#71807c;font-size:10px}
 .crmStatDivider{display:none}
@@ -492,8 +494,9 @@ button.dashAgendaRow:hover{background:#f7faf9}
 .intakeHistoryHead span{font-size:11px;font-weight:800;color:#5b6a66;background:#fff;border:1px solid #e0e7e4;padding:1px 9px;border-radius:20px}
 .intakeHistoryEmpty{margin:0;padding:12px 13px;color:#8a9995;font-size:12px}
 .intakeHistory ul{list-style:none;margin:0;padding:4px}
-.intakeHistory li a{display:grid;grid-template-columns:84px 1fr auto;align-items:center;gap:10px;padding:8px 10px;border-radius:8px;text-decoration:none;color:inherit}
-.intakeHistory li a:hover{background:#f4f8f7}
+.intakeHistory li a,.intakeHistory li button{display:grid;grid-template-columns:84px 1fr auto;align-items:center;gap:10px;padding:8px 10px;border-radius:8px;text-decoration:none;color:inherit}
+.intakeHistory li button{width:100%;background:transparent;border:0;font:inherit;text-align:left;cursor:pointer}
+.intakeHistory li a:hover,.intakeHistory li button:hover{background:#f4f8f7}
 .ihDate{font-size:11.5px;font-weight:700;color:#41544f;font-variant-numeric:tabular-nums}
 .ihSvc{font-size:12.5px;color:#3a4a45;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ihStatus{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.03em;padding:2px 8px;border-radius:20px;background:#eef2f0;color:#5b6a66;white-space:nowrap}

--- a/app/staff/intake/page.tsx
+++ b/app/staff/intake/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
+import BookingDrawer from "../booking-drawer";
+import { type CalBooking } from "../week-calendar";
 import { SERVICES, groupedServices } from "../../../lib/catalog";
 import { todayInKyiv } from "../../../lib/booking-rules";
 
@@ -88,6 +90,16 @@ export default function IntakePage() {
   }, [data]);
 
   const selected = data?.bookings.find(b => b.id === selectedId) || null;
+
+  // Drawer у Дошці: швидкий контекст попередніх досліджень пацієнта.
+  const [drawerId,setDrawerId] = useState<number | null>(null);
+  const drawerBookings = useMemo<CalBooking[]>(() => (data?.bookings || []).map((b) => ({
+    id:b.id, code:b.code, name:b.name, phone:b.phone, service:b.service, serviceCode:b.serviceCode,
+    equipmentId:b.equipmentId, durationMinutes:b.durationMinutes, desiredDate:b.desiredDate,
+    desiredTime:b.desiredTime, status:b.status, patientCategory:b.patientCategory,
+    paymentStatus:b.paymentStatus, paymentAmount:b.paymentAmount,
+  })), [data]);
+  const drawerBooking = drawerBookings.find((b) => b.id === drawerId) || null;
 
   // Попередні дослідження цього пацієнта — за номером телефону (без окремого
   // бекенду: беремо з уже завантаженого списку заявок). Пацієнт як центр.
@@ -256,11 +268,11 @@ export default function IntakePage() {
                 {history.length === 0
                   ? <p className="intakeHistoryEmpty">Перше звернення цього пацієнта (за номером телефону).</p>
                   : <ul>{history.slice(0,8).map(h => <li key={h.id}>
-                      <a href={`/staff?open=${h.id}#bookings`}>
+                      <button type="button" onClick={()=>setDrawerId(h.id)}>
                         <span className="ihDate">{h.desiredDate}</span>
                         <span className="ihSvc">{h.service}{h.equipmentId?` · ${EQUIP_UK[h.equipmentId]||h.equipmentId}`:""}</span>
                         <span className={`ihStatus st-${h.status}`}>{STATUS_LABELS[h.status]||h.status}</span>
-                      </a></li>)}
+                      </button></li>)}
                     {history.length>8 && <li className="ihMore">…і ще {history.length-8}</li>}
                   </ul>}
               </div>
@@ -280,7 +292,16 @@ export default function IntakePage() {
         {toast && <div className="intakeToast" role="status">{toast}</div>}
       </div>;
 
-  return <StaffWorkspaceShell active="intake" title="Дошка прийому" description="Заявки з сайту й ручні — перегляд, корекція та обробка в одному місці." staffName={data?.staff.displayName} staffRole={data?.staff.role}>{body}</StaffWorkspaceShell>;
+  return <StaffWorkspaceShell active="intake" title="Дошка прийому" description="Заявки з сайту й ручні — перегляд, корекція та обробка в одному місці." staffName={data?.staff.displayName} staffRole={data?.staff.role}>
+    {body}
+    {drawerBooking && <BookingDrawer
+      key={drawerBooking.id}
+      booking={drawerBooking}
+      all={drawerBookings}
+      onClose={()=>setDrawerId(null)}
+      onOpen={setDrawerId}
+    />}
+  </StaffWorkspaceShell>;
 }
 
 function IntakeForm({ form, set, times, serviceGroups, readOnly=false }:{

--- a/app/staff/patients/page.tsx
+++ b/app/staff/patients/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
+import BookingDrawer from "../booking-drawer";
+import { type CalBooking } from "../week-calendar";
 import {
   CHANNEL_LABELS,
   COMMUNICATION_CHANNELS,
@@ -193,6 +195,29 @@ export default function PatientsPage() {
   }
 
   const canManage = staff?.role === "admin" || staff?.role === "registrar";
+
+  // Drawer у CRM: візити пацієнта у форматі спільної панелі (контекст + дії),
+  // без переходу зі сторінки. Будуємо CalBooking із візиту + даних пацієнта.
+  const [openId,setOpenId] = useState<number | null>(null);
+  const [drawerBusy,setDrawerBusy] = useState<number | null>(null);
+  const drawerBookings = useMemo<CalBooking[]>(() => (card?.bookings || []).map((v) => ({
+    id:v.id, code:v.code, name:card?.profile?.displayName || card?.patient?.name || "", phone:card?.phone || "",
+    service:v.service, serviceCode:v.serviceCode, equipmentId:v.equipmentId, durationMinutes:30,
+    desiredDate:v.desiredDate, desiredTime:v.desiredTime, status:v.status,
+    patientCategory:card?.patient?.category, paymentStatus:v.paymentStatus, paymentAmount:v.paymentAmount,
+  })), [card]);
+  const openBooking = drawerBookings.find((b) => b.id === openId) || null;
+
+  async function drawerPatch(body:Record<string,unknown>) {
+    const id = body.id as number;
+    setDrawerBusy(id);
+    try {
+      const res = await fetch("/api/staff/bookings", { method:"PATCH", headers:{"content-type":"application/json"}, body:JSON.stringify(body) });
+      if (res.ok && card) await openPatient(card.phone);
+      else { const d = await res.json().catch(()=>({})) as { error?:string }; setActionError(d.error || "Не вдалося виконати дію"); }
+    } finally { setDrawerBusy(null); }
+  }
+
   const counts = useMemo(() => segmentCounts(patients), [patients]);
   const visible = useMemo(() => patients
     .filter((item) => matchesSegment(item, segment))
@@ -316,11 +341,11 @@ export default function PatientsPage() {
               <h3>Історія візитів</h3>
               {card.bookings.length === 0 ? <p className="empty">Візитів ще немає.</p> : <ol>
                 {card.bookings.map((booking)=><li key={booking.id}>
-                  <div className="crmVisitHead">
+                  <button type="button" className="crmVisitHead" onClick={()=>setOpenId(booking.id)} title="Швидкий перегляд у панелі">
                     <span className={`statusTag ${booking.status}`}>{statusLabels[booking.status] || booking.status}</span>
                     <b>{booking.service}</b>
                     <small>{booking.code} · {formatDate(booking.desiredDate)} {booking.desiredTime}</small>
-                  </div>
+                  </button>
                   <div className="crmVisitMeta">
                     <span>Протокол: {protocolLabels[booking.protocolStatus] || booking.protocolStatus}{booking.protocolNumber?` (№ ${booking.protocolNumber})`:""}</span>
                     <span>Оплата: {paymentLabels[booking.paymentStatus] || booking.paymentStatus}{booking.paidAmount?` · ${booking.paidAmount} грн`:""}</span>
@@ -354,6 +379,17 @@ export default function PatientsPage() {
           </div>
         </>}
       </section>
+      {openBooking && <BookingDrawer
+        key={openBooking.id}
+        booking={openBooking}
+        all={drawerBookings}
+        onClose={()=>setOpenId(null)}
+        onOpen={setOpenId}
+        onConfirm={canManage ? (id)=>void drawerPatch({ id, confirm:true }) : undefined}
+        confirming={drawerBusy===openBooking.id}
+        onReschedule={canManage ? (id,date,time)=>void drawerPatch({ id, desiredDate:date, desiredTime:time }) : undefined}
+        rescheduling={drawerBusy===openBooking.id}
+      />}
     </div>}
   </StaffWorkspaceShell>;
 }

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -59,6 +59,9 @@ test("intake board page is a two-pane queue + editable detail, wired into the sh
   // Пацієнт як центр: із Дошки — перехід у повну картку пацієнта (CRM).
   assert.match(page, /Картка пацієнта/);
   assert.match(page, /\/staff\/patients\?phone=/);
+  // Drawer у Дошці: клік по попередньому дослідженню відкриває спільну панель.
+  assert.match(page, /<BookingDrawer/);
+  assert.match(page, /setDrawerId\(h\.id\)/);
   const css = await read("app/globals.css");
   assert.match(css, /\.intakeHistory\b/); // стилі історії
   assert.match(css, /\.intakeFacts\b/);   // сітка фактів

--- a/tests/patient-crm.test.mjs
+++ b/tests/patient-crm.test.mjs
@@ -92,6 +92,10 @@ test("CRM card shows a loading state, a book action, and context-correct visit l
   // Майбутні візити ведуть у календар, виконані — у протокол.
   assert.match(page, /\/staff\/appointments\?date=/);
   assert.match(page, /performedAt \|\| \["ready","issued","in_progress"\]/);
+  // Drawer у CRM: клік по візиту відкриває спільну панель (контекст + дії).
+  assert.match(page, /<BookingDrawer/);
+  assert.match(page, /button type="button" className="crmVisitHead"/);
+  assert.match(page, /drawerPatch/); // підтвердження/перенесення з панелі
 });
 
 test("booking form pre-fills patient data from query params (CRM → book)", async () => {


### PR DESCRIPTION
Розширення Єдиного Workspace: той самий `BookingDrawer` тепер і в CRM, і на Дошці — на вкладених списках, де раніше клік вів зі сторінки.

## CRM (Картки пацієнтів)
Клік по візиту в **«Історії візитів»** відкриває панель із контекстом і **діями**:
- Підтвердити / Перенести (з перевіркою вільних слотів) — оновлюють картку пацієнта **на місці**, без переходу;
- WhatsApp, дзвінок, перехід у повну заявку.
Історія в панелі = інші візити цього ж пацієнта.

## Дошка прийому
Клік по **«Попередньому дослідженню»** відкриває панель зі швидким контекстом минулого візиту (WhatsApp, картка пацієнта, відкрити повну заявку). Двопанельний робочий процес Дошки лишається — drawer лише для швидкого перегляду вкладеного списку.

## Технічно
- Обидва екрани будують `CalBooking` зі своїх даних (візити пацієнта / заявки) — **без нового бекенду**.
- Рядки-посилання стали кнопками (скинуто UA-стилі), drawer keyed по `booking.id`.
- CRM-дії доступні лише admin/registrar.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test tests/*.test.mjs` — **273/273**; додано перевірки `<BookingDrawer>` у CRM і Дошці, `drawerPatch`, кнопок-рядків

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_