### PR TITLE
Сайт: спільний site.css — початок дедуплікації booking-стилів

### DIFF
--- a/public/site/assets/site.css
+++ b/public/site/assets/site.css
@@ -1,0 +1,33 @@
+/* Спільні стилі публічних booking-сторінок RadiologyOS.
+   Витягнуто з index/price/military (байт-ідентичні, унікальні селектори).
+   Підключається у <head> ПЕРЕД inline <style>, тож сторінкові правила мають пріоритет. */
+a{text-decoration:none;color:inherit}
+.hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
+.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}
+.cart-overlay.open{opacity:1;pointer-events:auto}
+.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}
+.floating-cart .cart-count{display:inline-grid;margin-left:6px}
+.req{color:#c0392b}
+.opt{font-weight:500;color:#7c8a94}
+.field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:var(--r-md);font:inherit;background:#fff}
+.phone-wrap{display:flex;align-items:stretch}
+.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:var(--r-md) 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
+.phone-wrap input{border-radius:0 11px 11px 0}
+.field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
+.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}
+.consent input{margin-top:3px;width:18px;height:18px;flex:0 0 18px}
+.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
+.success-summary div{margin:3px 0}
+.offline-note{background:#eef7f8;border:1px solid #c9e6ea;border-radius:var(--r-md);padding:10px 12px}
+/* Вибір вільного часу */
+.slot-picker{border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:12px;background:#fbfdfe;margin:10px 0}
+.sp-head{font-weight:700;font-size:13.5px;margin-bottom:9px}
+.sp-note{font-weight:500;color:#8a98a2;font-size:12px}
+.sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
+.sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
+.sp-day{flex-shrink:0;padding:8px 11px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
+.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
+.sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
+.sp-time{padding:8px 4px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
+.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
+.sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -31,6 +31,7 @@
 {"@type":"Question","name":"Де розташоване відділення променевої діагностики?","acceptedAnswer":{"@type":"Answer","text":"м. Чернігів, вул. Гетьмана Полуботка, 40 (Чернігівський військовий госпіталь)."}}
 ]}
 </script>
+<link rel="stylesheet" href="/site/assets/site.css">
 <style>
 /* ===== Токени ===== */
 :root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px;
@@ -44,7 +45,7 @@
 *{box-sizing:border-box}
 html{scroll-behavior:smooth}
 body{margin:0;padding:14px 0 24px;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}
-a{text-decoration:none;color:inherit}
+
 .wrap{width:min(960px,calc(100% - 28px));margin:auto}
 
 /* ===== Шапка ===== */
@@ -57,7 +58,7 @@ header::before{content:"";position:absolute;left:0;right:0;top:-16px;height:16px
   display:flex;align-items:center;gap:18px;color:#fff;
 }
 .brand{display:flex;align-items:center;gap:13px;flex:1;min-width:0}
-.hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
+
 .hospital-brand-title{font-size:clamp(20px,3vw,27px);font-weight:700;line-height:1.08;color:#fff;overflow-wrap:anywhere}
 .hospital-brand-subtitle{font-size:clamp(13px,1.8vw,17px);line-height:1.25;color:#e5ecf0;margin-top:5px}
 .hospital-brand-slogan{font-size:clamp(11px,1.45vw,14px);line-height:1.3;color:#cfe0e6;margin-top:6px;font-style:italic}
@@ -148,10 +149,9 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .eyebrow{text-transform:uppercase;letter-spacing:.13em;font-size:12px;font-weight:900}
 .btn{display:inline-flex;align-items:center;justify-content:center;min-height:50px;padding:0 18px;border-radius:var(--r-lg);font-weight:900}
 .cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:var(--r-pill);background:var(--gold);display:grid;place-items:center;font-size:12px}
-.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}
-.cart-overlay.open{opacity:1;pointer-events:auto}
+
 .cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}
-.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}
+
 .cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}
 .cart-empty{padding:35px 15px;text-align:center;color:var(--muted)}
 .cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid var(--line);border-radius:var(--r-lg);padding:14px;margin:10px 0}
@@ -160,7 +160,6 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:950}
 .cart-note{font-size:12px;color:var(--muted);margin:10px 0}
 .floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:var(--r-pill);background:var(--beige);color:#0f1a20;padding:14px 18px;font-weight:950;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}
-.floating-cart .cart-count{display:inline-grid;margin-left:6px}
 
 /* ===== Форма заявки ===== */
 .request-form{background:#fff;border:1px solid var(--line);border-radius:var(--r-lg);padding:18px}
@@ -171,35 +170,28 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 .field{margin:11px 0}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .field label{display:block;font-size:13px;font-weight:700;margin-bottom:5px}
-.req{color:#c0392b}
-.opt{font-weight:500;color:#7c8a94}
-.field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:var(--r-md);font:inherit;background:#fff}
+
 .field input:focus-visible,.field select:focus-visible,.field textarea:focus-visible{outline:2px solid var(--brand);outline-offset:1px}
 .field textarea{min-height:78px;resize:vertical}
-.phone-wrap{display:flex;align-items:stretch}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:var(--r-md) 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
-.phone-wrap input{border-radius:0 11px 11px 0}
-.field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
+
 .was-validated .field input:invalid,.was-validated .field select:invalid{border-color:#d9705f;background:#fdf0ee}
 .was-validated .field input:invalid ~ .field-error,.was-validated .field:has(input:invalid) .field-error{display:block}
 .was-validated:has(#dataConsent:invalid) .consent-error{display:block}
 .btn.secondary{background:#eef2f5;color:#0e454c}
-.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}
+
 .upload-box{border:1.5px dashed #9fb0bb;border-radius:var(--r-lg);padding:14px;background:#f7fafb}
 .upload-help{font-size:13px;color:var(--muted);margin-bottom:10px}
 .file-input{width:100%;padding:11px;background:#fff;border:1px solid var(--line);border-radius:var(--r-md)}
 .file-summary{margin-top:9px;font-size:13px;color:#0a5f68}
 .consent{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:#3a4a52}
-.consent input{margin-top:3px;width:18px;height:18px;flex:0 0 18px}
+
 .success-panel{background:#fff;border:1px solid var(--line);border-radius:var(--r-lg);padding:28px 20px;text-align:center}
-.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
+
 .success-panel h3{margin:0 0 8px}
 .success-summary{background:#f5f8fa;border:1px solid var(--line);border-radius:var(--r-md);padding:12px 14px;margin:0 0 12px;font-size:13.5px;text-align:left}
-.success-summary div{margin:3px 0}
-.offline-note{background:#eef7f8;border:1px solid #c9e6ea;border-radius:var(--r-md);padding:10px 12px}
+
 .success-panel p{color:#0a5f68;font-size:14px;line-height:1.5;margin:0 0 16px}
 @media(max-width:520px){.field-row{grid-template-columns:1fr}}
-
 
 /* ===== Адаптивність ===== */
 @media(min-width:1101px){
@@ -258,18 +250,6 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
   html{scroll-behavior:auto}
 }
 
-/* Вибір вільного часу */
-.slot-picker{border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:12px;background:#fbfdfe;margin:10px 0}
-.sp-head{font-weight:700;font-size:13.5px;margin-bottom:9px}
-.sp-note{font-weight:500;color:#8a98a2;font-size:12px}
-.sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
-.sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
-.sp-day{flex-shrink:0;padding:8px 11px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
-.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
-.sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
-.sp-time{padding:8px 4px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
-.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
-.sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
 /* ===== Тарифи на головній ===== */
 .tariffs-home{padding:22px 0 0}
 .tariffs-head{margin-bottom:14px}

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -4,6 +4,7 @@
 <meta name="description" content="Безоплатні дослідження для військовослужбовців у відділенні променевої діагностики Чернігівського військового госпіталю: КТ, рентгенографія, флюорографія."/>
 <meta name="theme-color" content="#123d3a"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
+<link rel="stylesheet" href="/site/assets/site.css">
 <style>
 :root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px}
 :root{
@@ -13,7 +14,7 @@
 }
 *{box-sizing:border-box}html{scroll-behavior:smooth}
 body{margin:0;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}
-a{text-decoration:none;color:inherit}.wrap{width:min(1160px,calc(100% - 28px));margin:auto}
+.wrap{width:min(1160px,calc(100% - 28px));margin:auto}
 header{position:sticky;top:0;z-index:50;background:linear-gradient(90deg,var(--dark),var(--dark2));color:#fff;box-shadow:0 8px 24px rgba(0,0,0,.18)}
 .header-row{min-height:84px;display:flex;align-items:center;gap:18px}
 .brand{display:flex;align-items:center;gap:13px}.mark{width:54px;height:54px;border:2px solid #d9eef0;border-radius:var(--r-lg);display:grid;place-items:center;font-weight:750}
@@ -70,7 +71,7 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
  .fixed a{min-height:48px;border-radius:var(--r-md);display:flex;align-items:center;justify-content:center;font-weight:700}.fixed a:first-child{background:var(--dark2);color:white}.fixed a:last-child{background:var(--beige)}
 }
 
-.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:var(--r-md);background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:var(--r-pill);background:#ef744d;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:var(--brand);color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:var(--brand);color:#fff;border-radius:var(--r-sm);padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}.cart-overlay.open{opacity:1;pointer-events:auto}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form{background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:16px}.request-form h3{margin-top:0}.field{margin:11px 0}.field label{display:block;font-size:13px;font-weight:650;margin-bottom:5px}.field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:var(--r-md);font:inherit;background:#fff}.field textarea{min-height:85px;resize:vertical}.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:var(--r-pill);background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}.floating-cart .cart-count{display:inline-grid;margin-left:6px}
+.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:var(--r-md);background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:var(--r-pill);background:#ef744d;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:var(--brand);color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:var(--brand);color:#fff;border-radius:var(--r-sm);padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form{background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:16px}.request-form h3{margin-top:0}.field{margin:11px 0}.field label{display:block;font-size:13px;font-weight:650;margin-bottom:5px}.field textarea{min-height:85px;resize:vertical}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:var(--r-pill);background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}
 @media(max-width:700px){body{padding-bottom:86px}header{position:relative;top:auto}.cart-button{padding:10px 12px}.cart-button .cart-label{display:none}.floating-cart{bottom:calc(10px + env(safe-area-inset-bottom));right:10px;padding:10px 12px;font-size:13px;box-shadow:0 8px 22px rgba(0,0,0,.18)}.price-group tr{grid-template-columns:46px 1fr auto}.row-add{grid-column:2/4;margin:0 8px 10px}.cart-drawer{padding:16px}}
 
 .upload-box{border:1.5px dashed #9fb0bb;border-radius:var(--r-lg);padding:16px;background:#f7fafb}
@@ -79,8 +80,6 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
 .file-input{width:100%;padding:11px;background:#fff;border:1px solid var(--line);border-radius:var(--r-md)}
 .file-summary{margin-top:10px;font-size:13px;color:#0a5f68}
 .consent{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:#3a4a52}
-.consent input{margin-top:3px;width:18px;height:18px;flex:0 0 18px}
-
 
 .price-group{margin-bottom:14px}
 .price-group h2{position:relative;cursor:pointer;padding-right:56px}
@@ -93,7 +92,6 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
   .price-group.open table{display:table}
   .price-group h2{font-size:19px}
 }
-
 
 .service-title{font-weight:700;color:#0e161c}
 .service-help{margin-top:4px;color:#5c6c78;font-size:13px;line-height:1.35;max-width:760px}
@@ -114,7 +112,6 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
   .price-group tr{grid-template-columns:52px 1fr}
 }
 
-.hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
 .hospital-brand-title{font-size:24px;font-weight:700;line-height:1.15;color:#fff}
 .hospital-brand-subtitle{font-size:16px;line-height:1.25;color:#e0e7ec}
 header .wrap{gap:18px}
@@ -238,12 +235,7 @@ header .brand{flex:1;min-width:0}
 .step-title{display:flex;align-items:center;gap:9px;font-weight:650;font-size:15px;margin-bottom:11px}
 .step-num{width:24px;height:24px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:13px;font-weight:700}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-.req{color:#c0392b}
-.opt{font-weight:500;color:#7c8a94}
-.phone-wrap{display:flex;align-items:stretch}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:var(--r-md) 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
-.phone-wrap input{border-radius:0 11px 11px 0}
-.field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
+
 .was-validated .field:has(input:invalid) .field-error{display:block}
 .was-validated:has(#militaryConsent:invalid) .consent-error{display:block}
 .was-validated .field input:invalid{border-color:#d9705f;background:#fdf0ee}
@@ -251,9 +243,7 @@ header .brand{flex:1;min-width:0}
 .file-input{width:100%;padding:11px;background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-md)}
 .success-panel{background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:24px 18px;text-align:center}
 .success-summary{background:#f5f8fa;border:1px solid #dbe3e8;border-radius:var(--r-md);padding:12px 14px;margin:0 0 12px;font-size:13.5px;text-align:left}
-.success-summary div{margin:3px 0}
-.offline-note{background:#eef7f8;border:1px solid #c9e6ea;border-radius:var(--r-md);padding:10px 12px}
-.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
+
 .req-text{white-space:pre-wrap;text-align:left;font:13px/1.5 ui-monospace,Menlo,Consolas,monospace;background:#f5f8fa;border:1px solid #dbe3e8;border-radius:var(--r-md);padding:13px;max-height:220px;overflow:auto;margin:0 0 10px}
 .msg-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:10px 0 12px}
 .next-steps{text-align:left;font-size:13.5px;color:#123039;padding-left:20px;margin:0 0 12px}
@@ -262,18 +252,6 @@ header .brand{flex:1;min-width:0}
 .btn.secondary{background:#eef2f5;color:#0e454c}
 @media(max-width:520px){.field-row{grid-template-columns:1fr}}
 
-/* Вибір вільного часу */
-.slot-picker{border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:12px;background:#fbfdfe;margin:10px 0}
-.sp-head{font-weight:700;font-size:13.5px;margin-bottom:9px}
-.sp-note{font-weight:500;color:#8a98a2;font-size:12px}
-.sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
-.sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
-.sp-day{flex-shrink:0;padding:8px 11px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
-.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
-.sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
-.sp-time{padding:8px 4px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
-.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
-.sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
 </style></head><body>
 <header><div class="wrap header-row"><a class="brand" href="/"><div class="hospital-brand-text"><div class="hospital-brand-title">Чернігівський військовий госпіталь</div><div class="hospital-brand-subtitle">Відділення променевої діагностики</div></div></a><nav><a href="/">Головна</a><button class="cart-button" onclick="openMilitaryCart()" type="button">
 <span class="cart-label">Моя заявка</span>

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -4,6 +4,7 @@
 <meta name="description" content="Повний прайс відділення променевої діагностики: цифрова флюорографія, рентгенографія, КТ з контрастуванням та без, КТ-ангіографія. Онлайн-заявка на обстеження у Чернігові."/>
 <meta name="theme-color" content="#123d3a"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
+<link rel="stylesheet" href="/site/assets/site.css">
 <style>
 :root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px}
 :root{
@@ -13,7 +14,7 @@
 }
 *{box-sizing:border-box}html{scroll-behavior:smooth}
 body{margin:0;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}
-a{text-decoration:none;color:inherit}.wrap{width:min(1160px,calc(100% - 28px));margin:auto}
+.wrap{width:min(1160px,calc(100% - 28px));margin:auto}
 header{position:sticky;top:0;z-index:50;background:linear-gradient(90deg,var(--dark),var(--dark2));color:#fff;box-shadow:0 8px 24px rgba(0,0,0,.18)}
 .header-row{min-height:84px;display:flex;align-items:center;gap:18px}
 .brand{display:flex;align-items:center;gap:13px}.mark{width:54px;height:54px;border:2px solid #d9eef0;border-radius:var(--r-lg);display:grid;place-items:center;font-weight:750}
@@ -70,17 +71,10 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
  .fixed a{min-height:48px;border-radius:var(--r-md);display:flex;align-items:center;justify-content:center;font-weight:700}.fixed a:first-child{background:var(--dark2);color:white}.fixed a:last-child{background:var(--beige)}
 }
 
-.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:var(--r-md);background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:var(--r-pill);background:#ef744d;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:var(--brand);color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:var(--brand);color:#fff;border-radius:var(--r-sm);padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}.cart-overlay.open{opacity:1;pointer-events:auto}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-head{display:flex;justify-content:space-between;align-items:center;gap:15px}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form h3{margin-top:0}.field{margin:11px 0}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:var(--r-pill);background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}.floating-cart .cart-count{display:inline-grid;margin-left:6px}
+.cart-button{position:relative;display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:var(--r-md);background:#fff;color:#0f1a20;font-weight:700;border:0;cursor:pointer}.cart-count{min-width:23px;height:23px;padding:0 6px;border-radius:var(--r-pill);background:#ef744d;display:grid;place-items:center;font-size:12px}.add-cart{margin-top:8px;width:100%;border:0;cursor:pointer;background:var(--brand);color:#fff}.add-cart.added{background:#7c8a94}.row-add{border:0;background:var(--brand);color:#fff;border-radius:var(--r-sm);padding:9px 12px;font-weight:650;cursor:pointer;white-space:nowrap}.cart-drawer{position:absolute;right:0;top:0;height:100%;width:min(520px,100%);background:#f7fafb;padding:22px;overflow:auto;box-shadow:-20px 0 60px rgba(0,0,0,.22)}.cart-close{border:0;background:#e5ecf0;width:42px;height:42px;border-radius:50%;font-size:22px;cursor:pointer}.cart-empty{padding:35px 15px;text-align:center;color:#5c6c78}.cart-item{display:grid;grid-template-columns:1fr auto;gap:10px;background:#fff;border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:14px;margin:10px 0}.cart-item small{display:block;color:#5c6c78}.remove-item{border:0;background:none;color:#c0392b;cursor:pointer;font-weight:650}.cart-total{display:flex;justify-content:space-between;padding:18px 4px;font-size:21px;font-weight:750}.request-form h3{margin-top:0}.field{margin:11px 0}.cart-note{font-size:12px;color:#5c6c78;margin:10px 0}.floating-cart{position:fixed;right:18px;bottom:20px;z-index:95;border:0;border-radius:var(--r-pill);background:#d9eef0;color:#0f1a20;padding:14px 18px;font-weight:750;box-shadow:0 12px 30px rgba(0,0,0,.2);cursor:pointer}
 @media(max-width:700px){body{padding-bottom:86px}header{position:relative;top:auto}.cart-button{padding:10px 12px}.cart-button .cart-label{display:none}.floating-cart{bottom:calc(10px + env(safe-area-inset-bottom));right:10px;padding:10px 12px;font-size:13px;box-shadow:0 8px 22px rgba(0,0,0,.18)}.price-group tr{grid-template-columns:46px 1fr auto}.row-add{grid-column:2/4;margin:0 8px 10px}.cart-drawer{padding:16px}}
 
-
-
-
-
-
 .consent{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:#3a4a52}
-
-
 
 .price-group{margin-bottom:14px}
 .price-group h2{position:relative;cursor:pointer;padding-right:56px}
@@ -93,7 +87,6 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
   .price-group.open table{display:table}
   .price-group h2{font-size:19px}
 }
-
 
 .service-title{font-weight:700;color:#0e161c}
 .service-help{margin-top:4px;color:#5c6c78;font-size:13px;line-height:1.35;max-width:760px}
@@ -118,7 +111,6 @@ td:last-child,th:last-child{text-align:right;white-space:nowrap;font-weight:700}
 @media(max-width:900px){.civ-benefits{grid-template-columns:1fr 1fr}}
 @media(max-width:520px){.civ-benefits{grid-template-columns:1fr}}
 
-.hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
 .hospital-brand-title{font-size:24px;font-weight:700;line-height:1.15;color:#fff}
 .hospital-brand-subtitle{font-size:16px;line-height:1.25;color:#e0e7ec}
 header .wrap{gap:18px}
@@ -147,32 +139,26 @@ header .brand{flex:1;min-width:0}
 .field{margin:11px 0}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .field label{display:block;font-size:13px;font-weight:700;margin-bottom:5px}
-.req{color:#c0392b}
-.opt{font-weight:500;color:#7c8a94}
-.field input,.field select,.field textarea{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:var(--r-md);font:inherit;background:#fff}
+
 .field input:focus-visible,.field select:focus-visible,.field textarea:focus-visible{outline:2px solid var(--brand);outline-offset:1px}
 .field textarea{min-height:78px;resize:vertical}
-.phone-wrap{display:flex;align-items:stretch}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:var(--r-md) 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
-.phone-wrap input{border-radius:0 11px 11px 0}
-.field-error{display:none;font-size:12px;color:#c0392b;margin-top:4px}
+
 .was-validated .field input:invalid,.was-validated .field select:invalid{border-color:#d9705f;background:#fdf0ee}
 .was-validated .field input:invalid ~ .field-error,.was-validated .field:has(input:invalid) .field-error{display:block}
 .was-validated:has(#dataConsent:invalid) .consent-error{display:block}
 .btn.secondary{background:#eef2f5;color:#0e454c}
-.send-request{width:100%;border:0;background:var(--brand);color:#fff;cursor:pointer}
+
 .upload-box{border:1.5px dashed #9fb0bb;border-radius:var(--r-lg);padding:14px;background:#f7fafb}
 .upload-help{font-size:13px;color:var(--muted);margin-bottom:10px}
 .file-input{width:100%;padding:11px;background:#fff;border:1px solid var(--line);border-radius:var(--r-md)}
 .file-summary{margin-top:9px;font-size:13px;color:#0a5f68}
 .consent{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:#3a4a52}
-.consent input{margin-top:3px;width:18px;height:18px;flex:0 0 18px}
+
 .success-panel{background:#fff;border:1px solid var(--line);border-radius:var(--r-lg);padding:28px 20px;text-align:center}
-.success-icon{width:56px;height:56px;margin:0 auto 12px;border-radius:50%;background:var(--brand);color:#fff;display:grid;place-items:center;font-size:28px}
+
 .success-panel h3{margin:0 0 8px}
 .success-summary{background:#f5f8fa;border:1px solid var(--line);border-radius:var(--r-md);padding:12px 14px;margin:0 0 12px;font-size:13.5px;text-align:left}
-.success-summary div{margin:3px 0}
-.offline-note{background:#eef7f8;border:1px solid #c9e6ea;border-radius:var(--r-md);padding:10px 12px}
+
 .success-panel p{color:#0a5f68;font-size:14px;line-height:1.5;margin:0 0 16px}
 @media(max-width:520px){.field-row{grid-template-columns:1fr}}
 
@@ -205,18 +191,6 @@ body{background:#f3f6f8}
 .fixed a:first-child{background:#123d3a;color:#fff}
 .fixed a:last-child{background:#eef7f8;color:#18302f}
 
-/* Вибір вільного часу */
-.slot-picker{border:1px solid #dbe3e8;border-radius:var(--r-lg);padding:12px;background:#fbfdfe;margin:10px 0}
-.sp-head{font-weight:700;font-size:13.5px;margin-bottom:9px}
-.sp-note{font-weight:500;color:#8a98a2;font-size:12px}
-.sp-loading,.sp-empty{color:#8a98a2;font-size:13px;padding:8px 2px}
-.sp-days{display:flex;gap:6px;overflow-x:auto;padding-bottom:6px}
-.sp-day{flex-shrink:0;padding:8px 11px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:12.5px;font-weight:700;cursor:pointer}
-.sp-day.on{border-color:var(--brand);background:#eef2f5;color:#0e454c}
-.sp-times{display:grid;grid-template-columns:repeat(auto-fill,minmax(64px,1fr));gap:6px;margin-top:8px;max-height:150px;overflow:auto}
-.sp-time{padding:8px 4px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
-.sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
-.sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
 </style></head><body>
 <header><div class="wrap header-row"><a class="brand" href="/"><div class="hospital-brand-text"><div class="hospital-brand-title">Чернігівський військовий госпіталь</div><div class="hospital-brand-subtitle">Відділення променевої діагностики</div></div></a><nav><a href="/">Головна</a><button class="cart-button" onclick="openCart()" type="button"><span class="cart-label">Моя заявка</span><span class="cart-count" data-cart-count="">0</span></button></nav></div></header>
 <main class="price-page">

--- a/tests/hosting-headers.test.mjs
+++ b/tests/hosting-headers.test.mjs
@@ -25,3 +25,17 @@ test("military mobile: bottom padding clears the fixed action bar", async () => 
   assert.doesNotMatch(html, /body\{padding:0 12px 12px/);
   assert.match(html, /body\{padding:0 12px 86px/);
 });
+
+test("public booking pages share one stylesheet (dedup, no per-page copies)", async () => {
+  const shared = await read("public/site/assets/site.css");
+  // Спільний файл містить витягнуті booking-правила (слот-пікер тощо).
+  assert.match(shared, /\.slot-picker/);
+  assert.match(shared, /\.sp-day/);
+  // Три booking-сторінки підключають його; логіни-кабінет — ні (немає кошика).
+  for (const p of ["index", "price", "military"]) {
+    const html = await read(`public/site/${p}.html`);
+    assert.match(html, /<link rel="stylesheet" href="\/site\/assets\/site\.css">/, `${p} має підключати site.css`);
+    // Витягнуті правила більше не дублюються в inline <style>.
+    assert.doesNotMatch(html, /\.sp-day\.on\{/, `${p}: .sp-day.on лишилось в inline`);
+  }
+});


### PR DESCRIPTION
Атакую корінь ×4-болю, про який писав у критиці: публічні сторінки дублюють CSS, тож кожна брендова зміна = правки в 4 файлах.

## Що зроблено (безпечний перший зріз)
Витягнув із `index` / `price` / `military` **29 правил**, які:
1. **байт-ідентичні** у всіх трьох (перетин множин правил), і
2. мають **унікальний селектор** у кожній сторінці (нема конфлікту каскаду),

у спільний `public/site/assets/site.css`. Це слот-пікер (`.sp-*`), поля форми, телефон-інпут, `cart-overlay`, база (`a`, `.hospital-brand-title`). Підключено `<link>` у `<head>` **перед** inline `<style>` — тож будь-яке сторінкове правило зберігає пріоритет. `cabinet` (без кошика) не зачеплено.

## Чому це безпечно
Не покладаюсь «на око»: скрипт перевірив **інваріант** для кожної сторінки — множина правил `(site.css ∪ залишок inline)` **дослівно дорівнює** оригіналу, а перетин порожній (нічого не загубилось і не роздвоїлось). Тобто сумарний CSS, який отримує браузер, ідентичний до байта.

## Чому лише 29, а не всі
Файли **дрейфонули** (коментарі, порядок, дрібні відмінності) — байт-ідентичних із безпечним каскадом рівно стільки. Повна дедуплікація решти потребує звірки рендера наживо (кошик/слоти — динамічні, офлайн не рендеряться), тож роблю фундаментом і мігруватиму інкрементально, а не ризикованим «великим вибухом» на живому booking-флоу.

## Перевірка
- `tsc`/`lint`/`build` — чисто; `site.css` присутній у `dist/client/site/assets/`
- `node --test` — **285/285** (додав тест: 3 сторінки лінкують `site.css`, витягнуті правила не лишились в inline)
- Інваріант рівності CSS — перевірено програмно

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_