### PR TITLE
Поведінкові тести: скасування заявки і вибір каналів notify

### DIFF
--- a/tests/booking-cancel.behavior.test.mjs
+++ b/tests/booking-cancel.behavior.test.mjs
@@ -1,0 +1,60 @@
+// Поведінковий тест самостійного скасування заявки пацієнтом:
+// власність (за телефоном сесії), дозволені стани, журнал події.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedPatientSession } from "./helpers/d1.mjs";
+
+async function seed(db, { code, phoneNormalized, status = "new" }) {
+  await db.prepare(
+    `INSERT INTO bookings (code, name, phone, phone_normalized, service, service_code,
+       desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,1)`
+  ).bind(code, "Пацієнт", "+" + phoneNormalized, phoneNormalized, "КТ", "CT-01",
+    "2026-09-01", "10:00", status, "1990-05-05", "civilian").run();
+}
+
+const cancel = (db, cookie, code) =>
+  callWorker(jsonRequest("/api/booking-status", { code, action: "cancel" }, { method: "PATCH", headers: { cookie } }), db);
+
+test("a patient cancels their own active booking; status and event are written", async () => {
+  await withD1(async (db) => {
+    await seed(db, { code: "RD-OWN0000001", phoneNormalized: "380971112233" });
+    const cookie = await seedPatientSession(db, "380971112233");
+    const res = await cancel(db, cookie, "RD-OWN0000001");
+    assert.equal(res.status, 200);
+    const row = await db.prepare("SELECT status FROM bookings WHERE code = ?").bind("RD-OWN0000001").first("status");
+    assert.equal(row, "cancelled");
+    const ev = await db.prepare("SELECT COUNT(*) AS n FROM booking_events WHERE action = 'cancelled'").first("n");
+    assert.equal(ev, 1);
+  });
+});
+
+test("a patient cannot cancel someone else's booking (ownership by phone)", async () => {
+  await withD1(async (db) => {
+    await seed(db, { code: "RD-OTHER00001", phoneNormalized: "380975556677" }); // чужа заявка
+    const cookie = await seedPatientSession(db, "380971112233");                 // сесія іншого номера
+    const res = await cancel(db, cookie, "RD-OTHER00001");
+    assert.equal(res.status, 404); // не знаходиться під чужою сесією
+    const row = await db.prepare("SELECT status FROM bookings WHERE code = ?").bind("RD-OTHER00001").first("status");
+    assert.equal(row, "new"); // лишилась незмінною
+  });
+});
+
+test("an already-performed booking cannot be cancelled online", async () => {
+  await withD1(async (db) => {
+    await seed(db, { code: "RD-DONE000001", phoneNormalized: "380971112233", status: "issued" });
+    const cookie = await seedPatientSession(db, "380971112233");
+    const res = await cancel(db, cookie, "RD-DONE000001");
+    assert.equal(res.status, 409);
+  });
+});
+
+test("cancelling requires a verified session", async () => {
+  await withD1(async (db) => {
+    await seed(db, { code: "RD-NOSESS0001", phoneNormalized: "380971112233" });
+    const res = await callWorker(
+      jsonRequest("/api/booking-status", { code: "RD-NOSESS0001", action: "cancel" }, { method: "PATCH" }), db);
+    assert.equal(res.status, 401);
+  });
+});

--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -137,6 +137,17 @@ export async function seedStaffSession(db, { email, role, displayName = "" }) {
   return `rid_session=${rawToken}`;
 }
 
+// Засідити активну сесію пацієнта за нормалізованим телефоном → cookie.
+export async function seedPatientSession(db, phoneNormalized) {
+  const rawToken = randomBytes(32).toString("hex");
+  const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
+  await db.prepare(
+    `INSERT INTO patient_sessions (token_hash, phone_normalized, expires_at)
+     VALUES (?, ?, datetime('now', '+30 minutes'))`
+  ).bind(tokenHash, phoneNormalized).run();
+  return `rid_patient=${rawToken}`;
+}
+
 export async function callWorker(request, db) {
   const worker = await loadWorker();
   const env = { DB: db, ASSETS: { fetch: async () => new Response("Not found", { status: 404 }) } };

--- a/tests/notify.behavior.test.mjs
+++ b/tests/notify.behavior.test.mjs
@@ -1,0 +1,75 @@
+// Поведінковий тест вибору каналів сповіщення через /api/staff/notify:
+// повага до «не турбувати», tenant-ізоляція, поведінка без налаштованих шлюзів.
+// Свідомо перевіряємо лише детерміновані гілки (без реальних мережевих викликів).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+
+async function seedBooking(db, { id = 1, phoneNormalized = "380971112233", orgId = 1, email = "" } = {}) {
+  await db.prepare(
+    `INSERT INTO bookings (id, code, name, phone, phone_normalized, patient_email, service, service_code,
+       desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+  ).bind(id, `RD-NOTIFY${String(id).padStart(4, "0")}`, "Пацієнт", "+" + phoneNormalized, phoneNormalized,
+    email, "КТ", "CT-01", "2026-09-01", "10:00", "confirmed", "1990-05-05", "civilian", orgId).run();
+}
+
+const notify = (db, cookie, bookingId, message = "Ваш результат готовий") =>
+  callWorker(jsonRequest("/api/staff/notify", { bookingId, message }, { headers: { cookie } }), db);
+
+test("do-not-contact is respected: message is skipped, nothing sent", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { id: 1, phoneNormalized: "380971112233" });
+    await db.prepare(
+      "INSERT INTO patient_profiles (phone_normalized, do_not_contact, updated_by) VALUES (?, 1, 'test')"
+    ).bind("380971112233").run();
+    const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
+    const res = await notify(db, cookie, 1);
+    assert.equal(res.status, 200);
+    const { summary } = await res.json();
+    assert.equal(summary.sent, 0);
+    assert.ok(summary.skipped >= 1, "має бути пропущено через «не турбувати»");
+    // У журналі — саме skipped, без жодного sent.
+    const sent = await db.prepare("SELECT COUNT(*) AS n FROM patient_notifications WHERE status = 'sent'").first("n");
+    assert.equal(sent, 0);
+    const skipped = await db.prepare("SELECT COUNT(*) AS n FROM patient_notifications WHERE status = 'skipped'").first("n");
+    assert.ok(skipped >= 1);
+  });
+});
+
+test("with no gateways configured nothing is sent (channel gated on config)", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { id: 2, phoneNormalized: "380972223344" });
+    const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
+    const res = await notify(db, cookie, 2);
+    assert.equal(res.status, 200);
+    const { summary } = await res.json();
+    assert.equal(summary.sent, 0);       // SMS-шлюз не налаштований → нічого не відправлено
+    assert.equal(summary.failed, 0);     // і не «провал» — саме «пропущено»
+    assert.ok(summary.skipped >= 1);
+  });
+});
+
+test("a message to a booking in another organization is not found (tenant isolation)", async () => {
+  await withD1(async (db) => {
+    // Друга організація + її заявка.
+    await db.prepare(
+      "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Інша', 1)"
+    ).run();
+    await seedBooking(db, { id: 3, phoneNormalized: "380973334455", orgId: 2 });
+    // Адмін автоматично прив'язується до організації з найменшим id (=1).
+    const cookie = await seedStaffSession(db, { email: "admin2@likarnya.test", role: "admin" });
+    const res = await notify(db, cookie, 3);
+    assert.equal(res.status, 404); // заявка чужої організації недосяжна
+  });
+});
+
+test("a clinical role may still send an ad-hoc message (canWriteNotes)", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { id: 4, phoneNormalized: "380974445566" });
+    const cookie = await seedStaffSession(db, { email: "rad@likarnya.test", role: "radiologist" });
+    const res = await notify(db, cookie, 4);
+    assert.equal(res.status, 200); // лікар-рентгенолог має право повідомляти
+  });
+});


### PR DESCRIPTION
## Навіщо

Третій крок конвертації grep-тестів у поведінкові. Обидва шляхи мають властивості безпеки/приватності, які раніше «перевірялися» лише наявністю рядка в коді.

## Скасування заявки (`PATCH /api/booking-status`)

- пацієнт скасовує **власну** активну заявку → 200, статус `cancelled`, подія в журналі;
- **не може скасувати чужу** заявку — власність визначається телефоном сесії → 404, чужа заявка недоторкана;
- **виконану** заявку (`issued`) скасувати онлайн не можна → 409;
- без підтвердженої сесії → 401.

## Вибір каналів `notify` (`POST /api/staff/notify`)

Перевіряються детерміновані гілки (без реальних мережевих викликів):

- **«не турбувати»** поважається: `sent = 0`, лише `skipped`, у журналі `patient_notifications` — жодного `sent`;
- **без налаштованих шлюзів** нічого не відправляється і це не «провал» (`failed = 0`, `skipped ≥ 1`) — канал справді gated на конфіг;
- заявка **чужої організації** недосяжна навіть адміну → 404 (tenant isolation);
- **клінічна роль** (radiologist) має право на разове повідомлення (`canWriteNotes`).

## Harness

`tests/helpers/d1.mjs` отримав `seedPatientSession` (активна сесія пацієнта → cookie), поряд із наявним `seedStaffSession`.

## Перевірки

- Тести: **335/335** (8 нових поведінкових).
- `npm run lint`, `tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_