### PR TITLE
Пульт: стійкий звіт «Недоставлені сповіщення»

### DIFF
--- a/app/api/staff/dashboard/route.ts
+++ b/app/api/staff/dashboard/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
     outstanding, nszuPending,
     patients, repeatPatients, doNotContact,
     equipmentToday,
-    needProtocolList, readyList, needImagingList, confirmList,
+    needProtocolList, readyList, needImagingList, confirmList, undeliveredList,
     clinicalQueueRows,
     equipmentWeekRows,
   ] = await Promise.all([
@@ -61,6 +61,17 @@ export async function GET(request: Request) {
     many("SELECT id, code, name, service_code AS serviceCode, protocol_number AS protocolNumber FROM bookings WHERE protocol_status = 'ready' ORDER BY protocol_updated_at DESC LIMIT 6"),
     many("SELECT b.id, b.code, b.name, b.service_code AS serviceCode, b.performed_at AS performedAt FROM bookings b LEFT JOIN imaging_studies i ON i.booking_id = b.id WHERE b.performed_at != '' AND b.status != 'cancelled' AND i.booking_id IS NULL ORDER BY b.performed_at DESC LIMIT 6"),
     many("SELECT id, code, name, service_code AS serviceCode, desired_date AS desiredDate, desired_time AS desiredTime FROM bookings WHERE status = 'new' ORDER BY desired_date, desired_time LIMIT 6"),
+    // Недоставлені сповіщення: остання невдала спроба на заявку (tenant-scoped),
+    // щоб реєстратор бачив стійкий список «передзвонити», а не лише сесійний.
+    many(
+      `SELECT b.id, b.code, b.name, b.phone, b.service_code AS serviceCode,
+              b.desired_date AS desiredDate, b.desired_time AS desiredTime,
+              MAX(n.created_at) AS failedAt
+       FROM patient_notifications n JOIN bookings b ON b.id = n.booking_id
+       WHERE n.organization_id = ? AND n.status = 'failed' AND b.status != 'cancelled'
+       GROUP BY b.id ORDER BY failedAt DESC LIMIT 8`,
+      orgId,
+    ),
     // Клінічна черга — лічильники активних станів дослідження (tenant-scoped).
     many(
       `SELECT status AS s, COUNT(*) AS c FROM bookings
@@ -116,6 +127,7 @@ export async function GET(request: Request) {
       readyToIssue: withTitle(readyList),
       needImaging: withTitle(needImagingList),
       confirmQueue: withTitle(confirmList),
+      undelivered: withTitle(undeliveredList),
     },
     staff: member,
   }, { headers: { "cache-control": "no-store" } });

--- a/app/globals.css
+++ b/app/globals.css
@@ -440,6 +440,14 @@ details.dashAnalytics[open]>summary{margin-bottom:14px}
 .dashCardPick input{width:17px;height:17px;accent-color:var(--ws-brand,#123d3a);cursor:pointer}
 .dashCard.picked{outline:2px solid var(--ws-brand,#123d3a);outline-offset:1px}
 .themeDark .dashSelAll{background:#121a20;border-color:#2a3843;color:#9fb0bb}
+/* Стійкий звіт «недоставлені сповіщення». */
+.dashUndelivered{max-width:var(--dash-w);margin:0 auto 16px;border-left:4px solid var(--mod-urgent)}
+.dashUndItem{display:flex!important;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px}
+.dashUndWho{min-width:0;display:flex;flex-direction:column;gap:2px}
+.dashUndWho b{font-size:13px;color:#18302f}
+.dashUndWho small{color:#6b7a76;font-size:var(--fs-xs)}
+.dashUndActions{display:flex;flex-wrap:wrap;gap:8px}
+.themeDark .dashUndWho b{color:#e6edf1}
 .dashPendingHead h2{font-size:var(--fs-lg);font-weight:750;margin:0;letter-spacing:-.01em}
 .dashPendingHead small{color:#71807c;font-size:12px}
 .dashPendingBadge{display:inline-block;margin-left:6px;padding:1px 9px;border-radius:99px;background:#b5761a;color:#fff;font-size:12px;font-weight:800;vertical-align:middle}

--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -14,7 +14,7 @@ type Kpi = {
   outstandingCount:number; outstandingSum:number; nszuPending:number;
   patients:number; repeatPatients:number; doNotContact:number;
 };
-type ListItem = { id:number; code:string; name:string; serviceTitle:string; performedAt?:string; protocolNumber?:string; desiredDate?:string; desiredTime?:string };
+type ListItem = { id:number; code:string; name:string; serviceTitle:string; performedAt?:string; protocolNumber?:string; desiredDate?:string; desiredTime?:string; phone?:string; failedAt?:string };
 type QueueState = { v:string; l:string; count:number };
 type Data = {
   today:string; kpi:Kpi;
@@ -22,7 +22,7 @@ type Data = {
   equipmentWeek:Array<{ d:string; id:string; c:number }>;
   weekStart:string;
   clinicalQueue:QueueState[];
-  lists:{ needProtocol:ListItem[]; readyToIssue:ListItem[]; needImaging:ListItem[]; confirmQueue:ListItem[] };
+  lists:{ needProtocol:ListItem[]; readyToIssue:ListItem[]; needImaging:ListItem[]; confirmQueue:ListItem[]; undelivered:ListItem[] };
   staff:StaffInfo;
 };
 
@@ -473,6 +473,25 @@ export default function DashboardPage() {
           </div>
         </>;
       })()}
+
+      {/* Стійкий звіт із patient_notifications: кому система НЕ доставила
+          нагадування (і від cron, і від підтверджень) — переживає перезавантаження. */}
+      {data && data.lists.undelivered.length > 0 &&
+        <section className="dashList dashUndelivered" id="dash-undelivered">
+          <div className="dashListHead"><h3>Недоставлені сповіщення</h3><span>{data.lists.undelivered.length}{data.lists.undelivered.length === 8 ? "+" : ""}</span></div>
+          <p className="dashListHint">Пацієнти, яким система не змогла надіслати нагадування. Зателефонуйте вручну.</p>
+          <ul>
+            {data.lists.undelivered.map(item => (
+              <li key={item.id} className="dashUndItem">
+                <span className="dashUndWho"><b>{item.name || "—"}</b><small>{item.serviceTitle}{item.desiredDate ? ` · ${item.desiredDate} ${item.desiredTime || ""}` : ""}</small></span>
+                <span className="dashUndActions">
+                  <a className="dashCardBtn" href={`tel:${item.phone || ""}`} title={item.phone}>📞 {item.phone || "—"}</a>
+                  <a className="dashCardBtn wa" href={waLink(item.phone || "")} target="_blank" rel="noreferrer">WhatsApp</a>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>}
 
       {/* Рівень 3 — аналітика: керівникові, не лікарю. Згорнута за замовчуванням,
           щоб Пульт лишався фокусованим; розгортається одним кліком (лише адмін). */}

--- a/tests/dashboard.test.mjs
+++ b/tests/dashboard.test.mjs
@@ -105,3 +105,17 @@ test("pending queue supports batch confirmation", async () => {
   assert.match(css, /\.dashCard\.picked\{/);
   assert.match(css, /\.dashBatchBtn\{/);
 });
+
+test("dashboard reports undelivered notifications (persistent, tenant-scoped)", async () => {
+  const route = await read("app/api/staff/dashboard/route.ts");
+  assert.match(route, /patient_notifications n JOIN bookings b/);
+  assert.match(route, /n\.status = 'failed'/);
+  assert.match(route, /n\.organization_id = \?/); // tenant-scoped
+  assert.match(route, /undelivered: withTitle\(undeliveredList\)/);
+  // Лишається SELECT-only (жодних мутацій схеми/даних).
+  assert.doesNotMatch(route, /UPDATE\s+patient_notifications/i);
+  const page = await read("app/staff/dashboard/page.tsx");
+  assert.match(page, /Недоставлені сповіщення/);
+  assert.match(page, /data\.lists\.undelivered/);
+  assert.match(page, /className="dashUndItem"/);
+});


### PR DESCRIPTION
Пункт 3 — довготривалий слід замість сесійного списку з #133. Сесійний «Потребує дзвінка» зникає при перезавантаженні й бачить лише збої підтверджень реєстратора. Цей звіт — постійний і охоплює **всі** невдалі сповіщення, зокрема **cron-нагадування**, що впали вночі.

## Що зроблено
- **API Пульта**: `SELECT` останньої невдалої спроби на заявку з `patient_notifications` (`status='failed'` `JOIN bookings`), **tenant-scoped** по `organization_id`, `GROUP BY booking`, `LIMIT 8`; віддано як `lists.undelivered`. Лише читання — жодних мутацій.
- **UI**: панель «Недоставлені сповіщення» з червоним акцентом, лічильником і **tel-лінком + WhatsApp** на кожного пацієнта. Показується лише коли є недоставлені.

Тепер збій нагадування має і миттєвий сигнал (#133), і **стійкий робочий список**.

## Перевірка
- `tsc`/`lint`/`build` — чисто; рендер-тест Пульта прогнав новий SQL проти реальної БД без збою
- `node --test` — **289/289** (додав тест: джерело з `patient_notifications`, tenant-scope, SELECT-only, панель у UI)
- Візуальний мок — нижче в чаті

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_