### PR TITLE
Дія «Повідомити пацієнта» (разове повідомлення)

### DIFF
--- a/app/api/staff/notify/route.ts
+++ b/app/api/staff/notify/route.ts
@@ -1,0 +1,41 @@
+import { sendPatientMessage, type ReminderBooking } from "../../../../lib/notify";
+import { canWriteNotes, type StaffRole } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { dbBinding } from "../../../../lib/db";
+
+// Разове повідомлення пацієнту, ініційоване персоналом (результат готовий,
+// затримка, жива черга тощо) — окремо від автопідтвердження. Доступне всім
+// активним працівникам (canWriteNotes), зокрема лікарю-рентгенологу.
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canWriteNotes(ctx.member.role as StaffRole)) {
+    return Response.json({ error: "Недостатньо прав" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as { bookingId?: unknown; message?: unknown };
+  const bookingId = Number(body.bookingId);
+  const message = typeof body.message === "string" ? body.message.trim().slice(0, 500) : "";
+  if (!Number.isInteger(bookingId) || bookingId <= 0) {
+    return Response.json({ error: "Некоректна заявка" }, { status: 400 });
+  }
+  if (message.length < 3) {
+    return Response.json({ error: "Введіть текст повідомлення" }, { status: 400 });
+  }
+
+  const booking = await db.prepare(
+    `SELECT id, name, phone, phone_normalized AS phoneNormalized, patient_email AS patientEmail,
+            service, desired_date AS desiredDate, desired_time AS desiredTime
+     FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1`
+  ).bind(bookingId, ctx.organizationId).first<ReminderBooking>();
+  if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+
+  const summary = await sendPatientMessage(db, booking, message);
+  await db.prepare(
+    "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'notified', ?, ?)"
+  ).bind(bookingId, `Повідомлення пацієнту: ${message}`.slice(0, 480), ctx.member.email).run();
+
+  return Response.json({ ok: true, summary }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -861,6 +861,12 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .apptDrawerReschedRow span{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:#41544f}
 .apptDrawerReschedRow input,.apptDrawerReschedRow select{padding:9px 10px;border:1px solid #cbd8d6;border-radius:8px;font:inherit}
 .apptDrawerReschedHint{margin:0;font-size:11.5px;color:#a5670f}
+.apptDrawerNotifyPresets{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px}
+.apptDrawerChipBtn{border:1px solid #d7e1e1;background:#fff;border-radius:var(--r-pill);padding:6px 10px;font-size:11px;color:#355b57;cursor:pointer}
+.apptDrawerChipBtn:hover{border-color:#9ebbb3}
+.apptDrawerNotifyText{width:100%;box-sizing:border-box;border:1px solid #ccd9d6;border-radius:var(--r-sm);padding:9px 11px;font:inherit;font-size:13px;resize:vertical;background:#fff}
+.themeDark .apptDrawerChipBtn{background:#121a20;border-color:#2a3843;color:#9fb0bb}
+.themeDark .apptDrawerNotifyText{background:#0f1720;border-color:#22303a;color:#e6edf1}
 .apptDrawerReschedActions{display:flex;gap:8px}
 .apptDrawerReschedActions .apptDrawerBtn.primary{flex:1}
 .themeDark .apptDrawerResched{background:#0e151a;border-color:#22303a}

--- a/app/staff/booking-drawer.tsx
+++ b/app/staff/booking-drawer.tsx
@@ -49,6 +49,34 @@ export default function BookingDrawer({ booking, all, doctorName = "", onClose, 
   const [rTimes, setRTimes] = useState<string[]>([]);
   const [rLoading, setRLoading] = useState(false);
 
+  // Разове повідомлення пацієнту (результат готовий, затримка, жива черга).
+  const NOTIFY_PRESETS = [
+    "Ваш результат готовий — можна забрати опис у відділенні.",
+    "Невелика затримка за розкладом, дякуємо за очікування.",
+    "Підійдіть, будь ласка, до реєстратури відділення.",
+  ];
+  const [notifyOpen, setNotifyOpen] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [sending, setSending] = useState(false);
+  const [notifyResult, setNotifyResult] = useState("");
+  async function sendNotify() {
+    if (msg.trim().length < 3) return;
+    setSending(true); setNotifyResult("");
+    try {
+      const res = await fetch("/api/staff/notify", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ bookingId: b.id, message: msg.trim() }),
+      });
+      const data = await res.json().catch(() => ({})) as { error?: string; summary?: { sent: number; skipped: number; failed: number } };
+      if (!res.ok) { setNotifyResult(data.error || "Не вдалося надіслати"); return; }
+      const s = data.summary || { sent: 0, skipped: 0, failed: 0 };
+      if (s.sent > 0) { setNotifyResult("✓ Надіслано пацієнту"); setMsg(""); }
+      else if (s.failed > 0) setNotifyResult("⚠ Не доставлено — перевірте канал або номер");
+      else setNotifyResult("Пропущено: канал вимкнено або пацієнт у «не турбувати»");
+    } catch { setNotifyResult("Помилка мережі — спробуйте ще раз"); }
+    finally { setSending(false); }
+  }
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", onKey);
@@ -126,9 +154,22 @@ export default function BookingDrawer({ booking, all, doctorName = "", onClose, 
         </div>
       </div>}
 
+      {notifyOpen && <div className="apptDrawerResched">
+        <div className="apptDrawerNotifyPresets">
+          {NOTIFY_PRESETS.map((p, i) => <button key={i} type="button" className="apptDrawerChipBtn" onClick={()=>setMsg(p)}>{p.length > 30 ? p.slice(0, 30) + "…" : p}</button>)}
+        </div>
+        <textarea className="apptDrawerNotifyText" rows={3} maxLength={500} value={msg} onChange={e=>setMsg(e.target.value)} placeholder="Текст повідомлення пацієнту (WhatsApp / SMS)…" />
+        {notifyResult && <p className="apptDrawerReschedHint">{notifyResult}</p>}
+        <div className="apptDrawerReschedActions">
+          <button type="button" className="apptDrawerBtn primary" disabled={sending || msg.trim().length < 3} onClick={sendNotify}>{sending ? "…" : "Надіслати повідомлення"}</button>
+          <button type="button" className="apptDrawerBtn" onClick={()=>{ setNotifyOpen(false); setNotifyResult(""); }}>Закрити</button>
+        </div>
+      </div>}
+
       <div className="apptDrawerActions">
         {canConfirm && <button type="button" className="apptDrawerBtn confirm" disabled={confirming} onClick={() => onConfirm!(b.id)}>{confirming ? "…" : "✓ Підтвердити"}</button>}
         {canReschedule && !reschedOpen && <button type="button" className="apptDrawerBtn" onClick={()=>setReschedOpen(true)}>↻ Перенести</button>}
+        {ph && <button type="button" className="apptDrawerBtn" onClick={()=>setNotifyOpen(v=>!v)}>✉ Повідомити</button>}
         {ph && <a className="apptDrawerBtn" href={`tel:${b.phone}`}>📞 Подзвонити</a>}
         {ph && <a className="apptDrawerBtn wa" href={`https://wa.me/${ph}`} target="_blank" rel="noreferrer">WhatsApp</a>}
         {ph && <a className="apptDrawerBtn" href={`/staff/patients?phone=${ph}`}>Картка пацієнта →</a>}

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -46,7 +46,7 @@ function truthy(value: string): boolean {
 async function record(
   db: D1Database,
   booking: ReminderBooking,
-  kind: ReminderKind,
+  kind: string,
   channel: "sms" | "email" | "whatsapp",
   recipient: string,
   body: string,
@@ -58,10 +58,13 @@ async function record(
      VALUES (?, ?, ?, ?, ?, ?, ?, CASE WHEN ? = 'sent' THEN CURRENT_TIMESTAMP ELSE '' END)`
   ).bind(booking.id, kind, channel, recipient, body, status, error.slice(0, 240), status).run();
   if (status === "sent" && booking.phoneNormalized) {
+    const label = kind === "confirmed" ? "Автонагадування (підтвердження)"
+      : kind === "rescheduled" ? "Автонагадування (перенесення)"
+        : "Повідомлення персоналу";
     await db.prepare(
       `INSERT INTO patient_communications (phone_normalized, channel, direction, summary, actor)
        VALUES (?, ?, 'outbound', ?, 'system')`
-    ).bind(booking.phoneNormalized, channel, `Автонагадування (${kind === "confirmed" ? "підтвердження" : "перенесення"}): ${body}`.slice(0, 500)).run();
+    ).bind(booking.phoneNormalized, channel, `${label}: ${body}`.slice(0, 500)).run();
   }
 }
 
@@ -142,6 +145,71 @@ export async function sendPatientReminder(
       summary.sent += 1;
     } catch (error) {
       await record(db, booking, kind, ch.channel, ch.recipient, body, "failed", error instanceof Error ? error.message : "Помилка відправлення");
+      summary.failed += 1;
+    }
+  }
+  return summary;
+}
+
+// Разове повідомлення пацієнту, ініційоване персоналом (не автонагадування).
+// Завжди намагається відправити (не залежить від patient_reminders_enabled),
+// але поважає «не турбувати» й наявність шлюзів. Ніколи не кидає виняток.
+export async function sendPatientMessage(
+  db: D1Database,
+  booking: ReminderBooking,
+  text: string,
+): Promise<ReminderSummary> {
+  const summary: ReminderSummary = { sent: 0, skipped: 0, failed: 0 };
+  const body = (text || "").trim();
+  if (!body) return summary;
+
+  const cfg = await getSettings(db, [
+    "sms_gateway_url", "sms_gateway_auth",
+    "email_gateway_url", "email_gateway_auth", "email_gateway_from",
+  ]);
+  const messaging = createMessagingProvider({
+    sms: { url: cfg.sms_gateway_url || "", auth: cfg.sms_gateway_auth || "" },
+    email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
+  });
+
+  if (booking.phoneNormalized) {
+    const profile = await db.prepare(
+      "SELECT do_not_contact AS dnc FROM patient_profiles WHERE phone_normalized = ?"
+    ).bind(booking.phoneNormalized).first<{ dnc: number }>().catch(() => null);
+    if (profile?.dnc) {
+      await record(db, booking, "custom", "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
+      summary.skipped += 1;
+      return summary;
+    }
+  }
+
+  const channels: Array<{ channel: "sms" | "email" | "whatsapp"; recipient: string; url: string; send: () => Promise<void> }> = [];
+  const wa = await whatsappConfig(db);
+  if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
+    channels.push({
+      channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
+      send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
+    });
+  }
+  if (booking.phone) {
+    channels.push({ channel: "sms", recipient: booking.phone, url: cfg.sms_gateway_url || "", send: () => messaging.sendSms(booking.phone, body) });
+  }
+  if (booking.patientEmail) {
+    channels.push({ channel: "email", recipient: booking.patientEmail, url: cfg.email_gateway_url || "", send: () => messaging.sendEmail(booking.patientEmail, "Повідомлення з відділення", body) });
+  }
+
+  for (const ch of channels) {
+    if (!ch.url) {
+      await record(db, booking, "custom", ch.channel, ch.recipient, body, "skipped", `Шлюз ${ch.channel.toUpperCase()} не налаштовано`);
+      summary.skipped += 1;
+      continue;
+    }
+    try {
+      await ch.send();
+      await record(db, booking, "custom", ch.channel, ch.recipient, body, "sent", "");
+      summary.sent += 1;
+    } catch (error) {
+      await record(db, booking, "custom", ch.channel, ch.recipient, body, "failed", error instanceof Error ? error.message : "Помилка відправлення");
       summary.failed += 1;
     }
   }

--- a/tests/notify-patient.test.mjs
+++ b/tests/notify-patient.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("ad-hoc patient message: lib + endpoint + drawer UI", async () => {
+  const lib = await read("lib/notify.ts");
+  assert.match(lib, /export async function sendPatientMessage/);
+  assert.match(lib, /Пацієнт у списку «не турбувати»/); // поважає DNC
+  assert.doesNotMatch(lib, /sendPatientMessage[\s\S]*patient_reminders_enabled/); // не залежить від тумблера автонагадувань
+
+  const route = await read("app/api/staff/notify/route.ts");
+  assert.match(route, /canWriteNotes\(ctx\.member\.role/); // доступ усім активним ролям (зокрема рентгенологу)
+  assert.match(route, /organization_id = \?/); // tenant-scoped
+  assert.match(route, /sendPatientMessage\(/);
+  assert.match(route, /'notified'/); // подія в журналі заявки
+
+  const drawer = await read("app/staff/booking-drawer.tsx");
+  assert.match(drawer, /\/api\/staff\/notify/);
+  assert.match(drawer, /✉ Повідомити/);
+  assert.match(drawer, /NOTIFY_PRESETS/);
+});


### PR DESCRIPTION
Фікс із «прогону» лікаря-рентгенолога — закриває реальну прогалину: сповіщення були **приварені** до підтвердження/перенесення, тож **ніхто** не міг надіслати разове повідомлення («результат готовий», «затримка», «підійдіть у живу чергу»).

## Що додано
- **`lib/notify.ts → sendPatientMessage(db, booking, text)`** — шле довільний текст тими самими каналами (WhatsApp / SMS / email). На відміну від автонагадувань, **завжди активна** (не залежить від `patient_reminders_enabled` — персонал ініціює свідомо), але **поважає «не турбувати»** й наявність шлюзів; логується в `patient_notifications` (`kind=custom`). Робочий `sendPatientReminder` не змінював.
- **`/api/staff/notify`** — POST `{bookingId, message}`; доступ **усім активним ролям** (`canWriteNotes` — зокрема **лікарю-рентгенологу**), **tenant-scoped** по `organization_id`, подія `notified` у журналі заявки з автором.
- **`BookingDrawer`** (спільний на Пульті / Календарі / CRM) — композер **«✉ Повідомити»** з пресетами (готовий результат / затримка / реєстратура) і статусом доставки (надіслано / не доставлено / пропущено).

Розподіл ролей не чіпав — підтвердити/скасувати/записати лишаються за реєстратором/адміном; додано лише **комунікацію**, яка бракувала всім.

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **293/293** (новий `tests/notify-patient.test.mjs`: DNC, не-залежність від тумблера, дозвіл, tenant-scope, UI)
- Візуальний мок композера — нижче в чаті

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_