### PR TITLE
Сайт: проактивне попередження про 18+ у цивільній формі

### DIFF
--- a/public/site/index.html
+++ b/public/site/index.html
@@ -439,6 +439,7 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
     <form class="request-form" id="requestForm" novalidate>
       <div class="form-step">
         <div class="step-title"><span class="step-num">1</span>Ваші дані</div>
+        <p class="cart-note">Онлайн-запис — для пацієнтів <strong>від 18 років</strong>. Для дитини зателефонуйте в реєстратуру: <a href="tel:+380972808899">+380 97 280 88 99</a>.</p>
         <div class="field">
           <label for="patientName">Прізвище, ім’я та по батькові <span class="req">*</span></label>
           <input autocomplete="name" id="patientName" required placeholder="Іваненко Іван Іванович"/>

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -448,6 +448,7 @@ body{background:#f3f6f8}
 <div aria-hidden="true" class="cart-overlay" id="cartOverlay"><aside aria-label="Моя заявка" aria-modal="true" class="cart-drawer" role="dialog"><div class="cart-head"><div><div class="eyebrow" style="color:var(--brand)">Попередній вибір</div><h2 style="margin:5px 0">Моя заявка</h2></div><button class="cart-close" onclick="closeCart()" type="button">×</button></div><div id="cartItems"></div><div class="cart-total"><span>Орієнтовна сума</span><span id="cartTotal">0 грн</span></div><form class="request-form" id="requestForm" novalidate>
       <div class="form-step">
         <div class="step-title"><span class="step-num">1</span>Ваші дані</div>
+        <p class="cart-note">Онлайн-запис — для пацієнтів <strong>від 18 років</strong>. Для дитини зателефонуйте в реєстратуру: <a href="tel:+380972808899">+380 97 280 88 99</a>.</p>
         <div class="field">
           <label for="patientName">Прізвище, ім’я та по батькові <span class="req">*</span></label>
           <input autocomplete="name" id="patientName" required placeholder="Іваненко Іван Іванович"/>

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -139,3 +139,12 @@ test("the military free-booking form saves to D1 as category 'military'", async 
   assert.match(military, /assets\/d1-bridge\.js/); // bridge loaded on the military page
   assert.doesNotMatch(military, /id="milSlotPicker"/);
 });
+
+test("civilian booking warns about the 18+ rule up front, not only on submit error", async () => {
+  for (const page of ["index", "price"]) {
+    const html = await read(`public/site/${page}.html`);
+    // Проактивна нотатка (завжди видима), а не лише .field-error після сабміту.
+    assert.match(html, /Онлайн-запис — для пацієнтів <strong>від 18 років<\/strong>/, `${page}: нема проактивної 18\+ нотатки`);
+    assert.match(html, /tel:\+380972808899/, `${page}: нема телефону реєстратури в нотатці`);
+  }
+});


### PR DESCRIPTION
Фікс #A з мого «прогону» пацієнтом.

## Проблема
Обмеження «онлайн-запис від 18 років» (сервер відхиляє `<18`) пацієнт бачив лише як `.field-error` **після** невдалого сабміту — тобто заповнивши всю форму. Батькам дитини — фрустрація.

## Виправлення
Додано **завжди-видиму** нотатку на початку кроку «Ваші дані» (на `index` і `price`):
> Онлайн-запис — для пацієнтів **від 18 років**. Для дитини зателефонуйте в реєстратуру: +380 97 280 88 99 *(tap-to-call)*.

Тепер обмеження видно **до** заповнення, з альтернативою (дзвінок).

## Про мульти-слот (друга частина A)
Виявилось неактуальним: **слот-пікера на сайті немає взагалі** (`#slotPicker` не монтується на жодній сторінці; час призначає реєстратор) — це фіксує й наявний тест «the public request does not force patients to choose a slot». Тож попереджати нема про що; мою критику знято.

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **290/290** (додав перевірку проактивної 18+ нотатки на обох сторінках)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_