### PR TITLE
Сайт: brand+radius токени в site.css (2-й зріз дедуплікації)

### DIFF
--- a/public/site/assets/site.css
+++ b/public/site/assets/site.css
@@ -1,6 +1,7 @@
 /* Спільні стилі публічних booking-сторінок RadiologyOS.
    Витягнуто з index/price/military (байт-ідентичні, унікальні селектори).
    Підключається у <head> ПЕРЕД inline <style>, тож сторінкові правила мають пріоритет. */
+:root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px}
 a{text-decoration:none;color:inherit}
 .hospital-brand-text{display:flex;flex-direction:column;gap:3px;min-width:0}
 .cart-overlay{position:fixed;inset:0;background:rgba(8,12,7,.55);z-index:120;opacity:0;pointer-events:none;transition:.2s}

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -8,8 +8,9 @@
 <meta name="robots" content="noindex"/>
 <meta name="theme-color" content="#123d3a"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
+<link rel="stylesheet" href="/site/assets/site.css">
 <style>
-:root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px}
+
 :root{
   --bg:#f3f6f8;--ink:#18302f;--muted:#5c6c78;--line:#dbe3e8;
   --gold:#ef744d;--olive:var(--brand);

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -34,7 +34,7 @@
 <link rel="stylesheet" href="/site/assets/site.css">
 <style>
 /* ===== Токени ===== */
-:root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px;
+:root{
   --bg:#f3f6f8;--ink:#18302f;--muted:#5c6c78;--line:#dbe3e8;
   --gold:#ef744d;--beige:#e7efec;
   --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -6,7 +6,7 @@
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <link rel="stylesheet" href="/site/assets/site.css">
 <style>
-:root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px}
+
 :root{
   --bg:#f3f6f8;--paper:#fff;--ink:#18302f;--muted:#5c6c78;--dark:var(--brand);
   --dark2:var(--brand-dark);--olive:#0a5f68;--beige:#e7efec;--line:#dbe3e8;

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -6,7 +6,7 @@
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23123d3a'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <link rel="stylesheet" href="/site/assets/site.css">
 <style>
-:root{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px}
+
 :root{
   --bg:#f3f6f8;--paper:#fff;--ink:#18302f;--muted:#5c6c78;--dark:var(--brand);
   --dark2:var(--brand-dark);--olive:#855a00;--beige:#e7efec;--line:#dbe3e8;

--- a/tests/design-tokens.test.mjs
+++ b/tests/design-tokens.test.mjs
@@ -76,10 +76,11 @@ test("staff chrome identity: brand vars drive sidebar/logo/topbar", async () => 
 });
 
 test("public site radii are unified on the design-system token scale", async () => {
+  // Радіус-токени тепер живуть у спільному site.css (дедуплікація).
+  const shared = await read("public/site/assets/site.css");
+  assert.match(shared, /--r-lg:16px/, "site.css: нема радіус-токенів");
   for (const page of ["index", "price", "military", "cabinet"]) {
     const html = await read(`public/site/${page}.html`);
-    // Радіус-токени визначені в :root сторінки.
-    assert.match(html, /--r-lg:16px/, `${page}: нема радіус-токенів`);
     // Радіуси зведені на var(--r-*) — жодного сирого border-radius:Npx.
     assert.doesNotMatch(html, /border-radius:\d+px/, `${page}: лишились сирі px-радіуси`);
   }

--- a/tests/hosting-headers.test.mjs
+++ b/tests/hosting-headers.test.mjs
@@ -39,3 +39,14 @@ test("public booking pages share one stylesheet (dedup, no per-page copies)", as
     assert.doesNotMatch(html, /\.sp-day\.on\{/, `${p}: .sp-day.on лишилось в inline`);
   }
 });
+
+test("brand + radius tokens live once in site.css (all public pages link it)", async () => {
+  const shared = await read("public/site/assets/site.css");
+  assert.match(shared, /:root\{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px\}/);
+  for (const p of ["index", "price", "military", "cabinet"]) {
+    const html = await read(`public/site/${p}.html`);
+    assert.match(html, /<link rel="stylesheet" href="\/site\/assets\/site\.css">/, `${p} лінкує site.css`);
+    // Окремий дубль-блок брендових токенів більше не сидить у сторінці.
+    assert.doesNotMatch(html, /:root\{--brand:#123d3a;--brand-dark:#0d302e;--r-sm:8px;--r-md:12px;--r-lg:16px;--r-xl:20px;--r-pill:999px\}/, `${p}: дубль токенів у inline`);
+  }
+});

--- a/tests/site-content.test.mjs
+++ b/tests/site-content.test.mjs
@@ -128,12 +128,14 @@ test("stage 2: color and storefront type are validated while logo stays disabled
 
 test("landing themes via CSS variable, honors storefront type and has no logo", async () => {
   const html = await read("public/site/index.html");
-  assert.match(html, /--brand:#123d3a/); // дефолт бренду = бренд /staff (дизайн-система)
+  const shared = await read("public/site/assets/site.css");
+  assert.match(shared, /--brand:#123d3a/); // дефолт бренду = бренд /staff (у спільному site.css)
+  assert.match(html, /<link rel="stylesheet" href="\/site\/assets\/site\.css">/); // сторінка лінкує токени
   assert.match(html, /setProperty\('--brand',c\.brandColor\)/); // застосування кольору
   assert.match(html, /storefrontType==='paid_only'/); // ховає картку військових
   assert.match(html, /id="scMilCard"/);
   assert.doesNotMatch(html, /id="scLogo"|brand-logo/);
-  // Колірні літерали замінено на var(--brand) — лишились тільки meta + визначення змінної.
+  // Токени винесено в site.css — у самій сторінці #123d3a лишається хіба в meta theme-color.
   assert.ok((html.match(/#123d3a/g) || []).length <= 2);
 });
 


### PR DESCRIPTION
Продовження дедуплікації (#131). Цього разу — **саме ті токени, які я правив 4× у кожному брендовому PR**.

## Що зроблено
7 токенів — `--brand`, `--brand-dark`, `--r-sm/md/lg/xl/pill` — дублювались у `:root` кожної сторінки. Тепер визначені **раз** у `site.css`:
- `price` / `military` / `cabinet` — прибрано окремий дубль-блок `:root{…}`;
- `index` — вирізано ці 7 токенів зі злитого `:root` (решта його токенів лишилась);
- `cabinet` теж тепер підключає `site.css`, тож усі 4 публічні сторінки беруть токени з одного місця.

**Наслідок:** змінити бренд-колір чи радіус-шкалу тепер = 1 правка замість 4.

## Чому безпечно
Інваріант перевірено скриптом: для кожної сторінки множина визначених CSS-змінних `(site.css ∪ inline, inline має пріоритет як у каскаді)` **дослівно дорівнює** оригіналу — жодна змінна не втрачена й не змінила значення. `site.css` підключається перед inline `<style>`, тож сторінкові перевизначення зберігають пріоритет.

## Тести
- Оновив 2 тести, що перевіряли токени **inline** (тепер дивляться в `site.css`) — це були саме ті «грепи по вихідному рядку», що ламаються від рефактора без зміни поведінки (про що я писав у критиці).
- `tsc`/`lint`/`build` — чисто; `node --test` — **286/286**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_