### PR TITLE
Командна палітра ⌘K — миттєвий пошук і навігація для персоналу

### DIFF
--- a/app/api/staff/search/route.ts
+++ b/app/api/staff/search/route.ts
@@ -1,0 +1,52 @@
+// Швидкий пошук для командної палітри (⌘K): заявки за ПІБ, телефоном або
+// кодом RD у межах організації персоналу. Лише для активного співробітника.
+
+import { requireOrgContext } from "../../../../lib/tenant";
+import { normalizeUkrainianPhone } from "../../../../lib/phone";
+import { stateLabel } from "../../../../lib/study-state";
+import { dbBinding } from "../../../../lib/db";
+
+// SQLite LOWER() не чіпає кирилицю, тож регістронезалежність по імені робимо
+// через варіанти запиту (як є / нижній / з великої) — toLowerCase/Upper у JS
+// кирилицю обробляють правильно.
+function nameVariants(q: string): string[] {
+  const lower = q.toLowerCase();
+  const title = q.replace(/\S+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+  return [...new Set([q, lower, title])];
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+
+  const q = (new URL(request.url).searchParams.get("q") || "").trim().slice(0, 60);
+  if (q.length < 2) return Response.json({ results: [] }, { headers: { "cache-control": "no-store" } });
+
+  // Динамічний WHERE: додаємо лише релевантні умови (без «нічого не матчить»
+  // сентинелів, які ламаються при мініфікації).
+  const conds: string[] = [];
+  const binds: (string | number)[] = [ctx.organizationId];
+  for (const v of nameVariants(q)) { conds.push("name LIKE ?"); binds.push(`%${v}%`); }
+  conds.push("UPPER(code) LIKE ?"); binds.push(`%${q.toUpperCase()}%`);
+  const phoneDigits = q.replace(/\D/g, "");
+  if (phoneDigits.length >= 3) { conds.push("phone_normalized LIKE ?"); binds.push(`%${normalizeUkrainianPhone(q) || phoneDigits}%`); }
+
+  const rows = await db.prepare(
+    `SELECT id, code, name, phone, service, desired_date AS desiredDate, desired_time AS desiredTime, status
+       FROM bookings
+      WHERE organization_id = ? AND (${conds.join(" OR ")})
+      ORDER BY created_at DESC, id DESC
+      LIMIT 12`
+  ).bind(...binds).all<{
+    id: number; code: string; name: string; phone: string;
+    desiredDate: string; desiredTime: string; status: string;
+  }>();
+
+  const results = (rows.results || []).map((r) => ({
+    ...r,
+    statusLabel: stateLabel(String(r.status)),
+  }));
+  return Response.json({ results }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,3 +11,4 @@
 @import "./styles/08-dark-theme.css";
 @import "./styles/09-records.css";
 @import "./styles/10-landing.css";
+@import "./styles/11-command-palette.css";

--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+// Командна палітра (⌘K / Ctrl+K): миттєвий пошук пацієнта/заявки за ПІБ,
+// телефоном чи кодом + швидка навігація. Керування лише клавіатурою.
+// Монтується один раз у Workspace-shell, доступна на всіх staff-сторінках.
+
+import { useEffect, useRef, useState } from "react";
+
+type Booking = {
+  id: number; code: string; name: string; phone: string;
+  service: string; desiredDate: string; desiredTime: string; statusLabel: string;
+};
+
+const COMMANDS: { label: string; hint: string; href: string }[] = [
+  { label: "Пульт відділення", hint: "огляд дня", href: "/staff/dashboard" },
+  { label: "Прийом", hint: "черга заявок", href: "/staff/intake" },
+  { label: "Календар записів", hint: "розклад", href: "/staff/appointments" },
+  { label: "Нова заявка", hint: "записати пацієнта", href: "/staff/book" },
+  { label: "Пацієнти", hint: "картки / CRM", href: "/staff/patients" },
+  { label: "Протоколи", hint: "опис досліджень", href: "/staff/protocols" },
+  { label: "Звіти", hint: "аналітика", href: "/staff/reports" },
+  { label: "Налаштування", hint: "адміністрування", href: "/staff/settings" },
+];
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Глобальний хоткей ⌘K / Ctrl+K.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+        e.preventDefault(); setOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      if (open) { setActive(0); inputRef.current?.focus(); }
+      else { setQ(""); setBookings([]); }
+    }, 20);
+    return () => window.clearTimeout(t);
+  }, [open]);
+
+  // Пошук заявок із дебаунсом; збіг за ПІБ / телефоном / кодом RD.
+  useEffect(() => {
+    if (!open) return;
+    if (q.trim().length < 2) {
+      const t0 = window.setTimeout(() => setBookings([]), 0);
+      return () => window.clearTimeout(t0);
+    }
+    const ctrl = new AbortController();
+    const t = window.setTimeout(() => {
+      fetch(`/api/staff/search?q=${encodeURIComponent(q.trim())}`, { signal: ctrl.signal, cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : { results: [] }))
+        .then((d) => setBookings(Array.isArray(d.results) ? d.results : []))
+        .catch(() => {});
+    }, 180);
+    return () => { ctrl.abort(); window.clearTimeout(t); };
+  }, [q, open]);
+
+  const cmds = COMMANDS.filter((c) => !q.trim() || `${c.label} ${c.hint}`.toLowerCase().includes(q.trim().toLowerCase()));
+  const items: { key: string; go: () => void; render: () => React.ReactNode }[] = [
+    ...cmds.map((c) => ({
+      key: `cmd-${c.href}`,
+      go: () => window.location.assign(c.href),
+      render: () => <><span className="cmdkIcon">→</span><span className="cmdkMain">{c.label}</span><span className="cmdkHint">{c.hint}</span></>,
+    })),
+    ...bookings.map((b) => ({
+      key: `bk-${b.id}`,
+      go: () => window.location.assign(`/staff?open=${b.id}`),
+      render: () => <><span className="cmdkIcon">🔖</span><span className="cmdkMain">{b.name || "Без імені"} · {b.code}</span><span className="cmdkHint">{b.service} · {b.desiredDate}{b.desiredTime ? ` ${b.desiredTime}` : ""} · {b.statusLabel}</span></>,
+    })),
+  ];
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") { setOpen(false); return; }
+    if (!items.length) return;
+    if (e.key === "ArrowDown") { e.preventDefault(); setActive((a) => (a + 1) % items.length); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); setActive((a) => (a - 1 + items.length) % items.length); }
+    else if (e.key === "Enter") { e.preventDefault(); items[Math.min(active, items.length - 1)]?.go(); }
+  }
+
+  if (!open) return null;
+  return (
+    <div className="cmdkOverlay" onClick={() => setOpen(false)} role="dialog" aria-modal="true" aria-label="Командна палітра">
+      <div className="cmdkBox" onClick={(e) => e.stopPropagation()}>
+        <input
+          ref={inputRef}
+          className="cmdkInput"
+          value={q}
+          onChange={(e) => { setQ(e.target.value); setActive(0); }}
+          onKeyDown={onKeyDown}
+          placeholder="Пошук пацієнта, коду RD, телефону… або команда"
+          aria-label="Пошук"
+        />
+        <ul className="cmdkList">
+          {items.length === 0
+            ? <li className="cmdkEmpty">{q.trim().length < 2 ? "Почніть вводити…" : "Нічого не знайдено"}</li>
+            : items.map((it, i) => (
+              <li key={it.key} className={`cmdkItem${i === active ? " on" : ""}`} onMouseEnter={() => setActive(i)} onMouseDown={(e) => { e.preventDefault(); it.go(); }}>
+                {it.render()}
+              </li>
+            ))}
+        </ul>
+        <div className="cmdkFoot"><kbd>↑↓</kbd> вибір · <kbd>↵</kbd> відкрити · <kbd>Esc</kbd> закрити · <kbd>⌘K</kbd> виклик</div>
+      </div>
+    </div>
+  );
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
+import CommandPalette from "./command-palette";
 
 type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake";
 
@@ -124,6 +125,7 @@ export default function StaffWorkspaceShell({
   // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
   const wide = active === "dashboard" || active === "appointments" || active === "intake";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
+    <CommandPalette />
     <aside className="workspaceSidebar">
       <Link className="workspaceBrand" href="/staff/appointments" aria-label="RadiologyOS — календар заявок">
         <span className="workspaceBrandMark">R</span>

--- a/app/styles/11-command-palette.css
+++ b/app/styles/11-command-palette.css
@@ -1,0 +1,19 @@
+/* ================= Командна палітра (⌘K) ================= */
+.cmdkOverlay{position:fixed;inset:0;z-index:1000;display:flex;align-items:flex-start;justify-content:center;padding:12vh 16px 16px;background:rgba(14,26,24,.44);backdrop-filter:blur(2px)}
+.cmdkBox{width:min(620px,100%);background:#fff;border:1px solid #d7e0dd;border-radius:14px;box-shadow:0 24px 64px rgba(12,30,24,.28);overflow:hidden;display:flex;flex-direction:column;max-height:70vh}
+.cmdkInput{width:100%;border:0;border-bottom:1px solid #e7ecea;padding:16px 18px;font:inherit;font-size:16px;color:var(--ink,#18302f);outline:none}
+.cmdkList{list-style:none;margin:0;padding:6px;overflow:auto}
+.cmdkItem{display:flex;align-items:baseline;gap:10px;padding:10px 12px;border-radius:9px;cursor:pointer;color:#18302f}
+.cmdkItem.on{background:#eef7f8}
+.cmdkIcon{flex:0 0 auto;color:#6c8b86;font-size:13px;width:18px;text-align:center}
+.cmdkMain{flex:1 1 auto;font-size:14px;font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cmdkHint{flex:0 0 auto;color:#7a8b88;font-size:12px;max-width:55%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cmdkEmpty{padding:22px 14px;text-align:center;color:#8a9994;font-size:13px}
+.cmdkFoot{border-top:1px solid #eef2f0;padding:9px 14px;color:#8a9994;font-size:11px;display:flex;gap:8px;flex-wrap:wrap}
+.cmdkFoot kbd{background:#f1f5f3;border:1px solid #dde5e2;border-radius:5px;padding:1px 6px;font:inherit;font-size:11px;color:#5a6c68}
+.themeDark .cmdkBox{background:#132a31;border-color:#2b4048}
+.themeDark .cmdkInput{color:#eaf2f3;border-bottom-color:#223a41;background:#132a31}
+.themeDark .cmdkItem{color:#dfe9ec}
+.themeDark .cmdkItem.on{background:#1c3a42}
+.themeDark .cmdkFoot{border-top-color:#223a41}
+.themeDark .cmdkFoot kbd{background:#1c3a42;border-color:#2b4048;color:#aebfc2}

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -1,0 +1,79 @@
+// Командна палітра (⌘K): пошуковий API проти живої схеми + монтаж у shell.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+async function seed(db, { id, code, name, phone, phoneNorm, org = 1 }) {
+  await db.prepare(
+    `INSERT INTO bookings (id, code, name, phone, phone_normalized, service, service_code,
+       desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
+  ).bind(id, code, name, phone, phoneNorm, "КТ", "CT-01", "2026-09-01", "10:00", "new", "1990-05-05", "civilian", org).run();
+}
+
+const search = (db, cookie, q) =>
+  callWorker(jsonRequest(`/api/staff/search?q=${encodeURIComponent(q)}`, undefined, { method: "GET", headers: { cookie } }), db);
+
+test("search is staff-only", async () => {
+  await withD1(async (db) => {
+    const res = await callWorker(jsonRequest("/api/staff/search?q=іван", undefined, { method: "GET" }), db);
+    assert.equal(res.status, 403);
+  });
+});
+
+test("search matches by name, phone and RD code", async () => {
+  await withD1(async (db) => {
+    await seed(db, { id: 1, code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNorm: "380971112233" });
+    await seed(db, { id: 2, code: "RD-BBBB2222", name: "Петренко Петро", phone: "+380975556677", phoneNorm: "380975556677" });
+    const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
+
+    const byName = await (await search(db, cookie, "іваненко")).json();
+    assert.equal(byName.results.length, 1);
+    assert.equal(byName.results[0].code, "RD-AAAA1111");
+
+    const byCode = await (await search(db, cookie, "bbbb2222")).json();
+    assert.equal(byCode.results.length, 1);
+    assert.equal(byCode.results[0].code, "RD-BBBB2222");
+
+    const byPhone = await (await search(db, cookie, "0971112233")).json();
+    assert.ok(byPhone.results.some((r) => r.code === "RD-AAAA1111"));
+    // Людський підпис статусу присутній.
+    assert.ok(byPhone.results[0].statusLabel);
+  });
+});
+
+test("a query shorter than 2 chars returns nothing (no full-table dump)", async () => {
+  await withD1(async (db) => {
+    await seed(db, { id: 3, code: "RD-CCCC3333", name: "Сидоренко", phone: "+380971110000", phoneNorm: "380971110000" });
+    const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
+    const res = await search(db, cookie, "і");
+    const data = await res.json();
+    assert.equal(data.results.length, 0);
+  });
+});
+
+test("search never leaks bookings from another organization", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2,'other','Інша',1)").run();
+    await seed(db, { id: 4, code: "RD-OWN00001", name: "Шевченко", phone: "+380971110001", phoneNorm: "380971110001", org: 1 });
+    await seed(db, { id: 5, code: "RD-OTHER0001", name: "Шевченко", phone: "+380971110002", phoneNorm: "380971110002", org: 2 });
+    const cookie = await seedStaffSession(db, { email: "admin@likarnya.test", role: "admin" }); // авто-онбординг у org 1
+    const data = await (await search(db, cookie, "шевченко")).json();
+    assert.equal(data.results.length, 1);
+    assert.equal(data.results[0].code, "RD-OWN00001");
+  });
+});
+
+test("the palette is mounted in the workspace shell and opens on Ctrl/⌘+K", async () => {
+  const shell = await read("app/staff/workspace-shell.tsx");
+  assert.match(shell, /import CommandPalette from "\.\/command-palette"/);
+  assert.match(shell, /<CommandPalette \/>/);
+  const cp = await read("app/staff/command-palette.tsx");
+  assert.match(cp, /e\.metaKey \|\| e\.ctrlKey/);
+  assert.match(cp, /\/api\/staff\/search/);
+  assert.match(cp, /\/staff\?open=\$\{b\.id\}/); // заявка → повна картка
+});


### PR DESCRIPTION
## Навіщо

«Найсильніше» рішення для відчуття швидкості в роботі — командна палітра (як у Linear / Raycast / GitHub / Vercel). Реєстратор перестає клікати по меню: один хоткей → пошук → перехід за 2 секунди з клавіатури. Адаптовано під наш стек, **self-contained** (без важких залежностей, сумісно з Cloudflare Workers).

## Що робить

- **`⌘K` / `Ctrl+K`** з будь-якої staff-сторінки (монтується у Workspace-shell).
- **Пошук пацієнта/заявки** за ПІБ, телефоном, кодом RD → перехід у повну картку `/staff?open=<id>` (той deep-link, що ми полагодили раніше).
- **Швидка навігація**: Пульт, Прийом, Календар, Нова заявка, Пацієнти, Протоколи, Звіти, Налаштування.
- Керування лише клавіатурою (`↑↓ / Enter / Esc`), світла й темна теми.

## API

`GET /api/staff/search?q=` — org-scoped, staff-only, поріг 2 символи (без дампу таблиці). **Кирилиця регістронезалежно**: SQLite `LOWER()` не чіпає кирилицю, тож матчимо за варіантами запиту (як є / нижній / з великої).

## Спіймано баг по дорозі

Перша версія використовувала сентинел `"% %"` для «телефон не шукаємо». Мініфікатор перетворював його на `"%\0%"`, а SQLite через NUL-термінацію трактував як голий `%` — і пошук повертав **усі** заявки. Виявлено поведінковим тестом (запит без цифр повертав усе), виправлено на динамічний WHERE без сентинелів.

## Перевірки

- Поведінкові тести: staff-only (403 аноніму), збіг за ПІБ/тел/код, поріг 2 символи, **tenant-ізоляція** (не показує чужу організацію), монтаж у shell.
- Тести: **348/348** (5 нових); `npm run build`, `lint`, `tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_