### PR TITLE
feat: tenant-scope PACS settings and imaging linkage

### DIFF
--- a/app/api/staff/imaging/route.ts
+++ b/app/api/staff/imaging/route.ts
@@ -13,11 +13,11 @@ type PacsRow = {
   dicomwebBaseUrl:string; viewerBaseUrl:string; aeTitle:string; enabled:number;
 };
 
-async function loadPacs(db:D1Database):Promise<PacsRow> {
+async function loadPacs(db:D1Database, organizationId:number):Promise<PacsRow> {
   const row = await db.prepare(
     `SELECT dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
-       ae_title AS aeTitle, enabled FROM pacs_settings WHERE id = 1 LIMIT 1`
-  ).first<PacsRow>();
+       ae_title AS aeTitle, enabled FROM pacs_settings WHERE organization_id = ? LIMIT 1`
+  ).bind(organizationId).first<PacsRow>();
   return row || { dicomwebBaseUrl:"", viewerBaseUrl:"", aeTitle:"", enabled:0 };
 }
 
@@ -62,7 +62,7 @@ export async function GET(request: Request) {
     return Response.json({ error: "Доступ до знімків має лише залучений медичний персонал" }, { status: 403 });
   }
 
-  const pacs = await loadPacs(db);
+  const pacs = await loadPacs(db, ctx.organizationId);
   const bookingId = Number(new URL(request.url).searchParams.get("bookingId"));
 
   if (Number.isInteger(bookingId) && bookingId > 0) {
@@ -73,9 +73,11 @@ export async function GET(request: Request) {
       db.prepare(
         `SELECT id, code, name, service, service_code AS serviceCode, equipment_id AS equipmentId,
           desired_date AS desiredDate, desired_time AS desiredTime, performed_at AS performedAt
-         FROM bookings WHERE id = ? LIMIT 1`
-      ).bind(bookingId).first<Record<string, unknown>>(),
-      db.prepare(`SELECT ${STUDY_COLUMNS} FROM imaging_studies WHERE booking_id = ? LIMIT 1`).bind(bookingId).first<Record<string, unknown>>(),
+         FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1`
+      ).bind(bookingId, ctx.organizationId).first<Record<string, unknown>>(),
+      db.prepare(
+        `SELECT ${STUDY_COLUMNS} FROM imaging_studies WHERE booking_id = ? AND organization_id = ? LIMIT 1`,
+      ).bind(bookingId, ctx.organizationId).first<Record<string, unknown>>(),
     ]);
     if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
 
@@ -86,8 +88,8 @@ export async function GET(request: Request) {
       await db.prepare(
         `UPDATE imaging_studies SET series_count = ?, instances_count = ?,
            study_status = CASE WHEN study_status = 'archived' THEN 'archived' ELSE 'available' END
-         WHERE booking_id = ?`
-      ).bind(series.length, instances, bookingId).run();
+         WHERE booking_id = ? AND organization_id = ?`
+      ).bind(series.length, instances, bookingId, ctx.organizationId).run();
     }
     return Response.json({
       booking, study: study || null, series,
@@ -111,7 +113,8 @@ export async function GET(request: Request) {
        COALESCE(i.study_instance_uid, '') AS studyInstanceUid,
        COALESCE(i.series_count, 0) AS seriesCount
      FROM bookings b
-     LEFT JOIN imaging_studies i ON i.booking_id = b.id
+     LEFT JOIN imaging_studies i
+       ON i.booking_id = b.id AND i.organization_id = b.organization_id
      WHERE b.organization_id = ? AND b.status != 'cancelled' AND (b.performed_at != '' OR i.booking_id IS NOT NULL)
      ${assignmentClause}
      ORDER BY (b.performed_at != '') DESC, b.desired_date DESC, b.desired_time DESC
@@ -152,23 +155,28 @@ export async function PUT(request: Request) {
     .bind(bookingId, ctx.organizationId).first();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
 
-  // Нова студія успадковує організацію заявки (tenant tag на запис).
   await db.prepare(
     `INSERT INTO imaging_studies
        (organization_id, booking_id, accession_number, study_instance_uid, modality, study_status, study_datetime, source, updated_by, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, 'manual', ?, CURRENT_TIMESTAMP)
      ON CONFLICT(booking_id) DO UPDATE SET
-       accession_number = excluded.accession_number, study_instance_uid = excluded.study_instance_uid,
-       modality = excluded.modality, study_status = excluded.study_status,
-       study_datetime = excluded.study_datetime, updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
+       organization_id = excluded.organization_id,
+       accession_number = excluded.accession_number,
+       study_instance_uid = excluded.study_instance_uid,
+       modality = excluded.modality,
+       study_status = excluded.study_status,
+       study_datetime = excluded.study_datetime,
+       updated_by = excluded.updated_by,
+       updated_at = CURRENT_TIMESTAMP`
   ).bind(
     ctx.organizationId, bookingId, study.accessionNumber, study.studyInstanceUid, study.modality,
     study.studyStatus, study.studyDatetime, member.email,
   ).run();
 
   await db.prepare(
-    "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'imaging_linked', ?, ?)"
+    "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'imaging_linked', ?, ?)"
   ).bind(
+    ctx.organizationId,
     bookingId,
     `${study.studyStatus}${study.accessionNumber ? ` · ${study.accessionNumber}` : ""}${study.studyInstanceUid ? " · UID" : ""}`,
     member.email,

--- a/app/api/staff/imaging/settings/route.ts
+++ b/app/api/staff/imaging/settings/route.ts
@@ -1,6 +1,6 @@
-import { requireStaff } from "../../../../../lib/staff-auth";
 import { sanitizePacsSettings } from "../../../../../lib/dicom";
 import { safeOutboundUrl } from "../../../../../lib/outbound";
+import { requireOrgContext } from "../../../../../lib/tenant";
 import { dbBinding } from "../../../../../lib/db";
 
 const SETTINGS_COLUMNS = `dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
@@ -9,20 +9,26 @@ const SETTINGS_COLUMNS = `dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url 
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Налаштування PACS доступні лише адміністратору" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.member.role !== "admin") {
+    return Response.json({ error: "Налаштування PACS доступні лише адміністратору" }, { status: 403 });
+  }
 
-  const settings = await db.prepare(`SELECT ${SETTINGS_COLUMNS} FROM pacs_settings WHERE id = 1 LIMIT 1`).first();
-  return Response.json({ settings: settings || null, staff: member }, { headers: { "cache-control": "no-store" } });
+  const settings = await db.prepare(
+    `SELECT ${SETTINGS_COLUMNS} FROM pacs_settings WHERE organization_id = ? LIMIT 1`,
+  ).bind(ctx.organizationId).first();
+  return Response.json({ settings: settings || null, staff: ctx.member }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Налаштування PACS може змінювати лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.member.role !== "admin") {
+    return Response.json({ error: "Налаштування PACS може змінювати лише адміністратор" }, { status: 403 });
+  }
 
   const parsed = sanitizePacsSettings(await request.json());
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
@@ -32,12 +38,26 @@ export async function PUT(request: Request) {
   }
 
   await db.prepare(
-    `UPDATE pacs_settings SET dicomweb_base_url = ?, viewer_base_url = ?, ae_title = ?,
-       enabled = ?, notes = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1`
+    `INSERT INTO pacs_settings
+      (organization_id, dicomweb_base_url, viewer_base_url, ae_title, enabled, notes, updated_by, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(organization_id) DO UPDATE SET
+       dicomweb_base_url = excluded.dicomweb_base_url,
+       viewer_base_url = excluded.viewer_base_url,
+       ae_title = excluded.ae_title,
+       enabled = excluded.enabled,
+       notes = excluded.notes,
+       updated_by = excluded.updated_by,
+       updated_at = CURRENT_TIMESTAMP`,
   ).bind(
-    settings.dicomwebBaseUrl, settings.viewerBaseUrl, settings.aeTitle,
-    settings.enabled, settings.notes, member.email,
+    ctx.organizationId,
+    settings.dicomwebBaseUrl,
+    settings.viewerBaseUrl,
+    settings.aeTitle,
+    settings.enabled,
+    settings.notes,
+    ctx.member.email,
   ).run();
 
-  return Response.json({ ok: true, settings: { ...settings, updatedBy: member.email } });
+  return Response.json({ ok: true, settings: { ...settings, updatedBy: ctx.member.email } });
 }

--- a/drizzle/0031_pacs_tenant_scope.sql
+++ b/drizzle/0031_pacs_tenant_scope.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `pacs_settings` ADD COLUMN `organization_id` integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `pacs_settings_organization_idx`
+ON `pacs_settings` (`organization_id`);
+--> statement-breakpoint
+UPDATE `pacs_settings` SET `organization_id` = 1 WHERE `organization_id` IS NULL OR `organization_id` = 0;

--- a/tests/imaging-tenant.behavior.test.mjs
+++ b/tests/imaging-tenant.behavior.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addOrganization(db, id, slug, name) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (?, ?, ?, 1)",
+  ).bind(id, slug, name).run();
+}
+
+async function addMembership(db, organizationId, email, role = "admin") {
+  await db.prepare(
+    `INSERT INTO memberships (organization_id, member_email, role, active)
+     VALUES (?, ?, ?, 1)`,
+  ).bind(organizationId, email, role).run();
+}
+
+async function seedBooking(db, organizationId, code) {
+  const result = await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, service, service_code, equipment_id,
+       desired_date, desired_time, patient_category, status, performed_at)
+     VALUES (?, ?, 'Пацієнт', '+380501112233', 'КТ ОГК', '403', 'ct',
+       '2026-08-20', '10:00', 'civilian', 'completed', '2026-08-20T10:30:00')`,
+  ).bind(organizationId, code).run();
+  return Number(result.meta.last_row_id);
+}
+
+test("PACS settings are isolated by organization", async () => {
+  await withD1(async (db) => {
+    await addOrganization(db, 2, "second-clinic", "Second Clinic");
+
+    const cookie1 = await seedStaffSession(db, { email: "admin-one@example.com", role: "admin" });
+    const cookie2 = await seedStaffSession(db, { email: "admin-two@example.com", role: "admin" });
+    await addMembership(db, 1, "admin-one@example.com");
+    await addMembership(db, 2, "admin-two@example.com");
+
+    const put1 = await callWorker(jsonRequest("/api/staff/imaging/settings", {
+      dicomwebBaseUrl: "https://pacs-one.example.com/dicom-web",
+      viewerBaseUrl: "https://viewer-one.example.com/viewer",
+      aeTitle: "RADONE",
+      enabled: true,
+      notes: "org one",
+    }, { method: "PUT", headers: { cookie: cookie1 } }), db);
+    assert.equal(put1.status, 200);
+
+    const put2 = await callWorker(jsonRequest("/api/staff/imaging/settings", {
+      dicomwebBaseUrl: "https://pacs-two.example.com/dicom-web",
+      viewerBaseUrl: "https://viewer-two.example.com/viewer",
+      aeTitle: "RADTWO",
+      enabled: true,
+      notes: "org two",
+    }, { method: "PUT", headers: { cookie: cookie2 } }), db);
+    assert.equal(put2.status, 200);
+
+    const get1 = await callWorker(jsonRequest("/api/staff/imaging/settings", undefined, {
+      method: "GET", headers: { cookie: cookie1 },
+    }), db);
+    const get2 = await callWorker(jsonRequest("/api/staff/imaging/settings", undefined, {
+      method: "GET", headers: { cookie: cookie2 },
+    }), db);
+    assert.equal(get1.status, 200);
+    assert.equal(get2.status, 200);
+    const body1 = await get1.json();
+    const body2 = await get2.json();
+    assert.equal(body1.settings.aeTitle, "RADONE");
+    assert.equal(body2.settings.aeTitle, "RADTWO");
+    assert.equal(body1.settings.notes, "org one");
+    assert.equal(body2.settings.notes, "org two");
+
+    const rows = await db.prepare(
+      "SELECT organization_id AS organizationId, ae_title AS aeTitle FROM pacs_settings ORDER BY organization_id",
+    ).all();
+    assert.deepEqual(rows.results.map((row) => [row.organizationId, row.aeTitle]), [[1, "RADONE"], [2, "RADTWO"]]);
+  });
+});
+
+test("imaging linkage and audit events cannot cross tenant scope", async () => {
+  await withD1(async (db) => {
+    await addOrganization(db, 2, "second-clinic", "Second Clinic");
+    const cookie1 = await seedStaffSession(db, { email: "image-one@example.com", role: "admin" });
+    const cookie2 = await seedStaffSession(db, { email: "image-two@example.com", role: "admin" });
+    await addMembership(db, 1, "image-one@example.com");
+    await addMembership(db, 2, "image-two@example.com");
+
+    const booking1 = await seedBooking(db, 1, "IMG-ORG-1");
+    const booking2 = await seedBooking(db, 2, "IMG-ORG-2");
+
+    const link2 = await callWorker(jsonRequest("/api/staff/imaging", {
+      bookingId: booking2,
+      accessionNumber: "ACC-ORG-2",
+      studyInstanceUid: "1.2.840.113619.2.2",
+      modality: "CT",
+      studyStatus: "available",
+      studyDatetime: "2026-08-20T10:30:00",
+    }, { method: "PUT", headers: { cookie: cookie2 } }), db);
+    assert.equal(link2.status, 200);
+
+    const foreignRead = await callWorker(jsonRequest(`/api/staff/imaging?bookingId=${booking2}`, undefined, {
+      method: "GET", headers: { cookie: cookie1 },
+    }), db);
+    assert.equal(foreignRead.status, 403);
+
+    const ownRead = await callWorker(jsonRequest(`/api/staff/imaging?bookingId=${booking2}`, undefined, {
+      method: "GET", headers: { cookie: cookie2 },
+    }), db);
+    assert.equal(ownRead.status, 200);
+    const ownBody = await ownRead.json();
+    assert.equal(ownBody.study.accessionNumber, "ACC-ORG-2");
+
+    const org1Worklist = await callWorker(jsonRequest("/api/staff/imaging", undefined, {
+      method: "GET", headers: { cookie: cookie1 },
+    }), db);
+    assert.equal(org1Worklist.status, 200);
+    const worklistBody = await org1Worklist.json();
+    assert.equal(worklistBody.worklist.some((row) => row.id === booking2), false);
+    assert.equal(worklistBody.worklist.some((row) => row.id === booking1), true);
+
+    const event = await db.prepare(
+      `SELECT organization_id AS organizationId FROM booking_events
+       WHERE booking_id = ? AND action = 'imaging_linked' ORDER BY id DESC LIMIT 1`,
+    ).bind(booking2).first();
+    assert.equal(event.organizationId, 2);
+  });
+});


### PR DESCRIPTION
Closes #175

Hardens the existing DICOM/PACS workflow so every PACS configuration and imaging-study operation is organization-scoped.

Highlights:
- migration `0031_pacs_tenant_scope.sql` adds `organization_id` to `pacs_settings` and preserves the existing config as organization 1;
- PACS settings GET/PUT use server-derived tenant context and upsert by organization;
- imaging API loads only the current organization's PACS/viewer configuration;
- booking and imaging-study reads/updates include explicit organization scope;
- worklist joins imaging studies on both booking and organization;
- imaging audit events now persist explicit `organization_id`;
- cross-tenant behavior tests prove independent PACS settings, foreign booking denial, worklist isolation and correct audit ownership.

No production deploy is performed by this PR.