### PR TITLE
Telegram-сповіщення пацієнтам (під'єднання через кабінет)

### DIFF
--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -1,0 +1,26 @@
+// Видає пацієнту (за активною сесією кабінету) deep-link для під'єднання
+// Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до його телефону.
+
+import { requirePatientSession } from "../../../lib/patient-auth";
+import { createTelegramLinkToken } from "../../../lib/telegram-link";
+import { telegramBotUsername } from "../../../lib/telegram";
+import { isRateLimited } from "../../../lib/rate-limit";
+import { dbBinding } from "../../../lib/db";
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+  const session = await requirePatientSession(request, db);
+  if (!session) return Response.json({ error: "Сесію не підтверджено" }, { status: 401 });
+  if (await isRateLimited(db, request, "telegram-link", 6, 15)) {
+    return Response.json({ error: "Забагато спроб. Спробуйте трохи пізніше." }, { status: 429 });
+  }
+
+  const username = await telegramBotUsername(db);
+  if (!username) {
+    return Response.json({ error: "Telegram-канал ще не налаштований відділенням", botConfigured: false }, { status: 503 });
+  }
+  const token = await createTelegramLinkToken(db, session.phoneNormalized);
+  const url = `https://t.me/${username}?start=${token}`;
+  return Response.json({ url }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/api/staff/settings/telegram-webhook/route.ts
+++ b/app/api/staff/settings/telegram-webhook/route.ts
@@ -1,0 +1,29 @@
+// Вмикає Telegram-канал для пацієнтів: реєструє webhook бота на наш публічний
+// ендпоінт із секретним заголовком. Лише для адміністратора.
+
+import { requireStaff } from "../../../../../lib/staff-auth";
+import { getSettings, setSetting } from "../../../../../lib/settings";
+import { setTelegramWebhook, telegramBotUsername } from "../../../../../lib/telegram";
+import { newSessionToken } from "../../../../../lib/auth";
+import { dbBinding } from "../../../../../lib/db";
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const member = await requireStaff(request, db);
+  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+
+  const { telegram_bot_token: token, telegram_webhook_secret: existing } =
+    await getSettings(db, ["telegram_bot_token", "telegram_webhook_secret"]);
+  if (!token) return Response.json({ error: "Спочатку збережіть токен бота Telegram" }, { status: 400 });
+
+  const secret = existing || newSessionToken();
+  const webhookUrl = `${new URL(request.url).origin}/api/telegram/webhook`;
+  const result = await setTelegramWebhook(db, webhookUrl, secret);
+  if (!result.ok) return Response.json({ error: result.error || "Не вдалося зареєструвати webhook" }, { status: 400 });
+
+  if (!existing) await setSetting(db, "telegram_webhook_secret", secret);
+  const username = await telegramBotUsername(db);
+  return Response.json({ ok: true, username });
+}

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -1,0 +1,25 @@
+// Публічний webhook бота Telegram. Приймає оновлення (натискання «Старт» із
+// токеном) і прив'язує chat_id до пацієнта. Захищено секретним заголовком, який
+// ми задали у setWebhook — сторонні запити відхиляються.
+
+import { getSettings } from "../../../../lib/settings";
+import { handleTelegramUpdate } from "../../../../lib/telegram-link";
+import { sendTelegramTo } from "../../../../lib/telegram";
+import { dbBinding } from "../../../../lib/db";
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return new Response("ok"); // best-effort: не даємо Telegram ретраїти вічно
+  const { telegram_webhook_secret: secret } = await getSettings(db, ["telegram_webhook_secret"]);
+  const provided = request.headers.get("x-telegram-bot-api-secret-token") || "";
+  if (!secret || provided !== secret) {
+    return new Response("forbidden", { status: 401 });
+  }
+
+  const update = await request.json().catch(() => ({}));
+  const { chatId, reply } = await handleTelegramUpdate(db, update);
+  if (chatId && reply) {
+    await sendTelegramTo(db, chatId, reply).catch(() => ({ ok: false }));
+  }
+  return new Response("ok");
+}

--- a/app/staff/settings/page.tsx
+++ b/app/staff/settings/page.tsx
@@ -31,6 +31,7 @@ export default function StaffSettingsPage() {
   const [smsTestTo, setSmsTestTo] = useState("");
   const [emailTestTo, setEmailTestTo] = useState("");
   const [msgTesting, setMsgTesting] = useState<"" | "sms" | "email">("");
+  const [tgBusy, setTgBusy] = useState(false);
   const [calBusy, setCalBusy] = useState(false);
   const [calCopied, setCalCopied] = useState(false);
   const [notice, setNotice] = useState("");
@@ -96,6 +97,20 @@ export default function StaffSettingsPage() {
     }
   }
 
+  async function enablePatientTelegram() {
+    setTgBusy(true); setNotice(""); setError("");
+    try {
+      const res = await fetch("/api/staff/settings/telegram-webhook", { method: "POST" });
+      const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; username?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося увімкнути");
+      setNotice(data.username ? `Telegram-канал для пацієнтів увімкнено (@${data.username})` : "Telegram-канал для пацієнтів увімкнено");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося увімкнути");
+    } finally {
+      setTgBusy(false);
+    }
+  }
+
   async function sendMessagingTest(channel: "sms" | "email") {
     const to = (channel === "sms" ? smsTestTo : emailTestTo).trim();
     if (!to) { setError(channel === "sms" ? "Вкажіть номер для тесту" : "Вкажіть e-mail для тесту"); return; }
@@ -140,6 +155,15 @@ export default function StaffSettingsPage() {
           {testing ? "Надсилаємо…" : "Надіслати тестове повідомлення"}
         </button>
         {!settings?.telegramConfigured && <small className="settingsHint">Спершу збережіть токен і ID чату — тоді кнопку буде розблоковано.</small>}
+      </section>
+
+      <section className="settingsBlock">
+        <h2>Telegram-сповіщення пацієнтам</h2>
+        <p>Пацієнт у своєму кабінеті натискає «Підключити Telegram», відкриває бота й тисне «Старт» — після цього нагадування (підтвердження, перенесення, повідомлення реєстратури) надходитимуть і в Telegram. Використовує того самого бота. Натисніть «Увімкнути», щоб зареєструвати webhook.</p>
+        <button type="button" className="button secondary" onClick={enablePatientTelegram} disabled={tgBusy || !settings?.telegramConfigured}>
+          {tgBusy ? "Вмикаємо…" : "Увімкнути Telegram для пацієнтів"}
+        </button>
+        {!settings?.telegramConfigured && <small className="settingsHint">Спершу налаштуйте бота вище (токен і ID чату).</small>}
       </section>
 
       <section className="settingsBlock">

--- a/drizzle/0025_patient_telegram.sql
+++ b/drizzle/0025_patient_telegram.sql
@@ -1,0 +1,10 @@
+-- Telegram-канал до пацієнта: зберігаємо chat_id у профілі та короткоживучі
+-- токени для deep-link прив'язки (пацієнт натискає «Старт» у боті один раз).
+ALTER TABLE `patient_profiles` ADD COLUMN `telegram_chat_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `telegram_link_tokens` (
+  `token_hash` text PRIMARY KEY NOT NULL,
+  `phone_normalized` text NOT NULL,
+  `created_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `expires_at` text NOT NULL
+);

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -9,6 +9,9 @@
 import { getSettings } from "./settings";
 import { createMessagingProvider } from "./providers/messaging";
 import { sendWhatsApp, whatsappConfig, whatsappConfigured } from "./whatsapp";
+import { sendTelegramTo } from "./telegram";
+
+type Channel = "sms" | "email" | "whatsapp" | "telegram";
 
 export type ReminderKind = "confirmed" | "rescheduled";
 
@@ -47,7 +50,7 @@ async function record(
   db: D1Database,
   booking: ReminderBooking,
   kind: string,
-  channel: "sms" | "email" | "whatsapp",
+  channel: Channel,
   recipient: string,
   body: string,
   status: "sent" | "skipped" | "failed",
@@ -79,7 +82,7 @@ export async function sendPatientReminder(
   const body = reminderText(kind, booking);
 
   const cfg = await getSettings(db, [
-    "patient_reminders_enabled",
+    "patient_reminders_enabled", "telegram_bot_token",
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
   ]);
@@ -91,19 +94,27 @@ export async function sendPatientReminder(
     email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
   });
 
-  // Повага до позначки «не турбувати» у картці пацієнта.
+  // Повага до позначки «не турбувати» у картці пацієнта + chat_id для Telegram.
+  let telegramChatId = "";
   if (booking.phoneNormalized) {
     const profile = await db.prepare(
-      "SELECT do_not_contact AS dnc FROM patient_profiles WHERE phone_normalized = ?"
-    ).bind(booking.phoneNormalized).first<{ dnc: number }>().catch(() => null);
+      "SELECT do_not_contact AS dnc, telegram_chat_id AS tg FROM patient_profiles WHERE phone_normalized = ?"
+    ).bind(booking.phoneNormalized).first<{ dnc: number; tg: string }>().catch(() => null);
     if (profile?.dnc) {
       await record(db, booking, kind, "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
       summary.skipped += 1;
       return summary;
     }
+    telegramChatId = profile?.tg || "";
   }
 
-  const channels: Array<{ channel: "sms" | "email" | "whatsapp"; recipient: string; url: string; send: () => Promise<void> }> = [];
+  const channels: Array<{ channel: Channel; recipient: string; url: string; send: () => Promise<void> }> = [];
+  if (telegramChatId) {
+    channels.push({
+      channel: "telegram", recipient: "Telegram", url: cfg.telegram_bot_token ? telegramChatId : "",
+      send: async () => { const r = await sendTelegramTo(db, telegramChatId, body); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
+    });
+  }
   const wa = await whatsappConfig(db);
   if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
     channels.push({
@@ -164,6 +175,7 @@ export async function sendPatientMessage(
   if (!body) return summary;
 
   const cfg = await getSettings(db, [
+    "telegram_bot_token",
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
   ]);
@@ -172,18 +184,26 @@ export async function sendPatientMessage(
     email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
   });
 
+  let telegramChatId = "";
   if (booking.phoneNormalized) {
     const profile = await db.prepare(
-      "SELECT do_not_contact AS dnc FROM patient_profiles WHERE phone_normalized = ?"
-    ).bind(booking.phoneNormalized).first<{ dnc: number }>().catch(() => null);
+      "SELECT do_not_contact AS dnc, telegram_chat_id AS tg FROM patient_profiles WHERE phone_normalized = ?"
+    ).bind(booking.phoneNormalized).first<{ dnc: number; tg: string }>().catch(() => null);
     if (profile?.dnc) {
       await record(db, booking, "custom", "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
       summary.skipped += 1;
       return summary;
     }
+    telegramChatId = profile?.tg || "";
   }
 
-  const channels: Array<{ channel: "sms" | "email" | "whatsapp"; recipient: string; url: string; send: () => Promise<void> }> = [];
+  const channels: Array<{ channel: Channel; recipient: string; url: string; send: () => Promise<void> }> = [];
+  if (telegramChatId) {
+    channels.push({
+      channel: "telegram", recipient: "Telegram", url: cfg.telegram_bot_token ? telegramChatId : "",
+      send: async () => { const r = await sendTelegramTo(db, telegramChatId, body); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
+    });
+  }
   const wa = await whatsappConfig(db);
   if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
     channels.push({

--- a/lib/telegram-link.ts
+++ b/lib/telegram-link.ts
@@ -1,0 +1,77 @@
+// Прив'язка Telegram пацієнта: короткоживучі токени для deep-link «Старт»
+// і обробник вхідних оновлень від бота (webhook). Пацієнт натискає «Старт»
+// у боті один раз — ми зіставляємо токен із його телефоном і зберігаємо chat_id.
+
+import { hashToken, newSessionToken } from "./auth";
+
+export const TELEGRAM_LINK_TTL_SECONDS = 15 * 60;
+
+// Створює токен, прив'язаний до телефону пацієнта; повертає «сирий» токен для
+// параметра ?start=. У БД зберігаємо лише SHA-256 хеш (як і сесії).
+export async function createTelegramLinkToken(db: D1Database, phoneNormalized: string): Promise<string> {
+  const rawToken = newSessionToken();
+  const tokenHash = await hashToken(rawToken);
+  await db.prepare(
+    `INSERT INTO telegram_link_tokens (token_hash, phone_normalized, expires_at)
+     VALUES (?, ?, datetime('now', ?))`
+  ).bind(tokenHash, phoneNormalized, `+${TELEGRAM_LINK_TTL_SECONDS} seconds`).run();
+  await db.prepare("DELETE FROM telegram_link_tokens WHERE expires_at <= CURRENT_TIMESTAMP").run();
+  return rawToken;
+}
+
+// Одноразово споживає токен: повертає телефон і одразу видаляє запис.
+export async function consumeTelegramLinkToken(db: D1Database, rawToken: string): Promise<string> {
+  const token = String(rawToken || "").trim();
+  if (!/^[a-f0-9]{64}$/.test(token)) return "";
+  const tokenHash = await hashToken(token);
+  const row = await db.prepare(
+    `SELECT phone_normalized AS phone FROM telegram_link_tokens
+     WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP LIMIT 1`
+  ).bind(tokenHash).first<{ phone: string }>().catch(() => null);
+  await db.prepare("DELETE FROM telegram_link_tokens WHERE token_hash = ?").bind(tokenHash).run();
+  return row?.phone || "";
+}
+
+// Зберігає chat_id у профілі пацієнта (upsert за нормалізованим телефоном).
+export async function linkPatientTelegram(db: D1Database, phoneNormalized: string, chatId: string): Promise<void> {
+  await db.prepare(
+    `INSERT INTO patient_profiles (phone_normalized, telegram_chat_id, updated_by, updated_at)
+     VALUES (?, ?, 'telegram', CURRENT_TIMESTAMP)
+     ON CONFLICT(phone_normalized) DO UPDATE SET telegram_chat_id = excluded.telegram_chat_id, updated_at = CURRENT_TIMESTAMP`
+  ).bind(phoneNormalized, chatId).run();
+}
+
+// Видаляє прив'язку (пацієнт написав /stop).
+export async function unlinkPatientTelegram(db: D1Database, chatId: string): Promise<void> {
+  await db.prepare(
+    "UPDATE patient_profiles SET telegram_chat_id = '', updated_at = CURRENT_TIMESTAMP WHERE telegram_chat_id = ?"
+  ).bind(chatId).run();
+}
+
+interface TelegramUpdate {
+  message?: { chat?: { id?: number | string }; text?: string };
+}
+
+// Обробляє одне оновлення від бота. Повертає текст відповіді пацієнту або "".
+// Best-effort: не кидає винятків, невідомі команди ігнорує.
+export async function handleTelegramUpdate(db: D1Database, update: TelegramUpdate): Promise<{ chatId: string; reply: string }> {
+  const chatId = update?.message?.chat?.id != null ? String(update.message.chat.id) : "";
+  const text = (update?.message?.text || "").trim();
+  if (!chatId || !text) return { chatId: "", reply: "" };
+
+  if (/^\/stop\b/.test(text)) {
+    await unlinkPatientTelegram(db, chatId);
+    return { chatId, reply: "Ви відписались від сповіщень. Щоб знову підключити — натисніть кнопку в кабінеті." };
+  }
+
+  const m = text.match(/^\/start\s+([a-f0-9]{64})$/);
+  if (!m) {
+    return { chatId, reply: "Щоб підключити сповіщення, відкрийте кабінет на сайті й натисніть «Підключити Telegram»." };
+  }
+  const phone = await consumeTelegramLinkToken(db, m[1]);
+  if (!phone) {
+    return { chatId, reply: "Посилання застаріло. Відкрийте кабінет і натисніть «Підключити Telegram» ще раз." };
+  }
+  await linkPatientTelegram(db, phone, chatId);
+  return { chatId, reply: "✅ Готово! Сповіщення про ваші дослідження надходитимуть у цей чат." };
+}

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -1,7 +1,7 @@
 // Best-effort Telegram notifications for the registrar. Disabled (a no-op)
 // until an admin saves a bot token and chat id in /staff/settings.
 
-import { getSettings } from "./settings";
+import { getSettings, setSetting } from "./settings";
 
 function escapeHtml(value: string): string {
   return value.replace(/[&<>]/g, (m) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[m] as string));
@@ -53,4 +53,64 @@ export async function sendTelegramResult(db: D1Database, text: string): Promise<
 // Best-effort variant for the booking path — never throws, ignores the reason.
 export async function sendTelegram(db: D1Database, text: string): Promise<boolean> {
   return (await sendTelegramResult(db, text)).ok;
+}
+
+// Надсилає повідомлення конкретному chat_id (пацієнту, який під'єднав бота).
+// Використовує той самий токен відділення. Повертає причину помилки укр.
+export async function sendTelegramTo(db: D1Database, chatId: string, text: string): Promise<{ ok: boolean; error?: string }> {
+  const { telegram_bot_token: token } = await getSettings(db, ["telegram_bot_token"]);
+  if (!token) return { ok: false, error: "Бот Telegram не налаштований" };
+  if (!chatId) return { ok: false, error: "Немає chat_id пацієнта" };
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML", disable_web_page_preview: true }),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (response.ok) return { ok: true };
+    const data = await response.json().catch(() => ({})) as { description?: string };
+    return { ok: false, error: data.description || `Telegram відповів помилкою (${response.status})` };
+  } catch {
+    return { ok: false, error: "Не вдалося з'єднатися з Telegram" };
+  }
+}
+
+// Ім'я бота (@username) для побудови deep-link t.me/<username>?start=…
+// Кешується в налаштуваннях, щоб не смикати getMe на кожен запит.
+export async function telegramBotUsername(db: D1Database): Promise<string> {
+  const { telegram_bot_token: token, telegram_bot_username: cached } =
+    await getSettings(db, ["telegram_bot_token", "telegram_bot_username"]);
+  if (!token) return "";
+  if (cached) return cached;
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+    const data = await response.json().catch(() => ({})) as { ok?: boolean; result?: { username?: string } };
+    const username = data.ok && data.result?.username ? data.result.username : "";
+    if (username) await setSetting(db, "telegram_bot_username", username);
+    return username;
+  } catch {
+    return "";
+  }
+}
+
+// Реєструє webhook бота на наш публічний ендпоінт із секретом-заголовком.
+export async function setTelegramWebhook(db: D1Database, url: string, secret: string): Promise<{ ok: boolean; error?: string }> {
+  const { telegram_bot_token: token } = await getSettings(db, ["telegram_bot_token"]);
+  if (!token) return { ok: false, error: "Спочатку збережіть токен бота" };
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/setWebhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url, secret_token: secret, allowed_updates: ["message"] }),
+    });
+    const data = await response.json().catch(() => ({})) as { ok?: boolean; description?: string };
+    if (data.ok) return { ok: true };
+    return { ok: false, error: data.description || `Telegram відповів помилкою (${response.status})` };
+  } catch {
+    return { ok: false, error: "Не вдалося з'єднатися з Telegram" };
+  }
 }

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -52,6 +52,10 @@ header{padding:0 14px;margin-bottom:18px}
 .cab-head h1{font-size:20px;margin:0}
 .cab-phone{font-size:13px;color:var(--muted)}
 .logout{border:0;background:none;color:#0e454c;font:inherit;font-size:13px;font-weight:700;cursor:pointer;padding:6px}
+.tg-connect{display:flex;align-items:center;flex-wrap:wrap;gap:10px;margin:0 2px 14px;padding:12px 14px;background:#eef7f8;border:1px solid #d3e6e8;border-radius:var(--r-md);font-size:13px;color:#18302f}
+.tg-connect .btn-ghost{border:1px solid var(--olive);background:#fff;color:var(--olive);font:inherit;font-weight:800;font-size:13px;border-radius:var(--r-sm);padding:8px 14px;cursor:pointer}
+.tg-connect .btn-ghost:disabled{opacity:.5;cursor:not-allowed}
+.tg-connect-msg{flex-basis:100%;color:#3a5c58;font-size:12px}
 
 .app-card{margin-bottom:14px}
 .visit-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;margin:6px 2px 8px;color:#123d3a;font-size:13px}
@@ -152,6 +156,11 @@ header{padding:0 14px;margin-bottom:18px}
         <div class="cab-phone" id="cabPhone"></div>
       </div>
       <button class="logout" id="logoutBtn" type="button">Вийти</button>
+    </div>
+    <div class="tg-connect" id="tgConnect" hidden>
+      <span>📩 Отримувати сповіщення про дослідження в Telegram?</span>
+      <button class="btn-ghost" id="tgConnectBtn" type="button">Підключити Telegram</button>
+      <span class="tg-connect-msg" id="tgConnectMsg"></span>
     </div>
     <div id="appList"></div>
     <div class="empty" id="emptyState" hidden>
@@ -375,7 +384,24 @@ async function enter(digits, dob) {
   dobValue = dob;
   document.getElementById('cabPhone').textContent = '+380 ' + digits.replace(/(\d{2})(\d{3})(\d{2})(\d{2})/, '$1 $2 $3 $4');
   const loaded = await loadBookings();
-  if (loaded) { gate.hidden = true; cabinet.hidden = false; }
+  if (loaded) { gate.hidden = true; cabinet.hidden = false; document.getElementById('tgConnect').hidden = false; }
+}
+
+async function connectTelegram() {
+  const btn = document.getElementById('tgConnectBtn');
+  const msg = document.getElementById('tgConnectMsg');
+  btn.disabled = true; msg.textContent = '';
+  try {
+    const res = await fetch('/api/my-telegram-link', { method: 'POST' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data.url) { msg.textContent = data.error || 'Не вдалося створити посилання'; return; }
+    window.open(data.url, '_blank', 'noopener');
+    msg.textContent = 'Відкрили Telegram — натисніть «Старт» у боті, щоб підключити.';
+  } catch (e) {
+    msg.textContent = 'Помилка мережі — спробуйте ще раз.';
+  } finally {
+    btn.disabled = false;
+  }
 }
 
 async function cancelBooking(code) {
@@ -451,11 +477,13 @@ if (savedAutoEnter && new URLSearchParams(window.location.search).get('new') ===
     enter(digits, dob);
   }
 }
+document.getElementById('tgConnectBtn').addEventListener('click', connectTelegram);
 document.getElementById('logoutBtn').addEventListener('click', async () => {
   await fetch(MY_BOOKINGS, { method: 'DELETE' }).catch(() => null);
   phoneDigits = '';
   dobValue = '';
   cabinet.hidden = true; gate.hidden = false;
+  document.getElementById('tgConnect').hidden = true;
   document.getElementById('gatePhone').value = '';
   document.getElementById('gateDob').value = '';
   try { sessionStorage.removeItem(PATIENT_PREFILL_KEY); } catch (e) {}

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("migration adds patient telegram_chat_id and link-token table", async () => {
+  const sql = await read("drizzle/0025_patient_telegram.sql");
+  assert.match(sql, /ALTER TABLE `patient_profiles` ADD COLUMN `telegram_chat_id`/);
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS `telegram_link_tokens`/);
+  assert.match(sql, /`token_hash` text PRIMARY KEY/);
+  assert.match(sql, /`expires_at` text NOT NULL/);
+});
+
+test("link lib: single-use hashed tokens + /start webhook handler", async () => {
+  const lib = await read("lib/telegram-link.ts");
+  assert.match(lib, /export async function createTelegramLinkToken/);
+  assert.match(lib, /export async function consumeTelegramLinkToken/);
+  assert.match(lib, /export async function linkPatientTelegram/);
+  assert.match(lib, /export async function handleTelegramUpdate/);
+  // Токен зберігається лише як хеш.
+  assert.match(lib, /hashToken\(/);
+  assert.match(lib, /DELETE FROM telegram_link_tokens WHERE token_hash = \?/); // одноразовість
+  // /start <token> прив'язує chat_id; /stop відписує.
+  assert.match(lib, /\/\^\\\/start\\s\+\(\[a-f0-9\]\{64\}\)\$\//);
+  assert.match(lib, /\/stop\\b/);
+  assert.match(lib, /ON CONFLICT\(phone_normalized\) DO UPDATE SET telegram_chat_id/);
+});
+
+test("patient link endpoint needs a verified session and returns a t.me deep link", async () => {
+  const route = await read("app/api/my-telegram-link/route.ts");
+  assert.match(route, /requirePatientSession\(/);
+  assert.match(route, /createTelegramLinkToken\(db, session\.phoneNormalized\)/);
+  assert.match(route, /https:\/\/t\.me\/\$\{username\}\?start=\$\{token\}/);
+  assert.match(route, /isRateLimited\(/);
+});
+
+test("public webhook is protected by the secret header set on setWebhook", async () => {
+  const route = await read("app/api/telegram/webhook/route.ts");
+  assert.match(route, /x-telegram-bot-api-secret-token/);
+  assert.match(route, /provided !== secret/);
+  assert.match(route, /status: 401/);
+  assert.match(route, /handleTelegramUpdate\(/);
+});
+
+test("admin enable endpoint registers the webhook with a stored secret", async () => {
+  const route = await read("app/api/staff/settings/telegram-webhook/route.ts");
+  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /setTelegramWebhook\(db, webhookUrl, secret\)/);
+  assert.match(route, /\/api\/telegram\/webhook/);
+  assert.match(route, /setSetting\(db, "telegram_webhook_secret"/);
+});
+
+test("telegram lib can message an arbitrary chat and register a webhook", async () => {
+  const lib = await read("lib/telegram.ts");
+  assert.match(lib, /export async function sendTelegramTo/);
+  assert.match(lib, /export async function telegramBotUsername/);
+  assert.match(lib, /export async function setTelegramWebhook/);
+  assert.match(lib, /getMe/);
+  assert.match(lib, /secret_token: secret/);
+});
+
+test("notify sends via Telegram when a patient linked their chat", async () => {
+  const notify = await read("lib/notify.ts");
+  assert.match(notify, /import \{ sendTelegramTo \} from ".\/telegram"/);
+  assert.match(notify, /telegram_chat_id AS tg/);
+  // Telegram-канал у обох шляхах (авто-нагадування і разове повідомлення).
+  const pushes = notify.match(/channel: "telegram"/g) || [];
+  assert.ok(pushes.length >= 2, "очікуємо Telegram-канал у reminder і message");
+  assert.match(notify, /sendTelegramTo\(db, telegramChatId, body\)/);
+});
+
+test("cabinet offers a Telegram connect button that calls the link endpoint", async () => {
+  const cabinet = await read("public/site/cabinet.html");
+  assert.match(cabinet, /id="tgConnectBtn"/);
+  assert.match(cabinet, /\/api\/my-telegram-link/);
+  assert.match(cabinet, /function connectTelegram/);
+});
+
+test("settings page can enable the patient Telegram channel", async () => {
+  const page = await read("app/staff/settings/page.tsx");
+  assert.match(page, /telegram-webhook/);
+  assert.match(page, /enablePatientTelegram/);
+  assert.match(page, /Увімкнути Telegram для пацієнтів/);
+});


### PR DESCRIPTION
## Що це

Пацієнт тепер може отримувати сповіщення про свої дослідження **в Telegram**. Оскільки Telegram не дозволяє боту писати за номером телефону, реалізовано коректний спосіб через **самостійне під'єднання**:

1. Пацієнт у кабінеті натискає **«Підключити Telegram»**.
2. Відкривається бот відділення за deep-link `t.me/<bot>?start=<token>`.
3. Пацієнт тисне **«Старт»** → бот отримує токен через webhook → ми прив'язуємо його `chat_id` до телефону.
4. Далі авто-нагадування (підтвердження/перенесення) і разові повідомлення реєстратури йдуть **і в Telegram**.

Використовується той самий бот відділення, що вже налаштований для сповіщень реєстратурі.

## Зміни

**Дані**
- `drizzle/0025_patient_telegram.sql` — `patient_profiles.telegram_chat_id` + таблиця `telegram_link_tokens`.

**Логіка**
- `lib/telegram-link.ts` — одноразові **хешовані** токени (SHA-256, TTL 15 хв), обробник оновлень: `/start <token>` прив'язує, `/stop` відписує.
- `lib/telegram.ts` — `sendTelegramTo` (повідомлення конкретному chat_id), `telegramBotUsername` (getMe з кешем), `setTelegramWebhook`.
- `lib/notify.ts` — Telegram як ще один канал у **обох** шляхах; поважає «не турбувати».

**API**
- `POST /api/my-telegram-link` — лише за активною сесією кабінету; віддає deep-link; rate-limited.
- `POST /api/telegram/webhook` — публічний, захищений **секретним заголовком** `x-telegram-bot-api-secret-token` (сторонні запити → 401).
- `POST /api/staff/settings/telegram-webhook` — **admin-only**, реєструє webhook і зберігає секрет.

**UI**
- Кабінет: кнопка «Підключити Telegram» + підказка.
- Налаштування: секція «Telegram-сповіщення пацієнтам» з кнопкою «Увімкнути».

## Безпека

- Токени зберігаються лише як SHA-256 хеш, одноразові, з TTL.
- Webhook перевіряє секретний заголовок, заданий у `setWebhook`; без збігу — 401.
- Прив'язка можлива тільки з підтвердженої сесії пацієнта (телефон + дата народження).

## Після мержу (потрібні дії адміністратора)

1. Задеплоїти.
2. У `/staff/settings` натиснути **«Увімкнути Telegram для пацієнтів»** (бот має бути налаштований токеном і ID чату).

## Перевірки

- Тести: **310/310** (9 нових).
- `npm run lint` — чисто.
- `npm run build` — артефакт валідний.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_