### PR TITLE
Пульт: пакетне підтвердження заявок

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -430,6 +430,16 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 @media(max-width:640px){.dashLoadRow{font-size:11px}.dashLoadCell{height:40px}}
 .dashPending{max-width:var(--dash-w);margin:0 auto 16px;background:#fff;border:1px solid #e7ece9;border-radius:var(--r-lg);box-shadow:var(--sh-2);padding:var(--sp-4)}
 .dashPendingHead{display:flex;flex-wrap:wrap;align-items:baseline;gap:10px;margin-bottom:10px}
+/* Пакетне підтвердження: панель у заголовку + чекбокси на картках. */
+.dashPendingTools{margin-left:auto;display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.dashSelAll{border:1px solid #d7e1e1;background:#fff;border-radius:var(--r-sm);padding:8px 12px;font-size:12px;font-weight:700;color:#355b57;cursor:pointer}
+.dashSelAll:hover{border-color:#9ebbb3}
+.dashBatchBtn{border:0;border-radius:var(--r-sm);padding:8px 14px;font-size:12px;font-weight:800;background:var(--ws-brand,#123d3a);color:#fff;cursor:pointer;transition:opacity var(--dur-fast) var(--ease)}
+.dashBatchBtn:disabled{opacity:.45;cursor:default}
+.dashCardPick{display:inline-flex;align-items:center;cursor:pointer}
+.dashCardPick input{width:17px;height:17px;accent-color:var(--ws-brand,#123d3a);cursor:pointer}
+.dashCard.picked{outline:2px solid var(--ws-brand,#123d3a);outline-offset:1px}
+.themeDark .dashSelAll{background:#121a20;border-color:#2a3843;color:#9fb0bb}
 .dashPendingHead h2{font-size:var(--fs-lg);font-weight:750;margin:0;letter-spacing:-.01em}
 .dashPendingHead small{color:#71807c;font-size:12px}
 .dashPendingBadge{display:inline-block;margin-left:6px;padding:1px 9px;border-radius:99px;background:#b5761a;color:#fff;font-size:12px;font-weight:800;vertical-align:middle}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -153,6 +153,10 @@ export default function DashboardPage() {
   // Підтверджені, кому сповіщення НЕ дійшло — робочий список «передзвонити»
   // (на сесію; сам факт збою також лишається в patient_notifications).
   const [needsCall,setNeedsCall] = useState<CalBooking[]>([]);
+  // Пакетне підтвердження: вибрані заявки + індикатор виконання.
+  const [selected,setSelected] = useState<Set<number>>(new Set());
+  const [batchBusy,setBatchBusy] = useState(false);
+  const toggleSel = (id:number) => setSelected(s => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
   const [agendaFilter,setAgendaFilter] = useState<AgendaFilter>("all");
   const [nowMin,setNowMin] = useState(() => nowMinutesKyiv());
   const [openId,setOpenId] = useState<number | null>(null);
@@ -204,36 +208,61 @@ export default function DashboardPage() {
 
   const canManage = staff?.role === "admin" || staff?.role === "registrar";
 
+  // Одне підтвердження: мутує стан заявки, повертає підсумок (без тосту),
+  // щоб і поштучний, і пакетний режим користувались тією самою логікою.
+  async function sendConfirm(id:number): Promise<{ ok:boolean; outcome:"delivered"|"failed"|"skipped"; error?:string }> {
+    const res = await fetch("/api/staff/bookings", {
+      method:"PATCH", headers:{"content-type":"application/json"},
+      body:JSON.stringify({ id, confirm:true }),
+    });
+    const data = await res.json().catch(() => ({})) as { error?:string; reminder?:{ sent:number; skipped:number; failed:number } | null };
+    if (!res.ok) return { ok:false, outcome:"failed", error:data.error };
+    setBookings(cur => cur.map(b => b.id === id ? { ...b, status:"confirmed" } : b));
+    const r = data.reminder;
+    // r відсутнє/null → відправлення впало; r.failed>0 → шлюз не доставив.
+    const notNotified = !r || (r.failed ?? 0) > 0;
+    if (notNotified) {
+      const b = bookings.find(x => x.id === id);
+      if (b) setNeedsCall(cur => cur.some(x => x.id === id) ? cur : [...cur, { ...b, status:"confirmed" }]);
+      return { ok:true, outcome:"failed" };
+    }
+    return { ok:true, outcome:(r?.sent ?? 0) > 0 ? "delivered" : "skipped" };
+  }
+
   async function confirmBooking(id:number) {
     setBusyId(id); setToast("");
     try {
-      const res = await fetch("/api/staff/bookings", {
-        method:"PATCH", headers:{"content-type":"application/json"},
-        body:JSON.stringify({ id, confirm:true }),
-      });
-      const data = await res.json().catch(() => ({})) as { error?:string; reminder?:{ sent:number; skipped:number; failed:number } | null };
-      if (!res.ok) { setToast(data.error || "Не вдалося підтвердити запис"); return; }
-      setBookings(cur => cur.map(b => b.id === id ? { ...b, status:"confirmed" } : b));
-      const r = data.reminder;
-      // r===null → відправлення впало з помилкою; r.failed>0 → шлюз не доставив.
-      // В обох випадках пацієнта не попереджено — у робочий список «передзвонити».
-      const notNotified = !r || (r.failed ?? 0) > 0;
-      if (notNotified) {
-        const b = bookings.find(x => x.id === id);
-        if (b) setNeedsCall(cur => cur.some(x => x.id === id) ? cur : [...cur, { ...b, status:"confirmed" }]);
-        setToast(!r
-          ? "⚠ Підтверджено, але сповіщення НЕ надіслано (помилка системи) — зателефонуйте пацієнту"
-          : "⚠ Підтверджено, але WhatsApp НЕ доставлено — зателефонуйте пацієнту");
-      } else {
-        setToast((r?.sent ?? 0) > 0
+      const o = await sendConfirm(id);
+      if (!o.ok) { setToast(o.error || "Не вдалося підтвердити запис"); return; }
+      setToast(o.outcome === "failed"
+        ? "⚠ Підтверджено, але сповіщення НЕ доставлено — зателефонуйте пацієнту"
+        : o.outcome === "delivered"
           ? "✓ Підтверджено · повідомлення у WhatsApp надіслано пацієнту"
           : "✓ Підтверджено · сповіщення пропущено (вимкнено або немає телефону)");
-      }
     } catch {
       setToast("Помилка мережі — спробуйте ще раз");
     } finally {
       setBusyId(null);
     }
+  }
+
+  // Пакетне підтвердження обраних заявок: послідовно (щоб не перевантажити
+  // WhatsApp-шлюз), з агрегованим підсумком; невдалі — у «Потребує дзвінка».
+  async function confirmSelected() {
+    const ids = pending.filter(b => selected.has(b.id)).map(b => b.id);
+    if (!ids.length) return;
+    setBatchBusy(true); setToast("");
+    let done = 0, failed = 0, errors = 0;
+    for (const id of ids) {
+      try { const o = await sendConfirm(id); if (!o.ok) errors += 1; else { done += 1; if (o.outcome === "failed") failed += 1; } }
+      catch { errors += 1; }
+    }
+    setSelected(new Set());
+    setBatchBusy(false);
+    const parts = [`Підтверджено ${done}`];
+    if (failed) parts.push(`${failed} без сповіщення — у списку дзвінків`);
+    if (errors) parts.push(`${errors} з помилкою`);
+    setToast((failed || errors ? "⚠ " : "✓ ") + parts.join(" · "));
   }
 
   async function rescheduleBooking(id:number, date:string, time:string) {
@@ -337,15 +366,30 @@ export default function DashboardPage() {
         <div className="dashPendingHead">
           <h2>Нові заявки {pending.length ? <span className="dashPendingBadge">{pending.length}</span> : null}</h2>
           <small>{canManage
-            ? "Натисніть «Підтвердити» — пацієнту одразу піде повідомлення у WhatsApp."
+            ? "Позначте кілька й підтвердьте разом, або по одній. Пацієнту йде WhatsApp."
             : "Заявки, що очікують підтвердження реєстратури."}</small>
+          {canManage && pending.length > 0 &&
+            <div className="dashPendingTools">
+              <button type="button" className="dashSelAll"
+                onClick={()=>setSelected(selected.size === pending.length ? new Set() : new Set(pending.map(b=>b.id)))}>
+                {selected.size === pending.length ? "Зняти вибір" : "Обрати всі"}
+              </button>
+              <button type="button" className="dashBatchBtn" disabled={selected.size === 0 || batchBusy}
+                onClick={()=>void confirmSelected()}>
+                {batchBusy ? "Підтверджую…" : `✓ Підтвердити обрані · ${selected.size}`}
+              </button>
+            </div>}
         </div>
         {pending.length === 0
           ? <p className="dashListEmpty">Нових непідтверджених заявок немає — усе опрацьовано.</p>
           : <div className="dashCards">
               {pending.map(b => (
-                <article key={b.id} className={`dashCard ${b.status} ${modClass(b.equipmentId)}`}>
+                <article key={b.id} className={`dashCard ${b.status} ${modClass(b.equipmentId)}${selected.has(b.id) ? " picked" : ""}`}>
                   <div className="dashCardTop">
+                    {canManage &&
+                      <label className="dashCardPick" title="Обрати для пакетного підтвердження">
+                        <input type="checkbox" checked={selected.has(b.id)} onChange={()=>toggleSel(b.id)} />
+                      </label>}
                     <span className={`dashCardTag ${b.status}`}>{b.status === "rescheduled" ? "Перенесено" : "Нова"}</span>
                     {isContrast(b) && <span className="dashCardFlag">Контраст</span>}
                     {needsPay(b) && <span className="dashCardFlag pay">Оплата</span>}

--- a/tests/dashboard.test.mjs
+++ b/tests/dashboard.test.mjs
@@ -89,3 +89,19 @@ test("confirm surfaces a persistent call-back list when notification fails", asy
   assert.match(css, /\.dashNeedsCall\{[^}]*var\(--mod-urgent\)/);
   assert.match(css, /\.dashToast\.warn\{/);
 });
+
+test("pending queue supports batch confirmation", async () => {
+  const page = await read("app/staff/dashboard/page.tsx");
+  // Спільна логіка одного підтвердження, якою користуються поштучний і пакетний режим.
+  assert.match(page, /async function sendConfirm\(id:number\)/);
+  assert.match(page, /async function confirmSelected\(\)/);
+  // Пакет іде послідовно й агрегує підсумок; невдалі — у needsCall (через sendConfirm).
+  assert.match(page, /for \(const id of ids\)/);
+  assert.match(page, /const \[selected,setSelected\] = useState<Set<number>>/);
+  // UI: чекбокс на картці, кнопки «Обрати всі» / «Підтвердити обрані».
+  assert.match(page, /className="dashCardPick"/);
+  assert.match(page, /Підтвердити обрані · \$\{selected\.size\}/);
+  const css = await read("app/globals.css");
+  assert.match(css, /\.dashCard\.picked\{/);
+  assert.match(css, /\.dashBatchBtn\{/);
+});


### PR DESCRIPTION
Реєстратор із 8 однотипними «Новими заявками» робив 8 кліків. Тепер — один.

## Що додано
- **Чекбокс** на кожній картці заявки + **«Обрати всі» / «Зняти вибір»** у заголовку секції.
- **«✓ Підтвердити обрані · N»** — підтверджує вибрані **послідовно** (щоб не завалити WhatsApp-шлюз паралельними запитами) з **агрегованим підсумком**: `✓ Підтверджено N · M без сповіщення — у списку дзвінків · K з помилкою`.
- Обрані картки підсвічені (бірюзова обводка).

## Чисто зроблено
Логіку одного підтвердження винесено в спільний `sendConfirm(id)`, яким тепер користуються **і поштучна кнопка, і пакет** — тож поведінка ідентична, а невдалі сповіщення (з #133) так само потрапляють у «Потребує дзвінка».

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **288/288** (додав тест пакетної логіки)
- Візуальний мок — нижче в чаті (SSR цю секцію не показує: картки вантажяться клієнтом)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_