### PR TITLE
Поведінкові тести: жива SQLite + критичні шляхи пацієнта

### DIFF
--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -1,0 +1,128 @@
+// Поведінковий harness: справжня in-memory SQLite (node:sqlite) під інтерфейсом
+// D1, на яку спираються маршрути. Дає змогу перевіряти РЕАЛЬНУ поведінку —
+// SQL-фільтри, RBAC, збереження даних — а не наявність рядків у коді.
+//
+// Маршрути читають біндинг через globalThis.__RADIOLOGY_DB__ (див. lib/db.ts),
+// тож ми підставляємо адаптер туди на час тесту.
+
+import { DatabaseSync } from "node:sqlite";
+import { readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const DRIZZLE_DIR = new URL("../../drizzle/", import.meta.url);
+
+// Нормалізація аргументів під node:sqlite: undefined → null, boolean → 0/1.
+function normArg(a) {
+  if (a === undefined || a === null) return null;
+  if (typeof a === "boolean") return a ? 1 : 0;
+  if (typeof a === "bigint") return Number(a);
+  return a;
+}
+
+// Обгортає DatabaseSync у мінімальний, але вірний D1-сумісний інтерфейс:
+// prepare().bind().first()/all()/run() + batch().
+function wrapAsD1(db) {
+  const makeStmt = (sql) => {
+    const prepared = db.prepare(sql);
+    let bound = [];
+    const api = {
+      bind(...args) { bound = args.map(normArg); return api; },
+      async first(column) {
+        const row = prepared.get(...bound);
+        if (row == null) return null;
+        return column ? (row[column] ?? null) : row;
+      },
+      async all() {
+        return { results: prepared.all(...bound), success: true, meta: {} };
+      },
+      async run() {
+        const r = prepared.run(...bound);
+        return { success: true, meta: { changes: r.changes, last_row_id: Number(r.lastInsertRowid), duration: 0 } };
+      },
+      // Деякі шляхи звертаються до .raw(); повертаємо масив значень першого рядка.
+      async raw() {
+        const rows = prepared.all(...bound);
+        return rows.map((row) => Object.values(row));
+      },
+    };
+    return api;
+  };
+  return {
+    prepare(sql) { return makeStmt(sql); },
+    async batch(statements) {
+      const out = [];
+      for (const s of statements) out.push(await s.run());
+      return out;
+    },
+    async exec(sql) { db.exec(sql); return { count: 0, duration: 0 }; },
+    _raw: db,
+  };
+}
+
+// Застосовує всі drizzle-міграції по порядку до чистої БД.
+export async function applyMigrations(db) {
+  const files = (await readdir(fileURLToPath(DRIZZLE_DIR)))
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  for (const file of files) {
+    const sql = await readFile(new URL(file, DRIZZLE_DIR), "utf8");
+    // «--> statement-breakpoint» — коментар drizzle; SQLite exec виконає всі
+    // ;-термінальні інструкції файлу за раз.
+    try {
+      db.exec(sql);
+    } catch (e) {
+      throw new Error(`Міграція ${file} не застосувалась: ${e.message}`);
+    }
+  }
+}
+
+// Створює свіжу БД зі схемою і повертає { db, close }.
+export async function freshDb() {
+  const raw = new DatabaseSync(":memory:");
+  raw.exec("PRAGMA foreign_keys = ON;");
+  await applyMigrations(raw);
+  const db = wrapAsD1(raw);
+  return { db, raw, close: () => raw.close() };
+}
+
+// Виконує fn(db) з підставленим глобальним біндингом і прибирає його по завершенні.
+export async function withD1(fn) {
+  const { db, raw, close } = await freshDb();
+  const key = "__RADIOLOGY_DB__";
+  const previous = globalThis[key];
+  globalThis[key] = db;
+  try {
+    return await fn(db, raw);
+  } finally {
+    if (previous === undefined) delete globalThis[key];
+    else globalThis[key] = previous;
+    close();
+  }
+}
+
+// Зручний конструктор Request з JSON-тілом і Cloudflare-заголовком IP.
+export function jsonRequest(url, body, { method = "POST", headers = {}, ip = "203.0.113.7" } = {}) {
+  return new Request(`http://localhost${url}`, {
+    method,
+    headers: { "content-type": "application/json", "cf-connecting-ip": ip, ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+// Драйвер зібраного воркера (dist). Маршрутизація й код — справжні; воркер сам
+// кладе env.DB у globalThis, тож логіка маршрутів працює проти нашої SQLite.
+let workerPromise = null;
+function loadWorker() {
+  if (!workerPromise) {
+    const url = new URL("../../dist/server/index.js", import.meta.url);
+    workerPromise = import(url.href).then((m) => m.default);
+  }
+  return workerPromise;
+}
+
+export async function callWorker(request, db) {
+  const worker = await loadWorker();
+  const env = { DB: db, ASSETS: { fetch: async () => new Response("Not found", { status: 404 }) } };
+  const ctx = { waitUntil() {}, passThroughOnException() {} };
+  return worker.fetch(request, env, ctx);
+}

--- a/tests/my-bookings.behavior.test.mjs
+++ b/tests/my-bookings.behavior.test.mjs
@@ -1,0 +1,84 @@
+// Поведінковий тест справжнього шляху ідентифікації пацієнта:
+// /api/my-bookings проти живої SQLite-схеми (не перевірка рядків у коді).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker } from "./helpers/d1.mjs";
+
+const post = (db, body, opts) => callWorker(jsonRequest("/api/my-bookings", body, opts), db);
+
+async function seedBooking(db, over = {}) {
+  const b = {
+    code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNormalized: "380971112233",
+    service: "КТ головного мозку", serviceCode: "CT-01", desiredDate: "2026-09-01", desiredTime: "10:00",
+    status: "new", dob: "1990-05-05", category: "civilian", ...over,
+  };
+  await db.prepare(
+    `INSERT INTO bookings (code, name, phone, phone_normalized, service, service_code,
+       desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,1)`
+  ).bind(b.code, b.name, b.phone, b.phoneNormalized, b.service, b.serviceCode,
+    b.desiredDate, b.desiredTime, b.status, b.dob, b.category).run();
+  return b;
+}
+
+test("correct phone + DOB returns the patient's bookings and opens a session", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db);
+    const res = await post(db, { phone: "+380971112233", dob: "1990-05-05" });
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.bookings.length, 1);
+    assert.equal(data.bookings[0].code, "RD-AAAA1111");
+    // Сесію відкрито — cookie й реальний рядок у patient_sessions.
+    assert.match(res.headers.get("set-cookie") || "", /rid_patient=/);
+    const sessions = await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n");
+    assert.equal(sessions, 1);
+  });
+});
+
+test("wrong DOB is rejected as unverified (identity proof actually enforced)", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db);
+    const res = await post(db, { phone: "+380971112233", dob: "1980-01-01" });
+    assert.equal(res.status, 401);
+    const sessions = await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n");
+    assert.equal(sessions, 0); // жодної сесії при невдалій перевірці
+  });
+});
+
+test("a phone with no bookings cannot open a session", async () => {
+  await withD1(async (db) => {
+    const res = await post(db, { phone: "+380500000000", dob: "1990-05-05" });
+    assert.equal(res.status, 401);
+  });
+});
+
+test("malformed input is a 400 before any lookup", async () => {
+  await withD1(async (db) => {
+    const res = await post(db, { phone: "123", dob: "not-a-date" });
+    assert.equal(res.status, 400);
+  });
+});
+
+test("only bookings for the matching phone are returned (no cross-patient leak)", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { code: "RD-AAAA1111", phone: "+380971112233", phoneNormalized: "380971112233", dob: "1990-05-05" });
+    await seedBooking(db, { code: "RD-BBBB2222", name: "Петренко", phone: "+380975556677", phoneNormalized: "380975556677", dob: "1985-03-03" });
+    const res = await post(db, { phone: "+380971112233", dob: "1990-05-05" });
+    const data = await res.json();
+    assert.equal(data.bookings.length, 1);
+    assert.equal(data.bookings[0].code, "RD-AAAA1111");
+  });
+});
+
+test("brute force is rate-limited after the configured attempts", async () => {
+  await withD1(async (db) => {
+    let last = 200;
+    for (let i = 0; i < 10; i += 1) {
+      const res = await post(db, { phone: "+380509999999", dob: "1990-05-05" }, { ip: "198.51.100.42" });
+      last = res.status;
+    }
+    assert.equal(last, 429); // ліміт 8/15хв — 9-та+ спроби відбиваються
+  });
+});

--- a/tests/site-booking.behavior.test.mjs
+++ b/tests/site-booking.behavior.test.mjs
@@ -1,0 +1,94 @@
+// Поведінковий тест головного шляху «пацієнт створює заявку» проти живої
+// SQLite-схеми: справжні INSERT-и, ціна, ідемпотентність (без подвійного запису).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker } from "./helpers/d1.mjs";
+
+const CONSENT_VERSION = "2026-07-29";
+
+function validBody(over = {}) {
+  return {
+    name: "Іваненко Іван Іванович",
+    phone: "+380971112233",
+    dob: "1990-05-05",
+    category: "civilian",
+    items: [{ code: "201" }], // цифрова рентгенографія, доступна цивільним за замовчуванням
+    referralType: "none",
+    comment: "",
+    source: "",
+    consent: true,
+    consentVersion: CONSENT_VERSION,
+    ...over,
+  };
+}
+
+const book = (db, body, key = "idem-key-abcdef123456") =>
+  callWorker(jsonRequest("/api/site-booking", body, { headers: { "idempotency-key": key } }), db);
+
+test("a valid civilian request creates a booking, priced and pending payment", async () => {
+  await withD1(async (db) => {
+    const res = await book(db, validBody());
+    assert.equal(res.status, 201);
+    const data = await res.json();
+    assert.match(data.code, /^RD-[A-Z0-9]{16}$/);
+
+    const row = await db.prepare(
+      "SELECT status, payment_status AS pay, payment_amount AS amount, patient_category AS cat FROM bookings WHERE code = ?"
+    ).bind(data.code).first();
+    assert.ok(row, "заявку збережено в БД");
+    assert.equal(row.status, "new");
+    assert.equal(row.cat, "civilian");
+    assert.equal(row.pay, "pending");       // цивільний → очікує оплату
+    assert.equal(row.amount, 500);          // ціна з каталогу для коду 201
+
+    const events = await db.prepare(
+      "SELECT COUNT(*) AS n FROM booking_events WHERE action = 'created'"
+    ).first("n");
+    assert.equal(events, 1);
+  });
+});
+
+test("the same idempotency key never creates a second booking", async () => {
+  await withD1(async (db) => {
+    const first = await book(db, validBody(), "same-key-0001aaaa");
+    const second = await book(db, validBody(), "same-key-0001aaaa");
+    const a = await first.json();
+    const b = await second.json();
+    assert.equal(a.code, b.code); // та сама відповідь
+    const count = await db.prepare("SELECT COUNT(*) AS n FROM bookings").first("n");
+    assert.equal(count, 1);       // рівно одна заявка, не дві
+  });
+});
+
+test("missing consent is refused", async () => {
+  await withD1(async (db) => {
+    const res = await book(db, validBody({ consent: false }), "key-consent-0001");
+    assert.equal(res.status, 400);
+    const count = await db.prepare("SELECT COUNT(*) AS n FROM bookings").first("n");
+    assert.equal(count, 0);
+  });
+});
+
+test("under-18 is refused (server-side, not only UI)", async () => {
+  await withD1(async (db) => {
+    const res = await book(db, validBody({ dob: "2015-01-01" }), "key-minor-000001");
+    assert.equal(res.status, 400);
+    const count = await db.prepare("SELECT COUNT(*) AS n FROM bookings").first("n");
+    assert.equal(count, 0);
+  });
+});
+
+test("duplicated services in one request are refused", async () => {
+  await withD1(async (db) => {
+    const res = await book(db, validBody({ items: [{ code: "201" }, { code: "201" }] }), "key-dupe-0000001");
+    assert.equal(res.status, 400);
+  });
+});
+
+test("a request without an idempotency key is refused", async () => {
+  await withD1(async (db) => {
+    const res = await callWorker(jsonRequest("/api/site-booking", validBody()), db);
+    assert.equal(res.status, 400);
+  });
+});


### PR DESCRIPTION
## Навіщо

Це прямий фікс проблеми №1 з аудиту: з ~1106 тестових перевірок майже всі були «рядок присутній у вихідному коді» (grep у масці тесту) і лише 18 — поведінкові. Зелений CI не ловив **жодного логічного бага**.

Цей PR закладає інфраструктуру справжнього поведінкового тестування і покриває нею два найкритичніші шляхи пацієнта.

## Як це працює

`tests/helpers/d1.mjs`:
- Адаптер **`node:sqlite` → інтерфейс D1** (`prepare/bind/first/all/run/batch`).
- Застосовує **справжні drizzle-міграції** (усі 26) до in-memory БД → тестуємо проти реальної схеми.
- Підставляє біндинг через `globalThis.__RADIOLOGY_DB__` (як це робить воркер) і **проганяє зібраний `dist`-воркер** — маршрутизація й код справжні, не мок.

## Що реально перевіряється (не рядки — поведінка)

**`my-bookings.behavior.test.mjs`** — ідентифікація пацієнта:
- правильні телефон+ДН → 200, список заявок, **відкрита сесія** (реальний рядок у `patient_sessions`);
- неправильна ДН → 401 і **жодної сесії** (доказ особи справді enforced);
- заявки чужого номера **не витікають**;
- некоректний ввід → 400; brute-force → **429** після ліміту.

**`site-booking.behavior.test.mjs`** — головний грошовий шлях:
- валідна заявка → 201, збережена в БД, **ціна з каталогу (500)**, `payment_status = pending`, подія `created`;
- **ідемпотентність**: той самий `idempotency-key` → та сама відповідь і **рівно одна** заявка (без подвійного запису/оплати);
- 18+ і згода перевіряються **на сервері**, не лише в UI;
- дублікати послуг і відсутність ключа → 400.

## Далі (не в цьому PR)

Harness готовий — на ньому легко нарощувати: **RBAC staff-маршрутів** (роль без прав → 403), скасування заявки, вибір каналів `notify`. Це наступні кроки конвертації grep-тестів у поведінкові.

## Перевірки

- Тести: **322/322** (12 нових поведінкових).
- `npm run lint`, `tsc --noEmit` — чисто.
- `npm test` будує перед прогоном, тож dist-залежні тести працюють і в CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_