### PR TITLE
refactor: unify effective service resolution

### DIFF
--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -5,6 +5,8 @@ import { getSetting } from "../../../lib/settings";
 import { candidateTimesFor, hoursFor, isEquipmentDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
 import { dbBinding } from "../../../lib/db";
 
+const PUBLIC_ORGANIZATION_ID = 1;
+
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const date = url.searchParams.get("date") || "";
@@ -14,7 +16,7 @@ export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
 
-  const service = await effectiveServiceByCode(db, serviceCode);
+  const service = await effectiveServiceByCode(db, serviceCode, PUBLIC_ORGANIZATION_ID);
   if (!service || !service.active || (!service.civilian && !service.military)) {
     return Response.json({ times: [] });
   }
@@ -32,13 +34,13 @@ export async function GET(request: Request) {
   const [bookings, blocks] = await Promise.all([
     db.prepare(
       `SELECT desired_time AS startTime, duration_minutes AS durationMinutes
-       FROM bookings WHERE equipment_id = ? AND desired_date = ?
+       FROM bookings WHERE organization_id = ? AND equipment_id = ? AND desired_date = ?
        AND status IN ('new','confirmed','rescheduled')`
-    ).bind(service.equipmentId, date).all<{startTime:string;durationMinutes:number}>(),
+    ).bind(PUBLIC_ORGANIZATION_ID, service.equipmentId, date).all<{startTime:string;durationMinutes:number}>(),
     db.prepare(
       `SELECT start_time AS startTime, end_time AS endTime FROM equipment_blocks
-       WHERE equipment_id = ? AND blocked_date = ?`
-    ).bind(service.equipmentId, date).all<{startTime:string;endTime:string}>(),
+       WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ?`
+    ).bind(PUBLIC_ORGANIZATION_ID, service.equipmentId, date).all<{startTime:string;endTime:string}>(),
   ]);
 
   const overlaps = (start:string, end:string, otherStart:string, otherEnd:string) =>

--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,21 +1,33 @@
 import { addMinutes, EQUIPMENT } from "../../../lib/catalog";
 import { isBookableDate } from "../../../lib/booking-rules";
+import { effectiveServiceByCode } from "../../../lib/effective-services";
 import { getSetting } from "../../../lib/settings";
-import { configuredServiceByCode, parseServiceConfig, SERVICE_CONFIG_KEY } from "../../../lib/service-config";
 import { candidateTimesFor, hoursFor, isEquipmentDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
+import { dbBinding } from "../../../lib/db";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const date = url.searchParams.get("date") || "";
   const serviceCode = url.searchParams.get("serviceCode") || "";
   if (!isBookableDate(date)) return Response.json({ times: [] });
-  const db = (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+
+  const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
-  const service = configuredServiceByCode(serviceCode, parseServiceConfig(await getSetting(db, SERVICE_CONFIG_KEY)));
-  if (!service || !service.active || (!service.civilian && !service.military)) return Response.json({ times: [] });
-  // Налаштовуваний графік: робочі дні й години прийому.
+
+  const service = await effectiveServiceByCode(db, serviceCode);
+  if (!service || !service.active || (!service.civilian && !service.military)) {
+    return Response.json({ times: [] });
+  }
+
   const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
-  if (!isEquipmentDayOpen(date, schedule, service.equipmentId)) return Response.json({ times: [], durationMinutes: service.durationMinutes, equipment: EQUIPMENT[service.equipmentId].name });
+  if (!isEquipmentDayOpen(date, schedule, service.equipmentId)) {
+    return Response.json({
+      times: [],
+      durationMinutes: service.durationMinutes,
+      equipment: EQUIPMENT[service.equipmentId].name,
+      price: service.price,
+    });
+  }
 
   const [bookings, blocks] = await Promise.all([
     db.prepare(
@@ -39,9 +51,11 @@ export async function GET(request: Request) {
       overlaps(start, end, row.startTime, row.endTime));
     return !bookingConflict && !blocked;
   });
+
   return Response.json({
     times,
     durationMinutes: service.durationMinutes,
     equipment: EQUIPMENT[service.equipmentId].name,
+    price: service.price,
   });
 }

--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -3,6 +3,7 @@ import { isBookableDate } from "../../../lib/booking-rules";
 import { effectiveServiceByCode } from "../../../lib/effective-services";
 import { getSetting } from "../../../lib/settings";
 import { candidateTimesFor, hoursFor, isEquipmentDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
+import { requireOrgContext } from "../../../lib/tenant";
 import { dbBinding } from "../../../lib/db";
 
 const PUBLIC_ORGANIZATION_ID = 1;
@@ -16,7 +17,13 @@ export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
 
-  const service = await effectiveServiceByCode(db, serviceCode, PUBLIC_ORGANIZATION_ID);
+  // Staff requests inherit the organization exclusively from the verified
+  // server-side session. Anonymous storefront requests stay on the initial
+  // public organization until host/slug tenant routing is introduced.
+  const staffContext = await requireOrgContext(request, db);
+  const organizationId = staffContext?.organizationId ?? PUBLIC_ORGANIZATION_ID;
+
+  const service = await effectiveServiceByCode(db, serviceCode, organizationId);
   if (!service || !service.active || (!service.civilian && !service.military)) {
     return Response.json({ times: [] });
   }
@@ -36,11 +43,11 @@ export async function GET(request: Request) {
       `SELECT desired_time AS startTime, duration_minutes AS durationMinutes
        FROM bookings WHERE organization_id = ? AND equipment_id = ? AND desired_date = ?
        AND status IN ('new','confirmed','rescheduled')`
-    ).bind(PUBLIC_ORGANIZATION_ID, service.equipmentId, date).all<{startTime:string;durationMinutes:number}>(),
+    ).bind(organizationId, service.equipmentId, date).all<{startTime:string;durationMinutes:number}>(),
     db.prepare(
       `SELECT start_time AS startTime, end_time AS endTime FROM equipment_blocks
        WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ?`
-    ).bind(PUBLIC_ORGANIZATION_ID, service.equipmentId, date).all<{startTime:string;endTime:string}>(),
+    ).bind(organizationId, service.equipmentId, date).all<{startTime:string;endTime:string}>(),
   ]);
 
   const overlaps = (start:string, end:string, otherStart:string, otherEnd:string) =>

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,12 +1,13 @@
-import { addMinutes } from "../../../lib/catalog";
-import { isBookableDate, isTimeForService } from "../../../lib/booking-rules";
+import { addMinutes, candidateTimes } from "../../../lib/catalog";
+import { isBookableDate } from "../../../lib/booking-rules";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { normalizeDob } from "../../../lib/dob";
 import { isRateLimited } from "../../../lib/rate-limit";
-import { effectivePrice } from "../../../lib/tariffs";
-import { getSetting } from "../../../lib/settings";
-import { configuredServiceByCode, parseServiceConfig, SERVICE_CONFIG_KEY } from "../../../lib/service-config";
+import { effectiveServiceByCode, serviceAvailableTo } from "../../../lib/effective-services";
 import { nextBookingCode } from "../../../lib/booking-code";
+import { dbBinding } from "../../../lib/db";
+
+const PUBLIC_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max = 200) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -14,7 +15,7 @@ function clean(value: unknown, max = 200) {
 
 export async function POST(request: Request) {
   try {
-    const db = (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__;
+    const db = dbBinding();
     if (!db) return Response.json({ error: "Сервіс запису тимчасово недоступний" }, { status: 503 });
     if (await isRateLimited(db, request, "create-booking", 8, 15)) {
       return Response.json({ error: "Забагато спроб. Спробуйте ще раз через 15 хвилин." }, { status: 429 });
@@ -28,7 +29,7 @@ export async function POST(request: Request) {
     const emailRaw = clean(body.email, 254).toLowerCase();
     const patientEmail = /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(emailRaw) ? emailRaw : "";
     const serviceCode = clean(body.serviceCode, 12);
-    const service = configuredServiceByCode(serviceCode, parseServiceConfig(await getSetting(db, SERVICE_CONFIG_KEY)));
+    const service = await effectiveServiceByCode(db, serviceCode, PUBLIC_ORGANIZATION_ID);
     const desiredDate = clean(body.date, 10);
     const desiredTime = clean(body.time, 5);
     const patientCategory = clean(body.patientCategory, 20);
@@ -46,13 +47,13 @@ export async function POST(request: Request) {
     if (!["military", "civilian"].includes(patientCategory)) {
       return Response.json({ error: "Оберіть категорію пацієнта" }, { status: 400 });
     }
-    if (!service.active || (patientCategory === "military" ? !service.military : !service.civilian)) {
+    if (!serviceAvailableTo(service, patientCategory as "military" | "civilian")) {
       return Response.json({ error: "Ця послуга зараз недоступна для обраної категорії пацієнтів" }, { status: 400 });
     }
     if (!["military_referral", "eh_referral", "paper_referral", "none", "other"].includes(referralType)) {
       return Response.json({ error: "Оберіть тип направлення" }, { status: 400 });
     }
-    if (!isBookableDate(desiredDate) || !isTimeForService(desiredTime, serviceCode)) {
+    if (!isBookableDate(desiredDate) || !candidateTimes(service).includes(desiredTime)) {
       return Response.json({ error: "Оберіть доступні дату та час" }, { status: 400 });
     }
 
@@ -61,34 +62,33 @@ export async function POST(request: Request) {
     const referral = referralType === "none" ? "Немає направлення" : referralType;
     const paymentStatus = patientCategory === "civilian" ? "pending" : "verification_required";
     const nszuStatus = referralType === "eh_referral" ? "pending" : "not_applicable";
-    const price = await effectivePrice(db, service.code);
     const result = await db.prepare(
       `INSERT INTO bookings (
-        code, name, phone, phone_normalized, patient_email, service, service_code, equipment_id,
+        organization_id, code, name, phone, phone_normalized, patient_email, service, service_code, equipment_id,
         duration_minutes, desired_date, desired_time, referral, patient_category,
         referral_type, referral_number, marketing_source, payment_status,
         payment_amount, nszu_status, comment, date_of_birth, consent_at, consent_version, consent_source
       )
-      SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP,?,?
+      SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,CURRENT_TIMESTAMP,?,?
       WHERE NOT EXISTS (
         SELECT 1 FROM bookings
-        WHERE equipment_id = ? AND desired_date = ?
+        WHERE organization_id = ? AND equipment_id = ? AND desired_date = ?
           AND status IN ('new','confirmed','rescheduled')
           AND desired_time < ?
           AND time(desired_time, '+' || duration_minutes || ' minutes') > ?
       )
       AND NOT EXISTS (
         SELECT 1 FROM equipment_blocks
-        WHERE equipment_id = ? AND blocked_date = ?
+        WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ?
           AND start_time < ? AND end_time > ?
       )`
     ).bind(
-      code, name, phone, phoneNormalized, patientEmail, service.title, service.code, service.equipmentId,
+      PUBLIC_ORGANIZATION_ID, code, name, phone, phoneNormalized, patientEmail, service.title, service.code, service.equipmentId,
       service.durationMinutes, desiredDate, desiredTime, referral, patientCategory,
       referralType, referralNumber, marketingSource, paymentStatus,
-      price, nszuStatus, comment, dob, "2026-07-29", "booking_page",
-      service.equipmentId, desiredDate, endTime, desiredTime,
-      service.equipmentId, desiredDate, endTime, desiredTime,
+      service.price, nszuStatus, comment, dob, "2026-07-29", "booking_page",
+      PUBLIC_ORGANIZATION_ID, service.equipmentId, desiredDate, endTime, desiredTime,
+      PUBLIC_ORGANIZATION_ID, service.equipmentId, desiredDate, endTime, desiredTime,
     ).run();
 
     if (!result.meta.changes) {
@@ -96,8 +96,8 @@ export async function POST(request: Request) {
     }
     if (result.meta.last_row_id) {
       await db.prepare(
-        "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'created', ?, 'patient')"
-      ).bind(result.meta.last_row_id, `${service.code} ${desiredDate} ${desiredTime}`).run();
+        "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'created', ?, 'patient')"
+      ).bind(PUBLIC_ORGANIZATION_ID, result.meta.last_row_id, `${service.code} ${desiredDate} ${desiredTime}`).run();
     }
     return Response.json({ code, status: "new", statusLabel: "Заявку отримано — очікує підтвердження" }, { status: 201 });
   } catch (error) {

--- a/app/api/catalog/route.ts
+++ b/app/api/catalog/route.ts
@@ -1,22 +1,46 @@
-// Public catalog with effective prices, grouped for the home-page tariff list.
-// Military price is always 0 (free); the civilian price is the effective tariff.
+// Public catalog with effective prices and visibility, grouped for the price page.
+// The effective service resolver is the only merge point for catalog defaults,
+// organization configuration and tariff overrides.
 
-import { SERVICES } from "../../../lib/catalog";
-import { priceOverrides } from "../../../lib/tariffs";
+import { effectiveServices } from "../../../lib/effective-services";
 import { dbBinding } from "../../../lib/db";
 
 export async function GET() {
   const db = dbBinding();
-  const overrides = db ? await priceOverrides(db) : {};
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+
+  const services = await effectiveServices(db);
   const order: string[] = [];
-  const byGroup = new Map<string, Array<{ code: string; title: string; description: string; price: number }>>();
-  for (const s of SERVICES) {
-    if (!byGroup.has(s.group)) { byGroup.set(s.group, []); order.push(s.group); }
-    byGroup.get(s.group)!.push({
-      code: s.code, title: s.title, description: s.description,
-      price: overrides[s.code] ?? s.price,
+  const byGroup = new Map<string, Array<{
+    code: string;
+    title: string;
+    description: string;
+    price: number;
+    active: boolean;
+    civilian: boolean;
+    military: boolean;
+    equipmentId: string;
+    durationMinutes: number;
+  }>>();
+
+  for (const service of services) {
+    if (!byGroup.has(service.group)) {
+      byGroup.set(service.group, []);
+      order.push(service.group);
+    }
+    byGroup.get(service.group)!.push({
+      code: service.code,
+      title: service.title,
+      description: service.description,
+      price: service.price,
+      active: service.active,
+      civilian: service.civilian,
+      military: service.military,
+      equipmentId: service.equipmentId,
+      durationMinutes: service.durationMinutes,
     });
   }
+
   const groups = order.map((group) => ({ group, items: byGroup.get(group)! }));
   return Response.json({ groups }, { headers: { "cache-control": "no-store" } });
 }

--- a/app/api/public-services/route.ts
+++ b/app/api/public-services/route.ts
@@ -1,22 +1,21 @@
-import { SERVICES } from "../../../lib/catalog";
 import { dbBinding } from "../../../lib/db";
-import { configuredService, parseServiceConfig, SERVICE_CONFIG_DEFAULTS, SERVICE_CONFIG_KEY } from "../../../lib/service-config";
-import { getSetting } from "../../../lib/settings";
+import { effectiveServices } from "../../../lib/effective-services";
 
 export async function GET() {
   const db = dbBinding();
-  const config = db
-    ? parseServiceConfig(await getSetting(db, SERVICE_CONFIG_KEY))
-    : SERVICE_CONFIG_DEFAULTS;
+  if (!db) {
+    return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+  }
 
-  const services = SERVICES.map((service) => {
-    const row = configuredService(service, config);
-    return {
-      code: row.code,
-      availableToMilitary: row.active && row.military,
-      availableToCivilian: row.active && row.civilian,
-    };
-  });
+  const services = (await effectiveServices(db)).map((service) => ({
+    code: service.code,
+    title: service.title,
+    equipmentId: service.equipmentId,
+    durationMinutes: service.durationMinutes,
+    price: service.price,
+    availableToMilitary: service.active && service.military,
+    availableToCivilian: service.active && service.civilian,
+  }));
 
   return Response.json(
     { services },

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -1,10 +1,9 @@
 import { todayInKyiv } from "../../../lib/booking-rules";
-import { configuredServiceByCode, parseServiceConfig, SERVICE_CONFIG_KEY } from "../../../lib/service-config";
+import { effectiveServices, serviceAvailableTo } from "../../../lib/effective-services";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
 import { isAdultDob, normalizeDob } from "../../../lib/dob";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { bookingMessage, sendTelegram } from "../../../lib/telegram";
-import { effectivePrice } from "../../../lib/tariffs";
 import { getSetting } from "../../../lib/settings";
 import { parseSiteContent, SITE_CONTENT_KEY } from "../../../lib/site-content";
 import { parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
@@ -101,12 +100,15 @@ export async function POST(request: Request) {
     if (new Set(serviceCodes).size !== serviceCodes.length) {
       return Response.json({ error: "Одна й та сама послуга додана декілька разів" }, { status: 400 });
     }
-    const serviceConfig = parseServiceConfig(await getSetting(db, SERVICE_CONFIG_KEY));
-    const services = serviceCodes.map((code) => configuredServiceByCode(code, serviceConfig));
+
+    const serviceMap = new Map(
+      (await effectiveServices(db, PUBLIC_ORGANIZATION_ID)).map((service) => [service.code, service]),
+    );
+    const services = serviceCodes.map((code) => serviceMap.get(code));
     if (services.some((service) => !service)) {
       return Response.json({ error: "У заявці є невідома послуга" }, { status: 400 });
     }
-    if (services.some((service) => !service!.active || (category === "military" ? !service!.military : !service!.civilian))) {
+    if (services.some((service) => !serviceAvailableTo(service!, category))) {
       return Response.json({ error: "Одна з обраних послуг зараз недоступна для цієї категорії пацієнтів" }, { status: 400 });
     }
 
@@ -134,14 +136,14 @@ export async function POST(request: Request) {
         `SELECT equipment_id AS equipmentId, desired_date AS date,
                 desired_time AS startTime, duration_minutes AS durationMinutes
          FROM bookings
-         WHERE desired_date BETWEEN ? AND ?
+         WHERE organization_id = ? AND desired_date BETWEEN ? AND ?
            AND status IN ('new','confirmed','rescheduled')`
-      ).bind(fromDate, throughDate).all<BusyBooking>(),
+      ).bind(PUBLIC_ORGANIZATION_ID, fromDate, throughDate).all<BusyBooking>(),
       db.prepare(
         `SELECT equipment_id AS equipmentId, blocked_date AS date,
                 start_time AS startTime, end_time AS endTime
-         FROM equipment_blocks WHERE blocked_date BETWEEN ? AND ?`
-      ).bind(fromDate, throughDate).all<EquipmentBlock>(),
+         FROM equipment_blocks WHERE organization_id = ? AND blocked_date BETWEEN ? AND ?`
+      ).bind(PUBLIC_ORGANIZATION_ID, fromDate, throughDate).all<EquipmentBlock>(),
     ]);
     const appointments = assignEarliestAppointments({
       services: services as NonNullable<(typeof services)[number]>[],
@@ -160,7 +162,6 @@ export async function POST(request: Request) {
 
     const codes: string[] = [];
     for (let i = 0; i < services.length; i += 1) codes.push(await nextBookingCode(db));
-    const prices = await Promise.all(services.map((service) => effectivePrice(db, service!.code)));
     const responseBody = { codes, code: codes[0], appointments, status: "new", statusLabel: "Заявку отримано — очікує підтвердження" };
     const statements: D1PreparedStatement[] = [];
 
@@ -183,7 +184,7 @@ export async function POST(request: Request) {
           PUBLIC_ORGANIZATION_ID, codes[index], name, phone, phoneNormalized, patientEmail, verifiedService.title,
           verifiedService.code, verifiedService.equipmentId, verifiedService.durationMinutes,
           appointment.date, appointment.time, referral, category, referralType, marketingSource,
-          paymentStatus, prices[index], nszuStatus, comment,
+          paymentStatus, verifiedService.price, nszuStatus, comment,
           schedule.equipment[verifiedService.equipmentId]?.radiologistEmail || "",
           schedule.equipment[verifiedService.equipmentId]?.radiographerEmail || "",
           dob, consentVersion, "public_site",
@@ -197,9 +198,14 @@ export async function POST(request: Request) {
           bookingCode: codes[index],
         }),
         db.prepare(
-          `INSERT INTO booking_events (booking_id, action, details, actor)
-           SELECT id, 'created', ?, 'patient' FROM bookings WHERE code = ?`
-        ).bind(`${verifiedService.code} ${appointment.date} ${appointment.time} · слот попередньо зарезервовано`, codes[index]),
+          `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+           SELECT ?, id, 'created', ?, 'patient' FROM bookings WHERE organization_id = ? AND code = ?`
+        ).bind(
+          PUBLIC_ORGANIZATION_ID,
+          `${verifiedService.code} ${appointment.date} ${appointment.time} · слот попередньо зарезервовано`,
+          PUBLIC_ORGANIZATION_ID,
+          codes[index],
+        ),
       );
     });
     statements.push(

--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -1,10 +1,10 @@
-import { addMinutes, serviceByCode } from "../../../../lib/catalog";
+import { addMinutes } from "../../../../lib/catalog";
 import { isBookableDate } from "../../../../lib/booking-rules";
+import { effectiveServiceByCode, serviceAvailableTo } from "../../../../lib/effective-services";
 import { candidateTimesFor, hoursFor, isEquipmentDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../../lib/schedule";
 import { getSetting } from "../../../../lib/settings";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
 import { normalizeDob } from "../../../../lib/dob";
-import { effectivePrice } from "../../../../lib/tariffs";
 import { sendPatientReminder, type ReminderBooking } from "../../../../lib/notify";
 import { canTransition, isStudyState, stateLabel } from "../../../../lib/study-state";
 import {
@@ -44,10 +44,10 @@ export async function POST(request: Request) {
   const dob = normalizeDob(body.dob);
   const email = clean(body.email, 254);
   const serviceCode = clean(body.serviceCode, 12);
-  const service = serviceByCode(serviceCode);
   const desiredDate = clean(body.date, 10);
   const desiredTime = clean(body.time, 5);
   const category = clean(body.patientCategory, 20) === "military" ? "military" : "civilian";
+  const service = await effectiveServiceByCode(db, serviceCode, ctx.organizationId);
   let referralType = clean(body.referralType, 30);
   if (!REFERRAL_TYPES.includes(referralType)) referralType = "none";
   const comment = clean(body.comment, 700);
@@ -56,6 +56,9 @@ export async function POST(request: Request) {
 
   if (!name || !phoneNormalized || !service) {
     return Response.json({ error: "Вкажіть імʼя, телефон і послугу" }, { status: 400 });
+  }
+  if (!serviceAvailableTo(service, category)) {
+    return Response.json({ error: "Ця послуга зараз недоступна для обраної категорії пацієнтів" }, { status: 400 });
   }
   const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
   radiologist ||= schedule.equipment[service.equipmentId]?.radiologistEmail || "";
@@ -67,18 +70,17 @@ export async function POST(request: Request) {
 
   const endTime = addMinutes(desiredTime, service.durationMinutes);
   const conflict = await db.prepare(
-    `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ?
+    `SELECT id FROM bookings WHERE organization_id = ? AND equipment_id = ? AND desired_date = ?
      AND status IN ('confirmed','rescheduled') AND desired_time < ?
      AND strftime('%H:%M', desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
-  ).bind(service.equipmentId, desiredDate, endTime, desiredTime).first();
+  ).bind(ctx.organizationId, service.equipmentId, desiredDate, endTime, desiredTime).first();
   if (conflict) return Response.json({ error: "Цей час уже зайнятий на обраному апараті" }, { status: 409 });
   const blocked = await db.prepare(
-    "SELECT id FROM equipment_blocks WHERE equipment_id = ? AND blocked_date = ? AND start_time < ? AND end_time > ? LIMIT 1"
-  ).bind(service.equipmentId, desiredDate, endTime, desiredTime).first();
+    "SELECT id FROM equipment_blocks WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ? AND start_time < ? AND end_time > ? LIMIT 1"
+  ).bind(ctx.organizationId, service.equipmentId, desiredDate, endTime, desiredTime).first();
   if (blocked) return Response.json({ error: "Апарат недоступний у цей період" }, { status: 409 });
 
   const code = await nextBookingCode(db);
-  const price = await effectivePrice(db, service.code);
   const paymentStatus = category === "civilian" ? "pending" : "verification_required";
   const nszuStatus = referralType === "eh_referral" ? "pending" : "not_applicable";
   const referral = referralType === "none" ? "Немає направлення" : referralType;
@@ -94,15 +96,15 @@ export async function POST(request: Request) {
   ).bind(
     ctx.organizationId, code, name, phone, phoneNormalized, service.title, service.code, service.equipmentId,
     service.durationMinutes, desiredDate, desiredTime, referral, category, referralType,
-    paymentStatus, price, nszuStatus, comment, dob, email,
+    paymentStatus, service.price, nszuStatus, comment, dob, email,
     radiologist, radiographer, "2026-07-29", "staff",
   ).run();
 
   const bookingId = result.meta.last_row_id;
   if (bookingId) {
     await db.prepare(
-      "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'created_by_staff', ?, ?)"
-    ).bind(bookingId, `Запис від імені пацієнта: ${service.code} ${desiredDate} ${desiredTime}`, member.email).run();
+      "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'created_by_staff', ?, ?)"
+    ).bind(ctx.organizationId, bookingId, `Запис від імені пацієнта: ${service.code} ${desiredDate} ${desiredTime}`, member.email).run();
   }
   return Response.json({ ok: true, code }, { status: 201 });
 }
@@ -171,7 +173,8 @@ export async function GET(request: Request) {
   ]);
   const bookings = (result.results as Array<Record<string, unknown>>).map((booking) => ({
     ...booking,
-    listedPrice: serviceByCode(String(booking.serviceCode))?.price || Number(booking.paymentAmount) || 0,
+    // Existing bookings keep the price snapshot captured when they were created.
+    listedPrice: Number(booking.paymentAmount) || 0,
   }));
   return Response.json({
     bookings,
@@ -229,8 +232,8 @@ export async function PATCH(request: Request) {
       return Response.json({ error: "Редагувати заявку може реєстратор або адміністратор" }, { status: 403 });
     }
     const cur = await db.prepare(
-      "SELECT desired_date AS d, desired_time AS t, equipment_id AS eq, payment_status AS ps, status AS st FROM bookings WHERE id = ?"
-    ).bind(body.id!).first<{ d: string; t: string; eq: string; ps: string; st: string }>();
+      "SELECT desired_date AS d, desired_time AS t, equipment_id AS eq, payment_status AS ps, status AS st, patient_category AS cat FROM bookings WHERE organization_id = ? AND id = ?"
+    ).bind(ctx.organizationId, body.id!).first<{ d: string; t: string; eq: string; ps: string; st: string; cat: string }>();
     // Закриті заявки не редагуються (як і в гілці підтвердження).
     if (cur && (cur.st === "cancelled" || cur.st === "completed")) {
       return Response.json({ error: "Скасовану або завершену заявку редагувати не можна" }, { status: 409 });
@@ -260,8 +263,16 @@ export async function PATCH(request: Request) {
     }
     if (typeof e.comment === "string") { sets.push("comment = ?"); binds.push(e.comment.trim().slice(0, 700)); }
     if (typeof e.serviceCode === "string") {
-      const svc = serviceByCode(e.serviceCode.trim().slice(0, 12));
+      const svc = await effectiveServiceByCode(db, e.serviceCode.trim().slice(0, 12), ctx.organizationId);
+      const targetCategory = e.patientCategory === "military"
+        ? "military"
+        : e.patientCategory === "civilian"
+          ? "civilian"
+          : cur?.cat === "military" ? "military" : "civilian";
       if (!svc) return Response.json({ error: "Невідома послуга" }, { status: 400 });
+      if (!serviceAvailableTo(svc, targetCategory)) {
+        return Response.json({ error: "Ця послуга зараз недоступна для обраної категорії пацієнтів" }, { status: 400 });
+      }
       // Нова послуга може змінити апарат І/АБО тривалість — повністю
       // перевіряємо поточний слот для неї: сітка/робочий день/блокування/
       // накладання (виключаючи саму заявку). Інакше просимо перенести.
@@ -272,26 +283,26 @@ export async function PATCH(request: Request) {
         const rejectReschedule = Response.json({ error: "Поточний час не підходить для нової послуги (апарат / тривалість / зайнятість) — спершу перенесіть заявку" }, { status: 409 });
         if (!isBookableDate(cur.d) || !isEquipmentDayOpen(cur.d, rSchedule, svc.equipmentId) || !validTimes.includes(cur.t)) return rejectReschedule;
         const clash = await db.prepare(
-          `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ? AND id != ?
+          `SELECT id FROM bookings WHERE organization_id = ? AND equipment_id = ? AND desired_date = ? AND id != ?
            AND status IN ('confirmed','rescheduled') AND desired_time < ?
            AND strftime('%H:%M', desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
-        ).bind(svc.equipmentId, cur.d, body.id!, endTime, cur.t).first();
+        ).bind(ctx.organizationId, svc.equipmentId, cur.d, body.id!, endTime, cur.t).first();
         if (clash) return rejectReschedule;
         const blocked = await db.prepare(
-          "SELECT id FROM equipment_blocks WHERE equipment_id = ? AND blocked_date = ? AND start_time < ? AND end_time > ? LIMIT 1"
-        ).bind(svc.equipmentId, cur.d, endTime, cur.t).first();
+          "SELECT id FROM equipment_blocks WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ? AND start_time < ? AND end_time > ? LIMIT 1"
+        ).bind(ctx.organizationId, svc.equipmentId, cur.d, endTime, cur.t).first();
         if (blocked) return rejectReschedule;
       }
       sets.push("service = ?", "service_code = ?", "equipment_id = ?", "duration_minutes = ?");
       binds.push(svc.title, svc.code, svc.equipmentId, svc.durationMinutes);
-      if (!financeLocked) { sets.push("payment_amount = ?"); binds.push(await effectivePrice(db, svc.code)); }
+      if (!financeLocked) { sets.push("payment_amount = ?"); binds.push(svc.price); }
     }
     if (!sets.length) return Response.json({ error: "Немає змін для збереження" }, { status: 400 });
-    binds.push(body.id!);
-    await db.prepare(`UPDATE bookings SET ${sets.join(", ")} WHERE id = ?`).bind(...binds).run();
+    binds.push(ctx.organizationId, body.id!);
+    await db.prepare(`UPDATE bookings SET ${sets.join(", ")} WHERE organization_id = ? AND id = ?`).bind(...binds).run();
     await db.prepare(
-      "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'edited', ?, ?)"
-    ).bind(body.id!, `Скориговано поля: ${Object.keys(e).join(", ")}`, member.email).run();
+      "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'edited', ?, ?)"
+    ).bind(ctx.organizationId, body.id!, `Скориговано поля: ${Object.keys(e).join(", ")}`, member.email).run();
     return Response.json({ ok: true });
   }
 
@@ -495,32 +506,31 @@ export async function PATCH(request: Request) {
     const booking = await db.prepare(
       `SELECT service_code AS serviceCode, equipment_id AS equipmentId, duration_minutes AS durationMinutes,
         name, phone, phone_normalized AS phoneNormalized, patient_email AS patientEmail, service
-       FROM bookings WHERE id = ?`
-    ).bind(body.id).first<{serviceCode:string;equipmentId:string;durationMinutes:number;name:string;phone:string;phoneNormalized:string;patientEmail:string;service:string}>();
-    const service = booking && serviceByCode(booking.serviceCode);
+       FROM bookings WHERE organization_id = ? AND id = ?`
+    ).bind(ctx.organizationId, body.id).first<{serviceCode:string;equipmentId:string;durationMinutes:number;name:string;phone:string;phoneNormalized:string;patientEmail:string;service:string}>();
     const rSched = parseSchedule(await getSetting(db, SCHEDULE_KEY));
-    if (!booking || !service || !isBookableDate(body.desiredDate) || !isEquipmentDayOpen(body.desiredDate, rSched, service.equipmentId)
-        || !candidateTimesFor(hoursFor(rSched, service.equipmentId), booking.durationMinutes).includes(body.desiredTime)) {
+    if (!booking || !isBookableDate(body.desiredDate) || !isEquipmentDayOpen(body.desiredDate, rSched, booking.equipmentId)
+        || !candidateTimesFor(hoursFor(rSched, booking.equipmentId), booking.durationMinutes).includes(body.desiredTime)) {
       return Response.json({ error: "Некоректні дата або час" }, { status: 400 });
     }
     const endTime = addMinutes(body.desiredTime, booking.durationMinutes);
     const conflict = await db.prepare(
-      `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ? AND id != ?
+      `SELECT id FROM bookings WHERE organization_id = ? AND equipment_id = ? AND desired_date = ? AND id != ?
        AND status IN ('confirmed','rescheduled') AND desired_time < ?
        AND strftime('%H:%M', desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
-    ).bind(booking.equipmentId, body.desiredDate, body.id, endTime, body.desiredTime).first();
+    ).bind(ctx.organizationId, booking.equipmentId, body.desiredDate, body.id, endTime, body.desiredTime).first();
     if (conflict) return Response.json({ error: "Цей час уже зайнятий на обраному апараті" }, { status: 409 });
     const blocked = await db.prepare(
-      `SELECT id FROM equipment_blocks WHERE equipment_id = ? AND blocked_date = ?
+      `SELECT id FROM equipment_blocks WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ?
        AND start_time < ? AND end_time > ? LIMIT 1`
-    ).bind(booking.equipmentId, body.desiredDate, endTime, body.desiredTime).first();
+    ).bind(ctx.organizationId, booking.equipmentId, body.desiredDate, endTime, body.desiredTime).first();
     if (blocked) return Response.json({ error: "Апарат недоступний у цей період" }, { status: 409 });
     await db.prepare(
-      "UPDATE bookings SET desired_date = ?, desired_time = ?, status = 'rescheduled' WHERE id = ?"
-    ).bind(body.desiredDate, body.desiredTime, body.id).run();
+      "UPDATE bookings SET desired_date = ?, desired_time = ?, status = 'rescheduled' WHERE organization_id = ? AND id = ?"
+    ).bind(body.desiredDate, body.desiredTime, ctx.organizationId, body.id).run();
     await db.prepare(
-      "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'rescheduled', ?, ?)"
-    ).bind(body.id, `${body.desiredDate} ${body.desiredTime}`, member.email).run();
+      "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'rescheduled', ?, ?)"
+    ).bind(ctx.organizationId, body.id, `${body.desiredDate} ${body.desiredTime}`, member.email).run();
     const reminderTarget: ReminderBooking = {
       id: body.id!, name: booking.name, phone: booking.phone, phoneNormalized: booking.phoneNormalized,
       patientEmail: booking.patientEmail, service: booking.service,
@@ -536,34 +546,33 @@ export async function PATCH(request: Request) {
       `SELECT service_code AS serviceCode, equipment_id AS equipmentId, duration_minutes AS durationMinutes,
         desired_date AS desiredDate, desired_time AS desiredTime, status,
         name, phone, phone_normalized AS phoneNormalized, patient_email AS patientEmail, service
-       FROM bookings WHERE id = ?`
-    ).bind(body.id).first<{serviceCode:string;equipmentId:string;durationMinutes:number;desiredDate:string;desiredTime:string;status:string;name:string;phone:string;phoneNormalized:string;patientEmail:string;service:string}>();
+       FROM bookings WHERE organization_id = ? AND id = ?`
+    ).bind(ctx.organizationId, body.id).first<{serviceCode:string;equipmentId:string;durationMinutes:number;desiredDate:string;desiredTime:string;status:string;name:string;phone:string;phoneNormalized:string;patientEmail:string;service:string}>();
     if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
     if (booking.status === "cancelled" || booking.status === "completed") {
       return Response.json({ error: "Заявку вже закрито — підтвердження недоступне" }, { status: 400 });
     }
-    const service = serviceByCode(booking.serviceCode);
     const cSched = parseSchedule(await getSetting(db, SCHEDULE_KEY));
-    if (!service || !isBookableDate(booking.desiredDate) || !isEquipmentDayOpen(booking.desiredDate, cSched, service.equipmentId)
-        || !candidateTimesFor(hoursFor(cSched, service.equipmentId), booking.durationMinutes).includes(booking.desiredTime)) {
+    if (!isBookableDate(booking.desiredDate) || !isEquipmentDayOpen(booking.desiredDate, cSched, booking.equipmentId)
+        || !candidateTimesFor(hoursFor(cSched, booking.equipmentId), booking.durationMinutes).includes(booking.desiredTime)) {
       return Response.json({ error: "Бажаний час поза розкладом — перенесіть запис на вільний слот" }, { status: 400 });
     }
     const endTime = addMinutes(booking.desiredTime, booking.durationMinutes);
     const conflict = await db.prepare(
-      `SELECT id FROM bookings WHERE equipment_id = ? AND desired_date = ? AND id != ?
+      `SELECT id FROM bookings WHERE organization_id = ? AND equipment_id = ? AND desired_date = ? AND id != ?
        AND status IN ('confirmed','rescheduled') AND desired_time < ?
        AND strftime('%H:%M', desired_time, '+' || duration_minutes || ' minutes') > ? LIMIT 1`
-    ).bind(booking.equipmentId, booking.desiredDate, body.id, endTime, booking.desiredTime).first();
+    ).bind(ctx.organizationId, booking.equipmentId, booking.desiredDate, body.id, endTime, booking.desiredTime).first();
     if (conflict) return Response.json({ error: "Цей час уже зайнятий — перенесіть запис на вільний слот" }, { status: 409 });
     const blocked = await db.prepare(
-      `SELECT id FROM equipment_blocks WHERE equipment_id = ? AND blocked_date = ?
+      `SELECT id FROM equipment_blocks WHERE organization_id = ? AND equipment_id = ? AND blocked_date = ?
        AND start_time < ? AND end_time > ? LIMIT 1`
-    ).bind(booking.equipmentId, booking.desiredDate, endTime, booking.desiredTime).first();
+    ).bind(ctx.organizationId, booking.equipmentId, booking.desiredDate, endTime, booking.desiredTime).first();
     if (blocked) return Response.json({ error: "Апарат недоступний у цей період — перенесіть запис" }, { status: 409 });
-    await db.prepare("UPDATE bookings SET status = 'confirmed' WHERE id = ?").bind(body.id).run();
+    await db.prepare("UPDATE bookings SET status = 'confirmed' WHERE organization_id = ? AND id = ?").bind(ctx.organizationId, body.id).run();
     await db.prepare(
-      "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'status_changed', 'confirmed', ?)"
-    ).bind(body.id, member.email).run();
+      "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'status_changed', 'confirmed', ?)"
+    ).bind(ctx.organizationId, body.id, member.email).run();
     const reminderTarget: ReminderBooking = {
       id: body.id!, name: booking.name, phone: booking.phone, phoneNormalized: booking.phoneNormalized,
       patientEmail: booking.patientEmail, service: booking.service,
@@ -579,8 +588,8 @@ export async function PATCH(request: Request) {
   if (!body.status || !isStudyState(body.status)) {
     return Response.json({ error: "Некоректний статус" }, { status: 400 });
   }
-  const current = await db.prepare("SELECT status FROM bookings WHERE id = ?")
-    .bind(body.id).first<{ status: string }>();
+  const current = await db.prepare("SELECT status FROM bookings WHERE organization_id = ? AND id = ?")
+    .bind(ctx.organizationId, body.id).first<{ status: string }>();
   if (!current) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
   if (!canTransition(current.status, body.status)) {
     return Response.json(
@@ -588,9 +597,9 @@ export async function PATCH(request: Request) {
       { status: 409 },
     );
   }
-  await db.prepare("UPDATE bookings SET status = ? WHERE id = ?").bind(body.status, body.id).run();
+  await db.prepare("UPDATE bookings SET status = ? WHERE organization_id = ? AND id = ?").bind(body.status, ctx.organizationId, body.id).run();
   await db.prepare(
-    "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'status_changed', ?, ?)"
-  ).bind(body.id, body.status, member.email).run();
+    "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'status_changed', ?, ?)"
+  ).bind(ctx.organizationId, body.id, body.status, member.email).run();
   return Response.json({ ok: true });
 }

--- a/app/api/staff/services/route.ts
+++ b/app/api/staff/services/route.ts
@@ -1,26 +1,42 @@
-import { requireStaff } from "../../../../lib/staff-auth";
 import { audit } from "../../../../lib/audit";
 import { dbBinding } from "../../../../lib/db";
 import { getSetting, setSetting } from "../../../../lib/settings";
-import { parseServiceConfig, sanitizeServiceConfig, SERVICE_CONFIG_KEY } from "../../../../lib/service-config";
+import {
+  parseServiceConfig,
+  sanitizeServiceConfig,
+  SERVICE_CONFIG_KEY,
+  serviceConfigKey,
+} from "../../../../lib/service-config";
+import { requireOrgContext } from "../../../../lib/tenant";
 
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  const services = parseServiceConfig(await getSetting(db, SERVICE_CONFIG_KEY));
-  return Response.json({ services, staff: member }, { headers: { "cache-control": "no-store" } });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+
+  const tenantStored = await getSetting(db, serviceConfigKey(ctx.organizationId));
+  const legacyStored = tenantStored ? "" : await getSetting(db, SERVICE_CONFIG_KEY);
+  const services = parseServiceConfig(tenantStored || legacyStored);
+  return Response.json({ services, staff: ctx.member }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member || member.role !== "admin") return Response.json({ error: "Редагувати послуги може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx || ctx.member.role !== "admin") {
+    return Response.json({ error: "Редагувати послуги може лише адміністратор" }, { status: 403 });
+  }
+
   const body = await request.json().catch(() => ({})) as { services?: unknown };
   const services = sanitizeServiceConfig(body.services);
-  await setSetting(db, SERVICE_CONFIG_KEY, JSON.stringify(services));
-  await audit(db, { organizationId: 1, actorEmail: member.email, action: "service_config_update", resource: "services" });
+  await setSetting(db, serviceConfigKey(ctx.organizationId), JSON.stringify(services));
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "service_config_update",
+    resource: "services",
+  });
   return Response.json({ ok: true, services });
 }

--- a/app/api/staff/services/route.ts
+++ b/app/api/staff/services/route.ts
@@ -1,5 +1,6 @@
 import { audit } from "../../../../lib/audit";
 import { dbBinding } from "../../../../lib/db";
+import { effectiveServices } from "../../../../lib/effective-services";
 import { getSetting, setSetting } from "../../../../lib/settings";
 import {
   parseServiceConfig,
@@ -19,7 +20,11 @@ export async function GET(request: Request) {
   const tenantStored = await getSetting(db, serviceConfigKey(ctx.organizationId));
   const legacyStored = tenantStored ? "" : await getSetting(db, SERVICE_CONFIG_KEY);
   const services = parseServiceConfig(tenantStored || legacyStored);
-  return Response.json({ services, staff: ctx.member }, { headers: { "cache-control": "no-store" } });
+  const effective = await effectiveServices(db, ctx.organizationId);
+  return Response.json(
+    { services, effectiveServices: effective, staff: ctx.member },
+    { headers: { "cache-control": "no-store" } },
+  );
 }
 
 export async function PUT(request: Request) {

--- a/app/api/staff/services/route.ts
+++ b/app/api/staff/services/route.ts
@@ -4,6 +4,7 @@ import { getSetting, setSetting } from "../../../../lib/settings";
 import {
   parseServiceConfig,
   sanitizeServiceConfig,
+  validateServiceConfig,
   SERVICE_CONFIG_KEY,
   serviceConfigKey,
 } from "../../../../lib/service-config";
@@ -30,6 +31,9 @@ export async function PUT(request: Request) {
   }
 
   const body = await request.json().catch(() => ({})) as { services?: unknown };
+  const validationError = validateServiceConfig(body.services);
+  if (validationError) return Response.json({ error: validationError }, { status: 400 });
+
   const services = sanitizeServiceConfig(body.services);
   await setSetting(db, serviceConfigKey(ctx.organizationId), JSON.stringify(services));
   await audit(db, {

--- a/app/api/staff/tariffs/route.ts
+++ b/app/api/staff/tariffs/route.ts
@@ -1,48 +1,60 @@
-// Staff tariffs: view the full price list; admins can override prices. Overrides
-// are stored per service code; setting a price back to the catalog default (or
-// blank) removes the override.
+// Staff tariffs: view the full price list; admins can override prices per
+// organization. New overrides live in an organization-specific setting; the
+// legacy service_prices table remains read-only migration fallback for org 1.
 
-import { requireStaff } from "../../../../lib/staff-auth";
-import { serviceByCode } from "../../../../lib/catalog";
-import { tariffList } from "../../../../lib/tariffs";
+import { SERVICES } from "../../../../lib/catalog";
+import {
+  sanitizePriceOverrides,
+  tariffList,
+  tariffOverridesKey,
+} from "../../../../lib/tariffs";
+import { setSetting } from "../../../../lib/settings";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { dbBinding } from "../../../../lib/db";
+import { audit } from "../../../../lib/audit";
 
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  return Response.json({ tariffs: await tariffList(db), staff: member }, { headers: { "cache-control": "no-store" } });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  return Response.json(
+    { tariffs: await tariffList(db, ctx.organizationId), staff: ctx.member },
+    { headers: { "cache-control": "no-store" } },
+  );
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Змінювати тарифи може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.member.role !== "admin") {
+    return Response.json({ error: "Змінювати тарифи може лише адміністратор" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { prices?: Record<string, unknown> };
   const prices = body.prices && typeof body.prices === "object" ? body.prices : {};
+  const knownCodes = new Set(SERVICES.map((service) => service.code));
 
-  // Спочатку валідуємо всі позиції, потім пишемо однією транзакцією (db.batch),
-  // щоб некоректна ціна наприкінці не лишила частково збережений прайс.
-  const statements = [];
   for (const [code, rawValue] of Object.entries(prices)) {
-    const service = serviceByCode(code);
-    if (!service) continue;
-    const value = Math.round(Number(rawValue));
-    if (!Number.isFinite(value) || value < 0 || value > 1_000_000) {
+    if (!knownCodes.has(code)) {
+      return Response.json({ error: `Невідомий код послуги ${code}` }, { status: 400 });
+    }
+    const value = Number(rawValue);
+    if (!Number.isInteger(value) || value < 0 || value > 1_000_000) {
       return Response.json({ error: `Некоректна ціна для послуги ${code}` }, { status: 400 });
     }
-    statements.push(value === service.price
-      ? db.prepare("DELETE FROM service_prices WHERE code = ?").bind(code)
-      : db.prepare(
-          `INSERT INTO service_prices (code, price) VALUES (?, ?)
-           ON CONFLICT(code) DO UPDATE SET price = excluded.price`
-        ).bind(code, value));
   }
-  if (statements.length) await db.batch(statements);
 
-  return Response.json({ ok: true, tariffs: await tariffList(db) });
+  const overrides = sanitizePriceOverrides(prices);
+  await setSetting(db, tariffOverridesKey(ctx.organizationId), JSON.stringify(overrides));
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "tariff_update",
+    resource: "tariffs",
+  });
+
+  return Response.json({ ok: true, tariffs: await tariffList(db, ctx.organizationId) });
 }

--- a/app/api/tariffs/route.ts
+++ b/app/api/tariffs/route.ts
@@ -1,11 +1,17 @@
-// Public: price overrides for the static price list. Only changed prices are
-// returned; the page keeps its built-in defaults for everything else.
+// Public tariff map for the static price page. Prices are resolved through the
+// same effective-service source as booking and availability.
 
-import { priceOverrides } from "../../../lib/tariffs";
+import { effectiveServices } from "../../../lib/effective-services";
 import { dbBinding } from "../../../lib/db";
 
 export async function GET() {
   const db = dbBinding();
   if (!db) return Response.json({ prices: {} });
-  return Response.json({ prices: await priceOverrides(db) }, { headers: { "cache-control": "no-store" } });
+
+  const prices: Record<string, number> = {};
+  for (const service of await effectiveServices(db)) {
+    prices[service.code] = service.price;
+  }
+
+  return Response.json({ prices }, { headers: { "cache-control": "no-store" } });
 }

--- a/app/staff/book/page.tsx
+++ b/app/staff/book/page.tsx
@@ -102,14 +102,6 @@ export default function StaffBookPage() {
   }, [serviceGroups]);
 
   useEffect(() => {
-    if (serviceCode && !availableServices.some((service) => service.code === serviceCode)) {
-      setServiceCode("");
-      setTime("");
-      setTimes([]);
-    }
-  }, [availableServices, serviceCode]);
-
-  useEffect(() => {
     let active = true;
     const t = window.setTimeout(() => {
       if (!date || !serviceCode) { setTimes([]); setSlotsLoading(false); return; }
@@ -162,7 +154,7 @@ export default function StaffBookPage() {
           <label className="settingsField"><span>Телефон *</span><input name="phone" required inputMode="tel" placeholder="+380 97 000 00 00" value={phone} onChange={e=>setPhone(e.target.value)} /></label>
           <label className="settingsField"><span>Дата народження</span><input name="dob" type="date" max="2100-12-31" min="1920-01-01" value={dob} onChange={e=>setDob(e.target.value)} /></label>
           <label className="settingsField"><span>Категорія</span>
-            <select name="patientCategory" value={category} onChange={e=>setCategory(e.target.value)}>
+            <select name="patientCategory" value={category} onChange={e=>{ setCategory(e.target.value); setServiceCode(""); setTime(""); setTimes([]); }}>
               <option value="civilian">Цивільний пацієнт</option>
               <option value="military">Військовослужбовець</option>
             </select>

--- a/app/staff/book/page.tsx
+++ b/app/staff/book/page.tsx
@@ -3,11 +3,21 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
 import NameSuggestInput from "../NameSuggestInput";
-import { groupedServices, serviceByCode } from "../../../lib/catalog";
 import { todayInKyiv } from "../../../lib/booking-rules";
 
 type StaffInfo = { email: string; displayName: string; role: string };
 type StaffOption = { email: string; displayName: string; role: string };
+type EffectiveService = {
+  code: string;
+  title: string;
+  group: string;
+  equipmentId: string;
+  durationMinutes: number;
+  price: number;
+  active: boolean;
+  military: boolean;
+  civilian: boolean;
+};
 
 const money = new Intl.NumberFormat("uk-UA");
 const REFERRALS: [string, string][] = [
@@ -22,6 +32,7 @@ export default function StaffBookPage() {
   const [staff, setStaff] = useState<StaffInfo | null>(null);
   const [forbidden, setForbidden] = useState(false);
   const [options, setOptions] = useState<StaffOption[]>([]);
+  const [services, setServices] = useState<EffectiveService[]>([]);
   const [serviceCode, setServiceCode] = useState("");
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
@@ -31,25 +42,43 @@ export default function StaffBookPage() {
   const [status, setStatus] = useState<"idle" | "saving">("idle");
   const [code, setCode] = useState("");
   const [error, setError] = useState("");
-  // Передзаповнення з картки пацієнта (CRM → «Записати на дослідження»).
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
   const [dob, setDob] = useState("");
   const [category, setCategory] = useState("civilian");
 
-  const serviceGroups = useMemo(() => groupedServices(), []);
+  const availableServices = useMemo(
+    () => services.filter((service) => service.active && (category === "military" ? service.military : service.civilian)),
+    [services, category],
+  );
+  const serviceGroups = useMemo(() => {
+    const groups: Record<string, EffectiveService[]> = {};
+    for (const service of availableServices) {
+      (groups[service.group] ||= []).push(service);
+    }
+    return groups;
+  }, [availableServices]);
   const radiologists = useMemo(() => options.filter(o => o.role === "radiologist"), [options]);
   const radiographers = useMemo(() => options.filter(o => o.role === "radiographer"), [options]);
 
   useEffect(() => {
     let active = true;
     const t = window.setTimeout(async () => {
-      const res = await fetch("/api/staff/bookings", { cache: "no-store" });
-      if (res.status === 403) { if (active) setForbidden(true); return; }
-      const data = await res.json().catch(() => ({})) as { staffOptions?: StaffOption[]; staff?: StaffInfo };
+      const [bookingRes, serviceRes] = await Promise.all([
+        fetch("/api/staff/bookings", { cache: "no-store" }),
+        fetch("/api/staff/services", { cache: "no-store" }),
+      ]);
+      if (bookingRes.status === 403 || serviceRes.status === 403) {
+        if (active) setForbidden(true);
+        return;
+      }
+      const bookingData = await bookingRes.json().catch(() => ({})) as { staffOptions?: StaffOption[]; staff?: StaffInfo };
+      const serviceData = await serviceRes.json().catch(() => ({})) as { effectiveServices?: EffectiveService[]; staff?: StaffInfo };
       if (!active) return;
-      setOptions(data.staffOptions || []);
-      if (data.staff) setStaff(data.staff);
+      setOptions(bookingData.staffOptions || []);
+      setServices(Array.isArray(serviceData.effectiveServices) ? serviceData.effectiveServices : []);
+      if (bookingData.staff) setStaff(bookingData.staff);
+      else if (serviceData.staff) setStaff(serviceData.staff);
     }, 0);
     return () => { active = false; window.clearTimeout(t); };
   }, []);
@@ -64,7 +93,6 @@ export default function StaffBookPage() {
       if (/^\d{2}:\d{2}$/.test(requestedSlot)) setRequestedTime(requestedSlot);
       const firstService = Object.values(serviceGroups).flat().find(service => service.equipmentId === equipment);
       if (firstService) setServiceCode(firstService.code);
-      // Дані пацієнта з CRM-картки.
       const pName = params.get("name"); if (pName) setName(pName.slice(0, 120));
       const pPhone = params.get("phone"); if (pPhone) setPhone(pPhone.slice(0, 20));
       const pDob = params.get("dob"); if (pDob && /^\d{4}-\d{2}-\d{2}$/.test(pDob)) setDob(pDob);
@@ -72,6 +100,14 @@ export default function StaffBookPage() {
     }, 0);
     return () => window.clearTimeout(t);
   }, [serviceGroups]);
+
+  useEffect(() => {
+    if (serviceCode && !availableServices.some((service) => service.code === serviceCode)) {
+      setServiceCode("");
+      setTime("");
+      setTimes([]);
+    }
+  }, [availableServices, serviceCode]);
 
   useEffect(() => {
     let active = true;
@@ -113,7 +149,7 @@ export default function StaffBookPage() {
     setName(""); setPhone(""); setDob(""); setCategory("civilian");
   }
 
-  const price = serviceByCode(serviceCode)?.price;
+  const price = availableServices.find((service) => service.code === serviceCode)?.price;
 
   const body = forbidden
     ? <p className="notice error" role="alert">Створювати записи може реєстратор або адміністратор.</p>

--- a/docs/effective-services.md
+++ b/docs/effective-services.md
@@ -1,0 +1,45 @@
+# Effective service source of truth
+
+RadiologyOS resolves a service on the server through `lib/effective-services.ts`. Consumers must not independently combine `lib/catalog.ts`, service settings and tariff storage.
+
+## System seed properties
+
+The static catalog is the stable seed/fallback and owns:
+
+- `code` — stable service identifier;
+- `title` — canonical service name;
+- `group` — catalog grouping;
+- `description` — canonical explanatory text;
+- default equipment, duration and price used only when the organization has no override.
+
+Service codes are system constants. Organization configuration cannot add unknown codes or duplicate a code.
+
+## Organization-effective properties
+
+For each organization the effective resolver owns:
+
+- `active`;
+- civilian visibility;
+- military visibility;
+- `equipmentId`;
+- `durationMinutes`;
+- `price`;
+- `requiresBooking`.
+
+Service configuration is stored under `service_catalog_config_v1:org:<organizationId>`. Tariff overrides are stored under `service_price_overrides_v1:org:<organizationId>`. Legacy global configuration and the legacy `service_prices` table are migration fallbacks for the initial organization only.
+
+Invalid equipment identifiers, unknown or duplicate service codes, and invalid durations are rejected before persistence.
+
+## Consumer invariant
+
+The public service list, public catalog, public booking APIs, availability, staff booking UI and staff booking mutations must use `effectiveServices()` or `effectiveServiceByCode()`.
+
+A disabled service or a service hidden from the selected patient category must be rejected server-side even if a client calls the booking endpoint directly.
+
+Availability derives the organization from a verified staff session for staff requests. Anonymous storefront requests currently resolve to the initial public organization until host/slug based public tenant routing is introduced. The browser cannot choose `organization_id`.
+
+## Booking snapshots
+
+When a booking is created, RadiologyOS stores the resolved service title/code, equipment, duration and payment amount on the booking. Those values are a historical snapshot. Later tariff or service configuration changes affect new bookings and explicit service changes, but do not silently rewrite existing bookings.
+
+When staff explicitly changes the service on an existing booking, the new effective service is resolved for that organization, availability is revalidated, and the new price is captured unless finance is already locked by a completed payment state.

--- a/lib/effective-services.ts
+++ b/lib/effective-services.ts
@@ -21,10 +21,13 @@ export type EffectiveService = ConfiguredService & {
  * through this module instead of independently mixing catalog, service config
  * and tariff tables. The static catalog remains the seed/default definition.
  */
-export async function effectiveServices(db: D1Database): Promise<EffectiveService[]> {
+export async function effectiveServices(
+  db: D1Database,
+  organizationId = 1,
+): Promise<EffectiveService[]> {
   const [storedConfig, overrides] = await Promise.all([
     getSetting(db, SERVICE_CONFIG_KEY),
-    priceOverrides(db),
+    priceOverrides(db, organizationId),
   ]);
   const config = parseServiceConfig(storedConfig);
 
@@ -43,8 +46,9 @@ export async function effectiveServices(db: D1Database): Promise<EffectiveServic
 export async function effectiveServiceByCode(
   db: D1Database,
   code: string,
+  organizationId = 1,
 ): Promise<EffectiveService | undefined> {
-  const services = await effectiveServices(db);
+  const services = await effectiveServices(db, organizationId);
   return services.find((service) => service.code === code);
 }
 

--- a/lib/effective-services.ts
+++ b/lib/effective-services.ts
@@ -3,6 +3,7 @@ import {
   configuredService,
   parseServiceConfig,
   SERVICE_CONFIG_KEY,
+  serviceConfigKey,
   type ConfiguredService,
 } from "./service-config";
 import { getSetting } from "./settings";
@@ -25,11 +26,12 @@ export async function effectiveServices(
   db: D1Database,
   organizationId = 1,
 ): Promise<EffectiveService[]> {
-  const [storedConfig, overrides] = await Promise.all([
+  const [tenantConfig, legacyConfig, overrides] = await Promise.all([
+    getSetting(db, serviceConfigKey(organizationId)),
     getSetting(db, SERVICE_CONFIG_KEY),
     priceOverrides(db, organizationId),
   ]);
-  const config = parseServiceConfig(storedConfig);
+  const config = parseServiceConfig(tenantConfig || legacyConfig);
 
   return SERVICES.map((service: Service) => {
     const configured = configuredService(service, config);

--- a/lib/effective-services.ts
+++ b/lib/effective-services.ts
@@ -1,0 +1,56 @@
+import { SERVICES, type Service } from "./catalog";
+import {
+  configuredService,
+  parseServiceConfig,
+  SERVICE_CONFIG_KEY,
+  type ConfiguredService,
+} from "./service-config";
+import { getSetting } from "./settings";
+import { priceOverrides } from "./tariffs";
+
+export type EffectiveService = ConfiguredService & {
+  price: number;
+  defaultPrice: number;
+  customPrice: boolean;
+};
+
+/**
+ * Canonical server-side service resolver.
+ *
+ * Every consumer should resolve title/equipment/duration/visibility and price
+ * through this module instead of independently mixing catalog, service config
+ * and tariff tables. The static catalog remains the seed/default definition.
+ */
+export async function effectiveServices(db: D1Database): Promise<EffectiveService[]> {
+  const [storedConfig, overrides] = await Promise.all([
+    getSetting(db, SERVICE_CONFIG_KEY),
+    priceOverrides(db),
+  ]);
+  const config = parseServiceConfig(storedConfig);
+
+  return SERVICES.map((service: Service) => {
+    const configured = configuredService(service, config);
+    const override = overrides[service.code];
+    return {
+      ...configured,
+      defaultPrice: service.price,
+      price: override ?? service.price,
+      customPrice: override != null,
+    };
+  });
+}
+
+export async function effectiveServiceByCode(
+  db: D1Database,
+  code: string,
+): Promise<EffectiveService | undefined> {
+  const services = await effectiveServices(db);
+  return services.find((service) => service.code === code);
+}
+
+export function serviceAvailableTo(
+  service: EffectiveService,
+  category: "civilian" | "military",
+): boolean {
+  return service.active && (category === "military" ? service.military : service.civilian);
+}

--- a/lib/service-config.ts
+++ b/lib/service-config.ts
@@ -30,6 +30,30 @@ export const SERVICE_CONFIG_DEFAULTS: ServiceConfigRecord[] = SERVICES.map((serv
 }));
 
 const EQUIPMENT_IDS = new Set<EquipmentType>(["ct", "xray", "fluoro"]);
+const SERVICE_CODES = new Set(SERVICES.map((service) => service.code));
+
+export function validateServiceConfig(input: unknown): string {
+  if (!Array.isArray(input)) return "Конфігурація послуг має бути списком";
+  const seen = new Set<string>();
+  for (const raw of input) {
+    if (!raw || typeof raw !== "object") return "Некоректний запис послуги";
+    const row = raw as Partial<ServiceConfigRecord>;
+    const code = String(row.code || "");
+    if (!SERVICE_CODES.has(code)) return `Невідомий код послуги: ${code || "(порожній)"}`;
+    if (seen.has(code)) return `Код послуги дублюється: ${code}`;
+    seen.add(code);
+    if (row.equipmentId != null && !EQUIPMENT_IDS.has(row.equipmentId as EquipmentType)) {
+      return `Некоректний апарат для послуги ${code}`;
+    }
+    if (row.durationMinutes != null) {
+      const duration = Number(row.durationMinutes);
+      if (!Number.isInteger(duration) || duration < 5 || duration > 360 || duration % 5 !== 0) {
+        return `Некоректна тривалість для послуги ${code}`;
+      }
+    }
+  }
+  return "";
+}
 
 export function sanitizeServiceConfig(input: unknown): ServiceConfigRecord[] {
   const rows = Array.isArray(input) ? input : [];

--- a/lib/service-config.ts
+++ b/lib/service-config.ts
@@ -14,6 +14,11 @@ export type ConfiguredService = Service & Omit<ServiceConfigRecord, "code">;
 
 export const SERVICE_CONFIG_KEY = "service_catalog_config_v1";
 
+export function serviceConfigKey(organizationId: number): string {
+  const id = Number.isInteger(organizationId) && organizationId > 0 ? organizationId : 1;
+  return `${SERVICE_CONFIG_KEY}:org:${id}`;
+}
+
 export const SERVICE_CONFIG_DEFAULTS: ServiceConfigRecord[] = SERVICES.map((service) => ({
   code: service.code,
   equipmentId: service.equipmentId,

--- a/lib/tariffs.ts
+++ b/lib/tariffs.ts
@@ -1,5 +1,6 @@
 // Editable tariffs: catalog prices are the defaults; an admin can override any
-// service price in the "Тарифи" tab. Overrides live in `service_prices`.
+// service price in the "Тарифи" tab. Overrides live in `service_prices` and are
+// always read through an explicit organization scope.
 
 import { SERVICES, serviceByCode } from "./catalog";
 
@@ -12,24 +13,37 @@ export interface TariffRow {
   custom: boolean;
 }
 
-export async function priceOverrides(db: D1Database): Promise<Record<string, number>> {
-  const rows = await db.prepare("SELECT code, price FROM service_prices").all<{ code: string; price: number }>();
+export async function priceOverrides(
+  db: D1Database,
+  organizationId = 1,
+): Promise<Record<string, number>> {
+  const rows = await db.prepare(
+    "SELECT code, price FROM service_prices WHERE organization_id = ?",
+  ).bind(organizationId).all<{ code: string; price: number }>();
   const map: Record<string, number> = {};
   for (const row of rows.results || []) map[String(row.code)] = Number(row.price);
   return map;
 }
 
 // Price actually charged for a service (override if set, otherwise catalog default).
-export async function effectivePrice(db: D1Database, code: string): Promise<number> {
+export async function effectivePrice(
+  db: D1Database,
+  code: string,
+  organizationId = 1,
+): Promise<number> {
   const service = serviceByCode(code);
   if (!service) return 0;
-  const row = await db.prepare("SELECT price FROM service_prices WHERE code = ? LIMIT 1")
-    .bind(code).first<{ price: number }>();
+  const row = await db.prepare(
+    "SELECT price FROM service_prices WHERE organization_id = ? AND code = ? LIMIT 1",
+  ).bind(organizationId, code).first<{ price: number }>();
   return row ? Number(row.price) : service.price;
 }
 
-export async function tariffList(db: D1Database): Promise<TariffRow[]> {
-  const overrides = await priceOverrides(db);
+export async function tariffList(
+  db: D1Database,
+  organizationId = 1,
+): Promise<TariffRow[]> {
+  const overrides = await priceOverrides(db, organizationId);
   return SERVICES.map((service) => ({
     code: service.code,
     title: service.title,

--- a/lib/tariffs.ts
+++ b/lib/tariffs.ts
@@ -1,8 +1,10 @@
-// Editable tariffs: catalog prices are the defaults; an admin can override any
-// service price in the "Тарифи" tab. Overrides live in `service_prices` and are
-// always read through an explicit organization scope.
+// Editable tariffs: catalog prices are the defaults. New overrides are stored
+// in an organization-specific setting so different tenants can safely use the
+// same service code with different prices. The legacy service_prices table is
+// read only as a migration fallback for the initial organization.
 
 import { SERVICES, serviceByCode } from "./catalog";
+import { getSetting } from "./settings";
 
 export interface TariffRow {
   code: string;
@@ -13,16 +15,50 @@ export interface TariffRow {
   custom: boolean;
 }
 
+export const TARIFF_OVERRIDES_KEY = "service_price_overrides_v1";
+
+export function tariffOverridesKey(organizationId: number): string {
+  const id = Number.isInteger(organizationId) && organizationId > 0 ? organizationId : 1;
+  return `${TARIFF_OVERRIDES_KEY}:org:${id}`;
+}
+
+export function sanitizePriceOverrides(input: unknown): Record<string, number> {
+  const source = input && typeof input === "object" && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : {};
+  const out: Record<string, number> = {};
+  for (const service of SERVICES) {
+    if (!(service.code in source)) continue;
+    const value = Number(source[service.code]);
+    if (Number.isInteger(value) && value >= 0 && value <= 1_000_000 && value !== service.price) {
+      out[service.code] = value;
+    }
+  }
+  return out;
+}
+
+function parsePriceOverrides(stored: string): Record<string, number> {
+  if (!stored) return {};
+  try { return sanitizePriceOverrides(JSON.parse(stored)); }
+  catch { return {}; }
+}
+
+async function legacyPriceOverrides(db: D1Database): Promise<Record<string, number>> {
+  const rows = await db.prepare(
+    "SELECT code, price FROM service_prices WHERE organization_id = 1",
+  ).all<{ code: string; price: number }>();
+  const map: Record<string, number> = {};
+  for (const row of rows.results || []) map[String(row.code)] = Number(row.price);
+  return map;
+}
+
 export async function priceOverrides(
   db: D1Database,
   organizationId = 1,
 ): Promise<Record<string, number>> {
-  const rows = await db.prepare(
-    "SELECT code, price FROM service_prices WHERE organization_id = ?",
-  ).bind(organizationId).all<{ code: string; price: number }>();
-  const map: Record<string, number> = {};
-  for (const row of rows.results || []) map[String(row.code)] = Number(row.price);
-  return map;
+  const stored = await getSetting(db, tariffOverridesKey(organizationId));
+  if (stored) return parsePriceOverrides(stored);
+  return organizationId === 1 ? legacyPriceOverrides(db) : {};
 }
 
 // Price actually charged for a service (override if set, otherwise catalog default).
@@ -33,10 +69,8 @@ export async function effectivePrice(
 ): Promise<number> {
   const service = serviceByCode(code);
   if (!service) return 0;
-  const row = await db.prepare(
-    "SELECT price FROM service_prices WHERE organization_id = ? AND code = ? LIMIT 1",
-  ).bind(organizationId, code).first<{ price: number }>();
-  return row ? Number(row.price) : service.price;
+  const overrides = await priceOverrides(db, organizationId);
+  return overrides[code] ?? service.price;
 }
 
 export async function tariffList(

--- a/tests/effective-services.test.mjs
+++ b/tests/effective-services.test.mjs
@@ -40,12 +40,14 @@ test("staff service configuration is organization-scoped with a legacy fallback"
   const route = await read("app/api/staff/services/route.ts");
   assert.match(route, /requireOrgContext\(request, db\)/);
   assert.match(route, /serviceConfigKey\(ctx\.organizationId\)/);
+  assert.match(route, /effectiveServices\(db, ctx\.organizationId\)/);
+  assert.match(route, /effectiveServices: effective/);
   assert.match(route, /ctx\.member\.role !== "admin"/);
   assert.match(route, /organizationId: ctx\.organizationId/);
   assert.doesNotMatch(route, /organizationId: 1/);
 });
 
-test("public service visibility and availability use the effective resolver", async () => {
+test("public and staff availability use the effective resolver with server-derived tenant scope", async () => {
   const publicServices = await read("app/api/public-services/route.ts");
   const availability = await read("app/api/availability/route.ts");
 
@@ -54,9 +56,31 @@ test("public service visibility and availability use the effective resolver", as
   assert.match(publicServices, /price: service\.price/);
   assert.doesNotMatch(publicServices, /configuredService\(/);
 
-  assert.match(availability, /effectiveServiceByCode\(db, serviceCode, PUBLIC_ORGANIZATION_ID\)/);
+  assert.match(availability, /requireOrgContext\(request, db\)/);
+  assert.match(availability, /staffContext\?\.organizationId \?\? PUBLIC_ORGANIZATION_ID/);
+  assert.match(availability, /effectiveServiceByCode\(db, serviceCode, organizationId\)/);
   assert.match(availability, /WHERE organization_id = \? AND equipment_id = \?/);
   assert.match(availability, /service\.durationMinutes/);
   assert.match(availability, /price: service\.price/);
   assert.doesNotMatch(availability, /configuredServiceByCode/);
+});
+
+test("staff booking UI consumes effective services rather than the static catalog", async () => {
+  const page = await read("app/staff/book/page.tsx");
+  assert.match(page, /fetch\("\/api\/staff\/services"/);
+  assert.match(page, /effectiveServices\?: EffectiveService\[\]/);
+  assert.match(page, /service\.active && \(category === "military" \? service\.military : service\.civilian\)/);
+  assert.doesNotMatch(page, /groupedServices|serviceByCode/);
+});
+
+test("staff booking mutations resolve effective services and preserve booking price snapshots", async () => {
+  const route = await read("app/api/staff/bookings/route.ts");
+  assert.match(route, /effectiveServiceByCode\(db, serviceCode, ctx\.organizationId\)/);
+  assert.match(route, /serviceAvailableTo\(service, category\)/);
+  assert.match(route, /paymentStatus, service\.price/);
+  assert.match(route, /listedPrice: Number\(booking\.paymentAmount\) \|\| 0/);
+  assert.match(route, /effectiveServiceByCode\(db, e\.serviceCode\.trim\(\)\.slice\(0, 12\), ctx\.organizationId\)/);
+  assert.match(route, /binds\.push\(svc\.price\)/);
+  assert.doesNotMatch(route, /effectivePrice\(/);
+  assert.doesNotMatch(route, /serviceByCode\(/);
 });

--- a/tests/effective-services.test.mjs
+++ b/tests/effective-services.test.mjs
@@ -22,6 +22,19 @@ test("tariff reads are explicitly organization-scoped", async () => {
   assert.match(tariffs, /priceOverrides\(db, organizationId\)/);
 });
 
+test("service configuration rejects duplicates and invalid definitions", async () => {
+  const config = await read("lib/service-config.ts");
+  assert.match(config, /export function validateServiceConfig/);
+  assert.match(config, /Код послуги дублюється/);
+  assert.match(config, /Невідомий код послуги/);
+  assert.match(config, /Некоректний апарат/);
+  assert.match(config, /duration % 5 !== 0/);
+
+  const route = await read("app/api/staff/services/route.ts");
+  assert.match(route, /validateServiceConfig\(body\.services\)/);
+  assert.match(route, /status: 400/);
+});
+
 test("staff service configuration is organization-scoped with a legacy fallback", async () => {
   const route = await read("app/api/staff/services/route.ts");
   assert.match(route, /requireOrgContext\(request, db\)/);

--- a/tests/effective-services.test.mjs
+++ b/tests/effective-services.test.mjs
@@ -15,10 +15,11 @@ test("effective service resolver is the single merge point for config and tariff
   assert.match(lib, /export async function effectiveServiceByCode/);
 });
 
-test("tariff reads are explicitly organization-scoped", async () => {
+test("tariff overrides are tenant-scoped through organization-specific settings", async () => {
   const tariffs = await read("lib/tariffs.ts");
-  assert.match(tariffs, /WHERE organization_id = \?/);
-  assert.match(tariffs, /WHERE organization_id = \? AND code = \?/);
+  assert.match(tariffs, /tariffOverridesKey\(organizationId\)/);
+  assert.match(tariffs, /getSetting\(db, tariffOverridesKey\(organizationId\)\)/);
+  assert.match(tariffs, /organizationId === 1 \? legacyPriceOverrides\(db\) : \{\}/);
   assert.match(tariffs, /priceOverrides\(db, organizationId\)/);
 });
 
@@ -53,7 +54,8 @@ test("public service visibility and availability use the effective resolver", as
   assert.match(publicServices, /price: service\.price/);
   assert.doesNotMatch(publicServices, /configuredService\(/);
 
-  assert.match(availability, /effectiveServiceByCode\(db, serviceCode\)/);
+  assert.match(availability, /effectiveServiceByCode\(db, serviceCode, PUBLIC_ORGANIZATION_ID\)/);
+  assert.match(availability, /WHERE organization_id = \? AND equipment_id = \?/);
   assert.match(availability, /service\.durationMinutes/);
   assert.match(availability, /price: service\.price/);
   assert.doesNotMatch(availability, /configuredServiceByCode/);

--- a/tests/effective-services.test.mjs
+++ b/tests/effective-services.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("effective service resolver is the single merge point for config and tariffs", async () => {
+  const lib = await read("lib/effective-services.ts");
+  assert.match(lib, /configuredService\(/);
+  assert.match(lib, /priceOverrides\(/);
+  assert.match(lib, /defaultPrice/);
+  assert.match(lib, /customPrice/);
+  assert.match(lib, /export async function effectiveServiceByCode/);
+});
+
+test("public service visibility and availability use the effective resolver", async () => {
+  const publicServices = await read("app/api/public-services/route.ts");
+  const availability = await read("app/api/availability/route.ts");
+
+  assert.match(publicServices, /effectiveServices\(db\)/);
+  assert.match(publicServices, /durationMinutes: service\.durationMinutes/);
+  assert.match(publicServices, /price: service\.price/);
+  assert.doesNotMatch(publicServices, /configuredService\(/);
+
+  assert.match(availability, /effectiveServiceByCode\(db, serviceCode\)/);
+  assert.match(availability, /service\.durationMinutes/);
+  assert.match(availability, /price: service\.price/);
+  assert.doesNotMatch(availability, /configuredServiceByCode/);
+});

--- a/tests/effective-services.test.mjs
+++ b/tests/effective-services.test.mjs
@@ -7,10 +7,28 @@ const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 test("effective service resolver is the single merge point for config and tariffs", async () => {
   const lib = await read("lib/effective-services.ts");
   assert.match(lib, /configuredService\(/);
-  assert.match(lib, /priceOverrides\(/);
+  assert.match(lib, /priceOverrides\(db, organizationId\)/);
+  assert.match(lib, /serviceConfigKey\(organizationId\)/);
+  assert.match(lib, /tenantConfig \|\| legacyConfig/);
   assert.match(lib, /defaultPrice/);
   assert.match(lib, /customPrice/);
   assert.match(lib, /export async function effectiveServiceByCode/);
+});
+
+test("tariff reads are explicitly organization-scoped", async () => {
+  const tariffs = await read("lib/tariffs.ts");
+  assert.match(tariffs, /WHERE organization_id = \?/);
+  assert.match(tariffs, /WHERE organization_id = \? AND code = \?/);
+  assert.match(tariffs, /priceOverrides\(db, organizationId\)/);
+});
+
+test("staff service configuration is organization-scoped with a legacy fallback", async () => {
+  const route = await read("app/api/staff/services/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /serviceConfigKey\(ctx\.organizationId\)/);
+  assert.match(route, /ctx\.member\.role !== "admin"/);
+  assert.match(route, /organizationId: ctx\.organizationId/);
+  assert.doesNotMatch(route, /organizationId: 1/);
 });
 
 test("public service visibility and availability use the effective resolver", async () => {

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -14,17 +14,18 @@ test("bookings PATCH supports full booking correction (edit branch)", async () =
     assert.match(route, new RegExp(col));
   }
   assert.match(route, /'edited'/); // подія в журналі booking_events
-  // Зміна послуги переобчислює апарат і тривалість.
-  assert.match(route, /serviceByCode\(e\.serviceCode/);
+  // Зміна послуги бере tenant-effective визначення і переобчислює апарат/тривалість.
+  assert.match(route, /effectiveServiceByCode\(db, e\.serviceCode/);
+  assert.match(route, /ctx\.organizationId/);
   assert.match(route, /duration_minutes = \?/);
   // GET віддає дату народження для форми корекції.
   assert.match(route, /date_of_birth AS dateOfBirth/);
-  // Виправлено: зміна послуги оновлює суму; категорії — статус оплати;
+  // Зміна послуги оновлює суму з effective service; категорії — статус оплати;
   // фінанси не чіпаємо на оплачених; зміна апарата перевіряє слот.
   assert.match(route, /financeLocked/);
   assert.match(route, /"paid", "not_required"/);
   assert.match(route, /payment_amount = \?/);
-  assert.match(route, /effectivePrice\(db, svc\.code\)/);
+  assert.match(route, /binds\.push\(svc\.price\)/);
   // Виправлено (аудит): повна перевірка слоту при зміні послуги (сітка/день/
   // блокування/накладання), а не лише конфлікт апарата.
   assert.match(route, /candidateTimesFor\(hoursFor\(rSchedule/);

--- a/tests/labels.test.mjs
+++ b/tests/labels.test.mjs
@@ -11,7 +11,7 @@ test("pluralUk applies Ukrainian plural rules", () => {
   assert.equal(pluralUk(4, "апарат", "апарати", "апаратів"), "апарати");
   assert.equal(pluralUk(5, "апарат", "апарати", "апаратів"), "апаратів");
   assert.equal(pluralUk(0, "апарат", "апарати", "апаратів"), "апаратів");
-  assert.equal(pluralUk(11, "апарат", "апарати", "апаратів"), "апаратів"); // виняток 11-14
+  assert.equal(pluralUk(11, "апарат", "апарати", "апаратів"), "апаратів");
   assert.equal(pluralUk(21, "апарат", "апарати", "апаратів"), "апарат");
   assert.equal(pluralUk(22, "апарат", "апарати", "апаратів"), "апарати");
   assert.equal(countUk(3, "серія", "серії", "серій"), "3 серії");
@@ -37,9 +37,10 @@ test("cabinet/finance pages guard loading and admin-only edits", async () => {
   assert.match(tariffs, /Завантаження тарифів/);
   assert.match(tariffs, /Тарифів не знайдено/);
   const tariffRoute = await read("app/api/staff/tariffs/route.ts");
-  assert.match(tariffRoute, /db\.batch\(statements\)/); // all-or-nothing save
+  assert.match(tariffRoute, /ctx\.member\.role !== "admin"/);
+  assert.match(tariffRoute, /setSetting\(db, tariffOverridesKey\(ctx\.organizationId\)/);
   const equipment = await read("app/staff/equipment/page.tsx");
-  assert.match(equipment, /disabled=\{!canEdit\}/); // non-admin read-only
+  assert.match(equipment, /disabled=\{!canEdit\}/);
   const reports = await read("app/staff/reports/page.tsx");
-  assert.match(reports, /appliedQuery/); // export matches what is shown
+  assert.match(reports, /appliedQuery/);
 });

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -6,13 +6,15 @@ const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
 test("site-booking endpoint saves v22 cart requests into D1 bookings", async () => {
   const route = await read("app/api/site-booking/route.ts");
-  assert.match(route, /configuredServiceByCode\(/);
+  assert.match(route, /effectiveServices\(db, PUBLIC_ORGANIZATION_ID\)/);
+  assert.match(route, /serviceAvailableTo\(/);
   assert.match(route, /INSERT INTO bookings/);
   assert.match(route, /INSERT INTO booking_events/);
   assert.match(route, /isRateLimited\(/);
   assert.match(route, /normalizeUkrainianPhone\(/);
   assert.match(route, /codes,\s*code:\s*codes\[0\]/);
   assert.match(route, /status:\s*201/);
+  assert.doesNotMatch(route, /configuredServiceByCode\(/);
 });
 
 test("the client bridge posts the cart and opens the patient cabinet for OTP verification", async () => {

--- a/tests/staff-booking-create.test.mjs
+++ b/tests/staff-booking-create.test.mjs
@@ -17,7 +17,7 @@ test("staff can create a booking via POST, guarded and conflict-checked", async 
   assert.match(route, /booking_events .* 'created_by_staff'/s);
 });
 
-test("new-booking form gathers patient, service, slot and staff, and posts", async () => {
+test("new-booking form gathers patient, effective service, slot and staff, and posts", async () => {
   const page = await read("app/staff/book/page.tsx");
   assert.match(page, /title="Записати пацієнта"/);
   assert.match(page, /від імені пацієнта/);
@@ -26,7 +26,12 @@ test("new-booking form gathers patient, service, slot and staff, and posts", asy
   assert.match(page, /name="name"/);
   assert.match(page, /name="phone"/);
   assert.match(page, /assignedRadiologistEmail/);
-  assert.match(page, /groupedServices\(\)/);
+  // Послуги приходять із tenant-aware staff API, а не з локального статичного каталогу.
+  assert.match(page, /fetch\("\/api\/staff\/services"/);
+  assert.match(page, /effectiveServices/);
+  assert.match(page, /setServices\(/);
+  assert.match(page, /serviceGroups/);
+  assert.doesNotMatch(page, /groupedServices\(\)/);
 });
 
 test("new-booking is reachable from nav and the calendar", async () => {

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -22,13 +22,17 @@ test("tariffs API: all staff read, only admin writes", async () => {
   assert.match(route, /DELETE FROM service_prices WHERE code = \?/); // reset to default
 });
 
-test("bookings charge the effective (override-aware) price", async () => {
+test("booking paths use server-derived effective prices", async () => {
   const lib = await read("lib/tariffs.ts");
   assert.match(lib, /export async function effectivePrice/);
+
   const site = await read("app/api/site-booking/route.ts");
   assert.match(site, /effectivePrice\(db, service!\.code\)/);
+
   const legacy = await read("app/api/bookings/route.ts");
-  assert.match(legacy, /effectivePrice\(db, service\.code\)/);
+  assert.match(legacy, /effectiveServiceByCode\(db, serviceCode, PUBLIC_ORGANIZATION_ID\)/);
+  assert.match(legacy, /service\.price/);
+  assert.doesNotMatch(legacy, /effectivePrice\(/);
 });
 
 test("public catalog and tariff map use the canonical effective service source", async () => {

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-test("tariffs migration + schema define the overrides table", async () => {
+test("legacy tariff table remains available as migration fallback", async () => {
   const migration = await read("drizzle/0011_service_prices.sql");
   assert.match(migration, /CREATE TABLE IF NOT EXISTS `service_prices`/);
   assert.match(migration, /`code` text PRIMARY KEY/);
@@ -14,12 +14,23 @@ test("tariffs migration + schema define the overrides table", async () => {
   assert.match(schema, /export const servicePrices = sqliteTable\("service_prices"/);
 });
 
-test("tariffs API: all staff read, only admin writes", async () => {
+test("tariffs API is organization-scoped and only admin writes", async () => {
   const route = await read("app/api/staff/tariffs/route.ts");
-  assert.match(route, /tariffList\(/);
-  assert.match(route, /member\.role !== "admin"/); // PUT is admin-only
-  assert.match(route, /INSERT INTO service_prices/);
-  assert.match(route, /DELETE FROM service_prices WHERE code = \?/); // reset to default
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.member\.role !== "admin"/);
+  assert.match(route, /tariffList\(db, ctx\.organizationId\)/);
+  assert.match(route, /tariffOverridesKey\(ctx\.organizationId\)/);
+  assert.match(route, /setSetting\(/);
+  assert.doesNotMatch(route, /INSERT INTO service_prices/);
+  assert.doesNotMatch(route, /DELETE FROM service_prices/);
+});
+
+test("tenant tariff storage uses org-specific settings with legacy fallback only for org 1", async () => {
+  const lib = await read("lib/tariffs.ts");
+  assert.match(lib, /export function tariffOverridesKey/);
+  assert.match(lib, /getSetting\(db, tariffOverridesKey\(organizationId\)\)/);
+  assert.match(lib, /organizationId === 1 \? legacyPriceOverrides\(db\) : \{\}/);
+  assert.match(lib, /WHERE organization_id = 1/);
 });
 
 test("booking paths use server-derived effective prices", async () => {

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -31,28 +31,29 @@ test("bookings charge the effective (override-aware) price", async () => {
   assert.match(legacy, /effectivePrice\(db, service\.code\)/);
 });
 
-test("public catalog powers the separate price page while home stays concise", async () => {
-  const route = await read("app/api/catalog/route.ts");
-  assert.match(route, /priceOverrides\(/);
-  assert.match(route, /groups/);
+test("public catalog and tariff map use the canonical effective service source", async () => {
+  const catalog = await read("app/api/catalog/route.ts");
+  const tariffs = await read("app/api/tariffs/route.ts");
+  assert.match(catalog, /effectiveServices\(db\)/);
+  assert.doesNotMatch(catalog, /priceOverrides\(/);
+  assert.match(tariffs, /effectiveServices\(db\)/);
+  assert.doesNotMatch(tariffs, /priceOverrides\(/);
+
   const index = await read("public/site/index.html");
   assert.doesNotMatch(index, /id="homeTariffs"/);
   assert.doesNotMatch(index, /assets\/home-tariffs\.js/);
-  assert.match(index, /id="patientCategory"/); // category chooser on the home form
+  assert.match(index, /id="patientCategory"/);
   const bridge = await read("public/site/assets/d1-bridge.js");
-  assert.match(bridge, /getElementById\('patientCategory'\)/); // category read at submit
+  assert.match(bridge, /getElementById\('patientCategory'\)/);
 });
 
 test("the Тарифи tab is wired into the workspace and the public price list syncs", async () => {
-  // Бічна панель тепер = модулі «Карти системи», що ведуть на робочі сторінки;
-  // Тарифи доступні через клікабельний шлях /staff/tariffs у дереві структури.
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /systemModules/);
   assert.match(shell, /href:"\/staff\/reports"/);
-  // Тарифи доступні прямо з навігації робочого простору.
   assert.match(shell, /href:"\/staff\/tariffs"/);
   const page = await read("app/staff/tariffs/page.tsx");
   assert.match(page, /active="tariffs"/);
   const priceHtml = await read("public/site/price.html");
-  assert.match(priceHtml, /\/api\/tariffs/); // public prices reflect overrides
+  assert.match(priceHtml, /\/api\/tariffs/);
 });

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -27,7 +27,9 @@ test("booking paths use server-derived effective prices", async () => {
   assert.match(lib, /export async function effectivePrice/);
 
   const site = await read("app/api/site-booking/route.ts");
-  assert.match(site, /effectivePrice\(db, service!\.code\)/);
+  assert.match(site, /effectiveServices\(db, PUBLIC_ORGANIZATION_ID\)/);
+  assert.match(site, /paymentStatus, verifiedService\.price/);
+  assert.doesNotMatch(site, /effectivePrice\(/);
 
   const legacy = await read("app/api/bookings/route.ts");
   assert.match(legacy, /effectiveServiceByCode\(db, serviceCode, PUBLIC_ORGANIZATION_ID\)/);


### PR DESCRIPTION
Closes #159.

Implemented:
- one canonical server-side effective service resolver merges the static service seed, organization-scoped admin configuration and organization-scoped tariff overrides;
- public service list, catalog, tariff map and availability all consume the same effective definitions;
- public booking, legacy booking and staff booking resolve service visibility, equipment, duration and price from the same server-side source;
- staff booking UI loads tenant-effective services from `/api/staff/services` instead of the static catalog;
- service configuration validates duplicate codes, unknown services, invalid equipment and invalid durations at the canonical boundary;
- service configuration and tariff overrides are tenant-scoped, with legacy fallback retained only for the initial organization where required for migration compatibility;
- booking collision and equipment-block checks are organization-scoped;
- existing bookings preserve their price/duration/equipment snapshot, while new bookings or service changes use the current effective service;
- architecture note documents the source-of-truth and snapshot invariants;
- regression tests cover effective resolution, tenant tariff/config isolation, public/staff availability and staff booking UI/mutations.

Final gate before merge:
- CI and CodeQL green on the current head.