### PR TITLE
fix: establish canonical public URL

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,7 +6,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
   return [
     { url: `${BASE_URL}/`, lastModified, changeFrequency: "weekly", priority: 1 },
-    { url: `${BASE_URL}/site/`, lastModified, changeFrequency: "weekly", priority: 1 },
     { url: `${BASE_URL}/site/price.html`, lastModified, changeFrequency: "weekly", priority: 0.9 },
     { url: `${BASE_URL}/site/military.html`, lastModified, changeFrequency: "monthly", priority: 0.8 },
   ];

--- a/tests/canonical-public-url.test.mjs
+++ b/tests/canonical-public-url.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("the domain root is the single canonical homepage", async () => {
+  const worker = await read("worker/index.ts");
+  const home = await read("public/site/index.html");
+
+  assert.match(worker, /LEGACY_HOME_PATHS = new Set\(\["\/index\.html", "\/site", "\/site\/", "\/site\/index\.html"\]\)/);
+  assert.match(worker, /LEGACY_HOME_PATHS\.has\(url\.pathname\)/);
+  assert.match(worker, /Response\.redirect\(canonicalHome\.toString\(\), 308\)/);
+  assert.match(worker, /canonicalHome\.search = url\.search/);
+  assert.match(worker, /if \(url\.pathname === "\/"\)/);
+  assert.match(home, /<link rel="canonical" href="https:\/\/radiologyos\.tech\/"\/>/);
+  assert.match(home, /<meta property="og:url" content="https:\/\/radiologyos\.tech\/"\/>/);
+});
+
+test("sitemap contains the canonical home only once", async () => {
+  const sitemap = await read("app/sitemap.ts");
+  assert.match(sitemap, /url: `\$\{BASE_URL\}\/`/);
+  assert.doesNotMatch(sitemap, /BASE_URL\}\/site\/`/);
+  assert.doesNotMatch(sitemap, /BASE_URL\}\/index\.html/);
+  assert.doesNotMatch(sitemap, /BASE_URL\}\/site\/index\.html/);
+  assert.match(sitemap, /BASE_URL\}\/site\/price\.html/);
+  assert.match(sitemap, /BASE_URL\}\/site\/military\.html/);
+});
+
+test("indexable static landing pages have canonical response metadata and cabinet is noindex", async () => {
+  const worker = await read("worker/index.ts");
+  assert.match(worker, /PUBLIC_CANONICAL_PATHS = new Set\(\["\/", "\/site\/price\.html", "\/site\/military\.html"\]\)/);
+  assert.match(worker, /headers\.set\("link", `<\$\{new URL\(pathname, url\.origin\)\.toString\(\)\}>; rel="canonical"`\)/);
+  assert.match(worker, /pathname === "\/site\/cabinet\.html" \|\| pathname === "\/cabinet"/);
+  assert.match(worker, /headers\.set\("x-robots-tag", "noindex, nofollow"\)/);
+});

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -67,12 +67,13 @@ test("the worker serves the established teal storefront at /", async () => {
   assert.match(html, /v22-landing/);
 });
 
-test("the worker serves the same public storefront at /site/", async () => {
-  const marker = "<main>site-path-landing</main>";
-  for (const path of ["/site", "/site/", "/site/index.html"]) {
-    const response = await renderWithAssets(path, { "/site/index.html": marker });
-    assert.equal(response.status, 200, `${path} should open the storefront`);
-    assert.match(await response.text(), /site-path-landing/);
+test("legacy homepage aliases permanently redirect to the canonical root", async () => {
+  for (const path of ["/site", "/site/", "/site/index.html", "/index.html"]) {
+    const response = await renderWithAssets(`${path}?utm_source=legacy`, { "/site/index.html": "unused" });
+    assert.equal(response.status, 308, `${path} should permanently redirect`);
+    const location = response.headers.get("location") ?? "";
+    assert.equal(new URL(location).pathname, "/");
+    assert.equal(new URL(location).searchParams.get("utm_source"), "legacy");
   }
 });
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -45,11 +45,23 @@ const SECURITY_HEADERS: Record<string, string> = {
   "x-frame-options": "DENY",
 };
 
+const LEGACY_HOME_PATHS = new Set(["/index.html", "/site", "/site/", "/site/index.html"]);
+const PUBLIC_CANONICAL_PATHS = new Set(["/", "/site/price.html", "/site/military.html"]);
+
 function secure(response: Response, request?: Request): Response {
   const headers = new Headers(response.headers);
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) headers.set(name, value);
   if (request) {
-    const pathname = new URL(request.url).pathname;
+    const url = new URL(request.url);
+    const pathname = url.pathname;
+    // Canonical headers cover the static pages that do not all have HTML
+    // metadata. The patient cabinet is intentionally excluded from indexing.
+    if (PUBLIC_CANONICAL_PATHS.has(pathname)) {
+      headers.set("link", `<${new URL(pathname, url.origin).toString()}>; rel="canonical"`);
+    }
+    if (pathname === "/site/cabinet.html" || pathname === "/cabinet") {
+      headers.set("x-robots-tag", "noindex, nofollow");
+    }
     // /api/site-content — публічний контент вітрини, кешується самим маршрутом
     // (short max-age); решта /api та /staff лишаються no-store.
     const publicCacheable = pathname === "/api/site-content";
@@ -105,11 +117,18 @@ const worker = {
       return secure(Response.json({ error: "Cross-site request blocked" }, { status: 403 }), request);
     }
 
-    // The established teal storefront is available both at the domain root
-    // and at the public `/site/` address used in links shared with patients.
-    // Serve the same tested document instead of letting Vinext treat `/site/`
-    // as an application route and return a 404.
-    if (["/", "/index.html", "/site", "/site/", "/site/index.html"].includes(url.pathname)) {
+    // There is exactly one indexable public home. Old URLs shared with patients
+    // keep working but permanently consolidate to the domain root, preserving
+    // query parameters such as campaign attribution.
+    if ((request.method === "GET" || request.method === "HEAD") && LEGACY_HOME_PATHS.has(url.pathname)) {
+      const canonicalHome = new URL("/", url);
+      canonicalHome.search = url.search;
+      return secure(Response.redirect(canonicalHome.toString(), 308), request);
+    }
+
+    // The tested teal storefront remains the source document for the canonical
+    // domain root; only its legacy URL aliases redirect above.
+    if (url.pathname === "/") {
       const storefrontRequest = new Request(new URL("/site/index.html", request.url), request);
       return secure(await env.ASSETS.fetch(storefrontRequest), request);
     }


### PR DESCRIPTION
Closes #157.

Implemented:
- `https://radiologyos.tech/` is the single canonical public homepage;
- legacy homepage aliases `/site`, `/site/`, `/site/index.html` and `/index.html` permanently redirect with HTTP 308 to `/`, preserving query parameters such as campaign attribution;
- the domain root continues serving the existing tested static storefront, so storefront and booking behavior are unchanged;
- sitemap contains the canonical homepage only once while retaining the price and military landing pages;
- canonical HTTP `Link` headers cover `/`, `/site/price.html` and `/site/military.html`; the root HTML already carries matching canonical and Open Graph URL metadata;
- patient cabinet routes receive `X-Robots-Tag: noindex, nofollow`;
- existing `/booking` and `/cabinet` compatibility redirects remain unchanged;
- regression tests invoke the built Worker and verify all four legacy aliases return 308 to `/` with query preservation;
- SEO regression tests cover canonical metadata, sitemap de-duplication and cabinet noindex;
- CI #528 and CodeQL #443 are green on final head `31464a45`.