### PR TITLE
v2 Design System — Phase 2a: єдина система карток + ієрархія

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -179,6 +179,14 @@ footer { display:flex;justify-content:space-between;align-items:center;gap:25px;
   --mod-us:#0e8f8a; --mod-other:#8a9995;
   --mod-contrast:#7048c4; --mod-urgent:#dc4b3e;
 }
+/* Єдина система карток: одна поверхня з токенів. Ієрархія — через елевацію:
+   .raised (Primary — робота зараз) / базова (Secondary) / .flat (Details). */
+.ds-card{background:#fff;border:1px solid #e7ece9;border-radius:var(--r-lg);box-shadow:var(--sh-1);padding:var(--sp-4)}
+.ds-card.raised{box-shadow:var(--sh-2)}
+.ds-card.flat{box-shadow:none}
+.ds-card.pad-lg{padding:var(--sp-5)}
+.ds-section-label{font-size:var(--fs-xs);font-weight:900;text-transform:uppercase;letter-spacing:.08em;color:#8a9995}
+.themeDark .ds-card{background:#121a20;border-color:#22303a}
 .workspaceSidebar{position:fixed;inset:0 auto 0 0;width:var(--workspace-sidebar);display:flex;flex-direction:column;background:#123d3a;color:#fff;border-right:1px solid rgba(255,255,255,.08);z-index:40;transition:width .2s ease}
 .workspaceBrand{height:64px;display:flex;align-items:center;gap:11px;padding:0 18px;border-bottom:1px solid rgba(255,255,255,.1)}
 .workspaceBrandMark{width:34px;height:34px;flex:0 0 34px;display:grid;place-items:center;border-radius:8px;background:#fff;color:#0d5b50;font-family:var(--font-serif);font-size:18px;font-weight:700;box-shadow:0 8px 24px rgba(0,0,0,.14)}
@@ -391,7 +399,7 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .themeDark .dashChip.on{background:#2aa198;border-color:#2aa198;color:#08201f}
 .themeDark .dashAnalytics{border-top-color:#22303a}
 /* Пульт — нові заявки з миготінням і підтвердженням у 1 клік */
-.dashLoad{max-width:var(--dash-w);margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:14px;padding:16px}
+.dashLoad{max-width:var(--dash-w);margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:var(--r-lg);box-shadow:var(--sh-1);padding:var(--sp-4)}
 .dashLoadGrid{display:grid;gap:6px 8px;align-items:end;margin-top:12px}
 .dashLoadCorner{grid-row:1}
 .dashLoadDay{grid-row:1;text-align:center;font-size:11px;font-weight:800;color:#8a9995;display:flex;flex-direction:column;gap:1px}
@@ -403,7 +411,7 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .dashLoadCell i.empty{background:transparent;min-height:0}
 .dashLoadCell b{position:absolute;top:3px;font-size:11px;font-weight:800;color:#25332f}
 @media(max-width:640px){.dashLoadRow{font-size:11px}.dashLoadCell{height:40px}}
-.dashPending{max-width:var(--dash-w);margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:14px;padding:16px}
+.dashPending{max-width:var(--dash-w);margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:var(--r-lg);box-shadow:var(--sh-2);padding:var(--sp-4)}
 .dashPendingHead{display:flex;flex-wrap:wrap;align-items:baseline;gap:10px;margin-bottom:10px}
 .dashPendingHead h2{font-size:16px;font-weight:750;margin:0}
 .dashPendingHead small{color:#71807c;font-size:12px}
@@ -429,7 +437,7 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .dashCalActions a{font-size:13px;font-weight:700;color:var(--green,#0c7a85);text-decoration:none}
 .dashCalActions a:hover{text-decoration:underline}
 .dashAgendaCount{display:inline-block;margin-left:6px;padding:1px 9px;border-radius:99px;background:#e6f4f5;border:1px solid #bfe0e3;color:#0a5f68;font-size:12px;font-weight:800;vertical-align:middle}
-.dashAgenda{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #e7ece9;border-radius:14px;overflow:hidden}
+.dashAgenda{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #e7ece9;border-radius:var(--r-lg);box-shadow:var(--sh-1);overflow:hidden}
 .dashAgendaRow{display:flex;align-items:center;gap:12px;padding:10px 14px;border-top:1px solid #f0f3f1}
 button.dashAgendaRow{width:100%;background:transparent;border-left:0;border-right:0;border-bottom:0;font:inherit;text-align:left;cursor:pointer}
 button.dashAgendaRow:hover{background:#f7faf9}
@@ -905,7 +913,7 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 @media(max-width:720px){.chatShell{grid-template-columns:1fr;height:auto}.chatThread{min-height:420px}}
 .settingsCard .notice{margin:0;padding:11px 13px;border-radius:7px;font-size:13px}.settingsCard .notice.success{background:#eef4e6;color:#33632c}.settingsCard .notice.error{background:#fdf1ee;color:#a23c1d}
 .dashLists{max-width:var(--dash-w);margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:12px}
-.dashList{padding:0;background:#fff;border:1px solid #e7ece9;border-radius:18px;box-shadow:0 1px 2px rgba(24,40,30,.04),0 8px 24px rgba(24,40,30,.05);overflow:hidden}
+.dashList{padding:0;background:#fff;border:1px solid #e7ece9;border-radius:var(--r-lg);box-shadow:var(--sh-1);overflow:hidden}
 .dashListHead{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:15px 17px;border-bottom:1px solid #eef2f0}.dashListHead h3{font-size:14.5px;font-weight:700;color:#1b211e}.dashListHead span{font-size:12px;font-weight:700;color:#6b7672;background:#f2f6f4;border:1px solid #e7ece9;padding:2px 10px;border-radius:20px;font-variant-numeric:tabular-nums}
 .dashListHint{margin:0;padding:11px 17px 2px;color:#8b948f;font-size:11.5px}
 .dashListEmpty{margin:12px;padding:18px 14px;background:#f5f8f6;border-radius:12px;color:#5f716d;font-size:12px}
@@ -1628,7 +1636,7 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .studiesTable select.studiesAssign{min-width:130px}
 
 /* Пульт: клінічна черга за станами (state machine) */
-.dashQueue{display:block;max-width:var(--dash-w);margin:0 auto 16px;padding:16px 18px;border:1px solid #dce4e3;border-radius:14px;background:#fff;text-decoration:none;color:inherit;transition:border-color .12s,box-shadow .12s}
+.dashQueue{display:block;max-width:var(--dash-w);margin:0 auto 16px;padding:var(--sp-4) 18px;border:1px solid #dce4e3;border-radius:var(--r-lg);box-shadow:var(--sh-1);background:#fff;text-decoration:none;color:inherit;transition:border-color var(--dur-fast) var(--ease),box-shadow var(--dur-fast) var(--ease)}
 .dashQueue:hover{border-color:var(--ws-accent);box-shadow:0 6px 22px rgba(12,122,133,.1)}
 .dashQueueHead{display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:12px}
 .dashQueueHead b{font-size:14px;color:var(--ink)}

--- a/tests/design-tokens.test.mjs
+++ b/tests/design-tokens.test.mjs
@@ -33,3 +33,16 @@ test("modality colours reference tokens (no duplicated hex across surfaces)", as
   // Рух прив'язаний до токенів на ключових інтерактивних елементах.
   assert.match(css, /\.dashMcItem\{[^}]*transition:var\(--dur-fast\) var\(--ease\)\}/);
 });
+
+test("card system: .ds-card primitives + dashboard surfaces use token radius/elevation", async () => {
+  const css = await read("app/globals.css");
+  // Примітив картки й рівні елевації.
+  assert.match(css, /\.ds-card\{[^}]*border-radius:var\(--r-lg\)[^}]*box-shadow:var\(--sh-1\)/);
+  assert.match(css, /\.ds-card\.raised\{box-shadow:var\(--sh-2\)\}/);
+  assert.match(css, /\.ds-card\.flat\{box-shadow:none\}/);
+  // Ієрархія на Пульті: нові заявки — Primary (підняті), аналітика — пласкіша.
+  assert.match(css, /\.dashPending\{[^}]*border-radius:var\(--r-lg\)[^}]*box-shadow:var\(--sh-2\)/);
+  assert.match(css, /\.dashLoad\{[^}]*box-shadow:var\(--sh-1\)/);
+  // Радіуси уніфіковано на токен (без розкиду 12/14/18).
+  assert.doesNotMatch(css, /\.dashList\{[^}]*border-radius:18px/);
+});


### PR DESCRIPTION
Друга фаза дизайн-системи: одна система карток замість «плоских однакових білих прямокутників» (ваші п.4 і п.5).

## Що додано
- **Примітив `.ds-card`** на токенах: `border-radius:var(--r-lg)`, `box-shadow:var(--sh-1)`, `padding:var(--sp-4)`. Рівні елевації для ієрархії:
  - `.ds-card.raised` (`--sh-2`) — **Primary** (робота зараз);
  - базова — **Secondary**;
  - `.ds-card.flat` — **Details**.
- `.ds-section-label` — заголовок секції на токен-шкалі.

## Пульт: ієрархія замість «все однаково важливе»
- **Нові заявки** — підняті (`--sh-2`), читаються як головний блок;
- **Розклад** — базова поверхня;
- **Аналітика / списки / клінічна черга** — пласкіші (`--sh-1`), відступають на другий план.
- Радіуси уніфіковано на `--r-lg` (був розкид 12/14/18px), переходи — на `--dur-fast`.

Це прибирає «мозок швидко перестає помічати однакові прямокутники»: тепер видно, куди дивитися першим.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test tests/*.test.mjs` — **276/276**; додано перевірки `.ds-card`/`.raised`/`.flat` і токен-радіусів/елевації на Пульті

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_