### PR TITLE
test: add production release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Test and build
         run: npm test
+
+      - name: Production release gate
+        run: npm run test:production-gate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build and deploy
     if: ${{ inputs.confirmation == 'DEPLOY' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     environment: production
     steps:
       - name: Checkout
@@ -44,6 +44,9 @@ jobs:
 
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
+
+      - name: Production release gate
+        run: npm run test:production-gate
 
       - name: Build artifact
         run: npm run build
@@ -84,4 +87,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Smoke test production
-        run: curl --fail --silent --show-error --retry 5 --retry-all-errors https://radiologyos.tech/ > /dev/null
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --retry 5 --retry-all-errors https://radiologyos.tech/ > /dev/null
+          test "$(curl --silent --output /dev/null --write-out '%{http_code}' https://radiologyos.tech/site/)" = "308"
+          curl --fail --silent --show-error https://radiologyos.tech/robots.txt > /dev/null

--- a/docs/production-smoke-checklist.md
+++ b/docs/production-smoke-checklist.md
@@ -1,0 +1,111 @@
+# RadiologyOS production release smoke checklist
+
+This checklist is the manual production gate after a Cloudflare deployment. Use synthetic data only. Never enter a real patient name, phone number, diagnosis, protocol, image, or other medical data during a release smoke test.
+
+## 1. Preconditions
+
+- The PR CI is green, including the **Production release gate** step.
+- CodeQL is green.
+- The linked critical P0 issues for booking capacity, tenant isolation, canonical service/price resolution, payment lifecycle, canonical public URL, and this release gate are closed.
+- The deploy workflow recorded a D1 Time Travel recovery bookmark before applying migrations. Save the bookmark from the Actions log with the release SHA.
+- Confirm the deployment is from the expected `main` SHA.
+
+Stop the release if any item above is false.
+
+## 2. Migration verification
+
+Before deploy, record the D1 recovery bookmark:
+
+```bash
+npx wrangler d1 time-travel info radiologyos --config wrangler.cloudflare.toml
+```
+
+Apply migrations only through the production deploy workflow. After deploy, verify the expected schema exists without inspecting patient rows:
+
+```bash
+npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
+  --command "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('bookings','patient_sessions','payment_transactions','booking_events') ORDER BY name;"
+```
+
+Expected: all four table names are returned. For a release containing a new migration, additionally verify the new table/column/index named in that migration.
+
+## 3. Public and security smoke
+
+1. Open `https://radiologyos.tech/`; confirm the public storefront loads over HTTPS.
+2. Open `/site/`; confirm it permanently redirects to `/` and does not render a duplicate homepage.
+3. Confirm the civilian booking page shows the current service name and price from the server-backed catalog.
+4. Check a patient-cabinet response and authenticated API response in browser DevTools. Private/authenticated responses must not be publicly cacheable.
+5. Confirm expected security headers remain present, including anti-sniffing/frame policy where applicable.
+6. Confirm patient cabinet pages are not indexable by search engines.
+
+Stop the release for a wrong canonical URL, missing HTTPS, public caching of authenticated data, or missing critical security headers.
+
+## 4. Synthetic patient journey
+
+Use an obviously synthetic identity, for example:
+
+- Name: `TEST RELEASE <short-sha>`
+- Phone: a designated non-real test number controlled by the team; do not use a random real Ukrainian number.
+- Notes: `SYNTHETIC RELEASE SMOKE — DELETE AFTER TEST`
+- No diagnosis, medical history, images, real protocol text, or real personal data.
+
+Run the following journey:
+
+1. From the civilian booking flow, select an active service and confirm the displayed amount matches the current server-derived amount.
+2. Create one synthetic booking in an unused future slot.
+3. Attempt to create a second active booking for the same capacity-limited slot. It must be rejected or the slot must no longer be offered.
+4. In the staff workspace, confirm the synthetic booking appears with the same service, date, time, code, and amount.
+5. Confirm the booking, then reschedule it to another valid free slot. Verify the old capacity is released and the new capacity is reserved.
+6. Authenticate the synthetic patient through the normal patient OTP/session flow using the designated test contact.
+7. Confirm the patient sees only their own synthetic booking. A different booking code/id must not expose another patient's data (IDOR check).
+8. Start/reconcile the synthetic civilian payment using the configured non-charge/manual test path. The authoritative amount must remain the server booking amount even if a different amount is sent from the browser/client.
+9. Repeat the same payment reconciliation/provider reference. It must be idempotent and must not create a second paid transaction.
+10. In staff workflow, move the synthetic study through the allowed arrival/performance/reporting states. Illegal state jumps must remain rejected.
+11. Create only a harmless synthetic protocol marker such as `SYNTHETIC RELEASE SMOKE`. Confirm protocol access is limited to authorized staff and the owning patient session where patient delivery is enabled.
+12. Confirm dashboard/reporting reflects one completed synthetic study and the reconciled payment without cross-tenant data.
+
+Any ownership leak, duplicate active slot, client-controlled price, duplicate payment, unauthorized protocol access, or illegal workflow transition is a release blocker.
+
+## 5. Tenant isolation check
+
+For multi-tenant test fixtures/accounts only, verify that a staff or patient session for organization A cannot read or mutate a booking, payment, protocol, or dashboard data belonging to organization B. Do not perform this test against another real organization or real patient record.
+
+A cross-tenant read or write is an immediate rollback condition.
+
+## 6. Cleanup
+
+Immediately after a successful or failed smoke test:
+
+1. Locate the synthetic booking by its unique `TEST RELEASE <short-sha>` marker or booking code.
+2. Delete/cancel the synthetic booking through the supported staff workflow where possible.
+3. Remove synthetic protocol/report content and synthetic payment transaction created specifically for the smoke test if the product provides a supported cleanup/admin path. If the ledger is intentionally immutable, keep the synthetic transaction but ensure it is clearly marked/test-only and excluded from operational reporting according to the established finance procedure.
+4. Revoke/delete the synthetic patient session and any OTP/test-session artifacts where supported.
+5. Verify no synthetic booking occupies capacity and no synthetic record is mistaken for a real patient.
+6. Record completion of cleanup in the release notes or deployment log. Do not paste medical or patient data into GitHub.
+
+Never use direct production SQL deletion on real patient data as a smoke-test cleanup shortcut.
+
+## 7. Rollback criteria
+
+Rollback immediately when any of the following is observed after deployment:
+
+- booking creation fails for valid slots or permits capacity collisions;
+- a patient/staff user can access another tenant's or patient's record;
+- authenticated/private data is cached publicly;
+- payment amount can be overridden by the client, payment reconciliation duplicates charges/ledger entries, or paid state is inconsistent;
+- required migrations are missing or application queries fail because schema and code are out of sync;
+- staff cannot safely confirm/reschedule/complete studies;
+- protocol/report permissions regress;
+- the canonical site, booking flow, or critical API returns persistent 5xx errors.
+
+## 8. Rollback procedure
+
+1. Stop paid traffic and operational use of the affected flow.
+2. Redeploy the last known-good Worker/application SHA if the failure is code-only.
+3. If a migration caused data/schema corruption or the old application cannot run against the migrated schema, use the D1 Time Travel bookmark recorded immediately before deployment. Follow Cloudflare's current recovery procedure and confirm the recovery target before executing it.
+4. After rollback, rerun the public/security smoke and a synthetic booking ownership check.
+5. Open a blocking GitHub issue describing the release SHA, failed invariant, rollback action, and whether D1 recovery was used. Do not include patient data.
+
+## Release decision
+
+Production is considered ready only when automated CI/CodeQL gates are green, deployment completes, this smoke checklist passes, synthetic data is cleaned up, and all critical P0 release issues are closed.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "bash scripts/build-verified.sh",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
     "test": "npm run build && node --experimental-strip-types --test tests/*.test.mjs",
+    "test:production-gate": "npm run build && node --experimental-strip-types --test tests/canonical-public-url.test.mjs tests/hosting-headers.test.mjs tests/site-booking.behavior.test.mjs tests/booking-capacity.test.mjs tests/staff-confirm-reschedule.behavior.test.mjs tests/staff-rbac.behavior.test.mjs tests/patient-otp.behavior.test.mjs tests/patient-cabinet-tenant.test.mjs tests/my-bookings.behavior.test.mjs tests/payment-api.behavior.test.mjs tests/payment-ledger.behavior.test.mjs tests/payment-settlement.behavior.test.mjs tests/study-state.test.mjs tests/protocol-builder.test.mjs tests/dashboard.test.mjs tests/security-hardening.test.mjs tests/tenant-hardening.test.mjs",
     "validate:artifact": "bash scripts/validate-artifact.sh",
     "lint": "bash scripts/sites-env.sh -- eslint . --ignore-pattern dist --ignore-pattern .next --ignore-pattern public",
     "db:generate": "bash scripts/sites-env.sh -- drizzle-kit generate"

--- a/tests/production-release-gate.test.mjs
+++ b/tests/production-release-gate.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+const criticalTests = [
+  "canonical-public-url.test.mjs",
+  "hosting-headers.test.mjs",
+  "site-booking.behavior.test.mjs",
+  "booking-capacity.test.mjs",
+  "staff-confirm-reschedule.behavior.test.mjs",
+  "staff-rbac.behavior.test.mjs",
+  "patient-otp.behavior.test.mjs",
+  "patient-cabinet-tenant.test.mjs",
+  "my-bookings.behavior.test.mjs",
+  "payment-api.behavior.test.mjs",
+  "payment-ledger.behavior.test.mjs",
+  "payment-settlement.behavior.test.mjs",
+  "study-state.test.mjs",
+  "protocol-builder.test.mjs",
+  "dashboard.test.mjs",
+  "security-hardening.test.mjs",
+  "tenant-hardening.test.mjs",
+];
+
+test("package exposes a deterministic production release gate manifest", async () => {
+  const pkg = JSON.parse(await read("package.json"));
+  const gate = pkg.scripts?.["test:production-gate"] ?? "";
+  assert.match(gate, /npm run build/);
+  assert.match(gate, /node --experimental-strip-types --test/);
+  for (const file of criticalTests) {
+    assert.match(gate, new RegExp(file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${file} must remain release-blocking`);
+  }
+});
+
+test("CI and production deploy both run the release gate", async () => {
+  const ci = await read(".github/workflows/ci.yml");
+  const deploy = await read(".github/workflows/deploy.yml");
+
+  assert.match(ci, /name: Production release gate\s+run: npm run test:production-gate/);
+  assert.match(deploy, /name: Production release gate\s+run: npm run test:production-gate/);
+
+  const gatePosition = deploy.indexOf("name: Production release gate");
+  const migrationsPosition = deploy.indexOf("name: Apply D1 migrations");
+  const deployPosition = deploy.indexOf("name: Deploy Worker and assets");
+  assert.ok(gatePosition >= 0 && gatePosition < migrationsPosition, "gate must run before D1 migrations");
+  assert.ok(gatePosition < deployPosition, "gate must run before Worker deployment");
+});
+
+test("manual production smoke document covers the release-critical controls", async () => {
+  const doc = await read("docs/production-smoke-checklist.md");
+  for (const required of [
+    "synthetic",
+    "Migration verification",
+    "capacity",
+    "IDOR",
+    "payment",
+    "Tenant isolation",
+    "Cleanup",
+    "Rollback criteria",
+    "D1 Time Travel",
+    "security headers",
+  ]) {
+    assert.match(doc, new RegExp(required, "i"), `smoke checklist must cover ${required}`);
+  }
+  assert.match(doc, /Never enter a real patient/i);
+  assert.match(doc, /Do not include patient data/i);
+});


### PR DESCRIPTION
Closes #160.

Implemented:
- deterministic `npm run test:production-gate` manifest over critical booking, capacity, staff, patient OTP/ownership, payment, tenant, study, protocol/reporting, security-header and canonical-URL behavior tests;
- separately named blocking **Production release gate** step in PR CI;
- the same release gate runs again in the manual production deploy workflow before D1 migrations and Worker deployment;
- post-deploy smoke checks cover the canonical `/site/` 308 and `robots.txt` in addition to the production homepage;
- `docs/production-smoke-checklist.md` documents synthetic-only patient journey, migration verification, IDOR/tenant/cache/security/payment checks, cleanup, rollback criteria and D1 Time Travel recovery;
- meta-regression test prevents accidental removal of the release manifest, CI/deploy wiring or required smoke/rollback documentation;
- no production patient data is used by the automated gate;
- CI #530, including **Production release gate**, and CodeQL #445 are green on final head `25b52c84`.