### PR TITLE
Код заявки: людино-зрозумілий RD-РРММДД-N (дата + добовий номер)

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -6,6 +6,7 @@ import { isRateLimited } from "../../../lib/rate-limit";
 import { effectivePrice } from "../../../lib/tariffs";
 import { getSetting } from "../../../lib/settings";
 import { configuredServiceByCode, parseServiceConfig, SERVICE_CONFIG_KEY } from "../../../lib/service-config";
+import { nextBookingCode } from "../../../lib/booking-code";
 
 function clean(value: unknown, max = 200) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -55,7 +56,7 @@ export async function POST(request: Request) {
       return Response.json({ error: "Оберіть доступні дату та час" }, { status: 400 });
     }
 
-    const code = `RD-${crypto.randomUUID().replace(/-/g, "").slice(0, 16).toUpperCase()}`;
+    const code = await nextBookingCode(db);
     const endTime = addMinutes(desiredTime, service.durationMinutes);
     const referral = referralType === "none" ? "Немає направлення" : referralType;
     const paymentStatus = patientCategory === "civilian" ? "pending" : "verification_required";

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -9,6 +9,7 @@ import { getSetting } from "../../../lib/settings";
 import { parseSiteContent, SITE_CONTENT_KEY } from "../../../lib/site-content";
 import { parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
 import { assignEarliestAppointments, type BusyBooking, type EquipmentBlock } from "../../../lib/auto-booking";
+import { nextBookingCode } from "../../../lib/booking-code";
 import { dbBinding } from "../../../lib/db";
 
 const CONSENT_VERSION = "2026-07-29";
@@ -156,7 +157,8 @@ export async function POST(request: Request) {
       );
     }
 
-    const codes = services.map(() => `RD-${crypto.randomUUID().replace(/-/g, "").slice(0, 16).toUpperCase()}`);
+    const codes: string[] = [];
+    for (let i = 0; i < services.length; i += 1) codes.push(await nextBookingCode(db));
     const prices = await Promise.all(services.map((service) => effectivePrice(db, service!.code)));
     const responseBody = { codes, code: codes[0], appointments, status: "new", statusLabel: "Заявку отримано — очікує підтвердження" };
     const statements: D1PreparedStatement[] = [];

--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -16,6 +16,7 @@ import {
   type StaffRole,
 } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
+import { nextBookingCode } from "../../../../lib/booking-code";
 import { dbBinding } from "../../../../lib/db";
 
 function clean(value: unknown, max: number) {
@@ -76,7 +77,7 @@ export async function POST(request: Request) {
   ).bind(service.equipmentId, desiredDate, endTime, desiredTime).first();
   if (blocked) return Response.json({ error: "Апарат недоступний у цей період" }, { status: 409 });
 
-  const code = `RD-${crypto.randomUUID().replace(/-/g, "").slice(0, 16).toUpperCase()}`;
+  const code = await nextBookingCode(db);
   const price = await effectivePrice(db, service.code);
   const paymentStatus = category === "civilian" ? "pending" : "verification_required";
   const nszuStatus = referralType === "eh_referral" ? "pending" : "not_applicable";

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -170,11 +170,12 @@ export default function StudiesPage() {
       <div className="studiesTableWrap">
         <table className="studiesTable">
           <thead><tr>
-            <th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
+            <th>Код</th><th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
             <th>Апарат</th><th>Стан</th><th>Лікар</th><th>Лаборант</th>{data.features?.dicomPacs ? <th>Знімки</th> : null}<th>Дія</th>
           </tr></thead>
           <tbody>
             {visible.map((s)=><tr key={s.id}>
+              <td className="studiesCode">{s.code}</td>
               <td>{s.name || "—"}</td>
               <td>{s.service}</td>
               <td className="studiesWhen">{s.desiredDate}{s.desiredTime ? ` ${s.desiredTime}` : ""}</td>

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -170,12 +170,11 @@ export default function StudiesPage() {
       <div className="studiesTableWrap">
         <table className="studiesTable">
           <thead><tr>
-            <th>Код</th><th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
+            <th>Пацієнт</th><th>Дослідження</th><th>Дата / час</th>
             <th>Апарат</th><th>Стан</th><th>Лікар</th><th>Лаборант</th>{data.features?.dicomPacs ? <th>Знімки</th> : null}<th>Дія</th>
           </tr></thead>
           <tbody>
             {visible.map((s)=><tr key={s.id}>
-              <td className="studiesCode">{s.code}</td>
               <td>{s.name || "—"}</td>
               <td>{s.service}</td>
               <td className="studiesWhen">{s.desiredDate}{s.desiredTime ? ` ${s.desiredTime}` : ""}</td>

--- a/app/styles/10-landing.css
+++ b/app/styles/10-landing.css
@@ -169,7 +169,6 @@
 .studiesTable td{padding:11px 14px;border-bottom:1px solid #eef2f0;font-size:13.5px;color:var(--ink);vertical-align:middle}
 .studiesTable tr:last-child td{border-bottom:0}
 .studiesTable tbody tr:hover{background:#f7faf9}
-.studiesCode{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:var(--ws-deep);font-weight:700}
 .studiesWhen{white-space:nowrap;font-variant-numeric:tabular-nums}
 .studiesState{display:inline-block;padding:4px 10px;border-radius:999px;font-size:11px;font-weight:800;border:1px solid transparent}
 .studiesState.grp-intake{background:#e6f1fb;color:#1f5c94;border-color:#c9e0f4}
@@ -191,7 +190,6 @@
 .themeDark .studiesTable td{border-bottom-color:#1c2831;color:#e6edf1}
 .themeDark .studiesTable tbody tr:hover{background:#17212a}
 .themeDark .studiesTable select{background:#0e151a;border-color:#2a3843;color:#e6edf1}
-.themeDark .studiesCode{color:#7fd4dc}
 .themeDark .studiesState.grp-intake{background:#12283b;color:#8fc2ec;border-color:#1e3d55}
 .themeDark .studiesState.grp-active{background:#3a2a14;color:#e6b072;border-color:#553f1e}
 .themeDark .studiesState.grp-reporting{background:#241d3b;color:#b6a2e6;border-color:#392d55}

--- a/app/styles/10-landing.css
+++ b/app/styles/10-landing.css
@@ -189,7 +189,9 @@
 .themeDark .studiesTable th{background:#0e151a;color:#9fb0bb;border-bottom-color:#22303a}
 .themeDark .studiesTable td{border-bottom-color:#1c2831;color:#e6edf1}
 .themeDark .studiesTable tbody tr:hover{background:#17212a}
+.studiesCode{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:var(--ws-deep);font-weight:700;white-space:nowrap}
 .themeDark .studiesTable select{background:#0e151a;border-color:#2a3843;color:#e6edf1}
+.themeDark .studiesCode{color:#7fd4dc}
 .themeDark .studiesState.grp-intake{background:#12283b;color:#8fc2ec;border-color:#1e3d55}
 .themeDark .studiesState.grp-active{background:#3a2a14;color:#e6b072;border-color:#553f1e}
 .themeDark .studiesState.grp-reporting{background:#241d3b;color:#b6a2e6;border-color:#392d55}

--- a/lib/booking-code.ts
+++ b/lib/booking-code.ts
@@ -1,0 +1,19 @@
+import { todayInKyiv } from "./booking-rules";
+
+// Людино-зрозумілий код заявки: RD-РРММДД-N — префікс + дата створення +
+// добовий послідовний номер (лише цифри). Приклад: RD-260810-004.
+//
+// Номер отримуємо атомарно одним INSERT … ON CONFLICT … RETURNING, тож навіть
+// за одночасних запитів кожна заявка дістає унікальний номер — без гонок і
+// дублікатів. Лічильник зберігається по днях у app_settings (booking_seq_РРММДД).
+export async function nextBookingCode(db: D1Database): Promise<string> {
+  const ymd = todayInKyiv().slice(2).replace(/-/g, ""); // 2026-08-10 → 260810
+  const key = `booking_seq_${ymd}`;
+  const row = await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, '1')
+     ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1
+     RETURNING value`
+  ).bind(key).first<{ value: string | number }>();
+  const seq = Number(row?.value ?? 1) || 1;
+  return `RD-${ymd}-${String(seq).padStart(3, "0")}`;
+}

--- a/lib/patient-auth.ts
+++ b/lib/patient-auth.ts
@@ -5,7 +5,8 @@ export const PATIENT_SESSION_TTL_SECONDS = 30 * 60;
 
 export function normalizeBookingCode(value: unknown): string {
   const code = String(value || "").trim().toUpperCase().slice(0, 24);
-  return /^RD-[A-Z0-9]{8,16}$/.test(code) ? code : "";
+  // Новий формат RD-РРММДД-N (дата + добовий номер) та легасі RD-<hex16>.
+  return /^RD-(?:[A-Z0-9]{8,16}|\d{6}-\d{1,4})$/.test(code) ? code : "";
 }
 
 export async function createPatientSession(db: D1Database, phoneNormalized: string): Promise<string> {

--- a/tests/booking-code.behavior.test.mjs
+++ b/tests/booking-code.behavior.test.mjs
@@ -1,0 +1,57 @@
+// Людино-зрозумілий код заявки RD-РРММДД-N: формат, послідовна нумерація,
+// і що кабінет пацієнта приймає новий код (нормалізація/скасування).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedPatientSession } from "./helpers/d1.mjs";
+
+const CONSENT_VERSION = "2026-07-29";
+const validBody = (over = {}) => ({
+  name: "Іваненко Іван Іванович", phone: "+380971112233", dob: "1990-05-05",
+  category: "civilian", items: [{ code: "201" }], referralType: "none",
+  comment: "", source: "", consent: true, consentVersion: CONSENT_VERSION, ...over,
+});
+const book = (db, key) =>
+  callWorker(jsonRequest("/api/site-booking", validBody(), { headers: { "idempotency-key": key } }), db);
+
+test("codes are RD-YYMMDD-N and increment per day", async () => {
+  await withD1(async (db) => {
+    const a = await (await book(db, "code-key-00000001")).json();
+    const b = await (await book(db, "code-key-00000002")).json();
+    assert.match(a.code, /^RD-\d{6}-\d{3,}$/);
+    assert.match(b.code, /^RD-\d{6}-\d{3,}$/);
+    // Той самий день, послідовні номери.
+    const day = (c) => c.slice(3, 9), num = (c) => Number(c.split("-")[2]);
+    assert.equal(day(a.code), day(b.code));
+    assert.equal(num(b.code), num(a.code) + 1);
+    assert.equal(num(a.code), 1); // перша заявка дня — 001
+  });
+});
+
+test("the patient cabinet accepts the new code format (cancel by code)", async () => {
+  await withD1(async (db) => {
+    // Заявка з новим кодом + активна сесія пацієнта за телефоном.
+    await db.prepare(
+      `INSERT INTO bookings (code, name, phone, phone_normalized, service, service_code,
+         desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
+       VALUES ('RD-260810-004','Пацієнт','+380971112233','380971112233','КТ','CT-01',
+         '2026-09-01','10:00','new','1990-05-05','civilian',1)`
+    ).run();
+    const cookie = await seedPatientSession(db, "380971112233");
+    const res = await callWorker(
+      jsonRequest("/api/booking-status", { code: "RD-260810-004", action: "cancel" },
+        { method: "PATCH", headers: { cookie } }), db);
+    assert.equal(res.status, 200); // код нового формату розпізнано й скасовано
+    const st = await db.prepare("SELECT status FROM bookings WHERE code = 'RD-260810-004'").first("status");
+    assert.equal(st, "cancelled");
+  });
+});
+
+test("generation helper is used by every booking entry point (no raw RD-<uuid>)", async () => {
+  const { readFile } = await import("node:fs/promises");
+  for (const p of ["app/api/site-booking/route.ts", "app/api/staff/bookings/route.ts", "app/api/bookings/route.ts"]) {
+    const src = await readFile(new URL(`../${p}`, import.meta.url), "utf8");
+    assert.match(src, /nextBookingCode\(db\)/, `${p} має вживати nextBookingCode`);
+    assert.doesNotMatch(src, /RD-\$\{crypto\.randomUUID/, `${p} не має генерувати сирий RD-uuid`);
+  }
+});

--- a/tests/site-booking.behavior.test.mjs
+++ b/tests/site-booking.behavior.test.mjs
@@ -31,7 +31,7 @@ test("a valid civilian request creates a booking, priced and pending payment", a
     const res = await book(db, validBody());
     assert.equal(res.status, 201);
     const data = await res.json();
-    assert.match(data.code, /^RD-[A-Z0-9]{16}$/);
+    assert.match(data.code, /^RD-\d{6}-\d{3,}$/); // RD-РРММДД-N
 
     const row = await db.prepare(
       "SELECT status, payment_status AS pay, payment_amount AS amount, patient_category AS cat FROM bookings WHERE code = ?"


### PR DESCRIPTION
## Навіщо

Старий код `RD-2C74730A78A14B1C` — 16 випадкових hex: довгий, ніхто не запам'ятовує й не розуміє, як утворюється. Новий: **`RD-260810-004`** — префікс + **дата створення (РРММДД)** + **добовий послідовний номер** (лише цифри). Коротко й зрозуміло за схемою.

## Як зроблено безпечно

- **`lib/booking-code.ts` → `nextBookingCode(db)`**: номер отримуємо **атомарно** одним `INSERT … ON CONFLICT … RETURNING` — навіть за одночасних заявок кожна дістає унікальний номер, **без гонок і дублікатів**. Лічильник по днях у `app_settings` (`booking_seq_РРММДД`). Без міграції схеми.
- Усі **три точки генерації** уніфіковано на хелпер: `/api/site-booking`, `/api/staff/bookings`, `/api/bookings`.
- **Зворотна сумісність**: `normalizeBookingCode` приймає і новий формат, і легасі `RD-<hex16>` — старі заявки в БД лишаються валідними (кабінет: пошук/скасування).

## Реєстр досліджень

Колонку «Код» повернуто (в проміжному коміті прибирав, поки код був нечитабельним). Тепер код короткий — його зручно бачити; тримаємо в один рядок. Net-diff по сторінці = 0 (окрім `nowrap`).

## Перевірки (поведінкові, проти живої схеми)

- Формат `RD-\d{6}-\d{3,}`; **послідовна нумерація** дня (001, 002…); кабінет пацієнта **приймає новий код** (скасування за кодом); усі точки входу вживають хелпер (немає сирого `RD-${crypto.randomUUID()}`).
- Тести: **351/351**; `npm run build`, `lint`, `tsc --noEmit` — чисто.

## Примітка

Старі заявки зберігають 16-hex коди (історичні ідентифікатори, вживані в призначеннях платежу). Нові — вже RD-РРММДД-N.

🤖 Generated with [Claude Code](https://claude.com/claude-code)