### PR TITLE
feat: add canonical local SEO NAP and schema

### DIFF
--- a/app/components/public-local-seo.tsx
+++ b/app/components/public-local-seo.tsx
@@ -1,0 +1,43 @@
+import { publicOrganizationProfile, telephoneHref } from "../../lib/public-profile";
+
+function safeJson(value: unknown) {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+export async function PublicLocalSeo({ path }: { path: string }) {
+  const profile = await publicOrganizationProfile();
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "MedicalClinic",
+    name: `${profile.name} — ${profile.department}`,
+    url: new URL(path, profile.url).toString(),
+    telephone: profile.telephone,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: profile.address,
+      addressCountry: "UA",
+    },
+    openingHours: profile.openingHours,
+  };
+  const tel = telephoneHref(profile.telephone);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJson(schema) }}
+      />
+      <section
+        aria-label="Контактна інформація відділення"
+        style={{ maxWidth: 1080, margin: "0 auto", padding: "0 24px 48px" }}
+      >
+        <div style={{ borderTop: "1px solid #d7e8e6", paddingTop: 24, lineHeight: 1.7 }}>
+          <strong>{profile.name} — {profile.department}</strong>
+          <div>{profile.address}</div>
+          <div>{profile.openingHours}</div>
+          {tel ? <div><a href={tel}>{profile.telephone}</a></div> : null}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/ct/[[...slug]]/page.tsx
+++ b/app/ct/[[...slug]]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { PublicLocalSeo } from "../../components/public-local-seo";
 import { SeoServiceLanding } from "../../components/seo-service-landing";
 import { CT_SEO_PAGES } from "../../../lib/seo-service-pages";
+
+export const dynamic = "force-dynamic";
 
 type Props = { params: Promise<{ slug?: string[] }> };
 
@@ -33,5 +36,10 @@ export default async function CtSeoPage({ params }: Props) {
   const { slug } = await params;
   const page = pageFor(slug);
   if (!page) notFound();
-  return <SeoServiceLanding page={page} />;
+  return (
+    <>
+      <SeoServiceLanding page={page} />
+      <PublicLocalSeo path={page.path} />
+    </>
+  );
 }

--- a/app/fluorography/page.tsx
+++ b/app/fluorography/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import { PublicLocalSeo } from "../components/public-local-seo";
 import { SeoServiceLanding } from "../components/seo-service-landing";
 import { FLUORO_SEO_PAGE } from "../../lib/seo-service-pages";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: FLUORO_SEO_PAGE.metaTitle,
@@ -16,5 +19,10 @@ export const metadata: Metadata = {
 };
 
 export default function FluorographySeoPage() {
-  return <SeoServiceLanding page={FLUORO_SEO_PAGE} />;
+  return (
+    <>
+      <SeoServiceLanding page={FLUORO_SEO_PAGE} />
+      <PublicLocalSeo path={FLUORO_SEO_PAGE.path} />
+    </>
+  );
 }

--- a/app/xray/page.tsx
+++ b/app/xray/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import { PublicLocalSeo } from "../components/public-local-seo";
 import { SeoServiceLanding } from "../components/seo-service-landing";
 import { XRAY_SEO_PAGE } from "../../lib/seo-service-pages";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: XRAY_SEO_PAGE.metaTitle,
@@ -16,5 +19,10 @@ export const metadata: Metadata = {
 };
 
 export default function XraySeoPage() {
-  return <SeoServiceLanding page={XRAY_SEO_PAGE} />;
+  return (
+    <>
+      <SeoServiceLanding page={XRAY_SEO_PAGE} />
+      <PublicLocalSeo path={XRAY_SEO_PAGE.path} />
+    </>
+  );
 }

--- a/lib/public-profile.ts
+++ b/lib/public-profile.ts
@@ -1,0 +1,44 @@
+import { dbBinding } from "./db";
+import { getSetting } from "./settings";
+import {
+  parseSiteContent,
+  SITE_CONTENT_DEFAULTS,
+  SITE_CONTENT_KEY,
+} from "./site-content";
+import { SITE_URL } from "./site";
+
+export type PublicOrganizationProfile = {
+  name: string;
+  department: string;
+  telephone: string;
+  address: string;
+  openingHours: string;
+  url: string;
+};
+
+/**
+ * Canonical public NAP resolver.
+ *
+ * Public pages and structured data must use this function rather than keeping
+ * their own copies of hospital name, phone, address or opening hours.
+ */
+export async function publicOrganizationProfile(): Promise<PublicOrganizationProfile> {
+  const db = dbBinding();
+  const content = db
+    ? parseSiteContent(await getSetting(db, SITE_CONTENT_KEY))
+    : SITE_CONTENT_DEFAULTS;
+
+  return {
+    name: content.brandTitle,
+    department: content.brandSubtitle,
+    telephone: content.phone,
+    address: content.address,
+    openingHours: content.workHours,
+    url: SITE_URL,
+  };
+}
+
+export function telephoneHref(telephone: string): string {
+  const normalized = telephone.replace(/[^+\d]/g, "");
+  return normalized ? `tel:${normalized}` : "";
+}

--- a/tests/local-seo.test.mjs
+++ b/tests/local-seo.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("public NAP resolves from the editable site_content source", async () => {
+  const profile = await read("lib/public-profile.ts");
+  assert.match(profile, /SITE_CONTENT_KEY/);
+  assert.match(profile, /parseSiteContent/);
+  assert.match(profile, /brandTitle/);
+  assert.match(profile, /brandSubtitle/);
+  assert.match(profile, /content\.phone/);
+  assert.match(profile, /content\.address/);
+  assert.match(profile, /content\.workHours/);
+  assert.doesNotMatch(profile, /\+380 97 280 88 99/);
+  assert.doesNotMatch(profile, /Полуботка, 40/);
+});
+
+test("local SEO component emits MedicalClinic JSON-LD and visible NAP from one profile", async () => {
+  const component = await read("app/components/public-local-seo.tsx");
+  assert.match(component, /publicOrganizationProfile\(\)/);
+  assert.match(component, /"@type": "MedicalClinic"/);
+  assert.match(component, /"@type": "PostalAddress"/);
+  assert.match(component, /profile\.telephone/);
+  assert.match(component, /profile\.address/);
+  assert.match(component, /profile\.openingHours/);
+  assert.match(component, /application\/ld\+json/);
+  assert.match(component, /Контактна інформація відділення/);
+});
+
+test("all public diagnostic landing routes render dynamic local SEO identity", async () => {
+  for (const path of [
+    "app/ct/[[...slug]]/page.tsx",
+    "app/xray/page.tsx",
+    "app/fluorography/page.tsx",
+  ]) {
+    const route = await read(path);
+    assert.match(route, /dynamic = "force-dynamic"/);
+    assert.match(route, /PublicLocalSeo/);
+  }
+});
+
+test("patient and staff surfaces remain excluded from the public schema component", async () => {
+  const component = await read("app/components/public-local-seo.tsx");
+  assert.doesNotMatch(component, /patient|booking|protocol|staff/i);
+});


### PR DESCRIPTION
Closes #170

Adds a single public organization/NAP resolver backed by editable `site_content`, then reuses it for visible contact data and JSON-LD on all diagnostic SEO landing pages.

Highlights:
- one canonical resolver for hospital name, department, phone, address and working hours;
- no duplicated phone/address literals in SEO components;
- server-rendered `MedicalClinic` JSON-LD with `PostalAddress`, telephone and opening-hours text;
- visible NAP block rendered from the exact same profile;
- CT/X-ray/fluorography SEO routes are force-dynamic so staff edits can appear without rebuilding;
- regression tests for single-source NAP, schema output and route integration;
- no patient/staff/booking data enters structured data.

Structured markup follows Schema.org's MedicalClinic/telephone/address/openingHours vocabulary.