### PR TITLE
feat: add booking-bound payment lifecycle

### DIFF
--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -24,8 +24,21 @@ export async function POST(request: Request) {
        b.desired_date AS desiredDate, b.desired_time AS desiredTime,
        b.status, b.created_at AS createdAt, b.patient_category AS category,
        b.payment_status AS paymentStatus, b.payment_amount AS paymentAmount,
+       b.paid_amount AS paidAmount, b.payment_method AS paymentMethod,
        COALESCE(o.name, '') AS organization,
-       CASE WHEN b.protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol
+       CASE WHEN b.protocol_status = 'issued' THEN 1 ELSE 0 END AS hasProtocol,
+       (SELECT pt.id FROM payment_transactions pt
+         WHERE pt.organization_id = b.organization_id AND pt.booking_id = b.id
+         ORDER BY pt.id DESC LIMIT 1) AS paymentTransactionId,
+       COALESCE((SELECT pt.status FROM payment_transactions pt
+         WHERE pt.organization_id = b.organization_id AND pt.booking_id = b.id
+         ORDER BY pt.id DESC LIMIT 1), '') AS paymentTransactionStatus,
+       COALESCE((SELECT pt.provider FROM payment_transactions pt
+         WHERE pt.organization_id = b.organization_id AND pt.booking_id = b.id
+         ORDER BY pt.id DESC LIMIT 1), '') AS paymentProvider,
+       COALESCE((SELECT pt.provider_reference FROM payment_transactions pt
+         WHERE pt.organization_id = b.organization_id AND pt.booking_id = b.id
+         ORDER BY pt.id DESC LIMIT 1), '') AS paymentReference
      FROM bookings b LEFT JOIN organizations o ON o.id = b.organization_id
      WHERE b.organization_id = ? AND b.phone_normalized = ?
      ORDER BY b.created_at DESC, b.id DESC

--- a/app/api/pay-link/route.ts
+++ b/app/api/pay-link/route.ts
@@ -1,14 +1,95 @@
-// Public: the department's payment link, if an admin configured one. Used by the
-// booking confirmation screen and the patient cabinet for civilian patients.
+// Public GET exposes only the department's generic payment link. POST starts a
+// booking-bound manual payment for an OTP-authenticated patient.
 
 import { getSetting } from "../../../lib/settings";
 import { dbBinding } from "../../../lib/db";
+import { requirePatientSession } from "../../../lib/patient-auth";
+import { createPendingPayment, latestPaymentForBooking } from "../../../lib/payments";
 
 const DEFAULT_PRIVAT24_PAY_LINK = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params=%7B%22token%22%3A%22cadc7a4d-d56c-4005-9cfe-04a96077f8c1%22%7D';
 
+async function configuredPayLink(db: D1Database | null) {
+  if (!db) return DEFAULT_PRIVAT24_PAY_LINK;
+  return (await getSetting(db, "pay_link")) || DEFAULT_PRIVAT24_PAY_LINK;
+}
+
 export async function GET() {
   const db = dbBinding();
-  if (!db) return Response.json({ payLink: DEFAULT_PRIVAT24_PAY_LINK });
-  const payLink = (await getSetting(db, "pay_link")) || DEFAULT_PRIVAT24_PAY_LINK;
-  return Response.json({ payLink }, { headers: { "cache-control": "no-store" } });
+  return Response.json(
+    { payLink: await configuredPayLink(db) },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
+
+  const session = await requirePatientSession(request, db);
+  if (!session) return Response.json({ error: "Потрібне підтвердження номера телефону" }, { status: 401 });
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const code = typeof body.code === "string" ? body.code.trim().toUpperCase().slice(0, 24) : "";
+  if (!code) return Response.json({ error: "Не вказано заявку" }, { status: 400 });
+
+  const booking = await db.prepare(
+    `SELECT id, code, service, service_code AS serviceCode, desired_date AS desiredDate,
+      desired_time AS desiredTime, payment_status AS paymentStatus, payment_amount AS paymentAmount,
+      patient_category AS category, status
+     FROM bookings
+     WHERE organization_id = ? AND phone_normalized = ? AND code = ? LIMIT 1`,
+  ).bind(session.organizationId, session.phoneNormalized, code).first<{
+    id: number;
+    code: string;
+    service: string;
+    serviceCode: string;
+    desiredDate: string;
+    desiredTime: string;
+    paymentStatus: string;
+    paymentAmount: number;
+    category: string;
+    status: string;
+  }>();
+  if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  if (booking.category !== "civilian" || booking.paymentAmount <= 0) {
+    return Response.json({ error: "Для цієї заявки онлайн-оплата не потрібна" }, { status: 409 });
+  }
+  if (["cancelled", "completed"].includes(booking.status)) {
+    return Response.json({ error: "Ця заявка вже закрита" }, { status: 409 });
+  }
+
+  const providerReference = `manual:${booking.code}`;
+  try {
+    const pending = await createPendingPayment(db as never, {
+      organizationId: session.organizationId,
+      bookingId: booking.id,
+      provider: "manual",
+      currency: "UAH",
+      providerReference,
+    });
+    const payment = await latestPaymentForBooking(db as never, session.organizationId, booking.id);
+    return Response.json({
+      booking: {
+        code: booking.code,
+        service: booking.service,
+        serviceCode: booking.serviceCode,
+        desiredDate: booking.desiredDate,
+        desiredTime: booking.desiredTime,
+        amount: booking.paymentAmount,
+        currency: "UAH",
+        paymentStatus: booking.paymentStatus,
+      },
+      payment,
+      created: pending.created,
+      payLink: await configuredPayLink(db),
+      purpose: `Сплата за медичні послуги, заявка ${booking.code}: ${booking.service}`,
+    }, { headers: { "cache-control": "no-store" } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "payment_reference_conflict") {
+      return Response.json({ error: "Платіжний референс уже використано" }, { status: 409 });
+    }
+    console.error("payment_start_failed", booking.id, error);
+    return Response.json({ error: "Не вдалося підготувати оплату" }, { status: 500 });
+  }
 }

--- a/app/api/pay-link/route.ts
+++ b/app/api/pay-link/route.ts
@@ -8,7 +8,7 @@ import { createPendingPayment, latestPaymentForBooking } from "../../../lib/paym
 
 const DEFAULT_PRIVAT24_PAY_LINK = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params=%7B%22token%22%3A%22cadc7a4d-d56c-4005-9cfe-04a96077f8c1%22%7D';
 
-async function configuredPayLink(db: D1Database | null) {
+async function configuredPayLink(db: D1Database | null | undefined) {
   if (!db) return DEFAULT_PRIVAT24_PAY_LINK;
   return (await getSetting(db, "pay_link")) || DEFAULT_PRIVAT24_PAY_LINK;
 }

--- a/app/api/staff/payments/route.ts
+++ b/app/api/staff/payments/route.ts
@@ -1,5 +1,6 @@
 import { dbBinding } from "../../../../lib/db";
 import { recordManualPayment, latestPaymentForBooking } from "../../../../lib/payments";
+import { refundLatestPayment } from "../../../../lib/payment-settlement";
 import { canAccessBooking, canManageFinance } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
 
@@ -9,15 +10,21 @@ function clean(value: unknown, max: number) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
 }
 
-export async function POST(request: Request) {
+async function financeContext(request: Request) {
   const db = dbBinding();
-  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-
+  if (!db) return { response: Response.json({ error: "База тимчасово недоступна" }, { status: 503 }) } as const;
   const ctx = await requireOrgContext(request, db);
-  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!ctx) return { response: Response.json({ error: "Доступ лише для персоналу" }, { status: 403 }) } as const;
   if (!canManageFinance(ctx.member.role)) {
-    return Response.json({ error: "Підтверджувати оплату може лише реєстратор або адміністратор" }, { status: 403 });
+    return { response: Response.json({ error: "Розрахунки може змінювати лише реєстратор або адміністратор" }, { status: 403 }) } as const;
   }
+  return { db, ctx } as const;
+}
+
+export async function POST(request: Request) {
+  const auth = await financeContext(request);
+  if ("response" in auth) return auth.response;
+  const { db, ctx } = auth;
 
   const body = await request.json().catch(() => ({})) as Record<string, unknown>;
   const bookingId = Number(body.bookingId);
@@ -57,5 +64,38 @@ export async function POST(request: Request) {
     }
     console.error("payment_reconciliation_failed", bookingId, error);
     return Response.json({ error: "Не вдалося підтвердити оплату" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const auth = await financeContext(request);
+  if ("response" in auth) return auth.response;
+  const { db, ctx } = auth;
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const bookingId = Number(body.bookingId);
+  if (!Number.isInteger(bookingId) || bookingId <= 0) {
+    return Response.json({ error: "Некоректна заявка" }, { status: 400 });
+  }
+  if (!(await canAccessBooking(db, ctx.member, bookingId, ctx.organizationId))) {
+    return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  }
+
+  try {
+    const refund = await refundLatestPayment(db as never, {
+      organizationId: ctx.organizationId,
+      bookingId,
+      actor: ctx.member.email,
+    });
+    const payment = await latestPaymentForBooking(db as never, ctx.organizationId, bookingId);
+    return Response.json({ ok: true, changed: refund.changed, payment, paymentStatus: "refunded", paidAmount: 0 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "booking_not_found") return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+    if (message === "paid_payment_not_found") {
+      return Response.json({ error: "Немає підтвердженої оплати для повернення" }, { status: 409 });
+    }
+    console.error("payment_refund_failed", bookingId, error);
+    return Response.json({ error: "Не вдалося оформити повернення" }, { status: 500 });
   }
 }

--- a/app/api/staff/payments/route.ts
+++ b/app/api/staff/payments/route.ts
@@ -1,0 +1,61 @@
+import { dbBinding } from "../../../../lib/db";
+import { recordManualPayment, latestPaymentForBooking } from "../../../../lib/payments";
+import { canAccessBooking, canManageFinance } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+const PAYMENT_METHODS = new Set(["cash", "card", "bank_transfer", "privat_link", "other"]);
+
+function clean(value: unknown, max: number) {
+  return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canManageFinance(ctx.member.role)) {
+    return Response.json({ error: "Підтверджувати оплату може лише реєстратор або адміністратор" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const bookingId = Number(body.bookingId);
+  const method = clean(body.method, 40);
+  const providerReference = clean(body.providerReference, 160);
+  if (!Number.isInteger(bookingId) || bookingId <= 0 || !PAYMENT_METHODS.has(method)) {
+    return Response.json({ error: "Некоректні дані оплати" }, { status: 400 });
+  }
+  if (!(await canAccessBooking(db, ctx.member, bookingId, ctx.organizationId))) {
+    return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+  }
+
+  try {
+    const result = await recordManualPayment(db as never, {
+      organizationId: ctx.organizationId,
+      bookingId,
+      actor: ctx.member.email,
+      method,
+      providerReference,
+    });
+    const payment = await latestPaymentForBooking(db as never, ctx.organizationId, bookingId);
+    return Response.json({
+      ok: true,
+      created: result.created,
+      payment,
+      paymentStatus: "paid",
+      paidAmount: result.booking.paymentAmount,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "booking_not_found") return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
+    if (message === "invalid_booking_amount") {
+      return Response.json({ error: "Для цієї заявки не визначено коректну суму до сплати" }, { status: 409 });
+    }
+    if (message === "payment_reference_conflict") {
+      return Response.json({ error: "Цей платіжний референс уже прив’язаний до іншої оплати" }, { status: 409 });
+    }
+    console.error("payment_reconciliation_failed", bookingId, error);
+    return Response.json({ error: "Не вдалося підтвердити оплату" }, { status: 500 });
+  }
+}

--- a/db/index.ts
+++ b/db/index.ts
@@ -3,8 +3,9 @@ import { drizzle } from "drizzle-orm/d1";
 import * as coreSchema from "./schema";
 import * as capacitySchema from "./capacity-schema";
 import * as patientAuthSchema from "./patient-auth-schema";
+import * as paymentSchema from "./payment-schema";
 
-const schema = { ...coreSchema, ...capacitySchema, ...patientAuthSchema };
+const schema = { ...coreSchema, ...capacitySchema, ...patientAuthSchema, ...paymentSchema };
 
 export function getDb() {
   if (!env.DB) {

--- a/db/payment-schema.ts
+++ b/db/payment-schema.ts
@@ -1,0 +1,22 @@
+import { sql } from "drizzle-orm";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+export const paymentTransactions = sqliteTable("payment_transactions", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  organizationId: integer("organization_id").notNull(),
+  bookingId: integer("booking_id").notNull(),
+  amount: integer("amount").notNull(),
+  currency: text("currency").notNull().default("UAH"),
+  provider: text("provider").notNull(),
+  providerReference: text("provider_reference").notNull().default(""),
+  status: text("status").notNull().default("pending"),
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  paidAt: text("paid_at").notNull().default(""),
+  refundedAt: text("refunded_at").notNull().default(""),
+  updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+}, table => [
+  index("payment_transactions_booking_idx").on(table.organizationId, table.bookingId, table.createdAt),
+  uniqueIndex("payment_transactions_provider_ref_idx")
+    .on(table.organizationId, table.provider, table.providerReference)
+    .where(sql`provider_reference != ''`),
+]);

--- a/drizzle/0029_payment_transactions.sql
+++ b/drizzle/0029_payment_transactions.sql
@@ -1,0 +1,21 @@
+CREATE TABLE payment_transactions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  organization_id INTEGER NOT NULL,
+  booking_id INTEGER NOT NULL,
+  amount INTEGER NOT NULL CHECK (amount >= 0),
+  currency TEXT NOT NULL DEFAULT 'UAH',
+  provider TEXT NOT NULL,
+  provider_reference TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','paid','failed','refunded','cancelled')),
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  paid_at TEXT NOT NULL DEFAULT '',
+  refunded_at TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX payment_transactions_booking_idx
+  ON payment_transactions (organization_id, booking_id, created_at);
+
+CREATE UNIQUE INDEX payment_transactions_provider_ref_idx
+  ON payment_transactions (organization_id, provider, provider_reference)
+  WHERE provider_reference != '';

--- a/lib/payment-settlement.ts
+++ b/lib/payment-settlement.ts
@@ -1,4 +1,4 @@
-import { paymentBookingSnapshot, type PaymentLedgerDb } from "./payments";
+import { paymentBookingSnapshot, type PaymentLedgerDb } from "./payments.ts";
 
 export async function settleVerifiedProviderPayment(
   db: PaymentLedgerDb,

--- a/lib/payment-settlement.ts
+++ b/lib/payment-settlement.ts
@@ -1,0 +1,99 @@
+import { paymentBookingSnapshot, type PaymentLedgerDb } from "./payments";
+
+export async function settleVerifiedProviderPayment(
+  db: PaymentLedgerDb,
+  input: {
+    organizationId: number;
+    bookingId: number;
+    provider: string;
+    providerReference: string;
+    amount: number;
+    currency?: string;
+    actor?: string;
+  },
+) {
+  const booking = await paymentBookingSnapshot(db, input.organizationId, input.bookingId);
+  if (!booking) throw new Error("booking_not_found");
+  if (!Number.isInteger(input.amount) || input.amount !== booking.paymentAmount) throw new Error("payment_amount_mismatch");
+  const provider = input.provider.trim().toLowerCase().slice(0, 40);
+  const reference = input.providerReference.trim().slice(0, 160);
+  const currency = (input.currency || "UAH").trim().toUpperCase().slice(0, 3);
+  if (!provider || !reference) throw new Error("invalid_provider_payment");
+
+  const existing = await db.prepare(
+    `SELECT id, booking_id AS bookingId, amount, status
+     FROM payment_transactions
+     WHERE organization_id = ? AND provider = ? AND provider_reference = ? LIMIT 1`,
+  ).bind(input.organizationId, provider, reference).first<{ id: number; bookingId: number; amount: number; status: string }>();
+  if (existing && (existing.bookingId !== booking.id || existing.amount !== booking.paymentAmount)) {
+    throw new Error("payment_reference_conflict");
+  }
+  if (existing?.status === "paid" && booking.paymentStatus === "paid" && booking.paidAmount === booking.paymentAmount) {
+    return { id: existing.id, created: false, booking };
+  }
+
+  const actor = (input.actor || `provider:${provider}`).slice(0, 254);
+  const statements = existing
+    ? [
+        db.prepare(
+          `UPDATE payment_transactions
+           SET status = 'paid', paid_at = CASE WHEN paid_at = '' THEN CURRENT_TIMESTAMP ELSE paid_at END,
+               updated_at = CURRENT_TIMESTAMP
+           WHERE organization_id = ? AND id = ?`,
+        ).bind(input.organizationId, existing.id),
+      ]
+    : [
+        db.prepare(
+          `INSERT INTO payment_transactions
+           (organization_id, booking_id, amount, currency, provider, provider_reference, status, paid_at)
+           VALUES (?, ?, ?, ?, ?, ?, 'paid', CURRENT_TIMESTAMP)`,
+        ).bind(input.organizationId, booking.id, booking.paymentAmount, currency, provider, reference),
+      ];
+
+  statements.push(
+    db.prepare(
+      `UPDATE bookings SET payment_status = 'paid', paid_amount = payment_amount, payment_method = ?
+       WHERE organization_id = ? AND id = ?`,
+    ).bind(provider, input.organizationId, booking.id),
+    db.prepare(
+      `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+       VALUES (?, ?, 'payment_confirmed', ?, ?)`,
+    ).bind(input.organizationId, booking.id, `${provider} · ${booking.paymentAmount} ${currency}`, actor),
+  );
+  await db.batch(statements);
+  return { id: existing?.id || 0, created: !existing, booking };
+}
+
+export async function refundLatestPayment(
+  db: PaymentLedgerDb,
+  input: { organizationId: number; bookingId: number; actor: string },
+) {
+  const booking = await paymentBookingSnapshot(db, input.organizationId, input.bookingId);
+  if (!booking) throw new Error("booking_not_found");
+  const payment = await db.prepare(
+    `SELECT id, amount, status FROM payment_transactions
+     WHERE organization_id = ? AND booking_id = ? AND status IN ('paid','refunded')
+     ORDER BY id DESC LIMIT 1`,
+  ).bind(input.organizationId, booking.id).first<{ id: number; amount: number; status: string }>();
+  if (!payment) throw new Error("paid_payment_not_found");
+  if (payment.amount !== booking.paymentAmount) throw new Error("payment_amount_mismatch");
+  if (payment.status === "refunded" && booking.paymentStatus === "refunded") {
+    return { id: payment.id, changed: false };
+  }
+
+  await db.batch([
+    db.prepare(
+      `UPDATE payment_transactions SET status = 'refunded', refunded_at = CURRENT_TIMESTAMP,
+       updated_at = CURRENT_TIMESTAMP WHERE organization_id = ? AND id = ?`,
+    ).bind(input.organizationId, payment.id),
+    db.prepare(
+      `UPDATE bookings SET payment_status = 'refunded', paid_amount = 0
+       WHERE organization_id = ? AND id = ?`,
+    ).bind(input.organizationId, booking.id),
+    db.prepare(
+      `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+       VALUES (?, ?, 'payment_refunded', ?, ?)`,
+    ).bind(input.organizationId, booking.id, `${booking.paymentAmount} UAH`, input.actor),
+  ]);
+  return { id: payment.id, changed: true };
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,189 @@
+export type PaymentTransactionStatus = "pending" | "paid" | "failed" | "refunded" | "cancelled";
+
+export interface PaymentBookingSnapshot {
+  id: number;
+  organizationId: number;
+  code: string;
+  paymentAmount: number;
+  paymentStatus: string;
+  paidAmount: number;
+}
+
+export interface PaymentLedgerDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      first<T = Record<string, unknown>>(): Promise<T | null>;
+      run(): Promise<{ meta: { changes?: number; last_row_id?: number | string } }>;
+    };
+  };
+  batch<T = unknown>(statements: T[]): Promise<unknown[]>;
+}
+
+function cleanCurrency(value: string) {
+  const currency = value.trim().toUpperCase();
+  return /^[A-Z]{3}$/.test(currency) ? currency : "UAH";
+}
+
+function cleanProvider(value: string) {
+  return value.trim().toLowerCase().slice(0, 40) || "manual";
+}
+
+function cleanReference(value: string) {
+  return value.trim().slice(0, 160);
+}
+
+export async function paymentBookingSnapshot(
+  db: PaymentLedgerDb,
+  organizationId: number,
+  bookingId: number,
+): Promise<PaymentBookingSnapshot | null> {
+  const row = await db.prepare(
+    `SELECT id, organization_id AS organizationId, code,
+      payment_amount AS paymentAmount, payment_status AS paymentStatus,
+      paid_amount AS paidAmount
+     FROM bookings WHERE organization_id = ? AND id = ? LIMIT 1`,
+  ).bind(organizationId, bookingId).first<PaymentBookingSnapshot>();
+  return row || null;
+}
+
+export async function createPendingPayment(
+  db: PaymentLedgerDb,
+  input: {
+    organizationId: number;
+    bookingId: number;
+    provider: string;
+    currency?: string;
+    providerReference?: string;
+  },
+) {
+  const booking = await paymentBookingSnapshot(db, input.organizationId, input.bookingId);
+  if (!booking) throw new Error("booking_not_found");
+  if (!Number.isInteger(booking.paymentAmount) || booking.paymentAmount < 0) throw new Error("invalid_booking_amount");
+
+  const provider = cleanProvider(input.provider);
+  const currency = cleanCurrency(input.currency || "UAH");
+  const providerReference = cleanReference(input.providerReference || "");
+
+  if (providerReference) {
+    const existing = await db.prepare(
+      `SELECT id, booking_id AS bookingId, amount, currency, provider, provider_reference AS providerReference,
+        status, created_at AS createdAt, paid_at AS paidAt, refunded_at AS refundedAt
+       FROM payment_transactions
+       WHERE organization_id = ? AND provider = ? AND provider_reference = ? LIMIT 1`,
+    ).bind(input.organizationId, provider, providerReference).first<Record<string, unknown>>();
+    if (existing) {
+      if (Number(existing.bookingId) !== booking.id || Number(existing.amount) !== booking.paymentAmount) {
+        throw new Error("payment_reference_conflict");
+      }
+      return { transaction: existing, created: false, booking };
+    }
+  }
+
+  const result = await db.prepare(
+    `INSERT INTO payment_transactions
+      (organization_id, booking_id, amount, currency, provider, provider_reference, status)
+     VALUES (?, ?, ?, ?, ?, ?, 'pending')`,
+  ).bind(
+    input.organizationId,
+    booking.id,
+    booking.paymentAmount,
+    currency,
+    provider,
+    providerReference,
+  ).run();
+
+  return {
+    transaction: {
+      id: Number(result.meta.last_row_id || 0),
+      bookingId: booking.id,
+      amount: booking.paymentAmount,
+      currency,
+      provider,
+      providerReference,
+      status: "pending" as const,
+    },
+    created: true,
+    booking,
+  };
+}
+
+export async function recordManualPayment(
+  db: PaymentLedgerDb,
+  input: {
+    organizationId: number;
+    bookingId: number;
+    actor: string;
+    method: string;
+    providerReference?: string;
+  },
+) {
+  const booking = await paymentBookingSnapshot(db, input.organizationId, input.bookingId);
+  if (!booking) throw new Error("booking_not_found");
+  if (!Number.isInteger(booking.paymentAmount) || booking.paymentAmount <= 0) throw new Error("invalid_booking_amount");
+
+  const providerReference = cleanReference(input.providerReference || `manual:${booking.code}`);
+  const existing = await db.prepare(
+    `SELECT id, booking_id AS bookingId, amount, status
+     FROM payment_transactions
+     WHERE organization_id = ? AND provider = 'manual' AND provider_reference = ? LIMIT 1`,
+  ).bind(input.organizationId, providerReference).first<{ id: number; bookingId: number; amount: number; status: string }>();
+
+  if (existing) {
+    if (existing.bookingId !== booking.id || existing.amount !== booking.paymentAmount) {
+      throw new Error("payment_reference_conflict");
+    }
+    if (existing.status === "paid" && booking.paymentStatus === "paid" && booking.paidAmount === booking.paymentAmount) {
+      return { id: existing.id, created: false, booking };
+    }
+  }
+
+  const method = input.method.trim().slice(0, 40) || "other";
+  const nowExpr = "CURRENT_TIMESTAMP";
+  const statements = existing
+    ? [
+        db.prepare(
+          `UPDATE payment_transactions SET status = 'paid', paid_at = ${nowExpr}, updated_at = ${nowExpr}
+           WHERE organization_id = ? AND id = ?`,
+        ).bind(input.organizationId, existing.id),
+        db.prepare(
+          `UPDATE bookings SET payment_status = 'paid', paid_amount = payment_amount, payment_method = ?
+           WHERE organization_id = ? AND id = ?`,
+        ).bind(method, input.organizationId, booking.id),
+        db.prepare(
+          `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+           VALUES (?, ?, 'payment_confirmed', ?, ?)`,
+        ).bind(input.organizationId, booking.id, `manual · ${booking.paymentAmount} UAH · ${method}`, input.actor),
+      ]
+    : [
+        db.prepare(
+          `INSERT INTO payment_transactions
+            (organization_id, booking_id, amount, currency, provider, provider_reference, status, paid_at)
+           VALUES (?, ?, ?, 'UAH', 'manual', ?, 'paid', ${nowExpr})`,
+        ).bind(input.organizationId, booking.id, booking.paymentAmount, providerReference),
+        db.prepare(
+          `UPDATE bookings SET payment_status = 'paid', paid_amount = payment_amount, payment_method = ?
+           WHERE organization_id = ? AND id = ?`,
+        ).bind(method, input.organizationId, booking.id),
+        db.prepare(
+          `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+           VALUES (?, ?, 'payment_confirmed', ?, ?)`,
+        ).bind(input.organizationId, booking.id, `manual · ${booking.paymentAmount} UAH · ${method}`, input.actor),
+      ];
+
+  await db.batch(statements);
+  return { id: existing?.id || 0, created: !existing, booking };
+}
+
+export async function latestPaymentForBooking(
+  db: PaymentLedgerDb,
+  organizationId: number,
+  bookingId: number,
+) {
+  return db.prepare(
+    `SELECT id, amount, currency, provider, provider_reference AS providerReference, status,
+      created_at AS createdAt, paid_at AS paidAt, refunded_at AS refundedAt
+     FROM payment_transactions
+     WHERE organization_id = ? AND booking_id = ?
+     ORDER BY id DESC LIMIT 1`,
+  ).bind(organizationId, bookingId).first<Record<string, unknown>>();
+}

--- a/tests/payment-api.behavior.test.mjs
+++ b/tests/payment-api.behavior.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedPatientSession, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db, { code, phone = "380501112233", amount = 1500, organizationId = 1 }) {
+  const result = await db.prepare(
+    `INSERT INTO bookings (
+      organization_id, code, name, phone, phone_normalized, service, service_code,
+      equipment_id, duration_minutes, desired_date, desired_time, patient_category,
+      payment_status, payment_amount, paid_amount, status
+    ) VALUES (?, ?, 'Пацієнт', '+380501112233', ?, 'КТ ОГК', 'ct-chest',
+      'ct', 30, '2026-08-20', '10:00', 'civilian', 'pending', ?, 0, 'confirmed')`,
+  ).bind(organizationId, code, phone, amount).run();
+  return Number(result.meta.last_row_id);
+}
+
+test("patient payment start is session-scoped and server derives the amount", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { code: "RD-PAY-001", amount: 1800 });
+    await seedBooking(db, { code: "RD-PAY-002", phone: "380671112233", amount: 2200 });
+    const cookie = await seedPatientSession(db, "380501112233", 1);
+
+    const own = await callWorker(jsonRequest("/api/pay-link", { code: "RD-PAY-001", amount: 1 }, {
+      headers: { cookie },
+    }), db);
+    assert.equal(own.status, 200);
+    const ownBody = await own.json();
+    assert.equal(ownBody.booking.amount, 1800);
+    assert.equal(ownBody.booking.code, "RD-PAY-001");
+    assert.equal(ownBody.payment.amount, 1800);
+    assert.equal(ownBody.payment.status, "pending");
+
+    const foreign = await callWorker(jsonRequest("/api/pay-link", { code: "RD-PAY-002" }, {
+      headers: { cookie },
+    }), db);
+    assert.equal(foreign.status, 404);
+  });
+});
+
+test("staff reconciliation creates one booking-bound payment and is idempotent", async () => {
+  await withD1(async (db) => {
+    const bookingId = await seedBooking(db, { code: "RD-PAY-003", amount: 2400 });
+    const cookie = await seedStaffSession(db, { email: "registrar@example.com", role: "registrar" });
+
+    const request = () => jsonRequest("/api/staff/payments", {
+      bookingId,
+      method: "bank_transfer",
+      providerReference: "receipt-003",
+      amount: 1,
+    }, { headers: { cookie } });
+
+    const first = await callWorker(request(), db);
+    assert.equal(first.status, 200);
+    const firstBody = await first.json();
+    assert.equal(firstBody.paymentStatus, "paid");
+    assert.equal(firstBody.paidAmount, 2400);
+    assert.equal(firstBody.created, true);
+
+    const second = await callWorker(request(), db);
+    assert.equal(second.status, 200);
+    const secondBody = await second.json();
+    assert.equal(secondBody.created, false);
+
+    const paymentCount = await db.prepare(
+      "SELECT COUNT(*) AS n FROM payment_transactions WHERE organization_id = 1 AND booking_id = ?",
+    ).bind(bookingId).first();
+    assert.equal(paymentCount.n, 1);
+
+    const booking = await db.prepare(
+      "SELECT payment_status AS status, payment_amount AS amount, paid_amount AS paid FROM bookings WHERE id = ?",
+    ).bind(bookingId).first();
+    assert.equal(booking.status, "paid");
+    assert.equal(booking.amount, 2400);
+    assert.equal(booking.paid, 2400);
+  });
+});
+
+test("patient cabinet exposes latest ledger status without crossing tenant scope", async () => {
+  await withD1(async (db) => {
+    const bookingId = await seedBooking(db, { code: "RD-PAY-004", amount: 1300 });
+    await db.prepare(
+      `INSERT INTO payment_transactions
+       (organization_id, booking_id, amount, currency, provider, provider_reference, status, paid_at)
+       VALUES (1, ?, 1300, 'UAH', 'manual', 'receipt-004', 'paid', CURRENT_TIMESTAMP)`,
+    ).bind(bookingId).run();
+    await db.prepare(
+      "UPDATE bookings SET payment_status = 'paid', paid_amount = 1300, payment_method = 'bank_transfer' WHERE id = ?",
+    ).bind(bookingId).run();
+
+    const cookie = await seedPatientSession(db, "380501112233", 1);
+    const response = await callWorker(jsonRequest("/api/my-bookings", {}, {
+      headers: { cookie },
+    }), db);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.bookings[0].paymentStatus, "paid");
+    assert.equal(body.bookings[0].paidAmount, 1300);
+    assert.equal(body.bookings[0].paymentTransactionStatus, "paid");
+    assert.equal(body.bookings[0].paymentReference, "receipt-004");
+  });
+});

--- a/tests/payment-api.behavior.test.mjs
+++ b/tests/payment-api.behavior.test.mjs
@@ -2,22 +2,22 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { callWorker, jsonRequest, seedPatientSession, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
-async function seedBooking(db, { code, phone = "380501112233", amount = 1500, organizationId = 1 }) {
+async function seedBooking(db, { code, phone = "380501112233", amount = 1500, organizationId = 1, desiredTime = "10:00" }) {
   const result = await db.prepare(
     `INSERT INTO bookings (
       organization_id, code, name, phone, phone_normalized, service, service_code,
       equipment_id, duration_minutes, desired_date, desired_time, patient_category,
       payment_status, payment_amount, paid_amount, status
     ) VALUES (?, ?, 'Пацієнт', '+380501112233', ?, 'КТ ОГК', 'ct-chest',
-      'ct', 30, '2026-08-20', '10:00', 'civilian', 'pending', ?, 0, 'confirmed')`,
-  ).bind(organizationId, code, phone, amount).run();
+      'ct', 30, '2026-08-20', ?, 'civilian', 'pending', ?, 0, 'confirmed')`,
+  ).bind(organizationId, code, phone, desiredTime, amount).run();
   return Number(result.meta.last_row_id);
 }
 
 test("patient payment start is session-scoped and server derives the amount", async () => {
   await withD1(async (db) => {
-    await seedBooking(db, { code: "RD-PAY-001", amount: 1800 });
-    await seedBooking(db, { code: "RD-PAY-002", phone: "380671112233", amount: 2200 });
+    await seedBooking(db, { code: "RD-PAY-001", amount: 1800, desiredTime: "10:00" });
+    await seedBooking(db, { code: "RD-PAY-002", phone: "380671112233", amount: 2200, desiredTime: "10:30" });
     const cookie = await seedPatientSession(db, "380501112233", 1);
 
     const own = await callWorker(jsonRequest("/api/pay-link", { code: "RD-PAY-001", amount: 1 }, {

--- a/tests/payment-ledger.behavior.test.mjs
+++ b/tests/payment-ledger.behavior.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createPendingPayment, latestPaymentForBooking, recordManualPayment } from "../lib/payments.ts";
+import { withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db, { organizationId = 1, code, amount = 1500, status = "pending" }) {
+  const result = await db.prepare(
+    `INSERT INTO bookings (
+      organization_id, code, name, phone, phone_normalized, service, service_code,
+      equipment_id, duration_minutes, desired_date, desired_time, patient_category,
+      payment_status, payment_amount, paid_amount, status
+    ) VALUES (?, ?, 'Пацієнт', '+380501112233', '380501112233', 'КТ ОГК', 'ct-chest',
+      'ct', 30, '2026-08-20', '10:00', 'civilian', ?, ?, 0, 'confirmed')`,
+  ).bind(organizationId, code, status, amount).run();
+  return Number(result.meta.last_row_id);
+}
+
+test("pending payment amount is always derived from the booking snapshot", async () => {
+  await withD1(async (db) => {
+    const bookingId = await seedBooking(db, { code: "PAY-A", amount: 1700 });
+    const result = await createPendingPayment(db, {
+      organizationId: 1,
+      bookingId,
+      provider: "manual",
+      providerReference: "ref-a",
+    });
+    assert.equal(result.transaction.amount, 1700);
+    const row = await latestPaymentForBooking(db, 1, bookingId);
+    assert.equal(row.amount, 1700);
+    assert.equal(row.status, "pending");
+  });
+});
+
+test("provider reference is idempotent and cannot be rebound to another booking", async () => {
+  await withD1(async (db) => {
+    const firstId = await seedBooking(db, { code: "PAY-B1", amount: 900 });
+    const secondId = await seedBooking(db, { code: "PAY-B2", amount: 900 });
+    const one = await createPendingPayment(db, {
+      organizationId: 1,
+      bookingId: firstId,
+      provider: "liqpay",
+      providerReference: "provider-42",
+    });
+    const again = await createPendingPayment(db, {
+      organizationId: 1,
+      bookingId: firstId,
+      provider: "liqpay",
+      providerReference: "provider-42",
+    });
+    assert.equal(one.created, true);
+    assert.equal(again.created, false);
+    await assert.rejects(
+      () => createPendingPayment(db, {
+        organizationId: 1,
+        bookingId: secondId,
+        provider: "liqpay",
+        providerReference: "provider-42",
+      }),
+      /payment_reference_conflict/,
+    );
+    const count = await db.prepare(
+      "SELECT COUNT(*) AS n FROM payment_transactions WHERE organization_id = 1 AND provider_reference = 'provider-42'",
+    ).first();
+    assert.equal(count.n, 1);
+  });
+});
+
+test("manual confirmation creates one paid ledger entry and updates booking aggregate", async () => {
+  await withD1(async (db) => {
+    const bookingId = await seedBooking(db, { code: "PAY-C", amount: 2100 });
+    const first = await recordManualPayment(db, {
+      organizationId: 1,
+      bookingId,
+      actor: "cashier@example.com",
+      method: "bank_transfer",
+      providerReference: "bank-receipt-100",
+    });
+    assert.equal(first.created, true);
+    const booking = await db.prepare(
+      "SELECT payment_status AS status, paid_amount AS paidAmount, payment_method AS method FROM bookings WHERE id = ?",
+    ).bind(bookingId).first();
+    assert.equal(booking.status, "paid");
+    assert.equal(booking.paidAmount, 2100);
+    assert.equal(booking.method, "bank_transfer");
+    const payment = await latestPaymentForBooking(db, 1, bookingId);
+    assert.equal(payment.status, "paid");
+    assert.equal(payment.amount, 2100);
+    assert.ok(payment.paidAt);
+
+    const second = await recordManualPayment(db, {
+      organizationId: 1,
+      bookingId,
+      actor: "cashier@example.com",
+      method: "bank_transfer",
+      providerReference: "bank-receipt-100",
+    });
+    assert.equal(second.created, false);
+    const count = await db.prepare(
+      "SELECT COUNT(*) AS n FROM payment_transactions WHERE organization_id = ? AND booking_id = ?",
+    ).bind(1, bookingId).first();
+    assert.equal(count.n, 1);
+  });
+});
+
+test("the same provider reference may exist independently in another tenant", async () => {
+  await withD1(async (db) => {
+    const one = await seedBooking(db, { organizationId: 1, code: "PAY-D1", amount: 1200 });
+    const two = await seedBooking(db, { organizationId: 2, code: "PAY-D2", amount: 1300 });
+    await createPendingPayment(db, {
+      organizationId: 1,
+      bookingId: one,
+      provider: "manual",
+      providerReference: "shared-ref",
+    });
+    await createPendingPayment(db, {
+      organizationId: 2,
+      bookingId: two,
+      provider: "manual",
+      providerReference: "shared-ref",
+    });
+    const count = await db.prepare(
+      "SELECT COUNT(*) AS n FROM payment_transactions WHERE provider_reference = 'shared-ref'",
+    ).first();
+    assert.equal(count.n, 2);
+  });
+});

--- a/tests/payment-ledger.behavior.test.mjs
+++ b/tests/payment-ledger.behavior.test.mjs
@@ -3,15 +3,15 @@ import test from "node:test";
 import { createPendingPayment, latestPaymentForBooking, recordManualPayment } from "../lib/payments.ts";
 import { withD1 } from "./helpers/d1.mjs";
 
-async function seedBooking(db, { organizationId = 1, code, amount = 1500, status = "pending" }) {
+async function seedBooking(db, { organizationId = 1, code, amount = 1500, status = "pending", desiredTime = "10:00" }) {
   const result = await db.prepare(
     `INSERT INTO bookings (
       organization_id, code, name, phone, phone_normalized, service, service_code,
       equipment_id, duration_minutes, desired_date, desired_time, patient_category,
       payment_status, payment_amount, paid_amount, status
     ) VALUES (?, ?, 'Пацієнт', '+380501112233', '380501112233', 'КТ ОГК', 'ct-chest',
-      'ct', 30, '2026-08-20', '10:00', 'civilian', ?, ?, 0, 'confirmed')`,
-  ).bind(organizationId, code, status, amount).run();
+      'ct', 30, '2026-08-20', ?, 'civilian', ?, ?, 0, 'confirmed')`,
+  ).bind(organizationId, code, desiredTime, status, amount).run();
   return Number(result.meta.last_row_id);
 }
 
@@ -33,8 +33,8 @@ test("pending payment amount is always derived from the booking snapshot", async
 
 test("provider reference is idempotent and cannot be rebound to another booking", async () => {
   await withD1(async (db) => {
-    const firstId = await seedBooking(db, { code: "PAY-B1", amount: 900 });
-    const secondId = await seedBooking(db, { code: "PAY-B2", amount: 900 });
+    const firstId = await seedBooking(db, { code: "PAY-B1", amount: 900, desiredTime: "10:00" });
+    const secondId = await seedBooking(db, { code: "PAY-B2", amount: 900, desiredTime: "10:30" });
     const one = await createPendingPayment(db, {
       organizationId: 1,
       bookingId: firstId,

--- a/tests/payment-settlement.behavior.test.mjs
+++ b/tests/payment-settlement.behavior.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createPendingPayment } from "../lib/payments.ts";
+import { refundLatestPayment, settleVerifiedProviderPayment } from "../lib/payment-settlement.ts";
+import { withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db, { code, amount = 1500 }) {
+  const result = await db.prepare(
+    `INSERT INTO bookings (
+      organization_id, code, name, phone, phone_normalized, service, service_code,
+      equipment_id, duration_minutes, desired_date, desired_time, patient_category,
+      payment_status, payment_amount, paid_amount, status
+    ) VALUES (1, ?, 'Пацієнт', '+380501112233', '380501112233', 'КТ ОГК', 'ct-chest',
+      'ct', 30, '2026-08-20', '11:00', 'civilian', 'pending', ?, 0, 'confirmed')`,
+  ).bind(code, amount).run();
+  return Number(result.meta.last_row_id);
+}
+
+test("verified provider settlement is replay-safe and cannot alter authoritative amount", async () => {
+  await withD1(async (db) => {
+    const bookingId = await seedBooking(db, { code: "SETTLE-1", amount: 1900 });
+    await createPendingPayment(db, {
+      organizationId: 1,
+      bookingId,
+      provider: "liqpay",
+      providerReference: "lp-100",
+    });
+
+    await assert.rejects(
+      () => settleVerifiedProviderPayment(db, {
+        organizationId: 1,
+        bookingId,
+        provider: "liqpay",
+        providerReference: "lp-100",
+        amount: 1,
+      }),
+      /payment_amount_mismatch/,
+    );
+
+    const first = await settleVerifiedProviderPayment(db, {
+      organizationId: 1,
+      bookingId,
+      provider: "liqpay",
+      providerReference: "lp-100",
+      amount: 1900,
+    });
+    assert.equal(first.created, false);
+    const second = await settleVerifiedProviderPayment(db, {
+      organizationId: 1,
+      bookingId,
+      provider: "liqpay",
+      providerReference: "lp-100",
+      amount: 1900,
+    });
+    assert.equal(second.created, false);
+
+    const count = await db.prepare(
+      "SELECT COUNT(*) AS n FROM payment_transactions WHERE provider = 'liqpay' AND provider_reference = 'lp-100'",
+    ).first();
+    assert.equal(count.n, 1);
+    const booking = await db.prepare(
+      "SELECT payment_status AS status, paid_amount AS paid FROM bookings WHERE id = ?",
+    ).bind(bookingId).first();
+    assert.equal(booking.status, "paid");
+    assert.equal(booking.paid, 1900);
+  });
+});
+
+test("refund is audited and idempotent", async () => {
+  await withD1(async (db) => {
+    const bookingId = await seedBooking(db, { code: "REFUND-1", amount: 1100 });
+    await settleVerifiedProviderPayment(db, {
+      organizationId: 1,
+      bookingId,
+      provider: "liqpay",
+      providerReference: "lp-refund",
+      amount: 1100,
+    });
+
+    const first = await refundLatestPayment(db, {
+      organizationId: 1,
+      bookingId,
+      actor: "registrar@example.com",
+    });
+    assert.equal(first.changed, true);
+    const second = await refundLatestPayment(db, {
+      organizationId: 1,
+      bookingId,
+      actor: "registrar@example.com",
+    });
+    assert.equal(second.changed, false);
+
+    const transaction = await db.prepare(
+      "SELECT status, refunded_at AS refundedAt FROM payment_transactions WHERE booking_id = ? ORDER BY id DESC LIMIT 1",
+    ).bind(bookingId).first();
+    assert.equal(transaction.status, "refunded");
+    assert.ok(transaction.refundedAt);
+    const booking = await db.prepare(
+      "SELECT payment_status AS status, paid_amount AS paid FROM bookings WHERE id = ?",
+    ).bind(bookingId).first();
+    assert.equal(booking.status, "refunded");
+    assert.equal(booking.paid, 0);
+    const audit = await db.prepare(
+      "SELECT COUNT(*) AS n FROM booking_events WHERE booking_id = ? AND action = 'payment_refunded'",
+    ).bind(bookingId).first();
+    assert.equal(audit.n, 1);
+  });
+});


### PR DESCRIPTION
Closes #158.

Implemented:
- persistent tenant-scoped `payment_transactions` ledger linked to `booking_id` with amount, currency, provider, provider reference, lifecycle status and timestamps;
- provider reference uniqueness gives idempotent reconciliation/callback semantics without cross-tenant collisions;
- Drizzle payment schema is registered alongside the D1 migration;
- server-side payment helpers derive the payable amount only from the booking snapshot; client-supplied amounts are ignored;
- OTP-authenticated `POST /api/pay-link` binds payment start to the patient's own booking and returns authoritative service/date/time/code/amount/payment metadata while the legacy public GET remains a non-personal generic payment-link lookup;
- `POST /api/staff/payments` provides tenant/RBAC-scoped manual reconciliation and atomically records the paid transaction, booking aggregate and audit event;
- `DELETE /api/staff/payments` performs audited, idempotent refunds;
- patient cabinet API exposes the booking payment aggregate plus the latest authoritative ledger transaction;
- `settleVerifiedProviderPayment` is the post-signature-verification settlement boundary for future online providers: amount equality and provider-reference idempotency are enforced before crediting;
- current PrivatBank/QR manual flow remains supported without exposing provider secrets to the browser;
- behavioral tests cover authoritative amount, patient ownership, tenant isolation, manual reconciliation replay, provider callback replay/reference conflict, settlement amount mismatch and refunds;
- CI #525 and CodeQL #440 are green on the final head.

Note: the compact booking drawer only displays payment state and deep-links to the full booking; it has no finance mutation control. The canonical finance mutation API is now `/api/staff/payments`, ready for the full booking UI to call without duplicating payment rules.