### PR TITLE
Заявка: підказки імені та по батькові у полі ПІБ

### DIFF
--- a/public/site/assets/name-suggest.js
+++ b/public/site/assets/name-suggest.js
@@ -1,0 +1,128 @@
+// Токен-залежні підказки для поля ПІБ (одне поле, 3 слова).
+// 1-е слово — прізвище (не підказуємо), 2-е — ім'я, 3-є — по батькові.
+// Підказки з'являються під час набору; вибір мишею/клавіатурою.
+(function () {
+  'use strict';
+
+  var NAMES = [
+    // чоловічі
+    'Олександр','Андрій','Дмитро','Сергій','Іван','Володимир','Микола','Василь','Юрій','Олег',
+    'Ігор','Віктор','Максим','Артем','Богдан','Тарас','Роман','Павло','Петро','Михайло',
+    'Анатолій','Віталій','Валерій','Євген','Костянтин','Денис','Назар','Ростислав','Ярослав','Владислав',
+    'Станіслав','Григорій','Степан','Федір','Леонід','Валентин','Едуард','Руслан','Вадим','Геннадій',
+    'Мар’ян','Остап','Любомир','Тимофій','Захар','Матвій','Данило','Кирило','Марко','Гліб',
+    'Олексій','Антон','Борис','В’ячеслав','Юхим','Опанас','Пилип','Влас',
+    // жіночі
+    'Олена','Тетяна','Наталія','Ірина','Оксана','Людмила','Галина','Марія','Ольга','Світлана',
+    'Юлія','Вікторія','Анна','Катерина','Валентина','Надія','Любов','Лариса','Алла','Ніна',
+    'Віра','Раїса','Зоя','Лідія','Анастасія','Дарія','Софія','Христина','Соломія','Уляна',
+    'Мар’яна','Роксолана','Богдана','Яна','Аліна','Діана','Карина','Валерія','Вероніка','Інна',
+    'Жанна','Емілія','Злата','Мілана','Поліна','Ангеліна','Олеся','Леся','Оксана'
+  ];
+
+  var PATRO = [
+    'Олександрович','Олександрівна','Андрійович','Андріївна','Дмитрович','Дмитрівна','Сергійович','Сергіївна',
+    'Іванович','Іванівна','Володимирович','Володимирівна','Миколайович','Миколаївна','Васильович','Василівна',
+    'Юрійович','Юріївна','Олегович','Олегівна','Ігорович','Ігорівна','Вікторович','Вікторівна',
+    'Максимович','Максимівна','Артемович','Артемівна','Богданович','Богданівна','Тарасович','Тарасівна',
+    'Романович','Романівна','Павлович','Павлівна','Петрович','Петрівна','Михайлович','Михайлівна',
+    'Анатолійович','Анатоліївна','Віталійович','Віталіївна','Валерійович','Валеріївна','Євгенович','Євгенівна',
+    'Костянтинович','Костянтинівна','Денисович','Денисівна','Ярославович','Ярославівна','Владиславович','Владиславівна',
+    'Григорович','Григорівна','Степанович','Степанівна','Федорович','Федорівна','Леонідович','Леонідівна',
+    'Валентинович','Валентинівна','Едуардович','Едуардівна','Русланович','Русланівна','Вадимович','Вадимівна',
+    'Геннадійович','Геннадіївна','Тимофійович','Тимофіївна','Захарович','Захарівна','Матвійович','Матвіївна',
+    'Данилович','Данилівна','Кирилович','Кирилівна','Маркович','Марківна','Олексійович','Олексіївна',
+    'Антонович','Антонівна','Борисович','Борисівна','Пилипович','Пилипівна','Ілліч','Іллівна','Кузьмич','Кузьмівна'
+  ];
+
+  var lc = function (s) { return (s || '').toLowerCase(); };
+
+  function attach(input) {
+    if (!input || input.dataset.nameSuggest === '1') return;
+    input.dataset.nameSuggest = '1';
+    input.setAttribute('autocomplete', 'off');
+
+    var list = document.createElement('ul');
+    list.className = 'nameSuggest';
+    list.hidden = true;
+    document.body.appendChild(list);
+    var active = -1;
+    var items = [];
+
+    function place() {
+      var r = input.getBoundingClientRect();
+      list.style.left = r.left + 'px';
+      list.style.top = (r.bottom + 2) + 'px';
+      list.style.width = r.width + 'px';
+    }
+
+    function close() { list.hidden = true; active = -1; items = []; }
+
+    function parts() {
+      var raw = input.value;
+      var endsSpace = /\s$/.test(raw);
+      var arr = raw.trim().length ? raw.trim().split(/\s+/) : [];
+      var idx = endsSpace ? arr.length : Math.max(arr.length - 1, 0);
+      var prefix = endsSpace ? '' : (arr[arr.length - 1] || '');
+      return { arr: arr, idx: idx, prefix: prefix };
+    }
+
+    function pick(value) {
+      var p = parts();
+      var arr = p.arr.slice(0, p.idx);
+      arr[p.idx] = value;
+      // Після імені (idx 1) лишаємо пробіл для по батькові; після по батькові — ні.
+      input.value = arr.join(' ') + (p.idx < 2 ? ' ' : '');
+      close();
+      input.focus();
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    function render() {
+      var p = parts();
+      var source = p.idx === 1 ? NAMES : p.idx === 2 ? PATRO : null;
+      if (!source) { close(); return; }
+      var pre = lc(p.prefix);
+      var matches = source.filter(function (s) { return lc(s).indexOf(pre) === 0; }).slice(0, 8);
+      if (!matches.length) { close(); return; }
+      items = matches;
+      active = -1;
+      list.innerHTML = matches.map(function (s, i) {
+        return '<li data-i="' + i + '">' + s + '</li>';
+      }).join('');
+      place();
+      list.hidden = false;
+    }
+
+    input.addEventListener('input', render);
+    input.addEventListener('focus', render);
+    input.addEventListener('blur', function () { setTimeout(close, 150); });
+    window.addEventListener('scroll', function () { if (!list.hidden) place(); }, true);
+    window.addEventListener('resize', function () { if (!list.hidden) place(); });
+
+    list.addEventListener('mousedown', function (e) {
+      var li = e.target.closest('li');
+      if (li) { e.preventDefault(); pick(items[Number(li.dataset.i)]); }
+    });
+
+    input.addEventListener('keydown', function (e) {
+      if (list.hidden || !items.length) return;
+      if (e.key === 'ArrowDown') { e.preventDefault(); active = (active + 1) % items.length; }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); active = (active - 1 + items.length) % items.length; }
+      else if (e.key === 'Enter') { if (active >= 0) { e.preventDefault(); pick(items[active]); return; } }
+      else if (e.key === 'Escape') { close(); return; }
+      else return;
+      Array.prototype.forEach.call(list.children, function (li, i) {
+        li.classList.toggle('on', i === active);
+      });
+    });
+  }
+
+  function init() {
+    ['patientName', 'militaryPatientName'].forEach(function (id) {
+      attach(document.getElementById(id));
+    });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/public/site/assets/site.css
+++ b/public/site/assets/site.css
@@ -32,3 +32,7 @@ a{text-decoration:none;color:inherit}
 .sp-time{padding:8px 4px;border-radius:var(--r-sm);border:1.5px solid #dbe3e8;background:#fff;font:inherit;font-size:13px;font-weight:700;cursor:pointer}
 .sp-time.on{border-color:var(--brand);background:var(--brand);color:#fff}
 .sp-picked{margin-top:9px;font-size:13px;color:#1e7a3d}
+/* Підказки ПІБ (ім'я / по батькові) */
+.nameSuggest{position:fixed;z-index:200;margin:0;padding:4px;list-style:none;background:#fff;border:1px solid #dbe3e8;border-radius:12px;box-shadow:0 12px 30px rgba(18,40,30,.14);max-height:260px;overflow:auto}
+.nameSuggest li{padding:9px 12px;border-radius:8px;font-size:14px;color:#18302f;cursor:pointer}
+.nameSuggest li:hover,.nameSuggest li.on{background:#eef7f8}

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -582,5 +582,6 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
 <script src="/site/assets/slots.js"></script>
 <script src="/site/assets/cart.js" defer></script>
 <script src="/site/assets/d1-bridge.js" defer></script>
+<script src="/site/assets/name-suggest.js" defer></script>
 </body>
 </html>

--- a/public/site/military.html
+++ b/public/site/military.html
@@ -539,4 +539,5 @@ renderMilitaryCart();
 })();
 </script>
 <script src="/site/assets/d1-bridge.js" defer></script>
+<script src="/site/assets/name-suggest.js" defer></script>
 </body></html>

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -546,6 +546,7 @@ body{background:#f3f6f8}
 <script src="/site/assets/slots.js"></script>
 <script src="/site/assets/cart.js" defer></script>
 <script src="/site/assets/d1-bridge.js" defer></script>
+<script src="/site/assets/name-suggest.js" defer></script>
 
 <script>
 /* Підтягуємо змінені персоналом тарифи (кабінет → «Тарифи») і оновлюємо ціни в таблиці. */

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -167,3 +167,19 @@ test("visit reminder: cabinet tells patients what to bring; military form mentio
   const military = await read("public/site/military.html");
   assert.match(military, /Візьміть із собою направлення, документ, що посвідчує особу/);
 });
+
+test("ПІБ field suggests Ukrainian given names + patronymics by token", async () => {
+  const js = await read("public/site/assets/name-suggest.js");
+  assert.match(js, /var NAMES =/);
+  assert.match(js, /var PATRO =/);
+  assert.match(js, /Олександрович/); // по батькові у списку
+  assert.match(js, /Іванівна/);
+  // Токен: 2-е слово → імена, 3-є → по батькові.
+  assert.match(js, /p\.idx === 1 \? NAMES : p\.idx === 2 \? PATRO/);
+  assert.match(js, /'patientName', 'militaryPatientName'/);
+  // Підключено на публічних booking-сторінках.
+  for (const p of ["index", "price", "military"]) {
+    const html = await read(`public/site/${p}.html`);
+    assert.match(html, /assets\/name-suggest\.js/, `${p} лінкує name-suggest.js`);
+  }
+});


### PR DESCRIPTION
За вашим запитом — у полі «Прізвище, ім'я та по батькові» ім'я й по батькові тепер підказуються під час набору.

## Як працює
Поле лишається одним (3 слова), але підказки **токен-залежні**:
- 1-ше слово (**прізвище**) — без підказок (їх безліч);
- 2-ге слово (**ім'я**) — випадають українські імена (чоловічі + жіночі);
- 3-тє слово (**по батькові**) — випадають по батькові обох родів (Миколайович / Миколаївна…).

Вибір **мишею або клавіатурою** (↑↓, Enter, Esc). Після вибору імені автоматично додається пробіл для по батькові.

## Реалізація
- Новий `public/site/assets/name-suggest.js` (~110 імен, ~90 по батькові) — самопідключається до `#patientName` / `#militaryPatientName`, дропдаун `position:fixed` (не обрізається контейнером), `autocomplete=off` щоб не конфліктувати з браузерним.
- Стилі `.nameSuggest` — у спільному `site.css`.
- Підключено на `index` / `price` / `military`.

Бекенд-контракт не змінено — на сервер іде те саме єдине повне ПІБ (валідація ≥3 слів лишається).

## Перевірка
- `tsc`/`lint`/`build` — чисто; `node --test` — **294/294** (новий тест токен-логіки + підключення)
- Візуальний мок — нижче в чаті

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_