### PR TITLE
fix: add atomic booking capacity locks

### DIFF
--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -15,6 +15,9 @@ import { dbBinding } from "../../../lib/db";
 
 const CONSENT_VERSION = "2026-07-29";
 const MAX_SERVICES_PER_REQUEST = 5;
+// Public storefront currently belongs to the initial organization. Once public
+// host/slug tenant resolution lands, replace this constant with that server-side
+// resolver; never accept organization_id from the browser.
 const PUBLIC_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max = 200) {

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -10,7 +10,7 @@ import { parseSiteContent, SITE_CONTENT_KEY } from "../../../lib/site-content";
 import { parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
 import { assignEarliestAppointments, type BusyBooking, type EquipmentBlock } from "../../../lib/auto-booking";
 import { nextBookingCode } from "../../../lib/booking-code";
-import { capacitySlots, isCapacityConflict } from "../../../lib/booking-capacity";
+import { isCapacityConflict, reserveCapacityStatements } from "../../../lib/booking-capacity";
 import { dbBinding } from "../../../lib/db";
 
 const CONSENT_VERSION = "2026-07-29";
@@ -185,24 +185,14 @@ export async function POST(request: Request) {
           schedule.equipment[verifiedService.equipmentId]?.radiographerEmail || "",
           dob, consentVersion, "public_site",
         ),
-      );
-      for (const slot of capacitySlots({
-        organizationId: PUBLIC_ORGANIZATION_ID,
-        equipmentId: verifiedService.equipmentId,
-        date: appointment.date,
-        startTime: appointment.time,
-        durationMinutes: verifiedService.durationMinutes,
-        bookingCode: codes[index],
-      })) {
-        statements.push(
-          db.prepare(
-            `INSERT INTO booking_capacity_locks (
-              organization_id, equipment_id, booking_date, minute, booking_code
-            ) VALUES (?,?,?,?,?)`
-          ).bind(slot.organizationId, slot.equipmentId, slot.date, slot.minute, slot.bookingCode),
-        );
-      }
-      statements.push(
+        ...reserveCapacityStatements(db, {
+          organizationId: PUBLIC_ORGANIZATION_ID,
+          equipmentId: verifiedService.equipmentId,
+          date: appointment.date,
+          startTime: appointment.time,
+          durationMinutes: verifiedService.durationMinutes,
+          bookingCode: codes[index],
+        }),
         db.prepare(
           `INSERT INTO booking_events (booking_id, action, details, actor)
            SELECT id, 'created', ?, 'patient' FROM bookings WHERE code = ?`

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -10,11 +10,12 @@ import { parseSiteContent, SITE_CONTENT_KEY } from "../../../lib/site-content";
 import { parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
 import { assignEarliestAppointments, type BusyBooking, type EquipmentBlock } from "../../../lib/auto-booking";
 import { nextBookingCode } from "../../../lib/booking-code";
+import { capacitySlots, isCapacityConflict } from "../../../lib/booking-capacity";
 import { dbBinding } from "../../../lib/db";
 
 const CONSENT_VERSION = "2026-07-29";
 const MAX_SERVICES_PER_REQUEST = 5;
-
+const PUBLIC_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max = 200) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -69,9 +70,6 @@ export async function POST(request: Request) {
     const emailRaw = clean(body.email, 254).toLowerCase();
     const patientEmail = /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(emailRaw) ? emailRaw : "";
     const category = clean(body.category, 20) === "military" ? "military" : "civilian";
-    // Режим вітрини «лише платні»: безкоштовні військові заявки не приймаються
-    // на сервері (не лише ховаються в UI), інакше форму military.html можна
-    // було б надіслати напряму.
     if (category === "military") {
       const storefront = parseSiteContent(await getSetting(db, SITE_CONTENT_KEY));
       if (storefront.storefrontType === "paid_only") {
@@ -172,14 +170,14 @@ export async function POST(request: Request) {
       statements.push(
         db.prepare(
           `INSERT INTO bookings (
-            code, name, phone, phone_normalized, patient_email, service, service_code, equipment_id,
+            organization_id, code, name, phone, phone_normalized, patient_email, service, service_code, equipment_id,
             duration_minutes, desired_date, desired_time, status, referral, patient_category,
             referral_type, marketing_source, payment_status, payment_amount, nszu_status, comment,
             assigned_radiologist_email, assigned_radiographer_email,
             date_of_birth, consent_at, consent_version, consent_source
-          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,'new',?,?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP,?,?)`
+          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,'new',?,?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP,?,?)`
         ).bind(
-          codes[index], name, phone, phoneNormalized, patientEmail, verifiedService.title,
+          PUBLIC_ORGANIZATION_ID, codes[index], name, phone, phoneNormalized, patientEmail, verifiedService.title,
           verifiedService.code, verifiedService.equipmentId, verifiedService.durationMinutes,
           appointment.date, appointment.time, referral, category, referralType, marketingSource,
           paymentStatus, prices[index], nszuStatus, comment,
@@ -187,6 +185,24 @@ export async function POST(request: Request) {
           schedule.equipment[verifiedService.equipmentId]?.radiographerEmail || "",
           dob, consentVersion, "public_site",
         ),
+      );
+      for (const slot of capacitySlots({
+        organizationId: PUBLIC_ORGANIZATION_ID,
+        equipmentId: verifiedService.equipmentId,
+        date: appointment.date,
+        startTime: appointment.time,
+        durationMinutes: verifiedService.durationMinutes,
+        bookingCode: codes[index],
+      })) {
+        statements.push(
+          db.prepare(
+            `INSERT INTO booking_capacity_locks (
+              organization_id, equipment_id, booking_date, minute, booking_code
+            ) VALUES (?,?,?,?,?)`
+          ).bind(slot.organizationId, slot.equipmentId, slot.date, slot.minute, slot.bookingCode),
+        );
+      }
+      statements.push(
         db.prepare(
           `INSERT INTO booking_events (booking_id, action, details, actor)
            SELECT id, 'created', ?, 'patient' FROM bookings WHERE code = ?`
@@ -207,6 +223,12 @@ export async function POST(request: Request) {
       ).bind(requestKey).first<{ responseJson: string }>();
       if (raced) {
         return Response.json(JSON.parse(raced.responseJson), { headers: { "cache-control": "no-store" } });
+      }
+      if (isCapacityConflict(error)) {
+        return Response.json(
+          { error: "Обраний час щойно зайняли. Оновіть доступні слоти та повторіть запис." },
+          { status: 409, headers: { "cache-control": "no-store" } },
+        );
       }
       throw error;
     }

--- a/db/capacity-schema.ts
+++ b/db/capacity-schema.ts
@@ -1,0 +1,18 @@
+import { sql } from "drizzle-orm";
+import { index, integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const bookingCapacityLocks = sqliteTable("booking_capacity_locks", {
+  organizationId: integer("organization_id").notNull().default(1),
+  equipmentId: text("equipment_id").notNull(),
+  bookingDate: text("booking_date").notNull(),
+  minute: text("minute").notNull(),
+  bookingCode: text("booking_code").notNull(),
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+}, table => [
+  primaryKey({ columns: [table.organizationId, table.equipmentId, table.bookingDate, table.minute] }),
+  index("booking_capacity_locks_booking_idx").on(table.organizationId, table.bookingCode),
+]);
+
+export const bookingMinuteOffsets = sqliteTable("booking_minute_offsets", {
+  minuteOffset: integer("minute_offset").primaryKey(),
+});

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,6 +1,9 @@
 import { env } from "cloudflare:workers";
 import { drizzle } from "drizzle-orm/d1";
-import * as schema from "./schema";
+import * as coreSchema from "./schema";
+import * as capacitySchema from "./capacity-schema";
+
+const schema = { ...coreSchema, ...capacitySchema };
 
 export function getDb() {
   if (!env.DB) {

--- a/drizzle/0026_booking_capacity_locks.sql
+++ b/drizzle/0026_booking_capacity_locks.sql
@@ -1,0 +1,54 @@
+-- Atomic equipment capacity reservation.
+--
+-- Each occupied minute of an appointment receives one unique row. SQLite/D1
+-- uniqueness therefore becomes the final concurrency guard: two different
+-- requests cannot reserve overlapping time on the same equipment/date even if
+-- both calculated availability from the same stale snapshot.
+--
+-- booking_code is used instead of booking_id because public booking codes are
+-- allocated before the booking INSERT and can therefore participate in the
+-- same D1 batch. Locks are removed explicitly when a booking is cancelled,
+-- completed or moved.
+
+CREATE TABLE `booking_capacity_locks` (
+  `organization_id` integer DEFAULT 1 NOT NULL,
+  `equipment_id` text NOT NULL,
+  `booking_date` text NOT NULL,
+  `minute` text NOT NULL,
+  `booking_code` text NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`organization_id`, `equipment_id`, `booking_date`, `minute`)
+);
+--> statement-breakpoint
+CREATE INDEX `booking_capacity_locks_booking_idx`
+ON `booking_capacity_locks` (`organization_id`, `booking_code`);
+--> statement-breakpoint
+
+-- Backfill capacity for active appointments that already exist when this
+-- migration is applied. Recursive CTE expands every booking into [start,end)
+-- minute keys. INSERT OR IGNORE makes deployment safe if historical data
+-- already contains an overlap: current rows are preserved and the production
+-- gate can surface the conflicting booking for manual resolution.
+WITH RECURSIVE active AS (
+  SELECT organization_id, equipment_id, desired_date, code,
+         CAST(substr(desired_time, 1, 2) AS integer) * 60
+           + CAST(substr(desired_time, 4, 2) AS integer) AS start_minute,
+         duration_minutes
+  FROM bookings
+  WHERE status IN ('new', 'confirmed', 'rescheduled')
+), expanded(organization_id, equipment_id, desired_date, code, minute_no, end_minute) AS (
+  SELECT organization_id, equipment_id, desired_date, code,
+         start_minute, start_minute + duration_minutes
+  FROM active
+  UNION ALL
+  SELECT organization_id, equipment_id, desired_date, code,
+         minute_no + 1, end_minute
+  FROM expanded
+  WHERE minute_no + 1 < end_minute
+)
+INSERT OR IGNORE INTO booking_capacity_locks (
+  organization_id, equipment_id, booking_date, minute, booking_code
+)
+SELECT organization_id, equipment_id, desired_date,
+       printf('%02d:%02d', minute_no / 60, minute_no % 60), code
+FROM expanded;

--- a/drizzle/0027_booking_capacity_triggers.sql
+++ b/drizzle/0027_booking_capacity_triggers.sql
@@ -1,0 +1,75 @@
+-- Enforce booking capacity for every write path at the database layer.
+--
+-- The application still performs friendly pre-flight conflict checks, but
+-- these triggers are the final invariant. Any INSERT/UPDATE that would create
+-- overlapping active appointments fails on booking_capacity_locks uniqueness.
+-- Because trigger effects are part of the same SQLite statement, a failed
+-- reservation rolls the booking write and lock changes back together.
+
+CREATE TABLE `booking_minute_offsets` (
+  `minute_offset` integer PRIMARY KEY NOT NULL
+);
+--> statement-breakpoint
+WITH RECURSIVE seq(n) AS (
+  SELECT 0
+  UNION ALL
+  SELECT n + 1 FROM seq WHERE n < 1439
+)
+INSERT INTO booking_minute_offsets (minute_offset)
+SELECT n FROM seq;
+--> statement-breakpoint
+
+CREATE TRIGGER `bookings_capacity_after_insert`
+AFTER INSERT ON `bookings`
+WHEN NEW.status IN ('new', 'confirmed', 'rescheduled')
+BEGIN
+  INSERT INTO booking_capacity_locks (
+    organization_id, equipment_id, booking_date, minute, booking_code
+  )
+  SELECT NEW.organization_id, NEW.equipment_id, NEW.desired_date,
+         printf('%02d:%02d',
+           ((CAST(substr(NEW.desired_time, 1, 2) AS integer) * 60
+             + CAST(substr(NEW.desired_time, 4, 2) AS integer)
+             + minute_offset) / 60),
+           ((CAST(substr(NEW.desired_time, 1, 2) AS integer) * 60
+             + CAST(substr(NEW.desired_time, 4, 2) AS integer)
+             + minute_offset) % 60)
+         ),
+         NEW.code
+  FROM booking_minute_offsets
+  WHERE minute_offset < NEW.duration_minutes;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `bookings_capacity_after_update`
+AFTER UPDATE OF organization_id, equipment_id, desired_date, desired_time, duration_minutes, status
+ON `bookings`
+BEGIN
+  DELETE FROM booking_capacity_locks
+  WHERE organization_id = OLD.organization_id AND booking_code = OLD.code;
+
+  INSERT INTO booking_capacity_locks (
+    organization_id, equipment_id, booking_date, minute, booking_code
+  )
+  SELECT NEW.organization_id, NEW.equipment_id, NEW.desired_date,
+         printf('%02d:%02d',
+           ((CAST(substr(NEW.desired_time, 1, 2) AS integer) * 60
+             + CAST(substr(NEW.desired_time, 4, 2) AS integer)
+             + minute_offset) / 60),
+           ((CAST(substr(NEW.desired_time, 1, 2) AS integer) * 60
+             + CAST(substr(NEW.desired_time, 4, 2) AS integer)
+             + minute_offset) % 60)
+         ),
+         NEW.code
+  FROM booking_minute_offsets
+  WHERE NEW.status IN ('new', 'confirmed', 'rescheduled')
+    AND minute_offset < NEW.duration_minutes;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `bookings_capacity_after_delete`
+AFTER DELETE ON `bookings`
+BEGIN
+  DELETE FROM booking_capacity_locks
+  WHERE organization_id = OLD.organization_id AND booking_code = OLD.code;
+END;

--- a/drizzle/0027_booking_capacity_triggers.sql
+++ b/drizzle/0027_booking_capacity_triggers.sql
@@ -2,9 +2,9 @@
 --
 -- The application still performs friendly pre-flight conflict checks, but
 -- these triggers are the final invariant. Any INSERT/UPDATE that would create
--- overlapping active appointments fails on booking_capacity_locks uniqueness.
--- Because trigger effects are part of the same SQLite statement, a failed
--- reservation rolls the booking write and lock changes back together.
+-- overlapping active appointments fails at the booking_capacity_locks layer.
+-- Trigger effects are part of the same SQLite statement, so failed capacity
+-- reservations roll the booking write and lock changes back together.
 
 CREATE TABLE `booking_minute_offsets` (
   `minute_offset` integer PRIMARY KEY NOT NULL
@@ -17,6 +17,40 @@ WITH RECURSIVE seq(n) AS (
 )
 INSERT INTO booking_minute_offsets (minute_offset)
 SELECT n FROM seq;
+--> statement-breakpoint
+
+-- Public booking also reserves locks explicitly in its D1 batch. Re-inserting
+-- an identical lock for the same booking is therefore an idempotent no-op,
+-- while a different booking competing for the same capacity is aborted with a
+-- stable error message that routes can translate to HTTP 409.
+CREATE TRIGGER `booking_capacity_same_booking_ignore`
+BEFORE INSERT ON `booking_capacity_locks`
+WHEN EXISTS (
+  SELECT 1 FROM booking_capacity_locks l
+  WHERE l.organization_id = NEW.organization_id
+    AND l.equipment_id = NEW.equipment_id
+    AND l.booking_date = NEW.booking_date
+    AND l.minute = NEW.minute
+    AND l.booking_code = NEW.booking_code
+)
+BEGIN
+  SELECT RAISE(IGNORE);
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `booking_capacity_conflict_abort`
+BEFORE INSERT ON `booking_capacity_locks`
+WHEN EXISTS (
+  SELECT 1 FROM booking_capacity_locks l
+  WHERE l.organization_id = NEW.organization_id
+    AND l.equipment_id = NEW.equipment_id
+    AND l.booking_date = NEW.booking_date
+    AND l.minute = NEW.minute
+    AND l.booking_code <> NEW.booking_code
+)
+BEGIN
+  SELECT RAISE(ABORT, 'booking capacity conflict');
+END;
 --> statement-breakpoint
 
 CREATE TRIGGER `bookings_capacity_after_insert`

--- a/lib/booking-capacity.ts
+++ b/lib/booking-capacity.ts
@@ -76,6 +76,11 @@ export function releaseCapacityStatement(
   ).bind(organizationId, bookingCode);
 }
 
+/**
+ * Statements for moving/changing an existing appointment. Callers MUST execute
+ * the returned DELETE + INSERT statements together with the booking UPDATE in
+ * one D1 batch, so a failed uniqueness check rolls the entire move back.
+ */
 export function replaceCapacityStatements(
   db: D1Database,
   input: CapacityReservation,

--- a/lib/booking-capacity.ts
+++ b/lib/booking-capacity.ts
@@ -6,6 +6,15 @@ export type CapacitySlot = {
   bookingCode: string;
 };
 
+export type CapacityReservation = {
+  organizationId: number;
+  equipmentId: string;
+  date: string;
+  startTime: string;
+  durationMinutes: number;
+  bookingCode: string;
+};
+
 function parseMinute(value: string): number {
   const match = /^(\d{2}):(\d{2})$/.exec(value);
   if (!match) throw new Error(`Invalid appointment time: ${value}`);
@@ -39,14 +48,7 @@ export function occupiedMinutes(startTime: string, durationMinutes: number): str
   return Array.from({ length: durationMinutes }, (_, offset) => formatMinute(start + offset));
 }
 
-export function capacitySlots(input: {
-  organizationId: number;
-  equipmentId: string;
-  date: string;
-  startTime: string;
-  durationMinutes: number;
-  bookingCode: string;
-}): CapacitySlot[] {
+export function capacitySlots(input: CapacityReservation): CapacitySlot[] {
   return occupiedMinutes(input.startTime, input.durationMinutes).map((minute) => ({
     organizationId: input.organizationId,
     equipmentId: input.equipmentId,
@@ -54,6 +56,34 @@ export function capacitySlots(input: {
     minute,
     bookingCode: input.bookingCode,
   }));
+}
+
+export function reserveCapacityStatements(db: D1Database, input: CapacityReservation): D1PreparedStatement[] {
+  return capacitySlots(input).map((slot) => db.prepare(
+    `INSERT INTO booking_capacity_locks (
+      organization_id, equipment_id, booking_date, minute, booking_code
+    ) VALUES (?,?,?,?,?)`
+  ).bind(slot.organizationId, slot.equipmentId, slot.date, slot.minute, slot.bookingCode));
+}
+
+export function releaseCapacityStatement(
+  db: D1Database,
+  organizationId: number,
+  bookingCode: string,
+): D1PreparedStatement {
+  return db.prepare(
+    "DELETE FROM booking_capacity_locks WHERE organization_id = ? AND booking_code = ?"
+  ).bind(organizationId, bookingCode);
+}
+
+export function replaceCapacityStatements(
+  db: D1Database,
+  input: CapacityReservation,
+): D1PreparedStatement[] {
+  return [
+    releaseCapacityStatement(db, input.organizationId, input.bookingCode),
+    ...reserveCapacityStatements(db, input),
+  ];
 }
 
 /** D1/SQLite uniqueness violation produced by booking_capacity_locks. */

--- a/lib/booking-capacity.ts
+++ b/lib/booking-capacity.ts
@@ -77,9 +77,9 @@ export function releaseCapacityStatement(
 }
 
 /**
- * Statements for moving/changing an existing appointment. Callers MUST execute
- * the returned DELETE + INSERT statements together with the booking UPDATE in
- * one D1 batch, so a failed uniqueness check rolls the entire move back.
+ * Statements for callers that explicitly manage a capacity move. Database
+ * triggers are the final invariant for every bookings write path, but these
+ * helpers remain useful for batched workflows and tests.
  */
 export function replaceCapacityStatements(
   db: D1Database,
@@ -91,9 +91,9 @@ export function replaceCapacityStatements(
   ];
 }
 
-/** D1/SQLite uniqueness violation produced by booking_capacity_locks. */
+/** D1/SQLite capacity violation produced by the lock PK or conflict trigger. */
 export function isCapacityConflict(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error || "");
-  return message.includes("UNIQUE constraint failed")
-    && message.includes("booking_capacity_locks");
+  return message.includes("booking capacity conflict")
+    || (message.includes("UNIQUE constraint failed") && message.includes("booking_capacity_locks"));
 }

--- a/lib/booking-capacity.ts
+++ b/lib/booking-capacity.ts
@@ -1,0 +1,64 @@
+export type CapacitySlot = {
+  organizationId: number;
+  equipmentId: string;
+  date: string;
+  minute: string;
+  bookingCode: string;
+};
+
+function parseMinute(value: string): number {
+  const match = /^(\d{2}):(\d{2})$/.exec(value);
+  if (!match) throw new Error(`Invalid appointment time: ${value}`);
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    throw new Error(`Invalid appointment time: ${value}`);
+  }
+  return hour * 60 + minute;
+}
+
+function formatMinute(value: number): string {
+  const hour = Math.floor(value / 60);
+  const minute = value % 60;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+/**
+ * Returns every occupied minute in the half-open interval [start, end).
+ * Adjacent appointments therefore never share a key: 08:30-09:00 occupies
+ * through 08:59 and a 09:00 appointment starts at a different key.
+ */
+export function occupiedMinutes(startTime: string, durationMinutes: number): string[] {
+  const start = parseMinute(startTime);
+  if (!Number.isInteger(durationMinutes) || durationMinutes < 1 || durationMinutes > 24 * 60) {
+    throw new Error(`Invalid appointment duration: ${durationMinutes}`);
+  }
+  if (start + durationMinutes > 24 * 60) {
+    throw new Error("Appointment crosses midnight");
+  }
+  return Array.from({ length: durationMinutes }, (_, offset) => formatMinute(start + offset));
+}
+
+export function capacitySlots(input: {
+  organizationId: number;
+  equipmentId: string;
+  date: string;
+  startTime: string;
+  durationMinutes: number;
+  bookingCode: string;
+}): CapacitySlot[] {
+  return occupiedMinutes(input.startTime, input.durationMinutes).map((minute) => ({
+    organizationId: input.organizationId,
+    equipmentId: input.equipmentId,
+    date: input.date,
+    minute,
+    bookingCode: input.bookingCode,
+  }));
+}
+
+/** D1/SQLite uniqueness violation produced by booking_capacity_locks. */
+export function isCapacityConflict(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error || "");
+  return message.includes("UNIQUE constraint failed")
+    && message.includes("booking_capacity_locks");
+}

--- a/tests/booking-capacity.test.mjs
+++ b/tests/booking-capacity.test.mjs
@@ -85,3 +85,10 @@ test("public booking writes locks in the same D1 batch and maps races to 409", a
   assert.match(route, /isCapacityConflict\(error\)/);
   assert.match(route, /status: 409/);
 });
+
+test("shared helper exposes reserve, release and replace primitives for staff flows", async () => {
+  const helper = await readFile(new URL("../lib/booking-capacity.ts", import.meta.url), "utf8");
+  assert.match(helper, /export function reserveCapacityStatements/);
+  assert.match(helper, /export function releaseCapacityStatement/);
+  assert.match(helper, /export function replaceCapacityStatements/);
+});

--- a/tests/booking-capacity.test.mjs
+++ b/tests/booking-capacity.test.mjs
@@ -79,15 +79,15 @@ test("same clock time on different equipment or tenant is independent", async ()
 
 test("public booking writes locks in the same D1 batch and maps races to 409", async () => {
   const route = await readFile(new URL("../app/api/site-booking/route.ts", import.meta.url), "utf8");
-  assert.match(route, /capacitySlots\(/);
-  assert.match(route, /INSERT INTO booking_capacity_locks/);
+  assert.match(route, /reserveCapacityStatements\(db/);
   assert.match(route, /await db\.batch\(statements\)/);
   assert.match(route, /isCapacityConflict\(error\)/);
   assert.match(route, /status: 409/);
 });
 
-test("shared helper exposes reserve, release and replace primitives for staff flows", async () => {
+test("shared helper owns the lock SQL and exposes reserve, release and replace primitives", async () => {
   const helper = await readFile(new URL("../lib/booking-capacity.ts", import.meta.url), "utf8");
+  assert.match(helper, /INSERT INTO booking_capacity_locks/);
   assert.match(helper, /export function reserveCapacityStatements/);
   assert.match(helper, /export function releaseCapacityStatement/);
   assert.match(helper, /export function replaceCapacityStatements/);

--- a/tests/booking-capacity.test.mjs
+++ b/tests/booking-capacity.test.mjs
@@ -76,3 +76,12 @@ test("same clock time on different equipment or tenant is independent", async ()
     startTime: "08:30", durationMinutes: 30, bookingCode: "RD-260810-003",
   })));
 });
+
+test("public booking writes locks in the same D1 batch and maps races to 409", async () => {
+  const route = await readFile(new URL("../app/api/site-booking/route.ts", import.meta.url), "utf8");
+  assert.match(route, /capacitySlots\(/);
+  assert.match(route, /INSERT INTO booking_capacity_locks/);
+  assert.match(route, /await db\.batch\(statements\)/);
+  assert.match(route, /isCapacityConflict\(error\)/);
+  assert.match(route, /status: 409/);
+});

--- a/tests/booking-capacity.test.mjs
+++ b/tests/booking-capacity.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { capacitySlots, occupiedMinutes } from "../lib/booking-capacity.ts";
+
+async function freshDb() {
+  const dir = new URL("../drizzle/", import.meta.url);
+  const files = (await readdir(dir)).filter((f) => f.endsWith(".sql")).sort();
+  const db = new DatabaseSync(":memory:");
+  for (const f of files) {
+    const sql = await readFile(new URL(f, dir), "utf8");
+    for (const statement of sql.split(/-->\s*statement-breakpoint/).map((x) => x.trim()).filter(Boolean)) {
+      db.exec(statement);
+    }
+  }
+  return db;
+}
+
+function insertLocks(db, slots) {
+  const stmt = db.prepare(
+    `INSERT INTO booking_capacity_locks
+      (organization_id, equipment_id, booking_date, minute, booking_code)
+     VALUES (?, ?, ?, ?, ?)`
+  );
+  for (const slot of slots) {
+    stmt.run(slot.organizationId, slot.equipmentId, slot.date, slot.minute, slot.bookingCode);
+  }
+}
+
+test("occupiedMinutes uses a half-open interval", () => {
+  const minutes = occupiedMinutes("08:30", 30);
+  assert.equal(minutes.length, 30);
+  assert.equal(minutes[0], "08:30");
+  assert.equal(minutes.at(-1), "08:59");
+  assert.ok(!minutes.includes("09:00"));
+});
+
+test("adjacent appointments do not collide", async () => {
+  const db = await freshDb();
+  insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "ct", date: "2026-08-10",
+    startTime: "08:30", durationMinutes: 30, bookingCode: "RD-260810-001",
+  }));
+  assert.doesNotThrow(() => insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "ct", date: "2026-08-10",
+    startTime: "09:00", durationMinutes: 30, bookingCode: "RD-260810-002",
+  })));
+});
+
+test("overlapping appointments are rejected by database uniqueness", async () => {
+  const db = await freshDb();
+  insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "ct", date: "2026-08-10",
+    startTime: "08:30", durationMinutes: 30, bookingCode: "RD-260810-001",
+  }));
+  assert.throws(() => insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "ct", date: "2026-08-10",
+    startTime: "08:45", durationMinutes: 30, bookingCode: "RD-260810-002",
+  })), /UNIQUE constraint failed/);
+});
+
+test("same clock time on different equipment or tenant is independent", async () => {
+  const db = await freshDb();
+  insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "ct", date: "2026-08-10",
+    startTime: "08:30", durationMinutes: 30, bookingCode: "RD-260810-001",
+  }));
+  assert.doesNotThrow(() => insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "xray", date: "2026-08-10",
+    startTime: "08:30", durationMinutes: 30, bookingCode: "RD-260810-002",
+  })));
+  assert.doesNotThrow(() => insertLocks(db, capacitySlots({
+    organizationId: 2, equipmentId: "ct", date: "2026-08-10",
+    startTime: "08:30", durationMinutes: 30, bookingCode: "RD-260810-003",
+  })));
+});

--- a/tests/booking-capacity.test.mjs
+++ b/tests/booking-capacity.test.mjs
@@ -29,6 +29,15 @@ function insertLocks(db, slots) {
   }
 }
 
+function insertBooking(db, { code, time, duration = 30, status = "confirmed", equipment = "ct", org = 1, date = "2026-08-10" }) {
+  return db.prepare(
+    `INSERT INTO bookings (
+      organization_id, code, name, phone, phone_normalized, service,
+      service_code, equipment_id, duration_minutes, desired_date, desired_time, status
+    ) VALUES (?, ?, 'Test Patient', '0970000000', '380970000000', 'CT', 'ct-test', ?, ?, ?, ?, ?)`
+  ).run(org, code, equipment, duration, date, time, status);
+}
+
 test("occupiedMinutes uses a half-open interval", () => {
   const minutes = occupiedMinutes("08:30", 30);
   assert.equal(minutes.length, 30);
@@ -49,7 +58,7 @@ test("adjacent appointments do not collide", async () => {
   })));
 });
 
-test("overlapping appointments are rejected by database uniqueness", async () => {
+test("overlapping appointments are rejected by database capacity", async () => {
   const db = await freshDb();
   insertLocks(db, capacitySlots({
     organizationId: 1, equipmentId: "ct", date: "2026-08-10",
@@ -58,7 +67,7 @@ test("overlapping appointments are rejected by database uniqueness", async () =>
   assert.throws(() => insertLocks(db, capacitySlots({
     organizationId: 1, equipmentId: "ct", date: "2026-08-10",
     startTime: "08:45", durationMinutes: 30, bookingCode: "RD-260810-002",
-  })), /UNIQUE constraint failed/);
+  })), /booking capacity conflict|UNIQUE constraint failed/);
 });
 
 test("same clock time on different equipment or tenant is independent", async () => {
@@ -77,7 +86,50 @@ test("same clock time on different equipment or tenant is independent", async ()
   })));
 });
 
-test("public booking writes locks in the same D1 batch and maps races to 409", async () => {
+test("booking INSERT trigger reserves capacity for staff and any other write path", async () => {
+  const db = await freshDb();
+  insertBooking(db, { code: "RD-T1", time: "08:30" });
+  const count = db.prepare("SELECT count(*) AS n FROM booking_capacity_locks WHERE booking_code = ?").get("RD-T1");
+  assert.equal(count.n, 30);
+  assert.throws(() => insertBooking(db, { code: "RD-T2", time: "08:45" }), /booking capacity conflict/);
+  assert.doesNotThrow(() => insertBooking(db, { code: "RD-T3", time: "09:00" }));
+});
+
+test("booking UPDATE trigger atomically moves capacity and restores old locks on conflict", async () => {
+  const db = await freshDb();
+  insertBooking(db, { code: "RD-A", time: "08:30" });
+  insertBooking(db, { code: "RD-B", time: "09:30" });
+  db.prepare("UPDATE bookings SET desired_time = '09:00', status = 'rescheduled' WHERE code = 'RD-A'").run();
+  assert.equal(db.prepare("SELECT count(*) AS n FROM booking_capacity_locks WHERE booking_code='RD-A' AND minute='09:00'").get().n, 1);
+  assert.throws(
+    () => db.prepare("UPDATE bookings SET desired_time = '09:15', status = 'rescheduled' WHERE code = 'RD-A'").run(),
+    /booking capacity conflict/,
+  );
+  assert.equal(db.prepare("SELECT desired_time AS t FROM bookings WHERE code='RD-A'").get().t, "09:00");
+  assert.equal(db.prepare("SELECT count(*) AS n FROM booking_capacity_locks WHERE booking_code='RD-A' AND minute='09:00'").get().n, 1);
+});
+
+test("cancelled and completed bookings release capacity automatically", async () => {
+  const db = await freshDb();
+  insertBooking(db, { code: "RD-C", time: "10:00" });
+  db.prepare("UPDATE bookings SET status = 'cancelled' WHERE code='RD-C'").run();
+  assert.equal(db.prepare("SELECT count(*) AS n FROM booking_capacity_locks WHERE booking_code='RD-C'").get().n, 0);
+  assert.doesNotThrow(() => insertBooking(db, { code: "RD-D", time: "10:00" }));
+  db.prepare("UPDATE bookings SET status = 'completed' WHERE code='RD-D'").run();
+  assert.equal(db.prepare("SELECT count(*) AS n FROM booking_capacity_locks WHERE booking_code='RD-D'").get().n, 0);
+});
+
+test("same-booking explicit capacity reservation is idempotent", async () => {
+  const db = await freshDb();
+  insertBooking(db, { code: "RD-I", time: "11:00" });
+  assert.doesNotThrow(() => insertLocks(db, capacitySlots({
+    organizationId: 1, equipmentId: "ct", date: "2026-08-10",
+    startTime: "11:00", durationMinutes: 30, bookingCode: "RD-I",
+  })));
+  assert.equal(db.prepare("SELECT count(*) AS n FROM booking_capacity_locks WHERE booking_code='RD-I'").get().n, 30);
+});
+
+test("public booking uses one D1 batch and maps capacity races to 409", async () => {
   const route = await readFile(new URL("../app/api/site-booking/route.ts", import.meta.url), "utf8");
   assert.match(route, /reserveCapacityStatements\(db/);
   assert.match(route, /await db\.batch\(statements\)/);
@@ -87,10 +139,11 @@ test("public booking writes locks in the same D1 batch and maps races to 409", a
   assert.doesNotMatch(route, /organizationId\s*=\s*clean\(body\./);
 });
 
-test("shared helper owns the lock SQL and exposes reserve, release and replace primitives", async () => {
+test("shared helper owns explicit lock primitives for batched workflows", async () => {
   const helper = await readFile(new URL("../lib/booking-capacity.ts", import.meta.url), "utf8");
   assert.match(helper, /INSERT INTO booking_capacity_locks/);
   assert.match(helper, /export function reserveCapacityStatements/);
   assert.match(helper, /export function releaseCapacityStatement/);
   assert.match(helper, /export function replaceCapacityStatements/);
+  assert.match(helper, /booking capacity conflict/);
 });

--- a/tests/booking-capacity.test.mjs
+++ b/tests/booking-capacity.test.mjs
@@ -83,6 +83,8 @@ test("public booking writes locks in the same D1 batch and maps races to 409", a
   assert.match(route, /await db\.batch\(statements\)/);
   assert.match(route, /isCapacityConflict\(error\)/);
   assert.match(route, /status: 409/);
+  assert.match(route, /const PUBLIC_ORGANIZATION_ID = 1/);
+  assert.doesNotMatch(route, /organizationId\s*=\s*clean\(body\./);
 });
 
 test("shared helper owns the lock SQL and exposes reserve, release and replace primitives", async () => {

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -7,12 +7,12 @@ import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.
 
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
 
-async function seed(db, { id, code, name, phone, phoneNorm, org = 1 }) {
+async function seed(db, { id, code, name, phone, phoneNorm, org = 1, time = "10:00" }) {
   await db.prepare(
     `INSERT INTO bookings (id, code, name, phone, phone_normalized, service, service_code,
        desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
-  ).bind(id, code, name, phone, phoneNorm, "КТ", "CT-01", "2026-09-01", "10:00", "new", "1990-05-05", "civilian", org).run();
+  ).bind(id, code, name, phone, phoneNorm, "КТ", "CT-01", "2026-09-01", time, "new", "1990-05-05", "civilian", org).run();
 }
 
 const search = (db, cookie, q) =>
@@ -27,8 +27,8 @@ test("search is staff-only", async () => {
 
 test("search matches by name, phone and RD code", async () => {
   await withD1(async (db) => {
-    await seed(db, { id: 1, code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNorm: "380971112233" });
-    await seed(db, { id: 2, code: "RD-BBBB2222", name: "Петренко Петро", phone: "+380975556677", phoneNorm: "380975556677" });
+    await seed(db, { id: 1, code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNorm: "380971112233", time: "10:00" });
+    await seed(db, { id: 2, code: "RD-BBBB2222", name: "Петренко Петро", phone: "+380975556677", phoneNorm: "380975556677", time: "10:30" });
     const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
 
     const byName = await (await search(db, cookie, "іваненко")).json();

--- a/tests/my-bookings.behavior.test.mjs
+++ b/tests/my-bookings.behavior.test.mjs
@@ -63,8 +63,8 @@ test("malformed input is a 400 before any lookup", async () => {
 
 test("only bookings for the matching phone are returned (no cross-patient leak)", async () => {
   await withD1(async (db) => {
-    await seedBooking(db, { code: "RD-AAAA1111", phone: "+380971112233", phoneNormalized: "380971112233", dob: "1990-05-05" });
-    await seedBooking(db, { code: "RD-BBBB2222", name: "Петренко", phone: "+380975556677", phoneNormalized: "380975556677", dob: "1985-03-03" });
+    await seedBooking(db, { code: "RD-AAAA1111", phone: "+380971112233", phoneNormalized: "380971112233", dob: "1990-05-05", desiredTime: "10:00" });
+    await seedBooking(db, { code: "RD-BBBB2222", name: "Петренко", phone: "+380975556677", phoneNormalized: "380975556677", dob: "1985-03-03", desiredTime: "10:30" });
     const res = await post(db, { phone: "+380971112233", dob: "1990-05-05" });
     const data = await res.json();
     assert.equal(data.bookings.length, 1);


### PR DESCRIPTION
Closes #155

Implemented:
- `booking_capacity_locks` with unique organization/equipment/date/minute capacity keys;
- backfill for existing active bookings;
- DB triggers that automatically reserve capacity on booking INSERT, atomically rebuild capacity on equipment/date/time/duration/status UPDATE, and release it on cancellation/completion/delete;
- same-booking lock writes are idempotent, competing bookings abort with a stable `booking capacity conflict` error;
- public `/api/site-booking` keeps its atomic D1 batch and maps capacity races to HTTP 409;
- shared capacity helpers remain available for explicit batched workflows;
- Drizzle capacity schema registered alongside the core schema;
- regression tests cover overlap, adjacency, tenant/equipment isolation, automatic staff/write-path reservation, atomic reschedule rollback, cancellation/completion release, idempotent same-booking reservation, and capacity-valid legacy fixtures.

Validation:
- CI: passed
- CodeQL: passed