### PR TITLE
Пульт: минулі заявки не світяться у черзі підтвердження

### DIFF
--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -188,12 +188,16 @@ export default function DashboardPage() {
     return () => window.clearInterval(id);
   }, []);
 
+  // Дата «сьогодні» (Київ) — потрібна і для черги заявок, і для розкладу нижче.
+  const today = data?.today || new Intl.DateTimeFormat("en-CA", { timeZone:"Europe/Kyiv" }).format(new Date());
+
   // Нові/перенесені заявки, що чекають на реакцію реєстратури — миготять,
-  // доки їх не підтвердять. Найновіші згори.
+  // доки їх не підтвердять. Минулі (дата дослідження вже пройшла) не показуємо —
+  // підтверджувати вже пізно. Найновіші згори.
   const pending = useMemo(() => bookings
-    .filter(b => b.status === "new" || b.status === "rescheduled")
+    .filter(b => (b.status === "new" || b.status === "rescheduled") && (b.desiredDate || "") >= today)
     .sort((a, b) => (b.code || "").localeCompare(a.code || "")),
-  [bookings]);
+  [bookings, today]);
 
   const canManage = staff?.role === "admin" || staff?.role === "registrar";
 
@@ -242,7 +246,6 @@ export default function DashboardPage() {
 
   // Розклад на сьогодні (Київ). Пульт дає лише короткий огляд — повний
   // тижневий календар живе в окремому розділі «Календар записів».
-  const today = data?.today || new Intl.DateTimeFormat("en-CA", { timeZone:"Europe/Kyiv" }).format(new Date());
   const todayAgenda = useMemo(() => bookings
     .filter(b => b.desiredDate === today && b.status !== "cancelled")
     .sort((a, b) => (a.desiredTime || "").localeCompare(b.desiredTime || "")),

--- a/tests/dashboard.test.mjs
+++ b/tests/dashboard.test.mjs
@@ -46,6 +46,14 @@ test("dashboard exposes a tenant-scoped clinical queue by machine state", async 
   assert.match(page, /\/staff\/studies/);
 });
 
+test("pending queue hides bookings whose date has already passed", async () => {
+  const page = await read("app/staff/dashboard/page.tsx");
+  // Черга «Нові заявки» лишає тільки заявки з датою дослідження ≥ сьогодні.
+  assert.match(page, /\(b\.status === "new" \|\| b\.status === "rescheduled"\) && \(b\.desiredDate \|\| ""\) >= today/);
+  // today визначено до pending, щоб фільтр міг ним користуватися.
+  assert.match(page, /const today = data\?\.today \|\|/);
+});
+
 async function renderPath(path) {
   const workerUrl = new URL("../dist/server/index.js", import.meta.url);
   workerUrl.searchParams.set("test", `${process.pid}-${Date.now()}`);


### PR DESCRIPTION
Черга «Нові заявки» на Пульті показувала й дослідження, дата яких **уже минула** (на скріні — заявки на 28–31.07 і 03.08, хоча сьогодні 09.08). Підтверджувати такі вже пізно — вони лише захаращували чергу й миготіли.

## Виправлення
До фільтра черги додано умову `desiredDate >= today` — лишаються тільки заявки з датою дослідження сьогодні або в майбутньому. Змінна `today` (Київ) перенесена вище за `pending`, щоб фільтр міг нею користуватися.

- Статуси `new` / `rescheduled` з майбутньою датою — світяться, як і раніше.
- Ті самі статуси з минулою датою — більше не показуються в черзі (і не рахуються в лічильнику «нових заявок», бо він = `pending.length`).

Скасовані заявки не зачеплено (окрема логіка). Дані не змінюються — лише клієнтський фільтр відображення.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test tests/*.test.mjs` — усі зелені; додано перевірку фільтра дати в черзі

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_