### PR TITLE
Налаштування: кнопки «тест» для SMS та e-mail сповіщень

### DIFF
--- a/app/api/staff/settings/messaging-test/route.ts
+++ b/app/api/staff/settings/messaging-test/route.ts
@@ -1,0 +1,50 @@
+// Надсилає тестове SMS / e-mail через збережений шлюз, щоб адміністратор міг
+// перевірити налаштування в один клік (аналог telegram-test). Помилку шлюзу
+// повертає дослівно, щоб було видно причину (401, таймаут, заборонена адреса).
+
+import { requireStaff } from "../../../../../lib/staff-auth";
+import { getSettings } from "../../../../../lib/settings";
+import { createMessagingProvider } from "../../../../../lib/providers/messaging";
+import { normalizeUkrainianPhone } from "../../../../../lib/phone";
+import { dbBinding } from "../../../../../lib/db";
+
+const TEST_TEXT = "RadiologyOS: тестове повідомлення. Канал сповіщень налаштовано правильно.";
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+
+  const body = await request.json().catch(() => ({})) as { channel?: string; to?: string };
+  const channel = body.channel === "email" ? "email" : body.channel === "sms" ? "sms" : "";
+  const to = typeof body.to === "string" ? body.to.trim() : "";
+  if (!channel) return Response.json({ error: "Невідомий канал" }, { status: 400 });
+  if (!to) return Response.json({ error: "Вкажіть отримувача для тесту" }, { status: 400 });
+
+  const cfg = await getSettings(db, [
+    "sms_gateway_url", "sms_gateway_auth",
+    "email_gateway_url", "email_gateway_auth", "email_gateway_from",
+  ]);
+  const messaging = createMessagingProvider({
+    sms: { url: cfg.sms_gateway_url || "", auth: cfg.sms_gateway_auth || "" },
+    email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
+  });
+
+  try {
+    if (channel === "sms") {
+      if (!cfg.sms_gateway_url) return Response.json({ error: "Спершу збережіть адресу SMS-шлюзу" }, { status: 400 });
+      const phone = normalizeUkrainianPhone(to);
+      if (!phone) return Response.json({ error: "Некоректний номер телефону" }, { status: 400 });
+      await messaging.sendSms(phone, TEST_TEXT);
+    } else {
+      if (!cfg.email_gateway_url) return Response.json({ error: "Спершу збережіть адресу e-mail-шлюзу" }, { status: 400 });
+      if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(to)) return Response.json({ error: "Некоректна адреса e-mail" }, { status: 400 });
+      await messaging.sendEmail(to, "RadiologyOS — тест", TEST_TEXT);
+    }
+  } catch (error) {
+    return Response.json({ error: error instanceof Error ? error.message : "Не вдалося надіслати" }, { status: 400 });
+  }
+  return Response.json({ ok: true });
+}

--- a/app/staff/settings/page.tsx
+++ b/app/staff/settings/page.tsx
@@ -28,6 +28,9 @@ export default function StaffSettingsPage() {
   const [emailGatewayFrom, setEmailGatewayFrom] = useState("");
   const [status, setStatus] = useState<"idle" | "saving">("idle");
   const [testing, setTesting] = useState(false);
+  const [smsTestTo, setSmsTestTo] = useState("");
+  const [emailTestTo, setEmailTestTo] = useState("");
+  const [msgTesting, setMsgTesting] = useState<"" | "sms" | "email">("");
   const [calBusy, setCalBusy] = useState(false);
   const [calCopied, setCalCopied] = useState(false);
   const [notice, setNotice] = useState("");
@@ -90,6 +93,25 @@ export default function StaffSettingsPage() {
       setError(e instanceof Error ? e.message : "Не вдалося створити посилання");
     } finally {
       setCalBusy(false);
+    }
+  }
+
+  async function sendMessagingTest(channel: "sms" | "email") {
+    const to = (channel === "sms" ? smsTestTo : emailTestTo).trim();
+    if (!to) { setError(channel === "sms" ? "Вкажіть номер для тесту" : "Вкажіть e-mail для тесту"); return; }
+    setMsgTesting(channel); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/settings/messaging-test", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ channel, to }),
+      });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося надіслати");
+      setNotice(channel === "sms" ? "Тестове SMS надіслано" : "Тестовий e-mail надіслано");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося надіслати");
+    } finally {
+      setMsgTesting("");
     }
   }
 
@@ -182,6 +204,14 @@ export default function StaffSettingsPage() {
           <input value={smsGatewayAuth} onChange={(e) => setSmsGatewayAuth(e.target.value)} placeholder={settings?.smsGatewayAuthSet ? "Збережено — введіть, щоб змінити" : "Напр. Bearer <ключ>"} autoComplete="off" />
           <small>Значення заголовка Authorization. Порожнє — лишити збережене, «-» — очистити.</small>
         </label>
+        <label><span>Перевірка SMS-шлюзу</span>
+          <input value={smsTestTo} onChange={(e) => setSmsTestTo(e.target.value)} placeholder="+380 97 000 00 00" autoComplete="off" inputMode="tel" />
+          <small>Введіть номер і натисніть «Тест», щоб надіслати пробне SMS через збережений шлюз.</small>
+        </label>
+        <button type="button" className="button secondary" onClick={() => sendMessagingTest("sms")} disabled={msgTesting === "sms" || !settings?.smsGatewayUrl}>
+          {msgTesting === "sms" ? "Надсилаємо…" : "Тест SMS"}
+        </button>
+        {!settings?.smsGatewayUrl && <small className="settingsHint">Спершу збережіть адресу SMS-шлюзу — тоді кнопку буде розблоковано.</small>}
         <label><span>Адреса e-mail-шлюзу (HTTP POST)</span>
           <input value={emailGatewayUrl} onChange={(e) => setEmailGatewayUrl(e.target.value)} placeholder="https://email-провайдер/api/send" autoComplete="off" inputMode="url" />
           <small>Отримає JSON {"{ to, from, subject, text }"}. Порожнє поле — e-mail-канал вимкнено.</small>
@@ -193,6 +223,14 @@ export default function StaffSettingsPage() {
         <label><span>Адреса відправника e-mail</span>
           <input value={emailGatewayFrom} onChange={(e) => setEmailGatewayFrom(e.target.value)} placeholder="noreply@likarnya.example" autoComplete="off" inputMode="email" />
         </label>
+        <label><span>Перевірка e-mail-шлюзу</span>
+          <input value={emailTestTo} onChange={(e) => setEmailTestTo(e.target.value)} placeholder="admin@likarnya.example" autoComplete="off" inputMode="email" />
+          <small>Введіть адресу й натисніть «Тест», щоб надіслати пробний лист через збережений шлюз.</small>
+        </label>
+        <button type="button" className="button secondary" onClick={() => sendMessagingTest("email")} disabled={msgTesting === "email" || !settings?.emailGatewayUrl}>
+          {msgTesting === "email" ? "Надсилаємо…" : "Тест e-mail"}
+        </button>
+        {!settings?.emailGatewayUrl && <small className="settingsHint">Спершу збережіть адресу e-mail-шлюзу — тоді кнопку буде розблоковано.</small>}
       </section>
 
       {notice && <p className="notice success" role="status">{notice}</p>}

--- a/tests/messaging-test.test.mjs
+++ b/tests/messaging-test.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("messaging-test endpoint is admin-only and sends via the saved gateway", async () => {
+  const route = await read("app/api/staff/settings/messaging-test/route.ts");
+  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /createMessagingProvider\(/);
+  assert.match(route, /messaging\.sendSms\(/);
+  assert.match(route, /messaging\.sendEmail\(/);
+  // Валідація каналу й отримувача до відправлення.
+  assert.match(route, /body\.channel === "email"/);
+  assert.match(route, /normalizeUkrainianPhone\(/);
+  assert.match(route, /Спершу збережіть адресу SMS-шлюзу/);
+  assert.match(route, /Спершу збережіть адресу e-mail-шлюзу/);
+  // Причина помилки шлюзу повертається дослівно.
+  assert.match(route, /error instanceof Error \? error\.message/);
+});
+
+test("settings page exposes SMS and e-mail test buttons", async () => {
+  const page = await read("app/staff/settings/page.tsx");
+  assert.match(page, /messaging-test/);
+  assert.match(page, /sendMessagingTest\("sms"\)/);
+  assert.match(page, /sendMessagingTest\("email"\)/);
+  assert.match(page, /Тест SMS/);
+  assert.match(page, /Тест e-mail/);
+  // Кнопки заблоковані, доки шлюз не збережено.
+  assert.match(page, /disabled=\{msgTesting === "sms" \|\| !settings\?\.smsGatewayUrl\}/);
+  assert.match(page, /disabled=\{msgTesting === "email" \|\| !settings\?\.emailGatewayUrl\}/);
+});


### PR DESCRIPTION
## Що це

Адміністратор тепер може **перевірити SMS- та e-mail-шлюз одним кліком** прямо в `/staff/settings`, не чекаючи реального підтвердження запису. Це доповнює вже наявну кнопку тесту для Telegram.

## Контекст

Поля для налаштування SMS/email-шлюзу (URL, авторизація, відправник) у налаштуваннях **уже були** — бракувало лише способу переконатися, що шлюз працює. Тепер він є.

## Зміни

- **`app/api/staff/settings/messaging-test/route.ts`** (новий) — `POST { channel, to }`, лише для адміністратора. Валідує канал і отримувача (номер через `normalizeUkrainianPhone`, e-mail — regex), шле пробне повідомлення через збережений шлюз і **повертає причину помилки дослівно** (401 / таймаут / заборонена адреса).
- **`app/staff/settings/page.tsx`** — у секції «Нагадування пацієнтам» додані поля отримувача й кнопки **«Тест SMS»** / **«Тест e-mail»**; заблоковані, доки відповідний шлюз не збережено.

## Обмеження (без прихованих обіцянок)

Тест перевіряє **збережений** шлюз, тож спершу треба зберегти налаштування, а потім тестувати (як і кнопка Telegram). Viber і Telegram-до-пацієнта — окремі фічі з платформними обмеженнями, у цей PR не входять.

## Перевірки

- Тести: **301/301** (2 нових).
- `npm run lint` — чисто.
- `npm run build` — артефакт валідний.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_