### PR TITLE
Публічний сайт → бренд дизайн-системи + чистка блоку переваг price

### DIFF
--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -6,15 +6,15 @@
 <title>Особистий кабінет — RadiologyOS</title>
 <meta name="description" content="Особистий кабінет пацієнта відділення променевої діагностики: статус заявок, дата запису та протокол дослідження."/>
 <meta name="robots" content="noindex"/>
-<meta name="theme-color" content="#0c7a85"/>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
+<meta name="theme-color" content="#123d3a"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <style>
-:root{--brand:#0c7a85;--brand-dark:#0e6b74}
+:root{--brand:#123d3a;--brand-dark:#0d302e}
 :root{
-  --bg:#eef2f5;--ink:#0e161c;--muted:#5c6c78;--line:#dbe3e8;
-  --gold:#25b4c0;--olive:var(--brand);
+  --bg:#f3f6f8;--ink:#18302f;--muted:#5c6c78;--line:#dbe3e8;
+  --gold:#ef744d;--olive:var(--brand);
   --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));
-  --shadow:0 16px 42px rgba(24,34,19,.12);
+  --shadow:0 12px 32px rgba(18,40,30,.10);
 }
 *{box-sizing:border-box}
 body{margin:0;padding:14px 0 40px;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -17,8 +17,8 @@
 <meta name="twitter:description" content="Відділення променевої діагностики у Чернігові: КТ, рентген, флюорографія, онлайн-запис."/>
 <meta name="twitter:image" content="https://radiologyos.tech/hospital-emblem.jpg"/>
 <link rel="canonical" href="https://radiologyos.tech/"/>
-<meta name="theme-color" content="#0c7a85"/>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
+<meta name="theme-color" content="#123d3a"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"MedicalClinic","@id":"https://radiologyos.tech/#clinic","name":"Відділення променевої діагностики Чернігівського військового госпіталю","url":"https://radiologyos.tech/","telephone":"+380972808899","description":"КТ, КТ з контрастуванням, цифрова рентгенографія та флюорографія у Чернігові.","medicalSpecialty":"Radiologic","address":{"@type":"PostalAddress","streetAddress":"вул. Гетьмана Полуботка, 40","addressLocality":"Чернігів","postalCode":"14013","addressCountry":"UA"},"geo":{"@type":"GeoCoordinates","latitude":51.4978508,"longitude":31.3094428},"hasMap":"https://www.google.com/maps?q=51.4978508,31.3094428","areaServed":{"@type":"City","name":"Чернігів"},"openingHoursSpecification":[{"@type":"OpeningHoursSpecification","dayOfWeek":["Monday","Tuesday","Wednesday","Thursday","Friday"],"opens":"08:30","closes":"17:30"}]}
 </script>
@@ -33,11 +33,11 @@
 </script>
 <style>
 /* ===== Токени ===== */
-:root{--brand:#0c7a85;--brand-dark:#0e6b74;
-  --bg:#eef2f5;--ink:#0e161c;--muted:#5c6c78;--line:#dbe3e8;
-  --gold:#25b4c0;--beige:#d9eef0;
+:root{--brand:#123d3a;--brand-dark:#0d302e;
+  --bg:#f3f6f8;--ink:#18302f;--muted:#5c6c78;--line:#dbe3e8;
+  --gold:#ef744d;--beige:#e7efec;
   --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));
-  --shadow:0 16px 42px rgba(24,34,19,.12);
+  --shadow:0 12px 32px rgba(18,40,30,.10);
 }
 
 /* ===== База ===== */

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -2,14 +2,14 @@
 
 <html lang="uk"><head><meta charset="utf-8"/><meta content="width=device-width,initial-scale=1" name="viewport"/><title>Дослідження для військовослужбовців</title>
 <meta name="description" content="Безоплатні дослідження для військовослужбовців у відділенні променевої діагностики Чернігівського військового госпіталю: КТ, рентгенографія, флюорографія."/>
-<meta name="theme-color" content="#0c7a85"/>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
+<meta name="theme-color" content="#123d3a"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <style>
-:root{--brand:#26734d;--brand-dark:#15563a}
+:root{--brand:#123d3a;--brand-dark:#0d302e}
 :root{
-  --bg:#eef2f5;--paper:#fff;--ink:#0e161c;--muted:#5c6c78;--dark:var(--brand);
-  --dark2:var(--brand-dark);--olive:#0a5f68;--beige:#d9eef0;--line:#dbe3e8;
-  --gold:#25b4c0;--shadow:0 16px 42px rgba(24,34,19,.12);--r:24px
+  --bg:#f3f6f8;--paper:#fff;--ink:#18302f;--muted:#5c6c78;--dark:var(--brand);
+  --dark2:var(--brand-dark);--olive:#0a5f68;--beige:#e7efec;--line:#dbe3e8;
+  --gold:#ef744d;--shadow:0 12px 32px rgba(18,40,30,.10);--r:24px
 }
 *{box-sizing:border-box}html{scroll-behavior:smooth}
 body{margin:0;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -111,7 +111,7 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
   .civilian-heading-card{align-items:flex-start;flex-direction:column;padding:20px}
   .civilian-heading-card h1{font-size:30px}
 }
-.civ-benefits{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-top:14px}
+.civ-benefits{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;margin-top:14px}
 .civ-benefit{background:#fffdf5;border:1px solid #e7cf7a;border-radius:16px;padding:14px 16px;box-shadow:0 8px 24px rgba(126,91,0,.06)}
 .civ-benefit b{display:block;font-size:15px;color:#302400;margin-bottom:4px}
 .civ-benefit span{font-size:13px;color:#68551b;line-height:1.4}
@@ -229,8 +229,6 @@ body{background:#fff9e8}
 </div>
 <div class="civ-benefits">
   <div class="civ-benefit"><b>🩻 Сучасне цифрове обладнання</b><span>КТ, цифрова рентгенографія та флюорографія — низька доза й висока якість зображення.</span></div>
-  <div class="civ-benefit"><b>👨‍⚕️ Висновок лікаря-рентгенолога</b><span>Кожне дослідження — письмовий опис фахівця, а не лише знімок.</span></div>
-  <div class="civ-benefit"><b>📀 Результат зручно</b><span>Знімки на CD, опис — в електронну карту та на email.</span></div>
   <div class="civ-benefit"><b>🗓️ Онлайн-запис без черг</b><span>Оберіть дослідження й зручний вільний час прямо на сайті.</span></div>
 </div>
 </div></section>

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -2,14 +2,14 @@
 
 <html lang="uk"><head><meta charset="utf-8"/><meta content="width=device-width,initial-scale=1" name="viewport"/><title>Повний прайс — RadiologyOS</title>
 <meta name="description" content="Повний прайс відділення променевої діагностики: цифрова флюорографія, рентгенографія, КТ з контрастуванням та без, КТ-ангіографія. Онлайн-заявка на обстеження у Чернігові."/>
-<meta name="theme-color" content="#0c7a85"/>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230e161c'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%2325b4c0'/%3E%3C/svg%3E"/>
+<meta name="theme-color" content="#123d3a"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <style>
-:root{--brand:#b57c00;--brand-dark:#855a00}
+:root{--brand:#123d3a;--brand-dark:#0d302e}
 :root{
-  --bg:#eef2f5;--paper:#fff;--ink:#0e161c;--muted:#5c6c78;--dark:var(--brand);
-  --dark2:var(--brand-dark);--olive:#855a00;--beige:#fff1b8;--line:#e6dfc7;
-  --gold:#f2c94c;--shadow:0 16px 42px rgba(24,34,19,.12);--r:24px
+  --bg:#f3f6f8;--paper:#fff;--ink:#18302f;--muted:#5c6c78;--dark:var(--brand);
+  --dark2:var(--brand-dark);--olive:#855a00;--beige:#e7efec;--line:#dbe3e8;
+  --gold:#ef744d;--shadow:0 12px 32px rgba(18,40,30,.10);--r:24px
 }
 *{box-sizing:border-box}html{scroll-behavior:smooth}
 body{margin:0;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}

--- a/tests/site-content.test.mjs
+++ b/tests/site-content.test.mjs
@@ -128,13 +128,13 @@ test("stage 2: color and storefront type are validated while logo stays disabled
 
 test("landing themes via CSS variable, honors storefront type and has no logo", async () => {
   const html = await read("public/site/index.html");
-  assert.match(html, /--brand:#0c7a85/); // змінна визначена
+  assert.match(html, /--brand:#123d3a/); // дефолт бренду = бренд /staff (дизайн-система)
   assert.match(html, /setProperty\('--brand',c\.brandColor\)/); // застосування кольору
   assert.match(html, /storefrontType==='paid_only'/); // ховає картку військових
   assert.match(html, /id="scMilCard"/);
   assert.doesNotMatch(html, /id="scLogo"|brand-logo/);
   // Колірні літерали замінено на var(--brand) — лишились тільки meta + визначення змінної.
-  assert.ok((html.match(/#0c7a85/g) || []).length <= 2);
+  assert.ok((html.match(/#123d3a/g) || []).length <= 2);
 });
 
 test("legacy logo values are ignored", () => {


### PR DESCRIPTION
Два блоки: єдність бренду публічного сайту з `/staff` + правка контенту на `price`.

## Єдність бренду з `/staff`
Уніфіковано `:root` усіх публічних сторінок (`index` / `price` / `military` / `cabinet`):
- `--brand` → `#123d3a`, `--brand-dark` → `#0d302e` (темна бірюза, як сайдбар `/staff`);
- акцент `--gold` → `#ef744d`; спільний фон `#f3f6f8`, `--ink #18302f`, м'якші тіні;
- `theme-color` і favicon-акцент — на бренд.

Хром (хедер-градієнт, кнопки, лінки, кікери) перефарбувався цілісно. Картки-входи аудиторій лишено кольорово-розрізненними (навігація, не бренд).

## `price`: чистка блоку «переваги»
«Висновок лікаря-рентгенолога» і «Результат на CD/email» — це **базові послуги, а не переваги**. Прибрано; лишено дві реальні переваги (сучасне цифрове обладнання; онлайн-запис без черг), сітку зведено до 2 колонок.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто
- `node --test tests/*.test.mjs` — **280/280**
- Візуальні моки `index` / `price` звірено

🤖 Generated with [Claude Code](https://claude.com/claude-code)