### PR TITLE
Кабінет + військова форма: нагадування «що взяти» до візиту

### DIFF
--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -58,6 +58,7 @@ header{padding:0 14px;margin-bottom:18px}
 .visit-head b{font-size:14px}.visit-head small{color:#7c8a94}.visit-head strong{color:#123d3a}
 .visit-group{border-left:3px solid #bfe0e4;border-radius:var(--r-sm);padding-left:12px;margin-bottom:14px}
 .visit-group .app-card:last-child{margin-bottom:0}
+.bring-note{margin:10px 0 0;padding:9px 12px;background:#eef7f8;border:1px solid #cfe9ec;border-radius:var(--r-sm);color:#0e454c;font-size:12px}
 .app-top{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
 .app-study{font-weight:800;font-size:16px}
 .app-meta{font-size:13px;color:var(--muted);margin-top:3px}
@@ -255,6 +256,7 @@ function cardHtml(b) {
       <span class="badge ${meta.badge}">${esc(badgeLabel)}</span>
     </div>
     ${b.status !== 'cancelled' ? stepper(b.status) : ''}
+    ${(b.status !== 'cancelled' && b.status !== 'completed') ? `<div class="bring-note">🪪 Візьміть із собою: ${b.category === 'military' ? 'направлення та ' : ''}документ, що посвідчує особу.</div>` : ''}
     ${awaitingPayment ? `<div class="pay-row">💳 <span>До сплати: <strong>${esc(money(b.paymentAmount))} грн</strong></span></div>
       <button class="btn pay-toggle" type="button" data-pay-toggle="${esc(b.code)}">Сплатити</button>
       <div class="payment-panel" id="payment-${esc(b.code)}" hidden>

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -363,7 +363,7 @@ document.querySelectorAll('.price-group h2').forEach((heading)=>{
       </div>
       <div class="form-step">
         <div class="step-title"><span class="step-num">2</span>Надіслати заявку</div>
-        <p class="cart-note"><strong>Візьміть із собою направлення та попередні медичні документи.</strong> Завантаження документів через сайт не виконується.</p>
+        <p class="cart-note"><strong>Візьміть із собою направлення, документ, що посвідчує особу, та попередні медичні документи.</strong> Завантаження документів через сайт не виконується.</p>
         <div class="field">
           <label for="militaryComment">Коментар <span class="opt">(необов’язково)</span></label>
           <textarea id="militaryComment" placeholder="Додаткова інформація для реєстратури"></textarea>

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -159,3 +159,11 @@ test("cabinet groups a multi-study submission into one visit", async () => {
   assert.match(cabinet, /разом до сплати/);
   assert.match(cabinet, /list\.innerHTML = renderBookings\(bookings\)/);
 });
+
+test("visit reminder: cabinet tells patients what to bring; military form mentions ID", async () => {
+  const cabinet = await read("public/site/cabinet.html");
+  assert.match(cabinet, /Візьміть із собою:/);
+  assert.match(cabinet, /b\.category === 'military' \? 'направлення та '/); // військовим — з направленням
+  const military = await read("public/site/military.html");
+  assert.match(military, /Візьміть із собою направлення, документ, що посвідчує особу/);
+});


### PR DESCRIPTION
Фікс із «прогону» військовим пацієнтом.

## Що виправлено
1. **Кабінет** — біля кожної **активної** заявки (не скасованої/не завершеної) тепер видно нагадування:
   > 🪪 Візьміть із собою: **направлення** (військовослужбовцям) + **документ, що посвідчує особу**.
   
   Раніше нагадування жило лише на одноразовій формі запису; тепер воно під рукою саме тоді, коли пацієнт дивиться «коли йти». Текст адаптується за категорією (`b.category`): військовим — з направленням, цивільним — лише документ особи.
2. **Військова форма** — доповнено згадку **документа, що посвідчує особу** (потрібен для входу на територію госпіталю; на цивільних сторінках це вже було, на військовій — бракувало).

## Про решту з оцінки
Військовий флоу загалом добре змодельовано (живочергові дослідження без онлайн-запису, безоплатно, направлення в підказці) — тож фікс свідомо точковий, без переробок.

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **292/292** (додав перевірку нагадування в кабінеті та згадки посвідчення у формі)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_