### PR TITLE
feat: add privacy-safe first-party funnel analytics

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,56 @@
+import { analyticsEventName, recordAnalyticsEvent } from "../../../lib/analytics";
+import { dbBinding } from "../../../lib/db";
+
+const CLIENT_EVENTS = new Set(["page_view", "service_view", "booking_started", "slot_selected"]);
+const ALLOWED_KEYS = new Set(["eventName", "journeyId", "serviceCode", "patientCategory", "pageKey"]);
+const MAX_BODY_BYTES = 2048;
+
+export async function POST(request: Request) {
+  const contentLength = Number(request.headers.get("content-length") || 0);
+  if (contentLength > MAX_BODY_BYTES) {
+    return Response.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    const text = await request.text();
+    if (text.length > MAX_BODY_BYTES) return Response.json({ error: "Payload too large" }, { status: 413 });
+    body = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return Response.json({ error: "Invalid payload" }, { status: 400 });
+  }
+  for (const key of Object.keys(body)) {
+    if (!ALLOWED_KEYS.has(key)) return Response.json({ error: "Unexpected analytics field" }, { status: 400 });
+  }
+
+  const eventName = analyticsEventName(body.eventName);
+  if (!eventName || !CLIENT_EVENTS.has(eventName)) {
+    return Response.json({ error: "Unsupported client analytics event" }, { status: 400 });
+  }
+
+  const journeyId = typeof body.journeyId === "string" ? body.journeyId : "";
+  if (!/^[A-Za-z0-9_-]{8,64}$/.test(journeyId)) {
+    return Response.json({ error: "Invalid journey" }, { status: 400 });
+  }
+
+  const patientCategory = body.patientCategory === "civilian" || body.patientCategory === "military"
+    ? body.patientCategory
+    : "";
+
+  await recordAnalyticsEvent(dbBinding(), {
+    eventName,
+    organizationId: 1,
+    journeyId,
+    serviceCode: typeof body.serviceCode === "string" ? body.serviceCode : "",
+    patientCategory,
+    pageKey: typeof body.pageKey === "string" ? body.pageKey : "",
+    source: "client",
+  });
+
+  // Analytics is intentionally best-effort: collection failures never block UX.
+  return new Response(null, { status: 204 });
+}

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,5 +1,6 @@
 import { analyticsEventName, recordAnalyticsEvent } from "../../../lib/analytics";
 import { dbBinding } from "../../../lib/db";
+import { isRateLimited } from "../../../lib/rate-limit";
 
 const CLIENT_EVENTS = new Set(["page_view", "service_view", "booking_started", "slot_selected"]);
 const ALLOWED_KEYS = new Set(["eventName", "journeyId", "serviceCode", "patientCategory", "pageKey"]);
@@ -37,11 +38,19 @@ export async function POST(request: Request) {
     return Response.json({ error: "Invalid journey" }, { status: 400 });
   }
 
+  const db = dbBinding();
+  // Analytics is non-critical. If the binding is unavailable, silently accept
+  // the telemetry request so the patient journey is never affected.
+  if (!db) return new Response(null, { status: 204 });
+  if (await isRateLimited(db, request, "analytics", 120, 15).catch(() => false)) {
+    return Response.json({ error: "Too many analytics events" }, { status: 429 });
+  }
+
   const patientCategory = body.patientCategory === "civilian" || body.patientCategory === "military"
     ? body.patientCategory
     : "";
 
-  await recordAnalyticsEvent(dbBinding(), {
+  await recordAnalyticsEvent(db, {
     eventName,
     organizationId: 1,
     journeyId,

--- a/app/api/pay-link/route.ts
+++ b/app/api/pay-link/route.ts
@@ -5,6 +5,7 @@ import { getSetting } from "../../../lib/settings";
 import { dbBinding } from "../../../lib/db";
 import { requirePatientSession } from "../../../lib/patient-auth";
 import { createPendingPayment, latestPaymentForBooking } from "../../../lib/payments";
+import { recordAnalyticsEvent } from "../../../lib/analytics";
 
 const DEFAULT_PRIVAT24_PAY_LINK = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params=%7B%22token%22%3A%22cadc7a4d-d56c-4005-9cfe-04a96077f8c1%22%7D';
 
@@ -68,6 +69,13 @@ export async function POST(request: Request) {
       providerReference,
     });
     const payment = await latestPaymentForBooking(db as never, session.organizationId, booking.id);
+    await recordAnalyticsEvent(db, {
+      eventName: "payment_started",
+      organizationId: session.organizationId,
+      serviceCode: booking.serviceCode,
+      patientCategory: "civilian",
+      source: "server",
+    });
     return Response.json({
       booking: {
         code: booking.code,

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -1,3 +1,4 @@
+import { recordAnalyticsEvent } from "../../../lib/analytics";
 import { todayInKyiv } from "../../../lib/booking-rules";
 import { effectiveServices, serviceAvailableTo } from "../../../lib/effective-services";
 import { normalizeUkrainianPhone } from "../../../lib/phone";
@@ -14,9 +15,6 @@ import { dbBinding } from "../../../lib/db";
 
 const CONSENT_VERSION = "2026-07-29";
 const MAX_SERVICES_PER_REQUEST = 5;
-// Public storefront currently belongs to the initial organization. Once public
-// host/slug tenant resolution lands, replace this constant with that server-side
-// resolver; never accept organization_id from the browser.
 const PUBLIC_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max = 200) {
@@ -26,6 +24,11 @@ function clean(value: unknown, max = 200) {
 function idempotencyKey(request: Request): string {
   const value = (request.headers.get("idempotency-key") || "").trim();
   return /^[A-Za-z0-9_-]{16,80}$/.test(value) ? value : "";
+}
+
+function analyticsJourney(request: Request): string {
+  const value = (request.headers.get("x-analytics-journey-id") || "").trim();
+  return /^[A-Za-z0-9_-]{8,64}$/.test(value) ? value : "";
 }
 
 function currentTimeInKyiv(): string {
@@ -231,6 +234,16 @@ export async function POST(request: Request) {
       }
       throw error;
     }
+
+    const journeyId = analyticsJourney(request);
+    await Promise.all(services.map((service) => recordAnalyticsEvent(db, {
+      eventName: "booking_created",
+      organizationId: PUBLIC_ORGANIZATION_ID,
+      journeyId,
+      serviceCode: service!.code,
+      patientCategory: category,
+      source: "server",
+    })));
 
     await sendTelegram(db, bookingMessage({
       codes,

--- a/app/api/staff/analytics/route.ts
+++ b/app/api/staff/analytics/route.ts
@@ -1,0 +1,69 @@
+import { canViewReports } from "../../../../lib/staff-auth";
+import { dbBinding } from "../../../../lib/db";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { ANALYTICS_EVENTS } from "../../../../lib/analytics";
+
+function isoDate(value: string | null, fallback: string): string | undefined {
+  const candidate = value || fallback;
+  return /^\d{4}-\d{2}-\d{2}$/.test(candidate) ? candidate : undefined;
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canViewReports(ctx.member.role)) {
+    return Response.json({ error: "Аналітика доступна лише адміністратору" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const today = new Date().toISOString().slice(0, 10);
+  const monthAgo = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+  const from = isoDate(url.searchParams.get("from"), monthAgo);
+  const to = isoDate(url.searchParams.get("to"), today);
+  if (!from || !to || from > to) {
+    return Response.json({ error: "Некоректний період" }, { status: 400 });
+  }
+
+  const { results } = await db.prepare(
+    `SELECT event_name AS eventName,
+            COUNT(*) AS events,
+            COUNT(DISTINCT CASE WHEN journey_id != '' THEN journey_id END) AS journeys
+       FROM analytics_events
+      WHERE organization_id = ?
+        AND date(occurred_at) BETWEEN ? AND ?
+      GROUP BY event_name`,
+  ).bind(ctx.organizationId, from, to).all<{ eventName: string; events: number; journeys: number }>();
+
+  const counts = new Map(results.map(row => [row.eventName, {
+    events: Number(row.events || 0),
+    journeys: Number(row.journeys || 0),
+  }]));
+  const funnel = ANALYTICS_EVENTS.map(eventName => ({
+    eventName,
+    events: counts.get(eventName)?.events || 0,
+    journeys: counts.get(eventName)?.journeys || 0,
+  }));
+
+  const { results: services } = await db.prepare(
+    `SELECT service_code AS serviceCode, event_name AS eventName, COUNT(*) AS events
+       FROM analytics_events
+      WHERE organization_id = ?
+        AND service_code != ''
+        AND date(occurred_at) BETWEEN ? AND ?
+      GROUP BY service_code, event_name
+      ORDER BY events DESC
+      LIMIT 100`,
+  ).bind(ctx.organizationId, from, to).all<{ serviceCode: string; eventName: string; events: number }>();
+
+  return Response.json({
+    period: { from, to },
+    funnel,
+    services: services.map(row => ({
+      serviceCode: row.serviceCode,
+      eventName: row.eventName,
+      events: Number(row.events || 0),
+    })),
+  }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/api/staff/analytics/route.ts
+++ b/app/api/staff/analytics/route.ts
@@ -26,20 +26,39 @@ export async function GET(request: Request) {
     return Response.json({ error: "Некоректний період" }, { status: 400 });
   }
 
-  const { results } = await db.prepare(
-    `SELECT event_name AS eventName,
-            COUNT(*) AS events,
-            COUNT(DISTINCT CASE WHEN journey_id != '' THEN journey_id END) AS journeys
-       FROM analytics_events
-      WHERE organization_id = ?
-        AND date(occurred_at) BETWEEN ? AND ?
-      GROUP BY event_name`,
-  ).bind(ctx.organizationId, from, to).all<{ eventName: string; events: number; journeys: number }>();
+  const [{ results }, clinical] = await Promise.all([
+    db.prepare(
+      `SELECT event_name AS eventName,
+              COUNT(*) AS events,
+              COUNT(DISTINCT CASE WHEN journey_id != '' THEN journey_id END) AS journeys
+         FROM analytics_events
+        WHERE organization_id = ?
+          AND date(occurred_at) BETWEEN ? AND ?
+        GROUP BY event_name`,
+    ).bind(ctx.organizationId, from, to).all<{ eventName: string; events: number; journeys: number }>(),
+    db.prepare(
+      `SELECT
+         COUNT(DISTINCT CASE
+           WHEN e.action = 'status_changed' AND e.details = 'arrived' THEN e.booking_id END) AS arrived,
+         COUNT(DISTINCT CASE
+           WHEN (e.action = 'status_changed' AND e.details = 'completed')
+             OR e.action = 'execution_recorded' THEN e.booking_id END) AS completed
+       FROM booking_events e
+       JOIN bookings b ON b.id = e.booking_id
+       WHERE b.organization_id = ?
+         AND date(e.created_at) BETWEEN ? AND ?`,
+    ).bind(ctx.organizationId, from, to).first<{ arrived: number; completed: number }>(),
+  ]);
 
   const counts = new Map(results.map(row => [row.eventName, {
     events: Number(row.events || 0),
     journeys: Number(row.journeys || 0),
   }]));
+  // Clinical milestones are derived from the existing operational audit trail,
+  // so analytics storage can never block a clinical state transition.
+  counts.set("patient_arrived", { events: Number(clinical?.arrived || 0), journeys: 0 });
+  counts.set("study_completed", { events: Number(clinical?.completed || 0), journeys: 0 });
+
   const funnel = ANALYTICS_EVENTS.map(eventName => ({
     eventName,
     events: counts.get(eventName)?.events || 0,

--- a/app/api/staff/payments/route.ts
+++ b/app/api/staff/payments/route.ts
@@ -1,3 +1,4 @@
+import { recordAnalyticsEvent } from "../../../../lib/analytics";
 import { dbBinding } from "../../../../lib/db";
 import { recordManualPayment, latestPaymentForBooking } from "../../../../lib/payments";
 import { refundLatestPayment } from "../../../../lib/payment-settlement";
@@ -45,6 +46,15 @@ export async function POST(request: Request) {
       method,
       providerReference,
     });
+    if (result.changed) {
+      await recordAnalyticsEvent(db, {
+        eventName: "payment_completed",
+        organizationId: ctx.organizationId,
+        serviceCode: result.booking.serviceCode,
+        patientCategory: result.booking.patientCategory === "military" ? "military" : "civilian",
+        source: "server",
+      });
+    }
     const payment = await latestPaymentForBooking(db as never, ctx.organizationId, bookingId);
     return Response.json({
       ok: true,

--- a/app/components/seo-service-landing.tsx
+++ b/app/components/seo-service-landing.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { trackClientAnalytics } from "../../lib/client-analytics";
 import type { SeoServicePage } from "../../lib/seo-service-pages";
 
 type PublicService = {
@@ -21,6 +22,8 @@ export function SeoServiceLanding({ page }: { page: SeoServicePage }) {
   const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
+    trackClientAnalytics("page_view", { pageKey: page.path });
+    trackClientAnalytics("service_view", { pageKey: page.path });
     let active = true;
     fetch("/api/public-services", { headers: { accept: "application/json" } })
       .then(async (response) => {
@@ -34,12 +37,20 @@ export function SeoServiceLanding({ page }: { page: SeoServicePage }) {
         if (active) setLoadError(true);
       });
     return () => { active = false; };
-  }, []);
+  }, [page.path]);
 
   const visible = useMemo(() => {
     const wanted = new Set(page.serviceCodes);
     return services.filter((service) => wanted.has(service.code) && service.availableToCivilian);
   }, [page.serviceCodes, services]);
+
+  const bookingStarted = (serviceCode = "") => {
+    trackClientAnalytics("booking_started", {
+      pageKey: page.path,
+      serviceCode,
+      patientCategory: "civilian",
+    });
+  };
 
   return (
     <main style={{ minHeight: "100vh", background: "#f5fbfa", color: "#173b3a" }}>
@@ -59,7 +70,7 @@ export function SeoServiceLanding({ page }: { page: SeoServicePage }) {
         <h1 style={{ fontSize: "clamp(34px, 6vw, 60px)", lineHeight: 1.05, margin: 0, maxWidth: 900 }}>{page.title}</h1>
         <p style={{ fontSize: 20, lineHeight: 1.65, maxWidth: 850, marginTop: 22 }}>{page.intro}</p>
         <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 28 }}>
-          <Link href="/site/price.html" style={{ background: "#0d6b68", color: "white", padding: "13px 20px", borderRadius: 10, textDecoration: "none", fontWeight: 700 }}>Записатися на дослідження</Link>
+          <Link onClick={() => bookingStarted()} href="/site/price.html" style={{ background: "#0d6b68", color: "white", padding: "13px 20px", borderRadius: 10, textDecoration: "none", fontWeight: 700 }}>Записатися на дослідження</Link>
         </div>
       </section>
 
@@ -74,7 +85,7 @@ export function SeoServiceLanding({ page }: { page: SeoServicePage }) {
               <h3 style={{ fontSize: 20, lineHeight: 1.35 }}>{service.title}</h3>
               <div style={{ fontSize: 26, fontWeight: 800, marginTop: 16 }}>{money(service.price)}</div>
               <div style={{ opacity: 0.7, marginTop: 6 }}>Орієнтовний слот: {service.durationMinutes} хв</div>
-              <Link href="/site/price.html" style={{ display: "inline-block", marginTop: 18, fontWeight: 700 }}>Обрати час →</Link>
+              <Link onClick={() => bookingStarted(service.code)} href="/site/price.html" style={{ display: "inline-block", marginTop: 18, fontWeight: 700 }}>Обрати час →</Link>
             </article>
           ))}
         </div>
@@ -95,7 +106,7 @@ export function SeoServiceLanding({ page }: { page: SeoServicePage }) {
         <div style={{ background: "#dff3f0", borderRadius: 18, padding: 28 }}>
           <h2 style={{ marginTop: 0 }}>Онлайн-запис</h2>
           <p style={{ fontSize: 18, lineHeight: 1.6 }}>Оберіть послугу та доступний час. Остаточна вартість формується з актуального тарифу RadiologyOS на момент запису.</p>
-          <Link href="/site/price.html" style={{ display: "inline-block", background: "#0d6b68", color: "white", padding: "13px 20px", borderRadius: 10, textDecoration: "none", fontWeight: 700 }}>Перейти до запису</Link>
+          <Link onClick={() => bookingStarted()} href="/site/price.html" style={{ display: "inline-block", background: "#0d6b68", color: "white", padding: "13px 20px", borderRadius: 10, textDecoration: "none", fontWeight: 700 }}>Перейти до запису</Link>
         </div>
       </section>
     </main>

--- a/db/analytics-schema.ts
+++ b/db/analytics-schema.ts
@@ -1,0 +1,18 @@
+import { sql } from "drizzle-orm";
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const analyticsEvents = sqliteTable("analytics_events", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  organizationId: integer("organization_id").notNull().default(1),
+  eventName: text("event_name").notNull(),
+  journeyId: text("journey_id").notNull().default(""),
+  serviceCode: text("service_code").notNull().default(""),
+  patientCategory: text("patient_category").notNull().default(""),
+  pageKey: text("page_key").notNull().default(""),
+  source: text("source").notNull().default("server"),
+  occurredAt: text("occurred_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+}, table => [
+  index("analytics_events_org_time_idx").on(table.organizationId, table.occurredAt),
+  index("analytics_events_org_event_time_idx").on(table.organizationId, table.eventName, table.occurredAt),
+  index("analytics_events_journey_idx").on(table.organizationId, table.journeyId, table.occurredAt),
+]);

--- a/db/index.ts
+++ b/db/index.ts
@@ -4,8 +4,15 @@ import * as coreSchema from "./schema";
 import * as capacitySchema from "./capacity-schema";
 import * as patientAuthSchema from "./patient-auth-schema";
 import * as paymentSchema from "./payment-schema";
+import * as analyticsSchema from "./analytics-schema";
 
-const schema = { ...coreSchema, ...capacitySchema, ...patientAuthSchema, ...paymentSchema };
+const schema = {
+  ...coreSchema,
+  ...capacitySchema,
+  ...patientAuthSchema,
+  ...paymentSchema,
+  ...analyticsSchema,
+};
 
 export function getDb() {
   if (!env.DB) {

--- a/drizzle/0030_analytics_events.sql
+++ b/drizzle/0030_analytics_events.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `analytics_events` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL DEFAULT 1,
+  `event_name` text NOT NULL,
+  `journey_id` text NOT NULL DEFAULT '',
+  `service_code` text NOT NULL DEFAULT '',
+  `patient_category` text NOT NULL DEFAULT '',
+  `page_key` text NOT NULL DEFAULT '',
+  `source` text NOT NULL DEFAULT 'server',
+  `occurred_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (`event_name` IN ('page_view','service_view','booking_started','slot_selected','booking_created','payment_started','payment_completed','patient_arrived','study_completed')),
+  CHECK (`patient_category` IN ('','civilian','military')),
+  CHECK (`source` IN ('client','server')),
+  CHECK (length(`journey_id`) <= 64),
+  CHECK (length(`service_code`) <= 16),
+  CHECK (length(`page_key`) <= 64)
+);
+--> statement-breakpoint
+CREATE INDEX `analytics_events_org_time_idx` ON `analytics_events` (`organization_id`,`occurred_at`);
+--> statement-breakpoint
+CREATE INDEX `analytics_events_org_event_time_idx` ON `analytics_events` (`organization_id`,`event_name`,`occurred_at`);
+--> statement-breakpoint
+CREATE INDEX `analytics_events_journey_idx` ON `analytics_events` (`organization_id`,`journey_id`,`occurred_at`);

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,88 @@
+export const ANALYTICS_EVENTS = [
+  "page_view",
+  "service_view",
+  "booking_started",
+  "slot_selected",
+  "booking_created",
+  "payment_started",
+  "payment_completed",
+  "patient_arrived",
+  "study_completed",
+] as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[number];
+export type AnalyticsPatientCategory = "" | "civilian" | "military";
+export type AnalyticsSource = "client" | "server";
+
+export type AnalyticsEventInput = {
+  eventName: AnalyticsEventName;
+  organizationId?: number;
+  journeyId?: string;
+  serviceCode?: string;
+  patientCategory?: AnalyticsPatientCategory;
+  pageKey?: string;
+  source?: AnalyticsSource;
+};
+
+const EVENT_SET = new Set<string>(ANALYTICS_EVENTS);
+
+function boundedToken(value: unknown, max: number, pattern: RegExp): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim().slice(0, max);
+  return pattern.test(trimmed) ? trimmed : "";
+}
+
+export function analyticsEventName(value: unknown): AnalyticsEventName | undefined {
+  return typeof value === "string" && EVENT_SET.has(value)
+    ? value as AnalyticsEventName
+    : undefined;
+}
+
+export function sanitizeAnalyticsInput(input: AnalyticsEventInput): Required<AnalyticsEventInput> {
+  const eventName = analyticsEventName(input.eventName);
+  if (!eventName) throw new Error("Unknown analytics event");
+  const patientCategory = input.patientCategory === "civilian" || input.patientCategory === "military"
+    ? input.patientCategory
+    : "";
+  return {
+    eventName,
+    organizationId: Number.isInteger(input.organizationId) && Number(input.organizationId) > 0
+      ? Number(input.organizationId)
+      : 1,
+    journeyId: boundedToken(input.journeyId, 64, /^[A-Za-z0-9_-]*$/),
+    serviceCode: boundedToken(input.serviceCode, 16, /^[A-Za-z0-9_-]*$/),
+    patientCategory,
+    pageKey: boundedToken(input.pageKey, 64, /^[A-Za-z0-9_/-]*$/),
+    source: input.source === "client" ? "client" : "server",
+  };
+}
+
+/**
+ * Best-effort analytics recorder. Core clinical/payment flows must never fail
+ * because analytics storage is unavailable.
+ */
+export async function recordAnalyticsEvent(
+  db: D1Database | null | undefined,
+  input: AnalyticsEventInput,
+): Promise<boolean> {
+  if (!db) return false;
+  try {
+    const event = sanitizeAnalyticsInput(input);
+    await db.prepare(
+      `INSERT INTO analytics_events
+        (organization_id, event_name, journey_id, service_code, patient_category, page_key, source)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      event.organizationId,
+      event.eventName,
+      event.journeyId,
+      event.serviceCode,
+      event.patientCategory,
+      event.pageKey,
+      event.source,
+    ).run();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lib/client-analytics.ts
+++ b/lib/client-analytics.ts
@@ -1,0 +1,38 @@
+export type ClientAnalyticsEvent = "page_view" | "service_view" | "booking_started" | "slot_selected";
+
+const JOURNEY_KEY = "radiologyos_analytics_journey_v1";
+
+export function analyticsJourneyId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const existing = sessionStorage.getItem(JOURNEY_KEY) || "";
+    if (/^[A-Za-z0-9_-]{8,64}$/.test(existing)) return existing;
+    const created = typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID().replaceAll("-", "")
+      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+    sessionStorage.setItem(JOURNEY_KEY, created);
+    return created;
+  } catch {
+    return "";
+  }
+}
+
+export function trackClientAnalytics(
+  eventName: ClientAnalyticsEvent,
+  fields: { serviceCode?: string; patientCategory?: "civilian" | "military"; pageKey?: string } = {},
+): void {
+  const journeyId = analyticsJourneyId();
+  if (!journeyId) return;
+  void fetch("/api/analytics", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      eventName,
+      journeyId,
+      serviceCode: fields.serviceCode || "",
+      patientCategory: fields.patientCategory || "",
+      pageKey: fields.pageKey || "",
+    }),
+    keepalive: true,
+  }).catch(() => undefined);
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -7,6 +7,8 @@ export interface PaymentBookingSnapshot {
   paymentAmount: number;
   paymentStatus: string;
   paidAmount: number;
+  serviceCode: string;
+  patientCategory: string;
 }
 
 export interface PaymentLedgerDb {
@@ -40,7 +42,8 @@ export async function paymentBookingSnapshot(
   const row = await db.prepare(
     `SELECT id, organization_id AS organizationId, code,
       payment_amount AS paymentAmount, payment_status AS paymentStatus,
-      paid_amount AS paidAmount
+      paid_amount AS paidAmount, service_code AS serviceCode,
+      patient_category AS patientCategory
      FROM bookings WHERE organization_id = ? AND id = ? LIMIT 1`,
   ).bind(organizationId, bookingId).first<PaymentBookingSnapshot>();
   return row || null;
@@ -133,7 +136,7 @@ export async function recordManualPayment(
       throw new Error("payment_reference_conflict");
     }
     if (existing.status === "paid" && booking.paymentStatus === "paid" && booking.paidAmount === booking.paymentAmount) {
-      return { id: existing.id, created: false, booking };
+      return { id: existing.id, created: false, changed: false, booking };
     }
   }
 
@@ -171,7 +174,7 @@ export async function recordManualPayment(
       ];
 
   await db.batch(statements);
-  return { id: existing?.id || 0, created: !existing, booking };
+  return { id: existing?.id || 0, created: !existing, changed: true, booking };
 }
 
 export async function latestPaymentForBooking(

--- a/public/site/assets/d1-bridge.js
+++ b/public/site/assets/d1-bridge.js
@@ -145,9 +145,19 @@
   prepareIdentityFields('militaryPatientName', 'militaryPatientDob');
 
   async function postBooking(payload, requestKey) {
+    const journeyId = typeof radiologyAnalyticsJourney === 'function' ? radiologyAnalyticsJourney() : '';
+    const firstServiceCode = Array.isArray(payload.items) && payload.items[0] ? String(payload.items[0].code || '') : '';
+    if (typeof trackRadiologyAnalytics === 'function') {
+      trackRadiologyAnalytics('booking_started', {
+        serviceCode: firstServiceCode,
+        patientCategory: payload.category === 'military' ? 'military' : 'civilian',
+      });
+    }
+    const headers = { 'content-type': 'application/json', 'idempotency-key': requestKey };
+    if (journeyId) headers['x-analytics-journey-id'] = journeyId;
     const response = await fetch('/api/site-booking', {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'idempotency-key': requestKey },
+      headers,
       body: JSON.stringify(payload),
     });
     const data = await response.json().catch(() => ({}));
@@ -216,7 +226,6 @@
       if (nameInput) nameInput.dispatchEvent(new Event('input'));
       if (!civilForm.checkValidity()) { civilForm.classList.add('was-validated'); const bad = civilForm.querySelector(':invalid'); if (bad) bad.focus(); return; }
 
-      // Category comes from the form selector when present (home page), else the page.
       const catSel = document.getElementById('patientCategory');
       const category = catSel
         ? (catSel.value === 'military' ? 'military' : 'civilian')

--- a/public/site/assets/slots.js
+++ b/public/site/assets/slots.js
@@ -22,18 +22,19 @@ function radiologyAnalyticsJourney() {
   } catch (e) { return ''; }
 }
 
-function trackSlotSelected(serviceCode) {
+function trackRadiologyAnalytics(eventName, options) {
   const journeyId = radiologyAnalyticsJourney();
   if (!journeyId) return;
+  const input = options || {};
   fetch('/api/analytics', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
-      eventName: 'slot_selected',
+      eventName,
       journeyId,
-      serviceCode: String(serviceCode || '').slice(0, 16),
-      patientCategory: /military/i.test(location.pathname) ? 'military' : 'civilian',
-      pageKey: location.pathname.slice(0, 64),
+      serviceCode: String(input.serviceCode || '').slice(0, 16),
+      patientCategory: input.patientCategory === 'military' ? 'military' : (input.patientCategory === 'civilian' ? 'civilian' : ''),
+      pageKey: String(input.pageKey || location.pathname || '').slice(0, 64),
     }),
     keepalive: true,
   }).catch(() => {});
@@ -85,7 +86,10 @@ async function initSlotPicker({ container, serviceCode, onPick }) {
     }));
     container.querySelectorAll('.sp-time').forEach((b) => b.addEventListener('click', () => {
       selTime = b.dataset.time;
-      trackSlotSelected(serviceCode);
+      trackRadiologyAnalytics('slot_selected', {
+        serviceCode,
+        patientCategory: /military/i.test(location.pathname) ? 'military' : 'civilian',
+      });
       render();
       if (onPick) onPick({ date: selDay.iso, time: selTime });
     }));

--- a/public/site/assets/slots.js
+++ b/public/site/assets/slots.js
@@ -9,6 +9,36 @@
        onPick: ({date, time}) => {}   // '' коли вибір скинуто
      }) */
 
+function radiologyAnalyticsJourney() {
+  const key = 'radiologyos_analytics_journey_v1';
+  try {
+    const existing = sessionStorage.getItem(key) || '';
+    if (/^[A-Za-z0-9_-]{8,64}$/.test(existing)) return existing;
+    const created = crypto.randomUUID
+      ? crypto.randomUUID().replaceAll('-', '')
+      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+    sessionStorage.setItem(key, created);
+    return created;
+  } catch (e) { return ''; }
+}
+
+function trackSlotSelected(serviceCode) {
+  const journeyId = radiologyAnalyticsJourney();
+  if (!journeyId) return;
+  fetch('/api/analytics', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      eventName: 'slot_selected',
+      journeyId,
+      serviceCode: String(serviceCode || '').slice(0, 16),
+      patientCategory: /military/i.test(location.pathname) ? 'military' : 'civilian',
+      pageKey: location.pathname.slice(0, 64),
+    }),
+    keepalive: true,
+  }).catch(() => {});
+}
+
 async function initSlotPicker({ container, serviceCode, onPick }) {
   const pad = (n) => String(n).padStart(2, '0');
   const dayNames = ['Нд', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'];
@@ -55,6 +85,7 @@ async function initSlotPicker({ container, serviceCode, onPick }) {
     }));
     container.querySelectorAll('.sp-time').forEach((b) => b.addEventListener('click', () => {
       selTime = b.dataset.time;
+      trackSlotSelected(serviceCode);
       render();
       if (onPick) onPick({ date: selDay.iso, time: selTime });
     }));

--- a/tests/analytics.behavior.test.mjs
+++ b/tests/analytics.behavior.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { recordAnalyticsEvent } from "../lib/analytics.ts";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+test("public analytics accepts only anonymous allowlisted funnel fields", async () => {
+  await withD1(async (db) => {
+    const valid = await callWorker(jsonRequest("/api/analytics", {
+      eventName: "service_view",
+      journeyId: "journey_12345678",
+      serviceCode: "401",
+      patientCategory: "civilian",
+      pageKey: "/ct/head/",
+    }), db);
+    assert.equal(valid.status, 204);
+
+    const row = await db.prepare(
+      "SELECT event_name AS eventName, journey_id AS journeyId, service_code AS serviceCode FROM analytics_events LIMIT 1",
+    ).first();
+    assert.equal(row.eventName, "service_view");
+    assert.equal(row.journeyId, "journey_12345678");
+    assert.equal(row.serviceCode, "401");
+
+    for (const extra of [
+      { phone: "+380501112233" },
+      { name: "Пацієнт" },
+      { dob: "1990-01-01" },
+      { notes: "clinical text" },
+      { bookingId: 123 },
+    ]) {
+      const rejected = await callWorker(jsonRequest("/api/analytics", {
+        eventName: "page_view",
+        journeyId: "journey_abcdefgh",
+        ...extra,
+      }), db);
+      assert.equal(rejected.status, 400);
+    }
+  });
+});
+
+test("analytics event allowlist rejects fabricated server milestones from the browser", async () => {
+  await withD1(async (db) => {
+    for (const eventName of ["booking_created", "payment_started", "payment_completed", "patient_arrived", "study_completed", "made_up_event"]) {
+      const response = await callWorker(jsonRequest("/api/analytics", {
+        eventName,
+        journeyId: "journey_abcdefgh",
+      }), db);
+      assert.equal(response.status, 400);
+    }
+  });
+});
+
+test("analytics storage failure never throws into core workflows", async () => {
+  const brokenDb = {
+    prepare() { throw new Error("analytics unavailable"); },
+  };
+  const recorded = await recordAnalyticsEvent(brokenDb, {
+    eventName: "booking_created",
+    organizationId: 1,
+    serviceCode: "401",
+    patientCategory: "civilian",
+  });
+  assert.equal(recorded, false);
+  assert.equal(await recordAnalyticsEvent(null, { eventName: "page_view" }), false);
+});
+
+test("analytics ledger schema contains no direct patient identifiers or arbitrary metadata", async () => {
+  await withD1(async (db) => {
+    const { results } = await db.prepare("PRAGMA table_info(analytics_events)").all();
+    const columns = results.map((row) => row.name);
+    assert.deepEqual(columns, [
+      "id", "organization_id", "event_name", "journey_id", "service_code",
+      "patient_category", "page_key", "source", "occurred_at",
+    ]);
+    for (const forbidden of ["name", "phone", "dob", "date_of_birth", "booking_id", "ip", "user_agent", "metadata", "notes"]) {
+      assert.equal(columns.includes(forbidden), false);
+    }
+  });
+});
+
+test("staff funnel report is tenant-scoped and derives clinical milestones from operational audit", async () => {
+  await withD1(async (db) => {
+    await db.prepare(
+      `INSERT INTO analytics_events
+       (organization_id, event_name, journey_id, service_code, patient_category, page_key, source)
+       VALUES (1, 'page_view', 'journey_one', '401', 'civilian', '/ct/head/', 'client'),
+              (1, 'booking_created', 'journey_one', '401', 'civilian', '', 'server'),
+              (2, 'page_view', 'journey_other', '401', 'civilian', '/ct/head/', 'client')`,
+    ).run();
+
+    const booking = await db.prepare(
+      `INSERT INTO bookings (
+        organization_id, code, name, phone, phone_normalized, service, service_code,
+        equipment_id, duration_minutes, desired_date, desired_time, patient_category,
+        payment_status, payment_amount, status
+      ) VALUES (1, 'RD-AN-1', 'Synthetic', '+380501112233', '380501112233', 'КТ ГМ', '401',
+        'ct', 30, '2026-08-20', '11:30', 'civilian', 'paid', 1500, 'completed')`,
+    ).run();
+    const bookingId = Number(booking.meta.last_row_id);
+    await db.prepare(
+      `INSERT INTO booking_events (organization_id, booking_id, action, details, actor, created_at)
+       VALUES (1, ?, 'status_changed', 'arrived', 'test', '2026-08-20 10:00:00'),
+              (1, ?, 'status_changed', 'completed', 'test', '2026-08-20 10:30:00')`,
+    ).bind(bookingId, bookingId).run();
+
+    const cookie = await seedStaffSession(db, { email: "admin@example.com", role: "admin", organizationId: 1 });
+    const response = await callWorker(new Request(
+      "https://radiologyos.test/api/staff/analytics?from=2026-08-01&to=2026-08-31",
+      { headers: { cookie } },
+    ), db);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    const byEvent = Object.fromEntries(body.funnel.map((row) => [row.eventName, row]));
+    assert.equal(byEvent.page_view.events, 1);
+    assert.equal(byEvent.booking_created.events, 1);
+    assert.equal(byEvent.patient_arrived.events, 1);
+    assert.equal(byEvent.study_completed.events, 1);
+  });
+});


### PR DESCRIPTION
Closes #171

Adds first-party, privacy-minimized funnel analytics for the public patient journey and staff reporting.

Highlights:
- new `analytics_events` D1 ledger (migration 0030) with a strict event allowlist;
- no name, phone, DOB, booking ID, IP, user-agent, notes, protocol text or arbitrary metadata columns;
- anonymous random `journey_id` stored only in browser sessionStorage for public-funnel correlation;
- public analytics endpoint accepts only allowlisted anonymous fields and rejects extra keys;
- rate limiting uses the existing SHA-256 request fingerprint limiter (no raw IP stored in analytics);
- SEO/service pages track page/service views and booking-start events;
- booking slot picker tracks `slot_selected`;
- successful public booking records server-side `booking_created` only after the atomic booking batch succeeds;
- payment start/completion events are server-side, with idempotent completion tracking;
- clinical `patient_arrived` / `study_completed` metrics are derived from the existing operational booking audit trail, so analytics cannot block clinical state changes;
- tenant-scoped staff funnel report at `/api/staff/analytics`;
- behavioral tests enforce no-PHI schema/payloads, client event allowlist, tenant isolation, clinical milestone aggregation and best-effort failure semantics.

Analytics failure is intentionally non-fatal to booking and payment flows.