### PR TITLE
fix: run Cloudflare Worker before static assets

### DIFF
--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -105,11 +105,12 @@ test("production deployment refuses to migrate without a secure active administr
   assert.match(workflow, /count < 1/);
 });
 
-test("Cloudflare deployment uses custom domains only", async () => {
+test("Cloudflare deployment uses custom domains and worker-first asset routing", async () => {
   const config = await read("wrangler.cloudflare.toml");
   assert.match(config, /\nworkers_dev = false\n/);
   assert.match(config, /pattern = "radiologyos\.tech", custom_domain = true/);
   assert.match(config, /pattern = "www\.radiologyos\.tech", custom_domain = true/);
+  assert.match(config, /\nrun_worker_first = true\n/);
   assert.doesNotMatch(config, /\n\[triggers\]\n/);
   assert.doesNotMatch(config, /\ncrons\s*=/);
 });

--- a/wrangler.cloudflare.toml
+++ b/wrangler.cloudflare.toml
@@ -20,11 +20,15 @@ routes = [
   { pattern = "www.radiologyos.tech", custom_domain = true },
 ]
 
-# Static client bundle (JS/CSS, self-hosted fonts, favicon). Served directly by
-# Cloudflare; the Worker handles every dynamic / server-rendered route.
+# Static client bundle (JS/CSS, self-hosted fonts, favicon). The Worker must run
+# before asset matching so canonical redirects, security headers and access
+# rules apply consistently even to paths backed by HTML assets (for example
+# /site/ -> /site/index.html). The Worker explicitly delegates asset delivery
+# through env.ASSETS.fetch where appropriate.
 [assets]
 directory = "dist/client"
 binding = "ASSETS"
+run_worker_first = true
 
 # D1 database. Create it once (see HOSTING.md) and paste its id below.
 [[d1_databases]]


### PR DESCRIPTION
Fixes the failed production smoke check after deploy run #101.

Root cause: Cloudflare Workers Static Assets are asset-first by default. `/site/` can resolve to `/site/index.html` before `worker/index.ts` runs, bypassing the intended canonical 308 redirect and Worker-applied security/canonical headers.

Changes:
- set `[assets].run_worker_first = true` in `wrangler.cloudflare.toml`;
- keep explicit asset delivery through `env.ASSETS.fetch` in the Worker;
- add a regression assertion so production config cannot silently return to asset-first routing.

This matches Cloudflare's documented Worker-first routing model for middleware/canonical/auth behavior. No D1 schema changes.