### PR TITLE
Хостинг: /site/* без кеш-хешів — оновлення видно одразу

### DIFF
--- a/scripts/build-verified.sh
+++ b/scripts/build-verified.sh
@@ -25,4 +25,12 @@ timeout \
   "${SITES_BUILD_TIMEOUT:-3m}" \
   "${vinext}" build
 
+# Публічний статичний сайт /site/* не має кеш-хешів у іменах файлів, тож без
+# явного правила браузер/edge кешують стару версію і оновлення «не видно».
+# Просимо щоразу перевіряти свіжість (revalidate; 304 коли без змін).
+headers_file="${SITES_PROJECT_ROOT}/dist/client/_headers"
+if [[ -f "${headers_file}" ]] && ! grep -q '^/site/\*' "${headers_file}"; then
+  printf '\n# Публічний сайт: без кеш-хешів — завжди перевіряти свіжість\n/site/*\n  Cache-Control: no-cache\n' >> "${headers_file}"
+fi
+
 "${script_dir}/validate-artifact.sh"

--- a/tests/hosting-headers.test.mjs
+++ b/tests/hosting-headers.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("build emits a no-cache rule for the public /site so updates show at once", async () => {
+  // dist/client/_headers збирається білдом (див. scripts/build-verified.sh).
+  const headers = await read("dist/client/_headers");
+  // Хешовані ассети — вічний immutable-кеш.
+  assert.match(headers, /\/assets\/\*\s+Cache-Control: public, max-age=31536000, immutable/);
+  // Публічний сайт без кеш-хешів — revalidate, щоб деплой було видно одразу.
+  assert.match(headers, /\/site\/\*\s+Cache-Control: no-cache/);
+});
+
+test("build script appends the /site rule after vinext build", async () => {
+  const script = await read("scripts/build-verified.sh");
+  assert.match(script, /dist\/client\/_headers/);
+  assert.match(script, /\/site\/\*\\n\s+Cache-Control: no-cache/);
+});


### PR DESCRIPTION
Полагоджено те, через що зміни сайту «не було видно» без інкогніто/hard-refresh.

## Причина
Файли `/site/*` (публічний HTML + не-хешовані скрипти на кшталт `cart.js`) не мають кеш-хешів у іменах, а явного `Cache-Control` для них не було — тож браузер/edge кешували стару версію, і новий деплой не показувався.

## Виправлення
`scripts/build-verified.sh` після `vinext build` дописує в `dist/client/_headers`:
```
/site/*
  Cache-Control: no-cache
```
`no-cache` = браузер щоразу перевіряє свіжість (швидкий `304`, коли без змін; свіжий файл — коли є деплой). Хешовані `/assets/*` лишаються `immutable, max-age=1y`.

Правило додається в білді, бо `dist/` не в git і перегенеровується щодеплою.

## Перевірка
- `tsc --noEmit`, `lint`, `build` — чисто; `_headers` після білду містить обидва правила
- `node --test tests/*.test.mjs` — **282/282** (додав `tests/hosting-headers.test.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_