### PR TITLE
Кабінет: номер заявки RD- у призначенні платежу

### DIFF
--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -240,7 +240,8 @@ function cardHtml(b) {
   const canCancel = ['new', 'confirmed', 'rescheduled'].includes(b.status);
   const awaitingPayment = b.paymentStatus === 'pending' && Number(b.paymentAmount) > 0 && b.status !== 'cancelled' && b.status !== 'completed';
   const serviceWithCode = [b.serviceCode, b.service].filter(Boolean).join(' · ');
-  const paymentPurpose = `Сплата за медичні послуги${b.serviceCode ? ', код ' + b.serviceCode : ''}: ${b.service}`;
+  // Номер заявки (RD-…) у призначенні — єдиний ключ звірки платежу з бронюванням.
+  const paymentPurpose = `Сплата за медичні послуги, заявка ${b.code}${b.serviceCode ? ', код ' + b.serviceCode : ''}: ${b.service}`;
   return `<div class="card app-card" id="card-${esc(b.code)}">
     <div class="app-top">
       <div>

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -102,6 +102,8 @@ test("payment link is served publicly and used by the site, not hardcoded", asyn
   assert.doesNotMatch(index, /assets\/notify\.js/); // obsolete client-side gateway removed
   const cabinet = await read("public/site/cabinet.html");
   assert.match(cabinet, /До сплати/);
+  // Призначення платежу містить номер заявки (RD-…) — ключ звірки з бронюванням.
+  assert.match(cabinet, /const paymentPurpose = `Сплата за медичні послуги, заявка \$\{b\.code\}/);
 });
 
 test("the payment QR renders on the site and in the cabinet; button only for real URLs", async () => {


### PR DESCRIPTION
З мого «прогону» цивільним пацієнтом — фікс #1 (оплата з ідентифікацією).

## Уточнення до критики
Пройшовши флоу по коду, визнаю: оплата в кабінеті **вже** значно повніша, ніж я спершу написав — per-заявку показує **суму до сплати**, реквізити (платник, послуга, сума), **IBAN** отримувача (В/Ч А3120, ЄДРПОУ), QR і кнопку «Сплатити карткою будь-якого банку», усе з копіюванням. Тобто «плати як знаєш» — перебільшення.

## Реальна діра, яку закрито
У полі **«Призначення»** був лише **код послуги** («…код 501: КТ»), але **не номер заявки `RD-…`** — єдиний унікальний ключ звірки. Тобто платіж не прив'язувався до конкретного бронювання; реєстратор мусив вгадувати за ПІБ.

**Фікс:** додано `b.code` (RD-…) у `paymentPurpose`:
> Сплата за медичні послуги, **заявка RD-…**, код 501: КТ грудної клітки

Тепер кожен платіж однозначно звіряється із заявкою — прямо усуває «оплатив, а вам не видно». Для КТ+рентген (дві заявки) кожна несе власний RD- у призначенні → незалежна звірка.

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **289/289** (додав перевірку RD- у призначенні)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_