### PR TITLE
security: require OTP for patient cabinet access

### DIFF
--- a/app/api/booking-status/route.ts
+++ b/app/api/booking-status/route.ts
@@ -1,10 +1,7 @@
 import {
-  createPatientSession,
   normalizeBookingCode,
-  patientSessionCookie,
   requirePatientSession,
 } from "../../../lib/patient-auth";
-import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { stateLabel } from "../../../lib/study-state";
 import { dbBinding } from "../../../lib/db";
@@ -12,32 +9,26 @@ import { dbBinding } from "../../../lib/db";
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
-  if (await isRateLimited(db, request, "booking-status", 8, 15)) {
+  if (await isRateLimited(db, request, "booking-status", 12, 15)) {
     return Response.json({ error: "Забагато спроб. Повторіть перевірку пізніше." }, { status: 429 });
   }
-  const body = await request.json().catch(() => ({})) as { code?: string; phone?: string };
+  const session = await requirePatientSession(request, db);
+  if (!session) return Response.json({ error: "Сесію завершено. Увійдіть повторно." }, { status: 401 });
+
+  const body = await request.json().catch(() => ({})) as { code?: string };
   const code = normalizeBookingCode(body.code);
-  const phoneNormalized = normalizeUkrainianPhone(String(body.phone || ""));
-  if (!code || !phoneNormalized) {
-    return Response.json({ error: "Перевірте код і повний номер телефону" }, { status: 400 });
-  }
+  if (!code) return Response.json({ error: "Перевірте код заявки" }, { status: 400 });
+
   const result = await db.prepare(
     `SELECT b.code, b.service, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
       b.status, b.created_at AS createdAt, COALESCE(o.name, '') AS organization
      FROM bookings b LEFT JOIN organizations o ON o.id = b.organization_id
-     WHERE b.code = ? AND b.phone_normalized = ?
+     WHERE b.organization_id = ? AND b.code = ? AND b.phone_normalized = ?
      LIMIT 1`
-  ).bind(code, phoneNormalized).first<{ status: string }>();
+  ).bind(session.organizationId, code, session.phoneNormalized).first<{ status: string }>();
   if (!result) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
-  // Людський підпис стану дослідження (єдина state machine).
   const booking = { ...result, statusLabel: stateLabel(result.status) };
-  const sessionToken = await createPatientSession(db, phoneNormalized);
-  return Response.json({ booking }, {
-    headers: {
-      "cache-control": "no-store",
-      "set-cookie": patientSessionCookie(sessionToken),
-    },
-  });
+  return Response.json({ booking }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PATCH(request: Request) {
@@ -56,14 +47,14 @@ export async function PATCH(request: Request) {
   }
   const booking = await db.prepare(
     `SELECT id, status FROM bookings
-     WHERE code = ? AND phone_normalized = ? LIMIT 1`
-  ).bind(code, session.phoneNormalized).first<{ id: number; status: string }>();
+     WHERE organization_id = ? AND code = ? AND phone_normalized = ? LIMIT 1`
+  ).bind(session.organizationId, code, session.phoneNormalized).first<{ id: number; status: string }>();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
   if (!["new", "confirmed", "rescheduled"].includes(booking.status)) {
     return Response.json({ error: "Цю заявку вже не можна скасувати онлайн" }, { status: 409 });
   }
   await db.batch([
-    db.prepare("UPDATE bookings SET status = 'cancelled' WHERE id = ?").bind(booking.id),
+    db.prepare("UPDATE bookings SET status = 'cancelled' WHERE id = ? AND organization_id = ?").bind(booking.id, session.organizationId),
     db.prepare(
       "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'cancelled', 'patient_self_service', 'patient')"
     ).bind(booking.id),

--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -1,11 +1,8 @@
 import {
   clearedPatientSessionCookie,
-  createPatientSession,
   destroyPatientSession,
-  patientSessionCookie,
+  requirePatientSession,
 } from "../../../lib/patient-auth";
-import { normalizeUkrainianPhone } from "../../../lib/phone";
-import { normalizeDob } from "../../../lib/dob";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { stateLabel } from "../../../lib/study-state";
 import { dbBinding } from "../../../lib/db";
@@ -13,23 +10,13 @@ import { dbBinding } from "../../../lib/db";
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
-  if (await isRateLimited(db, request, "patient-login", 8, 15)) {
-    return Response.json({ error: "Забагато спроб. Повторіть перевірку пізніше." }, { status: 429 });
+  if (await isRateLimited(db, request, "patient-cabinet", 20, 15)) {
+    return Response.json({ error: "Забагато запитів. Повторіть пізніше." }, { status: 429 });
   }
 
-  const body = await request.json().catch(() => ({})) as { phone?: string; dob?: string };
-  const phoneNormalized = normalizeUkrainianPhone(String(body.phone || ""));
-  const dob = normalizeDob(body.dob);
-  if (!phoneNormalized || !dob) {
-    return Response.json({ error: "Введіть повний номер телефону та дату народження" }, { status: 400 });
-  }
-
-  // Підтвердження особи: збіг телефону і дати народження хоча б в одній заявці.
-  const proof = await db.prepare(
-    "SELECT id FROM bookings WHERE phone_normalized = ? AND date_of_birth = ? LIMIT 1"
-  ).bind(phoneNormalized, dob).first();
-  if (!proof) {
-    return Response.json({ error: "Не вдалося підтвердити номер телефону або дату народження" }, { status: 401 });
+  const session = await requirePatientSession(request, db);
+  if (!session) {
+    return Response.json({ error: "Сесію не підтверджено. Отримайте одноразовий код ще раз." }, { status: 401 });
   }
 
   const rows = await db.prepare(
@@ -40,26 +27,20 @@ export async function POST(request: Request) {
        COALESCE(o.name, '') AS organization,
        CASE WHEN b.protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol
      FROM bookings b LEFT JOIN organizations o ON o.id = b.organization_id
-     WHERE b.phone_normalized = ? AND b.date_of_birth = ?
+     WHERE b.organization_id = ? AND b.phone_normalized = ?
      ORDER BY b.created_at DESC, b.id DESC
      LIMIT 50`
-  ).bind(phoneNormalized, dob).all();
+  ).bind(session.organizationId, session.phoneNormalized).all();
 
   const bookings = (rows.results || []).map((row) => ({
     ...row,
     hasProtocol: Number((row as { hasProtocol: number }).hasProtocol) === 1,
-    // Людський підпис стану дослідження для пацієнта.
     statusLabel: stateLabel(String((row as { status: string }).status)),
   }));
-  const rawToken = await createPatientSession(db, phoneNormalized);
+
   return Response.json(
     { bookings },
-    {
-      headers: {
-        "set-cookie": patientSessionCookie(rawToken),
-        "cache-control": "no-store",
-      },
-    },
+    { headers: { "cache-control": "no-store" } },
   );
 }
 

--- a/app/api/my-protocol/route.ts
+++ b/app/api/my-protocol/route.ts
@@ -17,8 +17,9 @@ export async function POST(request: Request) {
 
   const booking = await db.prepare(
     `SELECT id, name, service, protocol_status AS protocolStatus, protocol_issued_at AS issuedAt
-     FROM bookings WHERE code = ? AND phone_normalized = ? LIMIT 1`
-  ).bind(code, session.phoneNormalized).first<{
+     FROM bookings
+     WHERE organization_id = ? AND code = ? AND phone_normalized = ? LIMIT 1`
+  ).bind(session.organizationId, code, session.phoneNormalized).first<{
     id: number; name: string; service: string; protocolStatus: string; issuedAt: string;
   }>();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
@@ -28,8 +29,8 @@ export async function POST(request: Request) {
 
   const proto = await db.prepare(
     `SELECT number, method, findings, conclusion, recommendations
-     FROM protocols WHERE booking_id = ? AND status = 'issued' LIMIT 1`
-  ).bind(booking.id).first<{
+     FROM protocols WHERE organization_id = ? AND booking_id = ? AND status = 'issued' LIMIT 1`
+  ).bind(session.organizationId, booking.id).first<{
     number: string; method: string; findings: string; conclusion: string; recommendations: string;
   }>();
   if (!proto) return Response.json({ error: "Протокол ще не готовий" }, { status: 409 });

--- a/app/api/patient-otp/route.ts
+++ b/app/api/patient-otp/route.ts
@@ -1,0 +1,217 @@
+import { audit } from "../../../lib/audit";
+import { hashPassword, newSessionToken } from "../../../lib/auth";
+import { normalizeDob } from "../../../lib/dob";
+import {
+  createPatientOtpChallenge,
+  createPatientSession,
+  normalizeBookingCode,
+  normalizeOtp,
+  patientSessionCookie,
+  verifyPatientOtpChallenge,
+} from "../../../lib/patient-auth";
+import { normalizeUkrainianPhone } from "../../../lib/phone";
+import { createMessagingProvider } from "../../../lib/providers/messaging";
+import { isRateLimited } from "../../../lib/rate-limit";
+import { getSettings } from "../../../lib/settings";
+import { dbBinding } from "../../../lib/db";
+
+const PURPOSE = "cabinet_login";
+const PHONE_REQUEST_LIMIT = 5;
+
+function maskedPhone(phoneNormalized: string): string {
+  return phoneNormalized ? `***${phoneNormalized.slice(-4)}` : "";
+}
+
+async function proofOrganization(
+  db: D1Database,
+  phoneNormalized: string,
+  body: { dob?: unknown; bookingCode?: unknown },
+): Promise<number | null> {
+  const dob = normalizeDob(body.dob);
+  if (dob) {
+    const row = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM bookings
+       WHERE phone_normalized = ? AND date_of_birth = ?
+       ORDER BY created_at DESC, id DESC LIMIT 1`,
+    ).bind(phoneNormalized, dob).first<{ organizationId: number }>();
+    return row?.organizationId || null;
+  }
+
+  const bookingCode = normalizeBookingCode(body.bookingCode);
+  if (bookingCode) {
+    const row = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM bookings WHERE phone_normalized = ? AND code = ? LIMIT 1`,
+    ).bind(phoneNormalized, bookingCode).first<{ organizationId: number }>();
+    return row?.organizationId || null;
+  }
+  return null;
+}
+
+// Step 1: prove a known booking identity (phone+DOB or phone+booking code), then
+// deliver a possession challenge. Unknown identities receive the same neutral
+// response shape and never get a session/challenge row.
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+
+  const body = await request.json().catch(() => ({})) as {
+    phone?: unknown;
+    dob?: unknown;
+    bookingCode?: unknown;
+  };
+  const phoneNormalized = normalizeUkrainianPhone(String(body.phone || ""));
+  if (!phoneNormalized || (!normalizeDob(body.dob) && !normalizeBookingCode(body.bookingCode))) {
+    return Response.json({ error: "Введіть номер телефону та дані запису" }, { status: 400 });
+  }
+
+  if (await isRateLimited(db, request, `patient-otp-request:${phoneNormalized}`, 5, 15)) {
+    return Response.json({ error: "Забагато запитів коду. Спробуйте пізніше." }, { status: 429 });
+  }
+
+  const cfg = await getSettings(db, ["sms_gateway_url", "sms_gateway_auth"]);
+  const messaging = createMessagingProvider({
+    sms: { url: cfg.sms_gateway_url || "", auth: cfg.sms_gateway_auth || "" },
+    email: { url: "", auth: "", from: "" },
+  });
+  // Do not fall back to knowledge-only login if possession verification is
+  // unavailable. The check happens before identity lookup to avoid enumeration.
+  if (!messaging.capabilities.sms) {
+    return Response.json(
+      { error: "Підтвердження номера телефону тимчасово недоступне" },
+      { status: 503, headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  const organizationId = await proofOrganization(db, phoneNormalized, body);
+  if (!organizationId) {
+    // Burn similar local crypto work and return an opaque fake challenge id.
+    // No database row exists, so verification can never succeed.
+    await hashPassword("000000");
+    return Response.json(
+      {
+        ok: true,
+        challengeId: newSessionToken(),
+        expiresIn: 300,
+        message: "Якщо дані збігаються із записом, код підтвердження надіслано.",
+      },
+      { status: 202, headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  const recent = await db.prepare(
+    `SELECT COUNT(*) AS n FROM patient_otp_challenges
+     WHERE organization_id = ? AND phone_normalized = ? AND purpose = ?
+       AND created_at > datetime('now', '-15 minutes')`,
+  ).bind(organizationId, phoneNormalized, PURPOSE).first<{ n: number }>();
+  if ((recent?.n || 0) >= PHONE_REQUEST_LIMIT) {
+    return Response.json({ error: "Забагато запитів коду. Спробуйте пізніше." }, { status: 429 });
+  }
+
+  const challenge = await createPatientOtpChallenge(db, phoneNormalized, organizationId, PURPOSE);
+  const text = `RadiologyOS: код підтвердження ${challenge.code}. Код діє 5 хвилин. Нікому його не повідомляйте.`;
+  try {
+    await messaging.sendSms(`+${phoneNormalized}`, text);
+  } catch (error) {
+    // A code that was never delivered must not remain usable.
+    await db.prepare(
+      "UPDATE patient_otp_challenges SET consumed_at = CURRENT_TIMESTAMP WHERE id = ?",
+    ).bind(challenge.challengeId).run().catch(() => undefined);
+    await audit(db, {
+      organizationId,
+      actorEmail: "patient",
+      action: "patient_otp_delivery_failed",
+      resource: "patient_auth",
+      targetId: challenge.challengeId.slice(0, 12),
+      details: { phone: maskedPhone(phoneNormalized) },
+    });
+    console.error("patient_otp_delivery_failed", error instanceof Error ? error.message : "unknown");
+    return Response.json(
+      { error: "Не вдалося надіслати код підтвердження. Спробуйте пізніше." },
+      { status: 503, headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  await audit(db, {
+    organizationId,
+    actorEmail: "patient",
+    action: "patient_otp_requested",
+    resource: "patient_auth",
+    targetId: challenge.challengeId.slice(0, 12),
+    details: { phone: maskedPhone(phoneNormalized), channel: "sms" },
+  });
+  return Response.json(
+    {
+      ok: true,
+      challengeId: challenge.challengeId,
+      expiresIn: challenge.expiresIn,
+      message: "Код підтвердження надіслано на ваш номер телефону.",
+    },
+    { status: 202, headers: { "cache-control": "no-store" } },
+  );
+}
+
+// Step 2: consume the one-time possession challenge and only then create the
+// tenant-scoped patient session used by cabinet/result endpoints.
+export async function PATCH(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+
+  const body = await request.json().catch(() => ({})) as {
+    phone?: unknown;
+    challengeId?: unknown;
+    code?: unknown;
+  };
+  const phoneNormalized = normalizeUkrainianPhone(String(body.phone || ""));
+  const challengeId = String(body.challengeId || "").trim();
+  const code = normalizeOtp(body.code);
+  if (!phoneNormalized || !/^[a-f0-9]{64}$/i.test(challengeId) || !code) {
+    return Response.json({ error: "Перевірте код підтвердження" }, { status: 400 });
+  }
+  if (await isRateLimited(db, request, `patient-otp-verify:${phoneNormalized}`, 8, 15)) {
+    return Response.json({ error: "Забагато спроб. Спробуйте пізніше." }, { status: 429 });
+  }
+
+  const challengeScope = await db.prepare(
+    `SELECT organization_id AS organizationId FROM patient_otp_challenges
+     WHERE id = ? AND phone_normalized = ? LIMIT 1`,
+  ).bind(challengeId, phoneNormalized).first<{ organizationId: number }>();
+
+  const verified = await verifyPatientOtpChallenge(db, {
+    challengeId,
+    phoneNormalized,
+    code,
+    purpose: PURPOSE,
+  });
+  if (!verified) {
+    await audit(db, {
+      organizationId: challengeScope?.organizationId || 1,
+      actorEmail: "patient",
+      action: "patient_otp_failed",
+      resource: "patient_auth",
+      targetId: challengeId.slice(0, 12),
+      details: { phone: maskedPhone(phoneNormalized) },
+    });
+    return Response.json({ error: "Невірний або прострочений код підтвердження" }, { status: 401 });
+  }
+
+  const rawToken = await createPatientSession(db, phoneNormalized, verified.organizationId);
+  await audit(db, {
+    organizationId: verified.organizationId,
+    actorEmail: "patient",
+    action: "patient_otp_verified",
+    resource: "patient_auth",
+    targetId: challengeId.slice(0, 12),
+    details: { phone: maskedPhone(phoneNormalized) },
+  });
+  return Response.json(
+    { ok: true },
+    {
+      headers: {
+        "set-cookie": patientSessionCookie(rawToken),
+        "cache-control": "no-store",
+      },
+    },
+  );
+}

--- a/db/index.ts
+++ b/db/index.ts
@@ -2,8 +2,9 @@ import { env } from "cloudflare:workers";
 import { drizzle } from "drizzle-orm/d1";
 import * as coreSchema from "./schema";
 import * as capacitySchema from "./capacity-schema";
+import * as patientAuthSchema from "./patient-auth-schema";
 
-const schema = { ...coreSchema, ...capacitySchema };
+const schema = { ...coreSchema, ...capacitySchema, ...patientAuthSchema };
 
 export function getDb() {
   if (!env.DB) {

--- a/db/patient-auth-schema.ts
+++ b/db/patient-auth-schema.ts
@@ -1,0 +1,30 @@
+import { sql } from "drizzle-orm";
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+// Drizzle representation of possession-based patient authentication added by
+// migration 0028. The legacy core schema keeps the original patientSessions
+// export for compatibility; this scoped model is the authoritative v2 shape.
+export const patientSessionsScoped = sqliteTable("patient_sessions", {
+  tokenHash: text("token_hash").primaryKey(),
+  phoneNormalized: text("phone_normalized").notNull(),
+  organizationId: integer("organization_id").notNull().default(1),
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  expiresAt: text("expires_at").notNull(),
+}, table => [
+  index("patient_sessions_org_phone_idx").on(table.organizationId, table.phoneNormalized, table.expiresAt),
+]);
+
+export const patientOtpChallenges = sqliteTable("patient_otp_challenges", {
+  id: text("id").primaryKey(),
+  organizationId: integer("organization_id").notNull().default(1),
+  phoneNormalized: text("phone_normalized").notNull(),
+  purpose: text("purpose").notNull().default("cabinet_login"),
+  codeHash: text("code_hash").notNull(),
+  attempts: integer("attempts").notNull().default(0),
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  expiresAt: text("expires_at").notNull(),
+  consumedAt: text("consumed_at").notNull().default(""),
+}, table => [
+  index("patient_otp_phone_idx").on(table.organizationId, table.phoneNormalized, table.createdAt),
+  index("patient_otp_expiry_idx").on(table.expiresAt, table.consumedAt),
+]);

--- a/drizzle/0028_patient_otp.sql
+++ b/drizzle/0028_patient_otp.sql
@@ -1,0 +1,28 @@
+-- Possession-based patient authentication.
+-- OTP values are never stored in plaintext: `code_hash` uses the same salted
+-- PBKDF2-HMAC-SHA256 primitive as staff PINs. Challenges are short-lived,
+-- single-use and explicitly scoped to an organization + normalized phone.
+
+ALTER TABLE `patient_sessions` ADD `organization_id` integer DEFAULT 1 NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `patient_sessions_org_phone_idx`
+ON `patient_sessions` (`organization_id`, `phone_normalized`, `expires_at`);
+--> statement-breakpoint
+
+CREATE TABLE `patient_otp_challenges` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` integer DEFAULT 1 NOT NULL,
+  `phone_normalized` text NOT NULL,
+  `purpose` text DEFAULT 'cabinet_login' NOT NULL,
+  `code_hash` text NOT NULL,
+  `attempts` integer DEFAULT 0 NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `expires_at` text NOT NULL,
+  `consumed_at` text DEFAULT '' NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `patient_otp_phone_idx`
+ON `patient_otp_challenges` (`organization_id`, `phone_normalized`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX `patient_otp_expiry_idx`
+ON `patient_otp_challenges` (`expires_at`, `consumed_at`);

--- a/lib/patient-auth.ts
+++ b/lib/patient-auth.ts
@@ -1,7 +1,15 @@
-import { hashToken, newSessionToken, readCookie } from "./auth";
+import {
+  hashPassword,
+  hashToken,
+  newSessionToken,
+  readCookie,
+  verifyPassword,
+} from "./auth";
 
 export const PATIENT_SESSION_COOKIE = "rid_patient";
 export const PATIENT_SESSION_TTL_SECONDS = 30 * 60;
+export const PATIENT_OTP_TTL_SECONDS = 5 * 60;
+export const PATIENT_OTP_MAX_ATTEMPTS = 5;
 
 export function normalizeBookingCode(value: unknown): string {
   const code = String(value || "").trim().toUpperCase().slice(0, 24);
@@ -9,13 +17,125 @@ export function normalizeBookingCode(value: unknown): string {
   return /^RD-(?:[A-Z0-9]{8,16}|\d{6}-\d{1,4})$/.test(code) ? code : "";
 }
 
-export async function createPatientSession(db: D1Database, phoneNormalized: string): Promise<string> {
+export function normalizeOtp(value: unknown): string {
+  const code = String(value || "").trim();
+  return /^\d{6}$/.test(code) ? code : "";
+}
+
+function newOtpCode(): string {
+  // Rejection sampling avoids modulo bias while keeping a simple six-digit OTP.
+  const limit = Math.floor(0x1_0000_0000 / 1_000_000) * 1_000_000;
+  let value = 0;
+  do {
+    value = crypto.getRandomValues(new Uint32Array(1))[0];
+  } while (value >= limit);
+  return String(value % 1_000_000).padStart(6, "0");
+}
+
+export async function createPatientOtpChallenge(
+  db: D1Database,
+  phoneNormalized: string,
+  organizationId: number,
+  purpose = "cabinet_login",
+): Promise<{ challengeId: string; code: string; expiresIn: number }> {
+  const challengeId = newSessionToken();
+  const code = newOtpCode();
+  const codeHash = await hashPassword(code);
+
+  // Only the newest challenge for this tenant/phone/purpose remains usable.
+  await db.batch([
+    db.prepare(
+      `UPDATE patient_otp_challenges SET consumed_at = CURRENT_TIMESTAMP
+       WHERE organization_id = ? AND phone_normalized = ? AND purpose = ?
+         AND consumed_at = '' AND expires_at > CURRENT_TIMESTAMP`,
+    ).bind(organizationId, phoneNormalized, purpose),
+    db.prepare(
+      `INSERT INTO patient_otp_challenges
+       (id, organization_id, phone_normalized, purpose, code_hash, expires_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now', ?))`,
+    ).bind(
+      challengeId,
+      organizationId,
+      phoneNormalized,
+      purpose.slice(0, 40),
+      codeHash,
+      `+${PATIENT_OTP_TTL_SECONDS} seconds`,
+    ),
+  ]);
+
+  // Opportunistic cleanup; never needed to validate the current challenge.
+  await db.prepare(
+    "DELETE FROM patient_otp_challenges WHERE expires_at <= datetime('now', '-1 day')",
+  ).run().catch(() => undefined);
+
+  return { challengeId, code, expiresIn: PATIENT_OTP_TTL_SECONDS };
+}
+
+export async function verifyPatientOtpChallenge(
+  db: D1Database,
+  input: {
+    challengeId: string;
+    phoneNormalized: string;
+    code: string;
+    purpose?: string;
+  },
+): Promise<{ organizationId: number } | null> {
+  const code = normalizeOtp(input.code);
+  if (!/^[a-f0-9]{64}$/i.test(input.challengeId) || !input.phoneNormalized || !code) return null;
+  const purpose = (input.purpose || "cabinet_login").slice(0, 40);
+
+  const row = await db.prepare(
+    `SELECT organization_id AS organizationId, code_hash AS codeHash, attempts
+     FROM patient_otp_challenges
+     WHERE id = ? AND phone_normalized = ? AND purpose = ?
+       AND consumed_at = '' AND expires_at > CURRENT_TIMESTAMP
+       AND attempts < ?
+     LIMIT 1`,
+  ).bind(
+    input.challengeId,
+    input.phoneNormalized,
+    purpose,
+    PATIENT_OTP_MAX_ATTEMPTS,
+  ).first<{ organizationId: number; codeHash: string; attempts: number }>();
+  if (!row) return null;
+
+  const valid = await verifyPassword(code, row.codeHash);
+  if (!valid) {
+    await db.prepare(
+      `UPDATE patient_otp_challenges SET attempts = attempts + 1
+       WHERE id = ? AND consumed_at = '' AND attempts < ?`,
+    ).bind(input.challengeId, PATIENT_OTP_MAX_ATTEMPTS).run();
+    return null;
+  }
+
+  // One-time consumption is the replay guard. A simultaneous second verifier
+  // sees zero changed rows and cannot establish another authenticated session.
+  const consumed = await db.prepare(
+    `UPDATE patient_otp_challenges
+     SET consumed_at = CURRENT_TIMESTAMP, attempts = attempts + 1
+     WHERE id = ? AND phone_normalized = ? AND purpose = ?
+       AND consumed_at = '' AND expires_at > CURRENT_TIMESTAMP
+       AND attempts < ?`,
+  ).bind(
+    input.challengeId,
+    input.phoneNormalized,
+    purpose,
+    PATIENT_OTP_MAX_ATTEMPTS,
+  ).run();
+  return consumed.meta.changes ? { organizationId: row.organizationId } : null;
+}
+
+export async function createPatientSession(
+  db: D1Database,
+  phoneNormalized: string,
+  organizationId = 1,
+): Promise<string> {
   const rawToken = newSessionToken();
   const tokenHash = await hashToken(rawToken);
   await db.prepare(
-    `INSERT INTO patient_sessions (token_hash, phone_normalized, expires_at)
-     VALUES (?, ?, datetime('now', ?))`
-  ).bind(tokenHash, phoneNormalized, `+${PATIENT_SESSION_TTL_SECONDS} seconds`).run();
+    `INSERT INTO patient_sessions (token_hash, phone_normalized, organization_id, expires_at)
+     VALUES (?, ?, ?, datetime('now', ?))`,
+  ).bind(tokenHash, phoneNormalized, organizationId, `+${PATIENT_SESSION_TTL_SECONDS} seconds`).run();
   await db.prepare("DELETE FROM patient_sessions WHERE expires_at <= CURRENT_TIMESTAMP").run();
   return rawToken;
 }
@@ -25,11 +145,11 @@ export async function requirePatientSession(request: Request, db: D1Database) {
   if (!rawToken) return null;
   const tokenHash = await hashToken(rawToken);
   return db.prepare(
-    `SELECT phone_normalized AS phoneNormalized
+    `SELECT phone_normalized AS phoneNormalized, organization_id AS organizationId
      FROM patient_sessions
      WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP
-     LIMIT 1`
-  ).bind(tokenHash).first<{ phoneNormalized: string }>();
+     LIMIT 1`,
+  ).bind(tokenHash).first<{ phoneNormalized: string; organizationId: number }>();
 }
 
 export async function destroyPatientSession(request: Request, db: D1Database): Promise<void> {

--- a/lib/patient-auth.ts
+++ b/lib/patient-auth.ts
@@ -4,7 +4,7 @@ import {
   newSessionToken,
   readCookie,
   verifyPassword,
-} from "./auth";
+} from "./auth.ts";
 
 export const PATIENT_SESSION_COOKIE = "rid_patient";
 export const PATIENT_SESSION_TTL_SECONDS = 30 * 60;

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -7,487 +7,108 @@
 <meta name="description" content="Особистий кабінет пацієнта відділення променевої діагностики: статус заявок, дата запису та протокол дослідження."/>
 <meta name="robots" content="noindex"/>
 <meta name="theme-color" content="#123d3a"/>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%234f5d3e'/%3E%3Cpath d='M26 14h12v12h12v12H38v12H26V38H14V26h12z' fill='%23ef744d'/%3E%3C/svg%3E"/>
 <link rel="stylesheet" href="/site/assets/site.css">
 <style>
-
-:root{
-  --bg:#f3f6f8;--ink:#18302f;--muted:#5c6c78;--line:#dbe3e8;
-  --gold:#ef744d;--olive:var(--brand);
-  --grad:linear-gradient(135deg,var(--brand),var(--brand-dark));
-  --shadow:0 12px 32px rgba(18,40,30,.10);
-}
-*{box-sizing:border-box}
-body{margin:0;padding:14px 0 40px;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}
-a{text-decoration:none;color:inherit}
-.wrap{width:min(760px,calc(100% - 28px));margin:auto}
-
-header{padding:0 14px;margin-bottom:18px}
-.header-row{width:min(760px,100%);margin:0 auto;padding:18px 20px;border-radius:var(--r-xl);background:var(--grad);box-shadow:var(--shadow);display:flex;align-items:center;gap:14px;color:#fff}
-.header-title{flex:1;min-width:0}
-.header-title strong{display:block;font-size:clamp(18px,3vw,24px);font-weight:700}
-.header-title span{display:block;font-size:13px;color:#e5ecf0;margin-top:3px}
-.back-link{flex-shrink:0;padding:9px 14px;border-radius:var(--r-md);background:rgba(255,255,255,.14);font-size:13px;font-weight:700;color:#fff}
-.back-link:hover{background:rgba(255,255,255,.22)}
-
-.card{background:#fff;border:1px solid var(--line);border-radius:var(--r-lg);padding:20px;box-shadow:0 8px 24px rgba(24,34,19,.06)}
-.gate p{color:var(--muted);font-size:14px;margin:6px 0 14px}
-.phone-wrap{display:flex}
-.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:var(--r-md) 0 0 11px;background:#f2f6f8;font-weight:700;color:var(--brand)}
-.phone-wrap input{flex:1;min-width:0;padding:12px;border:1px solid #dbe3e8;border-radius:0 11px 11px 0;font:inherit}
-.phone-wrap input:focus{outline:2px solid var(--olive);outline-offset:1px;border-color:var(--olive)}
-.code-wrap{margin-top:12px}
-.code-wrap label{display:block;font-size:13px;font-weight:700;color:#33434d;margin-bottom:5px}
-.code-wrap input{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:var(--r-md);font:inherit;text-transform:uppercase}
-.code-wrap input:focus{outline:2px solid var(--olive);outline-offset:1px;border-color:var(--olive)}
-.gate .btn{margin-top:14px}
-.btn{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:48px;padding:0 18px;border:0;border-radius:var(--r-md);background:var(--olive);color:#fff;font:inherit;font-weight:800;cursor:pointer}
-.btn:disabled{opacity:.6}
-.btn.secondary{background:#eef2f5;color:#0e454c}
-.btn.danger{background:#fbe9e6;color:#a5352a}
-.gate-error{display:none;color:#c0392b;font-size:13px;margin-top:10px}
-.gate-error.show{display:block}
-
-.cab-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin:4px 2px 14px}
-.cab-head h1{font-size:20px;margin:0}
-.cab-phone{font-size:13px;color:var(--muted)}
-.logout{border:0;background:none;color:#0e454c;font:inherit;font-size:13px;font-weight:700;cursor:pointer;padding:6px}
-.tg-connect{display:flex;align-items:center;flex-wrap:wrap;gap:10px;margin:0 2px 14px;padding:12px 14px;background:#eef7f8;border:1px solid #d3e6e8;border-radius:var(--r-md);font-size:13px;color:#18302f}
-.tg-connect .btn-ghost{border:1px solid var(--olive);background:#fff;color:var(--olive);font:inherit;font-weight:800;font-size:13px;border-radius:var(--r-sm);padding:8px 14px;cursor:pointer}
-.tg-connect .btn-ghost:disabled{opacity:.5;cursor:not-allowed}
-.tg-connect-msg{flex-basis:100%;color:#3a5c58;font-size:12px}
-
-.app-card{margin-bottom:14px}
-.visit-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;margin:6px 2px 8px;color:#123d3a;font-size:13px}
-.visit-head b{font-size:14px}.visit-head small{color:#7c8a94}.visit-head strong{color:#123d3a}
-.visit-group{border-left:3px solid #bfe0e4;border-radius:var(--r-sm);padding-left:12px;margin-bottom:14px}
-.visit-group .app-card:last-child{margin-bottom:0}
-.bring-note{margin:10px 0 0;padding:9px 12px;background:#eef7f8;border:1px solid #cfe9ec;border-radius:var(--r-sm);color:#0e454c;font-size:12px}
-.app-top{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-.app-study{font-weight:800;font-size:16px}
-.app-meta{font-size:13px;color:var(--muted);margin-top:3px}
-.badge{flex-shrink:0;padding:5px 11px;border-radius:var(--r-pill);font-size:12px;font-weight:800;white-space:nowrap}
-.badge.new{background:#e6f4f6;color:#0a5f68}
-.badge.progress{background:#e6eef7;color:#3c6ba6}
-.badge.booked{background:#e6f4ea;color:#1e7a3d}
-.badge.done{background:var(--olive);color:#fff}
-.badge.cancelled{background:#fbe9e6;color:#a5352a}
-
-.stepper{display:grid;grid-template-columns:repeat(3,1fr);gap:0;margin:16px 0 4px;counter-reset:step}
-.step{position:relative;text-align:center;font-size:12px;color:#9fb0bb;padding-top:26px}
-.step::before{content:'';position:absolute;top:9px;left:calc(50% + 12px);right:calc(-50% + 12px);height:2px;background:#e0e7ec}
-.step:last-child::before{display:none}
-.step::after{content:'';position:absolute;top:2px;left:50%;transform:translateX(-50%);width:16px;height:16px;border-radius:50%;background:#e0e7ec}
-.step.on{color:#0e454c;font-weight:700}
-.step.on::after{background:var(--olive)}
-.step.on::before{background:var(--olive)}
-
-.actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:14px}
-.actions .btn{width:auto;flex:1;min-width:150px;min-height:44px}
-.pay-row{display:flex;gap:10px;align-items:center;background:#eef7f8;border:1px solid #d9eef0;border-radius:var(--r-md);padding:12px 14px;margin-top:14px;font-size:14px;color:#0e454c}
-.pay-row strong{font-weight:800}
-.payment-details{margin-top:12px;border:1px solid #d9eef0;border-radius:var(--r-md);overflow:hidden;background:#fff}
-.payment-detail{display:grid;grid-template-columns:100px minmax(0,1fr) auto;align-items:center;gap:10px;padding:9px 12px;border-bottom:1px solid #edf2f4;font-size:13px}
-.payment-detail:last-child{border-bottom:0}.payment-detail span{color:var(--muted)}.payment-detail b{overflow-wrap:anywhere}.copy-one{border:0;border-radius:var(--r-sm);padding:7px 9px;background:#e6f4f6;color:#0e5f67;font-weight:800;cursor:pointer}.copy-one:hover{background:#d7edf0}
-.copy-payment{margin-top:10px}.pay-note{margin:8px 2px 0;color:var(--muted);font-size:12px;text-align:center}
-.pay-toggle{margin-top:10px}.payment-panel{margin-top:10px;padding:14px;border:1px solid #d9eef0;border-radius:var(--r-lg);background:#f7fbfc}
-.payment-panel[hidden]{display:none}.payment-instructions{font-size:13px;color:#33434d}.payment-instructions b{font-size:15px;color:#0e454c}.payment-instructions ol{margin:8px 0 2px;padding-left:22px}.payment-instructions li{margin:5px 0}
-.bank-choice{margin-top:10px}.bank-details{margin-top:10px;border:1px solid #d9eef0;border-radius:var(--r-md);overflow:hidden;background:#fff}.bank-details[hidden]{display:none}.bank-title{padding:11px 12px;background:#eef7f8;font-size:14px;font-weight:800;color:#0e454c}
-
-.protocol{display:none;margin-top:14px;border:1px solid var(--line);border-radius:var(--r-lg);padding:18px;background:#fdfefe}
-.protocol.open{display:block}
-.protocol h4{margin:0 0 2px;font-size:15px}
-.protocol .p-org{font-size:12px;color:var(--muted);margin-bottom:12px}
-.p-field{margin:10px 0}
-.p-field b{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:#6c7c86;margin-bottom:3px}
-.p-field div{font-size:14px;white-space:pre-wrap}
-.p-caveat{margin-top:12px;font-size:11px;color:#8a98a2}
-.print-btn{margin-top:14px}
-
-.empty{text-align:center;color:var(--muted);padding:30px 10px}
-.empty a{color:#0e454c;font-weight:700}
-.hint{font-size:12px;color:var(--muted);text-align:center;margin-top:18px;line-height:1.5}
-.hint a{color:#0e454c;font-weight:700}
-
-@media print{
-  body{background:#fff;padding:0}
-  header,.cab-head,.gate,.hint,.logout,.actions,.app-top,.stepper{display:none!important}
-  .app-card{border:0;box-shadow:none;padding:0;margin:0}
-  .app-card:not(.printing){display:none!important}
-  .protocol{display:block!important;border:0;padding:0}
-}
+:root{--bg:#f3f6f8;--ink:#18302f;--muted:#5c6c78;--line:#dbe3e8;--olive:var(--brand);--grad:linear-gradient(135deg,var(--brand),var(--brand-dark));--shadow:0 12px 32px rgba(18,40,30,.10)}
+*{box-sizing:border-box}body{margin:0;padding:14px 0 40px;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:var(--bg);color:var(--ink);line-height:1.45}a{text-decoration:none;color:inherit}.wrap{width:min(760px,calc(100% - 28px));margin:auto}
+header{padding:0 14px;margin-bottom:18px}.header-row{width:min(760px,100%);margin:0 auto;padding:18px 20px;border-radius:var(--r-xl);background:var(--grad);box-shadow:var(--shadow);display:flex;align-items:center;gap:14px;color:#fff}.header-title{flex:1;min-width:0}.header-title strong{display:block;font-size:clamp(18px,3vw,24px);font-weight:700}.header-title span{display:block;font-size:13px;color:#e5ecf0;margin-top:3px}.back-link{flex-shrink:0;padding:9px 14px;border-radius:var(--r-md);background:rgba(255,255,255,.14);font-size:13px;font-weight:700;color:#fff}
+.card{background:#fff;border:1px solid var(--line);border-radius:var(--r-lg);padding:20px;box-shadow:0 8px 24px rgba(24,34,19,.06)}.gate p{color:var(--muted);font-size:14px;margin:6px 0 14px}.phone-wrap{display:flex}.phone-prefix{display:grid;place-items:center;padding:0 12px;border:1px solid #dbe3e8;border-right:0;border-radius:var(--r-md) 0 0 var(--r-md);background:#f2f6f8;font-weight:700;color:var(--brand)}.phone-wrap input{flex:1;min-width:0;padding:12px;border:1px solid #dbe3e8;border-radius:0 var(--r-md) var(--r-md) 0;font:inherit}.field{margin-top:12px}.field label{display:block;font-size:13px;font-weight:700;color:#33434d;margin-bottom:5px}.field input{width:100%;padding:12px;border:1px solid #dbe3e8;border-radius:var(--r-md);font:inherit}.otp-input{font-size:24px!important;letter-spacing:.35em;text-align:center;font-weight:800}.btn{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:48px;padding:0 18px;border:0;border-radius:var(--r-md);background:var(--olive);color:#fff;font:inherit;font-weight:800;cursor:pointer}.btn.secondary{background:#eef2f5;color:#0e454c}.btn.danger{background:#fbe9e6;color:#a5352a}.btn:disabled{opacity:.6}.gate .btn{margin-top:14px}.gate-error{display:none;color:#c0392b;font-size:13px;margin-top:10px}.gate-error.show{display:block}.gate-note{font-size:12px;color:var(--muted);margin-top:10px}.otp-step[hidden],#cabinet[hidden]{display:none}
+.cab-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin:4px 2px 14px}.cab-head h1{font-size:20px;margin:0}.cab-phone{font-size:13px;color:var(--muted)}.logout{border:0;background:none;color:#0e454c;font:inherit;font-size:13px;font-weight:700;cursor:pointer;padding:6px}.tg-connect{display:flex;align-items:center;flex-wrap:wrap;gap:10px;margin:0 2px 14px;padding:12px 14px;background:#eef7f8;border:1px solid #d3e6e8;border-radius:var(--r-md);font-size:13px}.tg-connect .btn-ghost{border:1px solid var(--olive);background:#fff;color:var(--olive);font:inherit;font-weight:800;font-size:13px;border-radius:var(--r-sm);padding:8px 14px;cursor:pointer}.tg-connect-msg{flex-basis:100%;color:#3a5c58;font-size:12px}
+.app-card{margin-bottom:14px}.visit-head{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;margin:6px 2px 8px;color:#123d3a;font-size:13px}.visit-head b{font-size:14px}.visit-head small{color:#7c8a94}.visit-group{border-left:3px solid #bfe0e4;border-radius:var(--r-sm);padding-left:12px;margin-bottom:14px}.app-top{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}.app-study{font-weight:800;font-size:16px}.app-meta{font-size:13px;color:var(--muted);margin-top:3px}.badge{flex-shrink:0;padding:5px 11px;border-radius:var(--r-pill);font-size:12px;font-weight:800}.badge.new{background:#e6f4f6;color:#0a5f68}.badge.booked{background:#e6f4ea;color:#1e7a3d}.badge.done{background:var(--olive);color:#fff}.badge.cancelled{background:#fbe9e6;color:#a5352a}.bring-note{margin:10px 0 0;padding:9px 12px;background:#eef7f8;border:1px solid #cfe9ec;border-radius:var(--r-sm);color:#0e454c;font-size:12px}.actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:14px}.actions .btn{width:auto;flex:1;min-width:150px;min-height:44px}.pay-row{margin-top:14px;padding:12px 14px;background:#eef7f8;border:1px solid #d9eef0;border-radius:var(--r-md);font-size:14px}.payment-panel{margin-top:10px;padding:14px;border:1px solid #d9eef0;border-radius:var(--r-lg);background:#f7fbfc}.payment-panel[hidden]{display:none}.payment-detail{display:grid;grid-template-columns:100px minmax(0,1fr) auto;gap:10px;padding:8px 0;font-size:13px}.payment-detail span{color:var(--muted)}.copy-one{border:0;border-radius:var(--r-sm);padding:7px 9px;background:#e6f4f6;color:#0e5f67;font-weight:800;cursor:pointer}.protocol{display:none;margin-top:14px;border:1px solid var(--line);border-radius:var(--r-lg);padding:18px;background:#fdfefe}.protocol.open{display:block}.p-field{margin:10px 0}.p-field b{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:#6c7c86}.p-field div{font-size:14px;white-space:pre-wrap}.empty{text-align:center;color:var(--muted);padding:30px 10px}.hint{font-size:12px;color:var(--muted);text-align:center;margin-top:18px}
+@media print{body{background:#fff;padding:0}header,.cab-head,.gate,.hint,.logout,.actions,.app-top{display:none!important}.app-card{border:0;box-shadow:none;padding:0;margin:0}.app-card:not(.printing){display:none!important}.protocol{display:block!important;border:0;padding:0}}
 </style>
 </head>
 <body>
-
-<header>
-  <div class="header-row">
-    <div class="header-title">
-      <strong>Особистий кабінет</strong>
-      <span>Відділення променевої діагностики</span>
-    </div>
-    <a class="back-link" href="/">← На сайт</a>
-  </div>
-</header>
-
+<header><div class="header-row"><div class="header-title"><strong>Особистий кабінет</strong><span>Відділення променевої діагностики</span></div><a class="back-link" href="/">← На сайт</a></div></header>
 <main class="wrap">
-
-  <!-- Вхід за номером телефону та датою народження -->
   <div class="card gate" id="gate">
-    <h1 style="margin:0;font-size:20px">Вхід до кабінету</h1>
-    <p>Введіть номер телефону та дату народження, які ви вказали під час запису.</p>
-    <div class="phone-wrap">
-      <span class="phone-prefix">+380</span>
-      <input id="gatePhone" inputmode="numeric" maxlength="9" placeholder="97 000 00 00" aria-label="Номер телефону"/>
+    <div id="identityStep">
+      <h1 style="margin:0;font-size:20px">Вхід до кабінету</h1>
+      <p>Вкажіть номер телефону та дату народження. Після цього ми надішлемо одноразовий SMS-код.</p>
+      <div class="phone-wrap"><span class="phone-prefix">+380</span><input id="gatePhone" inputmode="numeric" maxlength="9" autocomplete="tel-national" placeholder="97 000 00 00" aria-label="Номер телефону"/></div>
+      <div class="field"><label for="gateDob">Дата народження</label><input id="gateDob" type="date" min="1900-01-01" autocomplete="bday"/></div>
+      <button class="btn" id="requestOtpBtn" type="button">Отримати код</button>
+      <div class="gate-note">Медичні результати не відкриваються лише за номером телефону, датою народження або номером заявки.</div>
     </div>
-    <div class="code-wrap">
-      <label for="gateDob">Дата народження</label>
-      <input id="gateDob" type="date" min="1900-01-01" aria-label="Дата народження" autocomplete="bday"/>
+    <div class="otp-step" id="otpStep" hidden>
+      <h1 style="margin:0;font-size:20px">Підтвердження номера</h1>
+      <p id="otpMessage">Введіть 6 цифр із SMS. Код діє 5 хвилин і використовується один раз.</p>
+      <div class="field"><label for="otpCode">Код підтвердження</label><input class="otp-input" id="otpCode" inputmode="numeric" maxlength="6" autocomplete="one-time-code" placeholder="000000"/></div>
+      <button class="btn" id="verifyOtpBtn" type="button">Увійти до кабінету</button>
+      <button class="btn secondary" id="backOtpBtn" type="button">Змінити номер або дату</button>
     </div>
     <span class="gate-error" id="gateError"></span>
-    <button class="btn" id="gateBtn" type="button">Переглянути заявки</button>
   </div>
 
-  <!-- Кабінет -->
   <div id="cabinet" hidden>
-    <div class="cab-head">
-      <div>
-        <h1>Мої заявки</h1>
-        <div class="cab-phone" id="cabPhone"></div>
-      </div>
-      <button class="logout" id="logoutBtn" type="button">Вийти</button>
-    </div>
-    <div class="tg-connect" id="tgConnect" hidden>
-      <span>📩 Отримувати сповіщення про дослідження в Telegram?</span>
-      <button class="btn-ghost" id="tgConnectBtn" type="button">Підключити Telegram</button>
-      <span class="tg-connect-msg" id="tgConnectMsg"></span>
-    </div>
+    <div class="cab-head"><div><h1>Мої заявки</h1><div class="cab-phone" id="cabPhone"></div></div><button class="logout" id="logoutBtn" type="button">Вийти</button></div>
+    <div class="tg-connect" id="tgConnect" hidden><span>📩 Отримувати сповіщення про дослідження в Telegram?</span><button class="btn-ghost" id="tgConnectBtn" type="button">Підключити Telegram</button><span class="tg-connect-msg" id="tgConnectMsg"></span></div>
     <div id="appList"></div>
-    <div class="empty" id="emptyState" hidden>
-      За цим номером заявок не знайдено.<br/>
-      <a href="/site/price.html">Подати заявку →</a>
-    </div>
-    <p class="hint">Показуються заявки, оформлені на цей номер телефону. Протокол дослідження стає доступним після того, як лікар його видасть.</p>
+    <div class="empty" id="emptyState" hidden>За цим номером заявок не знайдено.<br/><a href="/site/price.html">Подати заявку →</a></div>
+    <p class="hint">Протокол стає доступним після того, як лікар його видасть. Для повторного входу потрібне нове підтвердження номера.</p>
   </div>
-
 </main>
-
 <script src="/site/assets/qrgen.js"></script>
 <script>
 const MY_BOOKINGS = '/api/my-bookings';
 const STATUS_API = '/api/booking-status';
 const PROTOCOL_API = '/api/my-protocol';
+const OTP_API = '/api/patient-otp';
 const PATIENT_PREFILL_KEY = 'radiologyos_patient_prefill_v1';
-
 const statusMeta = {
-  new:               { badge: 'new',       label: 'Заявку отримано',    step: 'new' },
-  requested:         { badge: 'new',       label: 'Заявка',            step: 'new' },
-  needs_verification:{ badge: 'new',       label: 'Потребує перевірки',step: 'new' },
-  scheduled:         { badge: 'booked',    label: 'Заплановано',       step: 'booked' },
-  confirmed:         { badge: 'booked',    label: 'Підтверджена',      step: 'booked' },
-  rescheduled:       { badge: 'booked',    label: 'Перенесена',        step: 'booked' },
-  arrived:           { badge: 'booked',    label: 'Прибуття',          step: 'booked' },
-  queued:            { badge: 'booked',    label: 'У черзі',           step: 'booked' },
-  in_progress:       { badge: 'booked',    label: 'Виконується',       step: 'booked' },
-  performed:         { badge: 'booked',    label: 'Виконано',          step: 'done' },
-  images_ready:      { badge: 'booked',    label: 'Зображення готові', step: 'done' },
-  reporting:         { badge: 'booked',    label: 'Готуємо висновок',  step: 'done' },
-  protocol_ready:    { badge: 'done',      label: 'Протокол готовий',  step: 'done' },
-  issued:            { badge: 'done',      label: 'Видано',            step: 'done' },
-  completed:         { badge: 'done',      label: 'Виконана',          step: 'done' },
-  cancelled:         { badge: 'cancelled', label: 'Скасована',         step: 'cancelled' },
-  no_show:           { badge: 'cancelled', label: 'Неявка',            step: 'cancelled' },
+  new:{badge:'new',label:'Заявку отримано'},requested:{badge:'new',label:'Заявка'},needs_verification:{badge:'new',label:'Потребує перевірки'},scheduled:{badge:'booked',label:'Заплановано'},confirmed:{badge:'booked',label:'Підтверджена'},rescheduled:{badge:'booked',label:'Перенесена'},arrived:{badge:'booked',label:'Прибуття'},queued:{badge:'booked',label:'У черзі'},in_progress:{badge:'booked',label:'Виконується'},performed:{badge:'booked',label:'Виконано'},images_ready:{badge:'booked',label:'Зображення готові'},reporting:{badge:'booked',label:'Готуємо висновок'},protocol_ready:{badge:'done',label:'Протокол готовий'},issued:{badge:'done',label:'Видано'},completed:{badge:'done',label:'Виконана'},cancelled:{badge:'cancelled',label:'Скасована'},no_show:{badge:'cancelled',label:'Неявка'}
 };
-const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#2f5aa0;' }[m]));
-const humanDate = (iso) => (iso ? String(iso).split('-').reverse().join('.') : '');
-const money = (n) => new Intl.NumberFormat('uk-UA').format(Number(n) || 0);
-const isPayUrl = (s) => /^https?:\/\//i.test(String(s || ''));
-function payQrImg(payload) {
-  if (!payload || typeof qrcode !== 'function') return '';
-  try { const qr = qrcode(0, 'M'); qr.addData(payload); qr.make(); return qr.createImgTag(4, 6); }
-  catch (e) { return ''; }
-}
+const esc=(s)=>String(s==null?'':s).replace(/[&<>"']/g,(m)=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+const humanDate=(iso)=>(iso?String(iso).split('-').reverse().join('.'):'');
+const money=(n)=>new Intl.NumberFormat('uk-UA').format(Number(n)||0);
+const isPayUrl=(s)=>/^https?:\/\//i.test(String(s||''));
+function payQrImg(payload){if(!payload||typeof qrcode!=='function')return '';try{const qr=qrcode(0,'M');qr.addData(payload);qr.make();return qr.createImgTag(4,6)}catch(e){return ''}}
 
-const gate = document.getElementById('gate');
-const cabinet = document.getElementById('cabinet');
-const errorBox = document.getElementById('gateError');
-let phoneDigits = '';
-let dobValue = '';
-let payLink = '';
-let savedAutoEnter = false;
+const gate=document.getElementById('gate');const cabinet=document.getElementById('cabinet');const errorBox=document.getElementById('gateError');const identityStep=document.getElementById('identityStep');const otpStep=document.getElementById('otpStep');
+let phoneDigits='';let dobValue='';let challengeId='';let payLink='';
+function showError(message){errorBox.textContent=message;errorBox.classList.add('show')}
+function clearError(){errorBox.textContent='';errorBox.classList.remove('show')}
+function adultDobLimit(){const today=new Date();const limit=new Date(today.getFullYear()-18,today.getMonth(),today.getDate());return `${limit.getFullYear()}-${String(limit.getMonth()+1).padStart(2,'0')}-${String(limit.getDate()).padStart(2,'0')}`}
+document.getElementById('gateDob').max=adultDobLimit();
+try{const saved=JSON.parse(sessionStorage.getItem(PATIENT_PREFILL_KEY)||'null');if(saved&&/^\d{9}$/.test(String(saved.phone||'')))document.getElementById('gatePhone').value=saved.phone;if(saved&&/^\d{4}-\d{2}-\d{2}$/.test(String(saved.dob||'')))document.getElementById('gateDob').value=saved.dob}catch(e){}
 
-function adultDobLimit() {
-  const today = new Date();
-  const limit = new Date(today.getFullYear() - 18, today.getMonth(), today.getDate());
-  return `${limit.getFullYear()}-${String(limit.getMonth() + 1).padStart(2, '0')}-${String(limit.getDate()).padStart(2, '0')}`;
-}
-
-document.getElementById('gateDob').max = adultDobLimit();
-try {
-  const saved = JSON.parse(sessionStorage.getItem(PATIENT_PREFILL_KEY) || 'null');
-  if (saved && /^\d{9}$/.test(String(saved.phone || ''))) {
-    document.getElementById('gatePhone').value = saved.phone;
-  }
-  if (saved && /^\d{4}-\d{2}-\d{2}$/.test(String(saved.dob || ''))) {
-    document.getElementById('gateDob').value = saved.dob;
-  }
-  savedAutoEnter = Boolean(saved && saved.autoEnter);
-} catch (e) { /* залишаємо поля порожніми */ }
-
-function showError(message) { errorBox.textContent = message; errorBox.classList.add('show'); }
-
-function stepper(status) {
-  const order = ['new', 'booked', 'done'];
-  const labels = ['Заявку отримано', 'Запис підтверджено', 'Виконано'];
-  const step = (statusMeta[status] || {}).step || 'new';
-  const idx = order.indexOf(step);
-  return '<div class="stepper">' + labels.map((l, i) =>
-    `<div class="step ${i <= idx ? 'on' : ''}">${l}</div>`).join('') + '</div>';
-}
-
-function cardHtml(b) {
-  const meta = statusMeta[b.status] || { badge: 'new', label: b.status };
-  const badgeLabel = b.statusLabel || meta.label;
-  const org = b.organization ? ' · ' + esc(b.organization) : '';
-  const whenPrefix = ['new', 'requested', 'needs_verification'].includes(b.status) ? 'Попередньо призначено' : 'Призначено';
-  const when = b.desiredDate ? `${whenPrefix}: ${esc(humanDate(b.desiredDate))}${b.desiredTime ? ' о ' + esc(b.desiredTime) : ''}` : '';
-  const canCancel = ['new', 'confirmed', 'rescheduled'].includes(b.status);
-  const awaitingPayment = b.paymentStatus === 'pending' && Number(b.paymentAmount) > 0 && b.status !== 'cancelled' && b.status !== 'completed';
-  const serviceWithCode = [b.serviceCode, b.service].filter(Boolean).join(' · ');
-  // Номер заявки (RD-…) у призначенні — єдиний ключ звірки платежу з бронюванням.
+function cardHtml(b){
+  const meta=statusMeta[b.status]||{badge:'new',label:b.status};
+  const badgeLabel=b.statusLabel || meta.label;
+  const org=b.organization?` · ${esc(b.organization)}`:'';
+  const when=b.desiredDate?`${esc(humanDate(b.desiredDate))}${b.desiredTime?' о '+esc(b.desiredTime):''}`:'';
+  const canCancel=['new','confirmed','rescheduled'].includes(b.status);
+  const awaitingPayment=b.paymentStatus==='pending'&&Number(b.paymentAmount)>0&&b.status!=='cancelled'&&b.status!=='completed';
+  const serviceWithCode=[b.serviceCode,b.service].filter(Boolean).join(' · ');
   const paymentPurpose = `Сплата за медичні послуги, заявка ${b.code}${b.serviceCode ? ', код ' + b.serviceCode : ''}: ${b.service}`;
-  return `<div class="card app-card" id="card-${esc(b.code)}">
-    <div class="app-top">
-      <div>
-        <div class="app-study">${esc(b.service)}</div>
-        <div class="app-meta"><b>№ заявки: ${esc(b.code)}</b>${(org || when) ? ' · ' : ''}${org ? org.slice(3) : ''}${org && when ? ' · ' : ''}${when}</div>
-      </div>
-      <span class="badge ${meta.badge}">${esc(badgeLabel)}</span>
-    </div>
-    ${b.status !== 'cancelled' ? stepper(b.status) : ''}
-    ${(b.status !== 'cancelled' && b.status !== 'completed') ? `<div class="bring-note">🪪 Візьміть із собою: ${b.category === 'military' ? 'направлення та ' : ''}документ, що посвідчує особу.</div>` : ''}
-    ${awaitingPayment ? `<div class="pay-row">💳 <span>До сплати: <strong>${esc(money(b.paymentAmount))} грн</strong></span></div>
-      <button class="btn pay-toggle" type="button" data-pay-toggle="${esc(b.code)}">Сплатити</button>
-      <div class="payment-panel" id="payment-${esc(b.code)}" hidden>
-        <div class="payment-instructions"><b>Як оплатити</b><ol>
-          <li>Для швидкої оплати натисніть «Сплатити карткою будь-якого банку».</li>
-          <li>Можна використати картку Monobank, Ощадбанку або іншого українського банку.</li>
-          <li>Або відкрийте реквізити IBAN і створіть платіж у застосунку свого банку.</li>
-        </ol></div>
-        <div class="payment-details">
-          <div class="payment-detail"><span>Платник</span><b>${esc(b.patientName || '')}</b><button class="copy-one" type="button" data-copy-value="${esc(b.patientName || '')}">Копіювати</button></div>
-          <div class="payment-detail"><span>Послуга</span><b>${esc(serviceWithCode)}</b><button class="copy-one" type="button" data-copy-value="${esc(serviceWithCode)}">Копіювати</button></div>
-          <div class="payment-detail"><span>Сума</span><b>${esc(money(b.paymentAmount))} грн</b><button class="copy-one" type="button" data-copy-value="${esc(money(b.paymentAmount))}">Копіювати</button></div>
-          <div class="payment-detail"><span>Призначення</span><b>${esc(paymentPurpose)}</b><button class="copy-one" type="button" data-copy-value="${esc(paymentPurpose)}">Копіювати</button></div>
-        </div>
-        ${payLink ? `<div class="pay-qr" style="text-align:center;margin:12px 0 8px">${payQrImg(payLink)}<div style="font-size:12px;color:#7c8a94;margin-top:4px">Відскануйте QR камерою або відкрийте Privat24 кнопкою нижче</div></div>` : ''}
-        ${isPayUrl(payLink) ? `<button class="btn" type="button" data-open-payment data-url="${esc(payLink)}" data-name="${esc(b.patientName || '')}">Сплатити карткою будь-якого банку</button>` : ''}
-        <button class="btn secondary bank-choice" type="button" data-bank-toggle="${esc(b.code)}">Оплатити через Monobank / Ощад за IBAN</button>
-        <div class="bank-details" id="bank-${esc(b.code)}" hidden>
-          <div class="bank-title">Реквізити для платежу за IBAN</div>
-          <div class="payment-detail"><span>Отримувач</span><b>Військова частина А3120</b><button class="copy-one" type="button" data-copy-value="Військова частина А3120">Копіювати</button></div>
-          <div class="payment-detail"><span>IBAN</span><b>UA27 820172 0313 2510 0120 2006000</b><button class="copy-one" type="button" data-copy-value="UA278201720313251001202006000">Копіювати</button></div>
-          <div class="payment-detail"><span>ЄДРПОУ</span><b>08296098</b><button class="copy-one" type="button" data-copy-value="08296098">Копіювати</button></div>
-          <div class="payment-detail"><span>Сума</span><b>${esc(money(b.paymentAmount))} грн</b><button class="copy-one" type="button" data-copy-value="${esc(money(b.paymentAmount))}">Копіювати</button></div>
-          <div class="payment-detail"><span>Призначення</span><b>${esc(paymentPurpose)}</b><button class="copy-one" type="button" data-copy-value="${esc(paymentPurpose)}">Копіювати</button></div>
-        </div>
-      </div>` : ''}
-    <div class="actions">      ${b.hasProtocol ? `<button class="btn secondary" type="button" data-protocol="${esc(b.code)}">Переглянути протокол</button>` : ''}
-      ${canCancel ? `<button class="btn danger" type="button" data-cancel="${esc(b.code)}">Скасувати заявку</button>` : ''}
-    </div>
-    <div class="protocol" id="prot-${esc(b.code)}"></div>
-  </div>`;
+  return `<div class="card app-card" id="card-${esc(b.code)}"><div class="app-top"><div><div class="app-study">${esc(b.service)}</div><div class="app-meta"><b>№ заявки: ${esc(b.code)}</b>${org}${when?' · '+when:''}</div></div><span class="badge ${meta.badge}">${esc(badgeLabel)}</span></div>
+  ${(b.status!=='cancelled'&&b.status!=='completed')?`<div class="bring-note">🪪 Візьміть із собою: ${b.category === 'military' ? 'направлення та ' : ''}документ, що посвідчує особу.</div>`:''}
+  ${awaitingPayment?`<div class="pay-row">💳 До сплати: <strong>${esc(money(b.paymentAmount))} грн</strong></div><button class="btn secondary" type="button" data-pay-toggle="${esc(b.code)}">Сплатити</button><div class="payment-panel" id="payment-${esc(b.code)}" hidden><div class="payment-detail"><span>Послуга</span><b>${esc(serviceWithCode)}</b><button class="copy-one" data-copy-value="${esc(serviceWithCode)}">Копіювати</button></div><div class="payment-detail"><span>Сума</span><b>${esc(money(b.paymentAmount))} грн</b><button class="copy-one" data-copy-value="${esc(money(b.paymentAmount))}">Копіювати</button></div><div class="payment-detail"><span>Призначення</span><b>${esc(paymentPurpose)}</b><button class="copy-one" data-copy-value="${esc(paymentPurpose)}">Копіювати</button></div>${payLink ? `<div class="pay-qr" style="text-align:center;margin:12px 0 8px">${payQrImg(payLink)}</div>` : ''}${isPayUrl(payLink)?`<button class="btn" type="button" data-open-payment data-url="${esc(payLink)}">Сплатити карткою будь-якого банку</button>`:''}</div>`:''}
+  <div class="actions">${b.hasProtocol?`<button class="btn secondary" type="button" data-protocol="${esc(b.code)}">Переглянути протокол</button>`:''}${canCancel?`<button class="btn danger" type="button" data-cancel="${esc(b.code)}">Скасувати заявку</button>`:''}</div><div class="protocol" id="prot-${esc(b.code)}"></div></div>`;
+}
+function studyWord(n){const t=n%10,h=n%100;return(t===1&&h!==11)?'дослідження':(t>=2&&t<=4&&(h<12||h>14))?'дослідження':'досліджень'}
+function renderBookings(items){let html='',i=0;while(i<items.length){const group=[items[i]];while(i+1<items.length&&items[i + 1].createdAt&&items[i + 1].createdAt === items[i].createdAt){group.push(items[i+1]);i+=1}i+=1;if(group.length>1){const pending=group.filter((b)=>b.paymentStatus==='pending'&&Number(b.paymentAmount)>0&&b.status!=='cancelled'&&b.status!=='completed');const total=pending.reduce((s,b)=>s+Number(b.paymentAmount||0),0);html+=`<div class="visit-head"><b>Візит · ${group.length} ${studyWord(group.length)}</b>${total>0?` · <span>разом до сплати: <strong>${esc(money(total))} грн</strong></span>`:''}</div><div class="visit-group">${group.map(cardHtml).join('')}</div>`}else html+=cardHtml(group[0])}return html}
+
+async function loadBookings(){
+  try{const pr=await fetch('/api/pay-link',{cache:'no-store'});const pd=await pr.json().catch(()=>({}));payLink=pd.payLink||''}catch(e){payLink=''}
+  const res=await fetch(MY_BOOKINGS,{method:'POST',headers:{'content-type':'application/json'}});const data=await res.json().catch(()=>({}));if(!res.ok){showError(data.error||'Не вдалося завантажити заявки');return false}
+  const list=document.getElementById('appList');const bookings=data.bookings||[];document.getElementById('emptyState').hidden=bookings.length>0;list.innerHTML = renderBookings(bookings);
+  list.querySelectorAll('[data-cancel]').forEach((b)=>b.addEventListener('click',()=>cancelBooking(b.dataset.cancel)));list.querySelectorAll('[data-protocol]').forEach((b)=>b.addEventListener('click',()=>toggleProtocol(b.dataset.protocol,b)));list.querySelectorAll('[data-pay-toggle]').forEach((b)=>b.addEventListener('click',()=>{const p=document.getElementById('payment-'+b.dataset.payToggle);p.hidden=!p.hidden}));list.querySelectorAll('[data-copy-value]').forEach((b)=>b.addEventListener('click',()=>navigator.clipboard?.writeText(b.dataset.copyValue||'')));list.querySelectorAll('[data-open-payment]').forEach((b)=>b.addEventListener('click',()=>window.open(b.dataset.url,'_blank','noopener')));return true
 }
 
-// Заявки одного сабміту (КТ+рентген тощо) мають однаковий created_at і йдуть
-// поспіль — групуємо їх в один «візит», щоб не виглядало як задвоєння.
-function studyWord(n) { const t = n % 10, h = n % 100; return (t === 1 && h !== 11) ? 'дослідження' : (t >= 2 && t <= 4 && (h < 12 || h > 14)) ? 'дослідження' : 'досліджень'; }
-function renderBookings(items) {
-  let html = '', i = 0;
-  while (i < items.length) {
-    const group = [items[i]];
-    while (i + 1 < items.length && items[i + 1].createdAt && items[i + 1].createdAt === items[i].createdAt) { group.push(items[i + 1]); i += 1; }
-    i += 1;
-    if (group.length > 1) {
-      const pending = group.filter((b) => b.paymentStatus === 'pending' && Number(b.paymentAmount) > 0 && b.status !== 'cancelled' && b.status !== 'completed');
-      const total = pending.reduce((s, b) => s + Number(b.paymentAmount || 0), 0);
-      const day = (group[0].createdAt || '').slice(0, 10);
-      html += `<div class="visit-head"><b>Візит · ${group.length} ${studyWord(group.length)}</b>${day ? ` · <small>${esc(day)}</small>` : ''}${total > 0 ? ` · <span>разом до сплати: <strong>${esc(money(total))} грн</strong></span>` : ''}</div>`;
-      html += `<div class="visit-group">${group.map(cardHtml).join('')}</div>`;
-    } else {
-      html += cardHtml(group[0]);
-    }
-  }
-  return html;
+async function requestOtp(){
+  clearError();const digits=document.getElementById('gatePhone').value.replace(/\D/g,'');const dob=document.getElementById('gateDob').value.trim();if(digits.length!==9){showError('Введіть 9 цифр номера');return}if(!/^\d{4}-\d{2}-\d{2}$/.test(dob)){showError('Вкажіть дату народження');return}
+  const btn=document.getElementById('requestOtpBtn');btn.disabled=true;phoneDigits=digits;dobValue=dob;try{const res=await fetch(OTP_API,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({phone:'+380'+digits,dob})});const data=await res.json().catch(()=>({}));if(!res.ok){showError(data.error||'Не вдалося надіслати код');return}challengeId=data.challengeId||'';if(!challengeId){showError('Не вдалося створити перевірку');return}identityStep.hidden=true;otpStep.hidden=false;document.getElementById('otpMessage').textContent=data.message||'Введіть 6 цифр із SMS. Код діє 5 хвилин.';document.getElementById('otpCode').focus()}catch(e){showError('Помилка мережі — спробуйте ще раз.')}finally{btn.disabled=false}
 }
+async function verifyOtp(){
+  clearError();const code=document.getElementById('otpCode').value.replace(/\D/g,'');if(code.length!==6){showError('Введіть 6 цифр коду підтвердження');return}const btn=document.getElementById('verifyOtpBtn');btn.disabled=true;try{const res=await fetch(OTP_API,{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({phone:'+380'+phoneDigits,challengeId,code})});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){showError(data.error||'Не вдалося підтвердити код');return}document.getElementById('cabPhone').textContent='+380 '+phoneDigits.replace(/(\d{2})(\d{3})(\d{2})(\d{2})/,'$1 $2 $3 $4');const loaded=await loadBookings();if(loaded){gate.hidden=true;cabinet.hidden=false;document.getElementById('tgConnect').hidden=false;try{sessionStorage.setItem(PATIENT_PREFILL_KEY,JSON.stringify({phone:phoneDigits,dob:dobValue,autoEnter:false}))}catch(e){}}}finally{btn.disabled=false}
+}
+async function cancelBooking(code){if(!confirm('Скасувати цю заявку?'))return;const res=await fetch(STATUS_API,{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({code,action:'cancel'})});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){alert(data.error||'Не вдалося скасувати заявку');return}loadBookings()}
+async function toggleProtocol(code,btn){const box=document.getElementById('prot-'+code);if(box.classList.contains('open')){box.classList.remove('open');return}if(!box.dataset.loaded){btn.disabled=true;try{const res=await fetch(PROTOCOL_API,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({code})});const data=await res.json().catch(()=>({}));if(!res.ok||!data.protocol){alert(data.error||'Протокол недоступний');return}const p=data.protocol;box.innerHTML=`<h4>Протокол променевого дослідження ${p.number?'№ '+esc(p.number):''}</h4><div class="p-field"><b>Пацієнт</b><div>${esc(p.patient)}</div></div><div class="p-field"><b>Дослідження</b><div>${esc(p.service)}${p.method?' · '+esc(p.method):''}</div></div>${p.findings?`<div class="p-field"><b>Опис</b><div>${esc(p.findings)}</div></div>`:''}<div class="p-field"><b>Висновок</b><div>${esc(p.conclusion||'—')}</div></div>${p.recommendations?`<div class="p-field"><b>Рекомендації</b><div>${esc(p.recommendations)}</div></div>`:''}<button class="btn secondary" type="button" data-print="${esc(code)}">🖨 Роздрукувати / зберегти PDF</button>`;box.dataset.loaded='1';box.querySelector('[data-print]').addEventListener('click',()=>{const card=document.getElementById('card-'+code);card.classList.add('printing');window.print();card.classList.remove('printing')})}finally{btn.disabled=false}}box.classList.add('open')}
+async function connectTelegram(){const btn=document.getElementById('tgConnectBtn'),msg=document.getElementById('tgConnectMsg');btn.disabled=true;try{const res=await fetch('/api/my-telegram-link',{method:'POST'});const data=await res.json().catch(()=>({}));if(!res.ok||!data.url){msg.textContent=data.error||'Не вдалося створити посилання';return}window.open(data.url,'_blank','noopener');msg.textContent='Відкрили Telegram — натисніть «Старт» у боті.'}finally{btn.disabled=false}}
 
-async function loadBookings() {
-  try {
-    const pr = await fetch('/api/pay-link', { cache: 'no-store' });
-    const pd = await pr.json().catch(() => ({}));
-    payLink = (pd && pd.payLink) || '';
-  } catch (e) { payLink = ''; }
-  const res = await fetch(MY_BOOKINGS, {
-    method: 'POST', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ phone: '+380' + phoneDigits, dob: dobValue }),
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok) { showError(data.error || 'Не вдалося завантажити заявки'); return false; }
-  const list = document.getElementById('appList');
-  const bookings = data.bookings || [];
-  document.getElementById('emptyState').hidden = bookings.length > 0;
-  list.innerHTML = renderBookings(bookings);
-  list.querySelectorAll('[data-cancel]').forEach((b) => b.addEventListener('click', () => cancelBooking(b.dataset.cancel)));
-  list.querySelectorAll('[data-pay-toggle]').forEach((button) => button.addEventListener('click', () => togglePayment(button)));
-  list.querySelectorAll('[data-copy-value]').forEach((button) => button.addEventListener('click', () => copySingleValue(button)));
-  list.querySelectorAll('[data-open-payment]').forEach((button) => button.addEventListener('click', () => openPayment(button)));
-  list.querySelectorAll('[data-bank-toggle]').forEach((button) => button.addEventListener('click', () => toggleBankDetails(button)));
-  list.querySelectorAll('[data-protocol]').forEach((b) => b.addEventListener('click', () => toggleProtocol(b.dataset.protocol, b)));
-  return true;
-}
-
-function togglePayment(button) {
-  const panel = document.getElementById('payment-' + button.dataset.payToggle);
-  if (!panel) return;
-  const opening = panel.hidden;
-  panel.hidden = !opening;
-  button.textContent = opening ? 'Сховати оплату' : 'Сплатити';
-}
-async function copySingleValue(button) {
-  const value = button.dataset.copyValue || '';
-  try {
-    await navigator.clipboard.writeText(value);
-    const old = button.textContent;
-    button.textContent = 'Скопійовано ✓';
-    window.setTimeout(() => { button.textContent = old; }, 1600);
-  } catch (e) {
-    window.prompt('Скопіюйте значення', value);
-  }
-}
-
-function toggleBankDetails(button) {
-  const panel = document.getElementById('bank-' + button.dataset.bankToggle);
-  if (!panel) return;
-  const opening = panel.hidden;
-  panel.hidden = !opening;
-  button.textContent = opening ? 'Сховати реквізити IBAN' : 'Оплатити через Monobank / Ощад за IBAN';
-}
-function openPayment(button) {
-  const name = button.dataset.name || '';
-  if (name) navigator.clipboard?.writeText(name).catch(() => {});
-  window.open(button.dataset.url || payLink, '_blank', 'noopener');
-  button.textContent = 'Privat24 відкрито · ПІБ скопійовано';
-  window.setTimeout(() => { button.textContent = 'Сплатити карткою будь-якого банку'; }, 2200);
-}
-async function enter(digits, dob) {
-  phoneDigits = digits;
-  dobValue = dob;
-  document.getElementById('cabPhone').textContent = '+380 ' + digits.replace(/(\d{2})(\d{3})(\d{2})(\d{2})/, '$1 $2 $3 $4');
-  const loaded = await loadBookings();
-  if (loaded) { gate.hidden = true; cabinet.hidden = false; document.getElementById('tgConnect').hidden = false; }
-}
-
-async function connectTelegram() {
-  const btn = document.getElementById('tgConnectBtn');
-  const msg = document.getElementById('tgConnectMsg');
-  btn.disabled = true; msg.textContent = '';
-  try {
-    const res = await fetch('/api/my-telegram-link', { method: 'POST' });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || !data.url) { msg.textContent = data.error || 'Не вдалося створити посилання'; return; }
-    window.open(data.url, '_blank', 'noopener');
-    msg.textContent = 'Відкрили Telegram — натисніть «Старт» у боті, щоб підключити.';
-  } catch (e) {
-    msg.textContent = 'Помилка мережі — спробуйте ще раз.';
-  } finally {
-    btn.disabled = false;
-  }
-}
-
-async function cancelBooking(code) {
-  if (!confirm('Скасувати цю заявку?')) return;
-  const res = await fetch(STATUS_API, {
-    method: 'PATCH', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ code, action: 'cancel' }),
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok || !data.ok) { alert(data.error || 'Не вдалося скасувати заявку'); return; }
-  loadBookings();
-}
-
-async function toggleProtocol(code, btn) {
-  const box = document.getElementById('prot-' + code);
-  if (box.classList.contains('open')) { box.classList.remove('open'); return; }
-  if (!box.dataset.loaded) {
-    btn.disabled = true; btn.textContent = 'Завантажую…';
-    try {
-      const res = await fetch(PROTOCOL_API, {
-        method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ code }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || !data.protocol) { alert(data.error || 'Протокол недоступний'); return; }
-      const p = data.protocol;
-      box.innerHTML =
-        `<h4>Протокол променевого дослідження ${p.number ? '№ ' + esc(p.number) : ''}</h4>
-         <div class="p-org">Чернігівський військовий госпіталь · Відділення променевої діагностики</div>
-         <div class="p-field"><b>Пацієнт</b><div>${esc(p.patient)}</div></div>
-         <div class="p-field"><b>Дослідження</b><div>${esc(p.service)}${p.method ? ' · ' + esc(p.method) : ''}</div></div>
-         ${p.findings ? `<div class="p-field"><b>Опис</b><div>${esc(p.findings)}</div></div>` : ''}
-         <div class="p-field"><b>Висновок</b><div>${esc(p.conclusion || '—')}</div></div>
-         ${p.recommendations ? `<div class="p-field"><b>Рекомендації</b><div>${esc(p.recommendations)}</div></div>` : ''}
-         <div class="p-caveat">Роздруківка з інформаційної системи. Юридичну силу має протокол, засвідчений закладом у встановленому порядку.</div>
-         <button class="btn secondary print-btn" type="button" data-print="${esc(code)}">🖨 Роздрукувати / зберегти PDF</button>`;
-      box.dataset.loaded = '1';
-      box.querySelector('[data-print]').addEventListener('click', () => printProtocol(code));
-    } finally {
-      btn.disabled = false; btn.textContent = 'Переглянути протокол';
-    }
-  }
-  box.classList.add('open');
-}
-
-function printProtocol(code) {
-  const card = document.getElementById('card-' + code);
-  card.classList.add('printing');
-  window.print();
-  card.classList.remove('printing');
-}
-
-document.getElementById('gateBtn').addEventListener('click', () => {
-  const digits = document.getElementById('gatePhone').value.replace(/\D/g, '');
-  const dob = document.getElementById('gateDob').value.trim();
-  errorBox.classList.remove('show');
-  if (digits.length !== 9) { showError('Введіть 9 цифр номера'); return; }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(dob)) { showError('Вкажіть дату народження'); return; }
-  enter(digits, dob);
-});
-document.getElementById('gatePhone').addEventListener('keydown', (e) => { if (e.key === 'Enter') document.getElementById('gateBtn').click(); });
-document.getElementById('gateDob').addEventListener('keydown', (e) => { if (e.key === 'Enter') document.getElementById('gateBtn').click(); });
-if (savedAutoEnter && new URLSearchParams(window.location.search).get('new') === '1') {
-  const digits = document.getElementById('gatePhone').value.replace(/\D/g, '');
-  const dob = document.getElementById('gateDob').value.trim();
-  if (digits.length === 9 && /^\d{4}-\d{2}-\d{2}$/.test(dob)) {
-    try {
-      const saved = JSON.parse(sessionStorage.getItem(PATIENT_PREFILL_KEY) || '{}');
-      saved.autoEnter = false;
-      sessionStorage.setItem(PATIENT_PREFILL_KEY, JSON.stringify(saved));
-    } catch (e) {}
-    window.history.replaceState({}, '', '/site/cabinet.html');
-    enter(digits, dob);
-  }
-}
-document.getElementById('tgConnectBtn').addEventListener('click', connectTelegram);
-document.getElementById('logoutBtn').addEventListener('click', async () => {
-  await fetch(MY_BOOKINGS, { method: 'DELETE' }).catch(() => null);
-  phoneDigits = '';
-  dobValue = '';
-  cabinet.hidden = true; gate.hidden = false;
-  document.getElementById('tgConnect').hidden = true;
-  document.getElementById('gatePhone').value = '';
-  document.getElementById('gateDob').value = '';
-  try { sessionStorage.removeItem(PATIENT_PREFILL_KEY); } catch (e) {}
-});
+document.getElementById('requestOtpBtn').addEventListener('click',requestOtp);document.getElementById('verifyOtpBtn').addEventListener('click',verifyOtp);document.getElementById('backOtpBtn').addEventListener('click',()=>{clearError();challengeId='';document.getElementById('otpCode').value='';otpStep.hidden=true;identityStep.hidden=false});document.getElementById('otpCode').addEventListener('keydown',(e)=>{if(e.key==='Enter')verifyOtp()});document.getElementById('tgConnectBtn').addEventListener('click',connectTelegram);
+document.getElementById('logoutBtn').addEventListener('click',async()=>{await fetch(MY_BOOKINGS,{method:'DELETE'}).catch(()=>null);phoneDigits='';dobValue='';challengeId='';cabinet.hidden=true;gate.hidden=false;otpStep.hidden=true;identityStep.hidden=false;document.getElementById('tgConnect').hidden=true;document.getElementById('otpCode').value='';clearError()});
 </script>
 </body>
 </html>

--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -12,7 +12,6 @@ import { createHash, randomBytes } from "node:crypto";
 
 const DRIZZLE_DIR = new URL("../../drizzle/", import.meta.url);
 
-// Нормалізація аргументів під node:sqlite: undefined → null, boolean → 0/1.
 function normArg(a) {
   if (a === undefined || a === null) return null;
   if (typeof a === "boolean") return a ? 1 : 0;
@@ -20,8 +19,6 @@ function normArg(a) {
   return a;
 }
 
-// Обгортає DatabaseSync у мінімальний, але вірний D1-сумісний інтерфейс:
-// prepare().bind().first()/all()/run() + batch().
 function wrapAsD1(db) {
   const makeStmt = (sql) => {
     const prepared = db.prepare(sql);
@@ -40,7 +37,6 @@ function wrapAsD1(db) {
         const r = prepared.run(...bound);
         return { success: true, meta: { changes: r.changes, last_row_id: Number(r.lastInsertRowid), duration: 0 } };
       },
-      // Деякі шляхи звертаються до .raw(); повертаємо масив значень першого рядка.
       async raw() {
         const rows = prepared.all(...bound);
         return rows.map((row) => Object.values(row));
@@ -60,15 +56,12 @@ function wrapAsD1(db) {
   };
 }
 
-// Застосовує всі drizzle-міграції по порядку до чистої БД.
 export async function applyMigrations(db) {
   const files = (await readdir(fileURLToPath(DRIZZLE_DIR)))
     .filter((f) => f.endsWith(".sql"))
     .sort();
   for (const file of files) {
     const sql = await readFile(new URL(file, DRIZZLE_DIR), "utf8");
-    // «--> statement-breakpoint» — коментар drizzle; SQLite exec виконає всі
-    // ;-термінальні інструкції файлу за раз.
     try {
       db.exec(sql);
     } catch (e) {
@@ -77,7 +70,6 @@ export async function applyMigrations(db) {
   }
 }
 
-// Створює свіжу БД зі схемою і повертає { db, close }.
 export async function freshDb() {
   const raw = new DatabaseSync(":memory:");
   raw.exec("PRAGMA foreign_keys = ON;");
@@ -86,7 +78,6 @@ export async function freshDb() {
   return { db, raw, close: () => raw.close() };
 }
 
-// Виконує fn(db) з підставленим глобальним біндингом і прибирає його по завершенні.
 export async function withD1(fn) {
   const { db, raw, close } = await freshDb();
   const key = "__RADIOLOGY_DB__";
@@ -101,7 +92,6 @@ export async function withD1(fn) {
   }
 }
 
-// Зручний конструктор Request з JSON-тілом і Cloudflare-заголовком IP.
 export function jsonRequest(url, body, { method = "POST", headers = {}, ip = "203.0.113.7" } = {}) {
   return new Request(`http://localhost${url}`, {
     method,
@@ -110,8 +100,6 @@ export function jsonRequest(url, body, { method = "POST", headers = {}, ip = "20
   });
 }
 
-// Драйвер зібраного воркера (dist). Маршрутизація й код — справжні; воркер сам
-// кладе env.DB у globalThis, тож логіка маршрутів працює проти нашої SQLite.
 let workerPromise = null;
 function loadWorker() {
   if (!workerPromise) {
@@ -121,8 +109,6 @@ function loadWorker() {
   return workerPromise;
 }
 
-// Засідити співробітника з роллю і повернути cookie активної сесії.
-// Хеш токена рахуємо так само, як lib/auth.hashToken (SHA-256 hex від UTF-8).
 export async function seedStaffSession(db, { email, role, displayName = "" }) {
   await db.prepare(
     `INSERT INTO staff_members (email, display_name, role, active) VALUES (?, ?, ?, 1)
@@ -137,14 +123,13 @@ export async function seedStaffSession(db, { email, role, displayName = "" }) {
   return `rid_session=${rawToken}`;
 }
 
-// Засідити активну сесію пацієнта за нормалізованим телефоном → cookie.
-export async function seedPatientSession(db, phoneNormalized) {
+export async function seedPatientSession(db, phoneNormalized, organizationId = 1) {
   const rawToken = randomBytes(32).toString("hex");
   const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
   await db.prepare(
-    `INSERT INTO patient_sessions (token_hash, phone_normalized, expires_at)
-     VALUES (?, ?, datetime('now', '+30 minutes'))`
-  ).bind(tokenHash, phoneNormalized).run();
+    `INSERT INTO patient_sessions (token_hash, phone_normalized, organization_id, expires_at)
+     VALUES (?, ?, ?, datetime('now', '+30 minutes'))`
+  ).bind(tokenHash, phoneNormalized, organizationId).run();
   return `rid_patient=${rawToken}`;
 }
 

--- a/tests/my-bookings.behavior.test.mjs
+++ b/tests/my-bookings.behavior.test.mjs
@@ -1,84 +1,91 @@
-// Поведінковий тест справжнього шляху ідентифікації пацієнта:
-// /api/my-bookings проти живої SQLite-схеми (не перевірка рядків у коді).
+// Поведінкові тести кабінету після OTP: /api/my-bookings не автентифікує
+// знанням DOB/телефону, а лише читає вже підтверджену tenant-scoped session.
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { withD1, jsonRequest, callWorker } from "./helpers/d1.mjs";
+import { withD1, jsonRequest, callWorker, seedPatientSession } from "./helpers/d1.mjs";
 
-const post = (db, body, opts) => callWorker(jsonRequest("/api/my-bookings", body, opts), db);
+const post = (db, cookie = "", opts = {}) => callWorker(
+  jsonRequest("/api/my-bookings", undefined, {
+    ...opts,
+    headers: cookie ? { cookie, ...(opts.headers || {}) } : (opts.headers || {}),
+  }),
+  db,
+);
 
 async function seedBooking(db, over = {}) {
   const b = {
     code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNormalized: "380971112233",
     service: "КТ головного мозку", serviceCode: "CT-01", desiredDate: "2026-09-01", desiredTime: "10:00",
-    status: "new", dob: "1990-05-05", category: "civilian", ...over,
+    status: "new", dob: "1990-05-05", category: "civilian", organizationId: 1, ...over,
   };
   await db.prepare(
     `INSERT INTO bookings (code, name, phone, phone_normalized, service, service_code,
        desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
-     VALUES (?,?,?,?,?,?,?,?,?,?,?,1)`
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`
   ).bind(b.code, b.name, b.phone, b.phoneNormalized, b.service, b.serviceCode,
-    b.desiredDate, b.desiredTime, b.status, b.dob, b.category).run();
+    b.desiredDate, b.desiredTime, b.status, b.dob, b.category, b.organizationId).run();
   return b;
 }
 
-test("correct phone + DOB returns the patient's bookings and opens a session", async () => {
+test("knowledge-only phone + DOB cannot establish cabinet access", async () => {
   await withD1(async (db) => {
     await seedBooking(db);
-    const res = await post(db, { phone: "+380971112233", dob: "1990-05-05" });
+    const res = await callWorker(jsonRequest("/api/my-bookings", {
+      phone: "+380971112233", dob: "1990-05-05",
+    }), db);
+    assert.equal(res.status, 401);
+    assert.equal(await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n"), 0);
+  });
+});
+
+test("verified patient session returns only that patient's bookings", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { desiredTime: "10:00" });
+    await seedBooking(db, {
+      code: "RD-BBBB2222", name: "Петренко", phone: "+380975556677",
+      phoneNormalized: "380975556677", dob: "1985-03-03", desiredTime: "10:30",
+    });
+    const cookie = await seedPatientSession(db, "380971112233", 1);
+    const before = await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n");
+    const res = await post(db, cookie);
     assert.equal(res.status, 200);
     const data = await res.json();
     assert.equal(data.bookings.length, 1);
     assert.equal(data.bookings[0].code, "RD-AAAA1111");
-    // Сесію відкрито — cookie й реальний рядок у patient_sessions.
-    assert.match(res.headers.get("set-cookie") || "", /rid_patient=/);
-    const sessions = await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n");
-    assert.equal(sessions, 1);
+    const after = await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n");
+    assert.equal(after, before, "cabinet read must not mint another session");
   });
 });
 
-test("wrong DOB is rejected as unverified (identity proof actually enforced)", async () => {
+test("patient session is explicitly tenant-scoped", async () => {
   await withD1(async (db) => {
-    await seedBooking(db);
-    const res = await post(db, { phone: "+380971112233", dob: "1980-01-01" });
-    assert.equal(res.status, 401);
-    const sessions = await db.prepare("SELECT COUNT(*) AS n FROM patient_sessions").first("n");
-    assert.equal(sessions, 0); // жодної сесії при невдалій перевірці
-  });
-});
-
-test("a phone with no bookings cannot open a session", async () => {
-  await withD1(async (db) => {
-    const res = await post(db, { phone: "+380500000000", dob: "1990-05-05" });
-    assert.equal(res.status, 401);
-  });
-});
-
-test("malformed input is a 400 before any lookup", async () => {
-  await withD1(async (db) => {
-    const res = await post(db, { phone: "123", dob: "not-a-date" });
-    assert.equal(res.status, 400);
-  });
-});
-
-test("only bookings for the matching phone are returned (no cross-patient leak)", async () => {
-  await withD1(async (db) => {
-    await seedBooking(db, { code: "RD-AAAA1111", phone: "+380971112233", phoneNormalized: "380971112233", dob: "1990-05-05", desiredTime: "10:00" });
-    await seedBooking(db, { code: "RD-BBBB2222", name: "Петренко", phone: "+380975556677", phoneNormalized: "380975556677", dob: "1985-03-03", desiredTime: "10:30" });
-    const res = await post(db, { phone: "+380971112233", dob: "1990-05-05" });
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2,'other','Інша',1)").run();
+    await seedBooking(db, { code: "RD-OWN00001", organizationId: 1, desiredTime: "10:00" });
+    await seedBooking(db, { code: "RD-OTHER001", organizationId: 2, desiredTime: "10:30" });
+    const cookie = await seedPatientSession(db, "380971112233", 1);
+    const res = await post(db, cookie);
     const data = await res.json();
-    assert.equal(data.bookings.length, 1);
-    assert.equal(data.bookings[0].code, "RD-AAAA1111");
+    assert.deepEqual(data.bookings.map((b) => b.code), ["RD-OWN00001"]);
   });
 });
 
-test("brute force is rate-limited after the configured attempts", async () => {
+test("expired or missing session is rejected", async () => {
   await withD1(async (db) => {
+    assert.equal((await post(db)).status, 401);
+    const cookie = await seedPatientSession(db, "380971112233", 1);
+    await db.prepare("UPDATE patient_sessions SET expires_at = datetime('now', '-1 minute')").run();
+    assert.equal((await post(db, cookie)).status, 401);
+  });
+});
+
+test("cabinet reads are rate-limited", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedPatientSession(db, "380971112233", 1);
     let last = 200;
-    for (let i = 0; i < 10; i += 1) {
-      const res = await post(db, { phone: "+380509999999", dob: "1990-05-05" }, { ip: "198.51.100.42" });
-      last = res.status;
+    for (let i = 0; i < 22; i += 1) {
+      last = (await post(db, cookie, { ip: "198.51.100.42" })).status;
     }
-    assert.equal(last, 429); // ліміт 8/15хв — 9-та+ спроби відбиваються
+    assert.equal(last, 429);
   });
 });

--- a/tests/patient-dob.test.mjs
+++ b/tests/patient-dob.test.mjs
@@ -5,8 +5,6 @@ import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-// Міграція 0018 додає date_of_birth до bookings; вхід у кабінет — за
-// збігом телефону і дати народження.
 test("migration adds date_of_birth to bookings and phone+dob lookup works", async () => {
   const dir = new URL("../drizzle/", import.meta.url);
   const files = (await readdir(dir)).filter((f) => f.endsWith(".sql")).sort();
@@ -30,7 +28,6 @@ test("migration adds date_of_birth to bookings and phone+dob lookup works", asyn
   assert.ok(!wrong, "wrong dob does not match");
 });
 
-// normalizeDob приймає лише правдоподібну YYYY-MM-DD.
 test("normalizeDob validates the date shape and range", async () => {
   const { normalizeDob } = await import("../lib/dob.ts");
   assert.equal(normalizeDob("1990-05-21"), "1990-05-21");
@@ -44,7 +41,6 @@ test("online booking accepts only adults aged 18 or older", async () => {
   assert.equal(isAdultDob("2008-08-02", 18, "2026-08-01"), false);
 });
 
-// Публічний запис (обидві форми) збирає й зберігає дату народження.
 test("site-booking stores date_of_birth and requires it", async () => {
   const route = await read("app/api/site-booking/route.ts");
   assert.match(route, /normalizeDob\(body\.dob\)/);
@@ -55,7 +51,7 @@ test("site-booking stores date_of_birth and requires it", async () => {
   const bridge = await read("public/site/assets/d1-bridge.js");
   assert.match(bridge, /getElementById\('patientDob'\)/);
   assert.match(bridge, /getElementById\('militaryPatientDob'\)/);
-  assert.match(bridge, /name, phone, dob,/); // dob потрапляє у payload
+  assert.match(bridge, /name, phone, dob,/);
   assert.match(bridge, /dob-segmented/);
   assert.match(bridge, /День народження/);
   assert.match(bridge, /Місяць народження/);
@@ -82,20 +78,23 @@ test("public request is short and receives an automatic appointment", async () =
   }
 });
 
-// Кабінет пацієнта: вхід за телефоном + датою народження (не за кодом).
-test("patient cabinet logs in by phone and date of birth", async () => {
+test("patient cabinet uses DOB only to request a possession OTP, then verifies six digits", async () => {
+  const otp = await read("app/api/patient-otp/route.ts");
+  assert.match(otp, /normalizeDob\(body\.dob\)/);
+  assert.match(otp, /createPatientOtpChallenge/);
+  assert.match(otp, /verifyPatientOtpChallenge/);
+  assert.match(otp, /patientSessionCookie/);
+
   const bookings = await read("app/api/my-bookings/route.ts");
-  assert.match(bookings, /normalizeDob\(body\.dob\)/);
-  assert.match(bookings, /phone_normalized = \? AND date_of_birth = \?/);
-  assert.match(bookings, /дату народження/);
+  assert.match(bookings, /requirePatientSession/);
+  assert.doesNotMatch(bookings, /normalizeDob\(body\.dob\)/);
+  assert.doesNotMatch(bookings, /createPatientSession/);
+
   const cabinet = await read("public/site/cabinet.html");
   assert.match(cabinet, /id="gateDob"/);
-  assert.match(cabinet, /dob: dobValue/);
+  assert.match(cabinet, /\/api\/patient-otp/);
+  assert.match(cabinet, /6.{0,20}(?:циф|знач)/i);
   assert.match(cabinet, /radiologyos_patient_prefill_v1/);
-  assert.match(cabinet, /sessionStorage\.getItem/);
-  assert.match(cabinet, /savedAutoEnter/);
   assert.match(cabinet, /№ заявки:/);
-  assert.match(cabinet, /Заявку отримано/);
   assert.match(cabinet, /statusMeta/);
-  assert.doesNotMatch(cabinet, /id="gateCode"/);
 });

--- a/tests/patient-otp.behavior.test.mjs
+++ b/tests/patient-otp.behavior.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1 } from "./helpers/d1.mjs";
+import {
+  createPatientOtpChallenge,
+  createPatientSession,
+  normalizeOtp,
+  requirePatientSession,
+  verifyPatientOtpChallenge,
+} from "../lib/patient-auth.ts";
+
+test("OTP is six digits, stored only as a PBKDF2 hash, and verifies once", async () => {
+  await withD1(async (db) => {
+    const challenge = await createPatientOtpChallenge(db, "380971112233", 1);
+    assert.match(challenge.code, /^\d{6}$/);
+    assert.equal(challenge.expiresIn, 300);
+
+    const row = await db.prepare(
+      "SELECT code_hash AS codeHash, consumed_at AS consumedAt FROM patient_otp_challenges WHERE id = ?",
+    ).bind(challenge.challengeId).first();
+    assert.match(row.codeHash, /^pbkdf2\$sha256\$/);
+    assert.ok(!row.codeHash.includes(challenge.code));
+    assert.equal(row.consumedAt, "");
+
+    const verified = await verifyPatientOtpChallenge(db, {
+      challengeId: challenge.challengeId,
+      phoneNormalized: "380971112233",
+      code: challenge.code,
+    });
+    assert.deepEqual(verified, { organizationId: 1 });
+
+    const replay = await verifyPatientOtpChallenge(db, {
+      challengeId: challenge.challengeId,
+      phoneNormalized: "380971112233",
+      code: challenge.code,
+    });
+    assert.equal(replay, null);
+  });
+});
+
+test("wrong OTP increments attempts and cannot be used across phone identities", async () => {
+  await withD1(async (db) => {
+    const challenge = await createPatientOtpChallenge(db, "380971112233", 1);
+    const wrongPhone = await verifyPatientOtpChallenge(db, {
+      challengeId: challenge.challengeId,
+      phoneNormalized: "380975556677",
+      code: challenge.code,
+    });
+    assert.equal(wrongPhone, null);
+
+    const wrong = await verifyPatientOtpChallenge(db, {
+      challengeId: challenge.challengeId,
+      phoneNormalized: "380971112233",
+      code: challenge.code === "000000" ? "000001" : "000000",
+    });
+    assert.equal(wrong, null);
+    const attempts = await db.prepare(
+      "SELECT attempts FROM patient_otp_challenges WHERE id = ?",
+    ).bind(challenge.challengeId).first("attempts");
+    assert.equal(attempts, 1);
+  });
+});
+
+test("expired OTP is rejected", async () => {
+  await withD1(async (db) => {
+    const challenge = await createPatientOtpChallenge(db, "380971112233", 1);
+    await db.prepare(
+      "UPDATE patient_otp_challenges SET expires_at = datetime('now', '-1 second') WHERE id = ?",
+    ).bind(challenge.challengeId).run();
+    const verified = await verifyPatientOtpChallenge(db, {
+      challengeId: challenge.challengeId,
+      phoneNormalized: "380971112233",
+      code: challenge.code,
+    });
+    assert.equal(verified, null);
+  });
+});
+
+test("creating a newer OTP invalidates the older active challenge", async () => {
+  await withD1(async (db) => {
+    const first = await createPatientOtpChallenge(db, "380971112233", 1);
+    const second = await createPatientOtpChallenge(db, "380971112233", 1);
+    const stale = await verifyPatientOtpChallenge(db, {
+      challengeId: first.challengeId,
+      phoneNormalized: "380971112233",
+      code: first.code,
+    });
+    assert.equal(stale, null);
+    const current = await verifyPatientOtpChallenge(db, {
+      challengeId: second.challengeId,
+      phoneNormalized: "380971112233",
+      code: second.code,
+    });
+    assert.deepEqual(current, { organizationId: 1 });
+  });
+});
+
+test("patient sessions carry explicit tenant scope", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Інша', 1)").run();
+    const raw = await createPatientSession(db, "380971112233", 2);
+    const request = new Request("https://radiologyos.tech/api/my-bookings", {
+      headers: { cookie: `rid_patient=${raw}` },
+    });
+    const session = await requirePatientSession(request, db);
+    assert.equal(session.phoneNormalized, "380971112233");
+    assert.equal(session.organizationId, 2);
+  });
+});
+
+test("OTP normalizer accepts only six digits", () => {
+  assert.equal(normalizeOtp("123456"), "123456");
+  assert.equal(normalizeOtp(" 123456 "), "123456");
+  assert.equal(normalizeOtp("12345"), "");
+  assert.equal(normalizeOtp("1234567"), "");
+  assert.equal(normalizeOtp("12a456"), "");
+});

--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -19,15 +19,20 @@ test("worker applies browser security headers and rejects cross-site API mutatio
   assert.match(worker, /new URL\(origin\)\.origin !== url\.origin/);
 });
 
-test("patient data requires a short-lived server-side session", async () => {
+test("patient data requires a short-lived OTP-backed tenant-scoped server session", async () => {
   const auth = await read("lib/patient-auth.ts");
+  const otp = await read("app/api/patient-otp/route.ts");
   const bookings = await read("app/api/my-bookings/route.ts");
   const protocol = await read("app/api/my-protocol/route.ts");
   assert.match(auth, /PATIENT_SESSION_TTL_SECONDS = 30 \* 60/);
+  assert.match(auth, /PATIENT_OTP_TTL_SECONDS = 5 \* 60/);
   assert.match(auth, /HttpOnly; Secure; SameSite=Strict/);
-  assert.match(bookings, /createPatientSession\(/);
-  assert.match(bookings, /phone_normalized = \?/);
+  assert.match(otp, /createPatientSession\(db, phoneNormalized, verified\.organizationId\)/);
+  assert.match(bookings, /requirePatientSession\(/);
+  assert.doesNotMatch(bookings, /createPatientSession\(/);
+  assert.match(bookings, /WHERE b\.organization_id = \? AND b\.phone_normalized = \?/);
   assert.match(protocol, /requirePatientSession\(/);
+  assert.match(protocol, /WHERE organization_id = \? AND code = \? AND phone_normalized = \?/);
   assert.doesNotMatch(protocol, /substr\(phone_normalized, -4\)/);
 });
 
@@ -66,8 +71,6 @@ test("protocols use optimistic concurrency and immutable revision history", asyn
 
 test("server-side integrations block SSRF and oversized responses", async () => {
   const outbound = await read("lib/outbound.ts");
-  // Доставлення нагадувань перенесено у месенджинг-провайдер; захист від SSRF
-  // лишається на кожному зовнішньому виклику (safeOutboundUrl + fetchLimited).
   const messaging = await read("lib/providers/messaging.ts");
   const telegram = await read("lib/telegram.ts");
   assert.match(outbound, /privateHostname/);

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -11,18 +11,20 @@ test("site-booking endpoint saves v22 cart requests into D1 bookings", async () 
   assert.match(route, /INSERT INTO booking_events/);
   assert.match(route, /isRateLimited\(/);
   assert.match(route, /normalizeUkrainianPhone\(/);
-  assert.match(route, /codes,\s*code:\s*codes\[0\]/); // returns the RD codes
+  assert.match(route, /codes,\s*code:\s*codes\[0\]/);
   assert.match(route, /status:\s*201/);
 });
 
-test("the client bridge posts the cart and opens the authorized patient cabinet", async () => {
+test("the client bridge posts the cart and opens the patient cabinet for OTP verification", async () => {
   const bridge = await read("public/site/assets/d1-bridge.js");
   assert.match(bridge, /\/api\/site-booking/);
-  assert.match(bridge, /stopImmediatePropagation\(\)/); // takes over cart.js submit
+  assert.match(bridge, /stopImmediatePropagation\(\)/);
   assert.match(bridge, /items:\s*items\.map/);
-  assert.match(bridge, /autoEnter:\s*true/);
   assert.match(bridge, /cabinet\.html\?new=1/);
   assert.doesNotMatch(bridge, /Код заявки|Коди заявок/);
+  const cabinet = await read("public/site/cabinet.html");
+  assert.match(cabinet, /\/api\/patient-otp/);
+  assert.match(cabinet, /autoEnter:false/);
 });
 
 test("the booking pages load the D1 bridge after cart.js", async () => {
@@ -35,35 +37,38 @@ test("the booking pages load the D1 bridge after cart.js", async () => {
   }
 });
 
-test("patient cabinet lists bookings by phone and reads protocols from D1", async () => {
+test("patient cabinet lists verified-session bookings and reads protocols from D1", async () => {
   const cabinet = await read("public/site/cabinet.html");
-  assert.match(cabinet, /\/api\/my-bookings/); // list every booking for the phone
-  assert.match(cabinet, /\/api\/my-protocol/); // finalized protocol
-  assert.match(cabinet, /method:\s*'PATCH'[\s\S]*action:\s*'cancel'/); // self-service cancel
-  assert.doesNotMatch(cabinet, /radiologyos_applications_v1/); // no more localStorage data store
+  assert.match(cabinet, /\/api\/my-bookings/);
+  assert.match(cabinet, /\/api\/my-protocol/);
+  assert.match(cabinet, /method:\s*'PATCH'[\s\S]*action:\s*'cancel'/);
+  assert.doesNotMatch(cabinet, /radiologyos_applications_v1/);
 });
 
-test("my-bookings lists every booking for a full phone number", async () => {
+test("my-bookings lists only the verified phone inside the verified tenant", async () => {
   const route = await read("app/api/my-bookings/route.ts");
-  assert.match(route, /normalizeUkrainianPhone\(/);
-  assert.match(route, /WHERE b\.phone_normalized = \?/);
-  assert.match(route, /protocol_status = 'issued'/); // exposes hasProtocol flag
+  assert.match(route, /requirePatientSession\(/);
+  assert.doesNotMatch(route, /normalizeUkrainianPhone\(/);
+  assert.doesNotMatch(route, /createPatientSession\(/);
+  assert.match(route, /WHERE b\.organization_id = \? AND b\.phone_normalized = \?/);
+  assert.match(route, /session\.organizationId, session\.phoneNormalized/);
+  assert.match(route, /protocol_status = 'issued'/);
   assert.match(route, /isRateLimited\(/);
 });
 
-test("my-protocol only returns an issued protocol behind a verified patient session", async () => {
+test("my-protocol only returns an issued protocol behind the same tenant-scoped patient session", async () => {
   const route = await read("app/api/my-protocol/route.ts");
   assert.match(route, /normalizeBookingCode\(/);
   assert.match(route, /requirePatientSession\(/);
-  assert.match(route, /phone_normalized = \?/);
-  assert.match(route, /protocolStatus !== "issued"/); // gated until issued
-  assert.match(route, /FROM protocols WHERE booking_id = \?/);
+  assert.match(route, /WHERE organization_id = \? AND code = \? AND phone_normalized = \?/);
+  assert.match(route, /protocolStatus !== "issued"/);
+  assert.match(route, /FROM protocols WHERE organization_id = \? AND booking_id = \?/);
 });
 
 test("new bookings notify the registrar via Telegram (best-effort)", async () => {
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /api\.telegram\.org\/bot/);
-  assert.match(lib, /if \(!token \|\| !chatId\) return \{ ok: false/); // no-op until configured
+  assert.match(lib, /if \(!token \|\| !chatId\) return \{ ok: false/);
   const route = await read("app/api/site-booking/route.ts");
   assert.match(route, /sendTelegram\(/);
   assert.match(route, /bookingMessage\(/);
@@ -90,7 +95,7 @@ test("a test-message endpoint verifies the Telegram connection (admin-only)", as
   assert.match(route, /sendTelegramResult\(/);
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /export async function sendTelegramResult/);
-  assert.match(lib, /description \|\|/); // surfaces Telegram's error reason
+  assert.match(lib, /description \|\|/);
 });
 
 test("payment link is served publicly and used by the site, not hardcoded", async () => {
@@ -99,25 +104,22 @@ test("payment link is served publicly and used by the site, not hardcoded", asyn
   const bridge = await read("public/site/assets/d1-bridge.js");
   assert.match(bridge, /\/api\/pay-link/);
   const index = await read("public/site/index.html");
-  assert.doesNotMatch(index, /assets\/notify\.js/); // obsolete client-side gateway removed
+  assert.doesNotMatch(index, /assets\/notify\.js/);
   const cabinet = await read("public/site/cabinet.html");
   assert.match(cabinet, /До сплати/);
-  // Призначення платежу містить номер заявки (RD-…) — ключ звірки з бронюванням.
   assert.match(cabinet, /const paymentPurpose = `Сплата за медичні послуги, заявка \$\{b\.code\}/);
 });
 
 test("the payment QR renders on the site and in the cabinet; button only for real URLs", async () => {
-  // site: button hidden for a raw bank-QR payload, QR still drawn
   const bridge = await read("public/site/assets/d1-bridge.js");
-  assert.match(bridge, /if \(\/\^https\?:/); // button gated on a real http(s) URL
-  assert.match(bridge, /btn\.removeAttribute\('href'\); btn\.hidden = true/); // raw QR payload => scan-only
+  assert.match(bridge, /if \(\/\^https\?:/);
+  assert.match(bridge, /btn\.removeAttribute\('href'\); btn\.hidden = true/);
   assert.match(bridge, /qr\.createImgTag/);
-  // cabinet: loads the QR generator and draws a QR for pending payments
   const cabinet = await read("public/site/cabinet.html");
   assert.match(cabinet, /assets\/qrgen\.js/);
   assert.match(cabinet, /function payQrImg/);
   assert.match(cabinet, /payLink \? `<div class="pay-qr"/);
-  assert.match(cabinet, /isPayUrl\(payLink\)/); // link button gated on http(s)
+  assert.match(cabinet, /isPayUrl\(payLink\)/);
 });
 
 test("the public request does not force patients to choose a slot", async () => {
@@ -136,14 +138,13 @@ test("the military free-booking form saves to D1 as category 'military'", async 
   assert.match(bridge, /category:\s*'military'/);
   assert.match(bridge, /referralType:\s*'military_referral'/);
   const military = await read("public/site/military.html");
-  assert.match(military, /assets\/d1-bridge\.js/); // bridge loaded on the military page
+  assert.match(military, /assets\/d1-bridge\.js/);
   assert.doesNotMatch(military, /id="milSlotPicker"/);
 });
 
 test("civilian booking warns about the 18+ rule up front, not only on submit error", async () => {
   for (const page of ["index", "price"]) {
     const html = await read(`public/site/${page}.html`);
-    // Проактивна нотатка (завжди видима), а не лише .field-error після сабміту.
     assert.match(html, /Онлайн-запис — для пацієнтів <strong>від 18 років<\/strong>/, `${page}: нема проактивної 18\+ нотатки`);
     assert.match(html, /tel:\+380972808899/, `${page}: нема телефону реєстратури в нотатці`);
   }
@@ -152,10 +153,8 @@ test("civilian booking warns about the 18+ rule up front, not only on submit err
 test("cabinet groups a multi-study submission into one visit", async () => {
   const cabinet = await read("public/site/cabinet.html");
   assert.match(cabinet, /function renderBookings\(items\)/);
-  // Групування поспіль-заявок з однаковим created_at.
   assert.match(cabinet, /items\[i \+ 1\]\.createdAt === items\[i\]\.createdAt/);
   assert.match(cabinet, /Візит ·/);
-  // Спільна сума до сплати по візиту.
   assert.match(cabinet, /разом до сплати/);
   assert.match(cabinet, /list\.innerHTML = renderBookings\(bookings\)/);
 });
@@ -163,7 +162,7 @@ test("cabinet groups a multi-study submission into one visit", async () => {
 test("visit reminder: cabinet tells patients what to bring; military form mentions ID", async () => {
   const cabinet = await read("public/site/cabinet.html");
   assert.match(cabinet, /Візьміть із собою:/);
-  assert.match(cabinet, /b\.category === 'military' \? 'направлення та '/); // військовим — з направленням
+  assert.match(cabinet, /b\.category === 'military' \? 'направлення та '/);
   const military = await read("public/site/military.html");
   assert.match(military, /Візьміть із собою направлення, документ, що посвідчує особу/);
 });
@@ -172,12 +171,10 @@ test("ПІБ field suggests Ukrainian given names + patronymics by token", async
   const js = await read("public/site/assets/name-suggest.js");
   assert.match(js, /var NAMES =/);
   assert.match(js, /var PATRO =/);
-  assert.match(js, /Олександрович/); // по батькові у списку
+  assert.match(js, /Олександрович/);
   assert.match(js, /Іванівна/);
-  // Токен: 2-е слово → імена, 3-є → по батькові.
   assert.match(js, /p\.idx === 1 \? NAMES : p\.idx === 2 \? PATRO/);
   assert.match(js, /'patientName', 'militaryPatientName'/);
-  // Підключено на публічних booking-сторінках.
   for (const p of ["index", "price", "military"]) {
     const html = await read(`public/site/${p}.html`);
     assert.match(html, /assets\/name-suggest\.js/, `${p} лінкує name-suggest.js`);


### PR DESCRIPTION
Closes #156

Implemented:
- possession-based 6-digit SMS OTP before any patient session can be established;
- 5-minute OTP expiry, single-use consumption and bounded verification attempts;
- OTP values are never stored in plaintext (salted PBKDF2-HMAC-SHA256);
- strict request/verify rate limiting plus a per-phone OTP issuance cap;
- neutral anti-enumeration behavior for unknown patient identities;
- security audit events for OTP request, failure, delivery failure and success;
- 30-minute opaque hashed patient sessions with Secure/HttpOnly/SameSite=Strict cookies;
- explicit organization_id scope on patient sessions;
- my-bookings, booking-status/cancel and my-protocol require the verified tenant-scoped session;
- removed session creation from phone+DOB and booking-code+phone knowledge-only paths;
- patient cabinet migrated to phone+DOB → SMS OTP → verified cabinet flow, with no automatic authenticated entry after booking;
- existing cabinet functionality retained: statuses, grouped visits, payments/QR, cancellation, protocols and Telegram notification linking;
- patient OTP/session migration and Drizzle schema registered;
- regression/security tests cover OTP hashing, replay, expiry, failed codes, challenge replacement, knowledge-only rejection, rate limiting, cross-patient and cross-tenant access.

Validation:
- CI: passed
- CodeQL: passed