### PR TITLE
Пульт: видимий збій сповіщення — список «Потребує дзвінка»

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -308,6 +308,20 @@ a.dashKpi:hover{border-color:#c9d6d0;transform:translateY(-1px);box-shadow:0 2px
 @media(max-width:600px){.equipmentRegistryHead{align-items:flex-start;flex-direction:column}.equipmentFields{grid-template-columns:1fr}.equipmentFields label.wide{grid-column:auto}.equipmentCard summary{grid-template-columns:34px minmax(0,1fr)}.equipmentCard summary em{grid-column:2;justify-self:start}}
 /* Пульт — компактна стрічка показників (замість великих блоків) */
 .dashToast{max-width:1500px;margin:0 auto 12px;padding:10px 14px;background:#e6f4ec;border:1px solid #bfe0cc;border-radius:10px;color:#1f5c39;font-size:13px;font-weight:600;cursor:pointer}
+.dashToast.warn{background:#fdece9;border-color:#f3c3ba;color:#a5311f}
+/* Робочий список «передзвонити»: підтверджено, але сповіщення не дійшло. */
+.dashNeedsCall{max-width:var(--dash-w);margin:0 auto 16px;border:1px solid #f1c7bd;border-left:4px solid var(--mod-urgent);border-radius:var(--r-lg);background:#fef6f4;box-shadow:var(--sh-1);overflow:hidden}
+.dashNeedsCallHead{padding:12px 16px 8px}
+.dashNeedsCallHead b{display:block;color:#a5311f;font-size:var(--fs-lg);font-weight:800;letter-spacing:-.01em}
+.dashNeedsCallHead small{display:block;margin-top:2px;color:#8a5b52;font-size:var(--fs-xs)}
+.dashNeedsCall ul{list-style:none;margin:0;padding:0}
+.dashNeedsCall li{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px;padding:11px 16px;border-top:1px solid #f4d7d0}
+.dashNeedsCallWho{min-width:0;display:flex;flex-direction:column;gap:2px}
+.dashNeedsCallWho b{font-size:13px;color:#18302f}
+.dashNeedsCallWho small{color:#7a6a66;font-size:var(--fs-xs)}
+.dashNeedsCallActions{display:flex;flex-wrap:wrap;gap:8px}
+.themeDark .dashNeedsCall{background:#241715;border-color:#5a2c24}
+.themeDark .dashToast.warn{background:#241715;border-color:#5a2c24;color:#f0a99b}
 .dashKpiStrip{max-width:var(--dash-w);margin:0 auto 14px;display:grid;grid-template-columns:repeat(5,1fr);gap:8px;align-items:start}
 .dashStat{display:block;padding:10px 12px;background:#fff;border:1px solid #e7ece9;border-radius:12px;transition:var(--dur-fast) var(--ease)}
 a.dashStat:hover{border-color:#c9d6d0;transform:translateY(-1px)}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -150,6 +150,9 @@ export default function DashboardPage() {
   const [error,setError] = useState("");
   const [toast,setToast] = useState("");
   const [busyId,setBusyId] = useState<number | null>(null);
+  // Підтверджені, кому сповіщення НЕ дійшло — робочий список «передзвонити»
+  // (на сесію; сам факт збою також лишається в patient_notifications).
+  const [needsCall,setNeedsCall] = useState<CalBooking[]>([]);
   const [agendaFilter,setAgendaFilter] = useState<AgendaFilter>("all");
   const [nowMin,setNowMin] = useState(() => nowMinutesKyiv());
   const [openId,setOpenId] = useState<number | null>(null);
@@ -212,11 +215,20 @@ export default function DashboardPage() {
       if (!res.ok) { setToast(data.error || "Не вдалося підтвердити запис"); return; }
       setBookings(cur => cur.map(b => b.id === id ? { ...b, status:"confirmed" } : b));
       const r = data.reminder;
-      setToast(r?.sent
-        ? "✓ Підтверджено · повідомлення у WhatsApp надіслано пацієнту"
-        : r?.failed
-          ? "✓ Підтверджено, але WhatsApp не надіслався — перевірте підключення у розділі WhatsApp"
-          : "✓ Підтверджено · WhatsApp-сповіщення вимкнено або не підключено");
+      // r===null → відправлення впало з помилкою; r.failed>0 → шлюз не доставив.
+      // В обох випадках пацієнта не попереджено — у робочий список «передзвонити».
+      const notNotified = !r || (r.failed ?? 0) > 0;
+      if (notNotified) {
+        const b = bookings.find(x => x.id === id);
+        if (b) setNeedsCall(cur => cur.some(x => x.id === id) ? cur : [...cur, { ...b, status:"confirmed" }]);
+        setToast(!r
+          ? "⚠ Підтверджено, але сповіщення НЕ надіслано (помилка системи) — зателефонуйте пацієнту"
+          : "⚠ Підтверджено, але WhatsApp НЕ доставлено — зателефонуйте пацієнту");
+      } else {
+        setToast((r?.sent ?? 0) > 0
+          ? "✓ Підтверджено · повідомлення у WhatsApp надіслано пацієнту"
+          : "✓ Підтверджено · сповіщення пропущено (вимкнено або немає телефону)");
+      }
     } catch {
       setToast("Помилка мережі — спробуйте ще раз");
     } finally {
@@ -274,7 +286,29 @@ export default function DashboardPage() {
     {error ? <section className="accessDenied"><b>Захищений розділ</b><p>{error}. Увійдіть через дозволений робочий обліковий запис.</p><a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Fdashboard">Увійти для роботи</a></section> :
     !staff ? <p className="dashLoading">Завантаження зведення…</p> :
     <>
-      {toast && <p className="dashToast" role="status" onClick={()=>setToast("")}>{toast}</p>}
+      {toast && <p className={`dashToast${toast.startsWith("⚠") ? " warn" : ""}`} role="status" onClick={()=>setToast("")}>{toast}</p>}
+
+      {/* Стійкий робочий список: підтверджено, але сповіщення не дійшло —
+          реєстратор має зателефонувати вручну, а не покладатись на зниклий тост. */}
+      {needsCall.length > 0 &&
+        <section className="dashNeedsCall" aria-label="Потребує дзвінка">
+          <div className="dashNeedsCallHead">
+            <b>☎ Потребує дзвінка · {needsCall.length}</b>
+            <small>Підтверджено, але сповіщення пацієнту не доставлено. Зателефонуйте вручну.</small>
+          </div>
+          <ul>
+            {needsCall.map(b => (
+              <li key={b.id}>
+                <span className="dashNeedsCallWho"><b>{b.name || "Без імені"}</b><small>{b.service}{b.desiredDate ? ` · ${b.desiredDate} ${b.desiredTime || ""}` : ""}</small></span>
+                <span className="dashNeedsCallActions">
+                  <a className="dashCardBtn" href={`tel:${b.phone}`} title={b.phone}>📞 {b.phone || "—"}</a>
+                  <a className="dashCardBtn wa" href={waLink(b.phone)} target="_blank" rel="noreferrer">WhatsApp</a>
+                  <button type="button" className="dashCardBtn ok" onClick={()=>setNeedsCall(cur => cur.filter(x => x.id !== b.id))}>✓ Подзвонив</button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>}
 
       {/* Панель місії: головні числа дня в один рядок. Клік веде до дії. */}
       <nav className="dashMc" aria-label="Головні показники дня">

--- a/tests/dashboard.test.mjs
+++ b/tests/dashboard.test.mjs
@@ -71,3 +71,21 @@ test("dashboard page renders inside the staff workspace", async () => {
   const html = await response.text();
   assert.match(html, /Пульт відділення/);
 });
+
+test("confirm surfaces a persistent call-back list when notification fails", async () => {
+  const page = await read("app/staff/dashboard/page.tsx");
+  // null (крах) і failed>0 трактуються як «не попереджено».
+  assert.match(page, /const notNotified = !r \|\| \(r\.failed \?\? 0\) > 0/);
+  // Невдача → у стійкий список needsCall (а не лише зниклий тост).
+  assert.match(page, /setNeedsCall\(cur =>/);
+  assert.match(page, /const \[needsCall,setNeedsCall\]/);
+  // Попереджувальний тост і блок із дзвінком.
+  assert.match(page, /dashToast\$\{toast\.startsWith\("⚠"\)/);
+  assert.match(page, /className="dashNeedsCall"/);
+  assert.match(page, /href=\{`tel:\$\{b\.phone\}`\}/);
+  // Успіх лишається лише коли реально надіслано.
+  assert.match(page, /\(r\?\.sent \?\? 0\) > 0/);
+  const css = await read("app/globals.css");
+  assert.match(css, /\.dashNeedsCall\{[^}]*var\(--mod-urgent\)/);
+  assert.match(css, /\.dashToast\.warn\{/);
+});


### PR DESCRIPTION
Пункт 2 з критики — про пацієнтів, не косметика. Раніше підтвердження заявки показувало «ok» навіть коли пацієнта **не** попереджено, а тост зникав.

## Проблема
- `reminder === null` означає, що відправлення **впало з винятком**, але UI показував benign «WhatsApp вимкнено або не підключено» — реєстратор думав, що все гаразд.
- Навіть коректне «не доставлено» жило лише у **тості**, який зникає. Після підтвердження картка залишає чергу — і слід губиться. Пацієнт не приходить.

## Виправлення
- Розрізнено три випадки: `null`/виняток і `failed>0` (шлюз не доставив) → **не попереджено**; `skipped>0` → нейтрально (вимкнено/немає телефону); `sent>0` → успіх.
- Невдалі потрапляють у **стійкий блок «☎ Потребує дзвінка»** (на сесію) — робочий список із **tap-to-call** телефоном, WhatsApp і кнопкою «✓ Подзвонив». Реєстратор бачить, кому передзвонити, а не покладається на зниклий тост.
- Варнінг-тост візуально відрізняється від успіху (`--mod-urgent`).
- Сам факт збою й далі логується в `patient_notifications` (`status=failed`) — тобто є й довготривалий слід для окремого звіту в майбутньому.

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **287/287** (додав тест логіки: null/failed → needsCall, warn-тост, tel-лінк)
- Панель звірено візуальним моком (нижче в чаті) — SSR її не показує, бо вона залежить від клієнтської дії

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_