### PR TITLE
test: add production migration upgrade gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
           node-version: 22.13.0
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install dependencies deterministically
+        run: npm run install:ci
 
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "22.19.19",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.6",
+    "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "@vitejs/plugin-rsc": "0.5.26",
     "drizzle-kit": "0.31.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "bash scripts/build-verified.sh",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
     "test": "npm run build && node --experimental-strip-types --test tests/*.test.mjs",
-    "test:production-gate": "npm run build && node --experimental-strip-types --test tests/canonical-public-url.test.mjs tests/hosting-headers.test.mjs tests/site-booking.behavior.test.mjs tests/booking-capacity.test.mjs tests/staff-confirm-reschedule.behavior.test.mjs tests/staff-rbac.behavior.test.mjs tests/patient-otp.behavior.test.mjs tests/patient-cabinet-tenant.test.mjs tests/my-bookings.behavior.test.mjs tests/payment-api.behavior.test.mjs tests/payment-ledger.behavior.test.mjs tests/payment-settlement.behavior.test.mjs tests/study-state.test.mjs tests/protocol-builder.test.mjs tests/dashboard.test.mjs tests/security-hardening.test.mjs tests/tenant-hardening.test.mjs",
+    "test:production-gate": "npm run build && node --experimental-strip-types --test tests/canonical-public-url.test.mjs tests/hosting-headers.test.mjs tests/site-booking.behavior.test.mjs tests/booking-capacity.test.mjs tests/staff-confirm-reschedule.behavior.test.mjs tests/staff-rbac.behavior.test.mjs tests/patient-otp.behavior.test.mjs tests/patient-cabinet-tenant.test.mjs tests/my-bookings.behavior.test.mjs tests/payment-api.behavior.test.mjs tests/payment-ledger.behavior.test.mjs tests/payment-settlement.behavior.test.mjs tests/study-state.test.mjs tests/protocol-builder.test.mjs tests/dashboard.test.mjs tests/security-hardening.test.mjs tests/tenant-hardening.test.mjs tests/migration-upgrade.test.mjs",
     "validate:artifact": "bash scripts/validate-artifact.sh",
     "lint": "bash scripts/sites-env.sh -- eslint . --ignore-pattern dist --ignore-pattern .next --ignore-pattern public",
     "db:generate": "bash scripts/sites-env.sh -- drizzle-kit generate"
@@ -28,7 +28,7 @@
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "22.19.19",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
+    "@types/react-dom": "19.2.6",
     "@vitejs/plugin-react": "6.0.2",
     "@vitejs/plugin-rsc": "0.5.26",
     "drizzle-kit": "0.31.10",

--- a/tests/migration-upgrade.test.mjs
+++ b/tests/migration-upgrade.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DatabaseSync } from "node:sqlite";
+import { readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const DRIZZLE_DIR = new URL("../drizzle/", import.meta.url);
+
+function migrationNumber(file) {
+  const match = /^(\d{4})_[A-Za-z0-9_.-]+\.sql$/.exec(file);
+  return match ? Number(match[1]) : null;
+}
+
+async function migrationInventory() {
+  const files = (await readdir(fileURLToPath(DRIZZLE_DIR)))
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+  const numbered = files.map((file) => ({ file, number: migrationNumber(file) }));
+  for (const item of numbered) {
+    assert.notEqual(item.number, null, `Migration filename must start with a four-digit prefix: ${item.file}`);
+  }
+  const seen = new Map();
+  for (const item of numbered) {
+    const prior = seen.get(item.number);
+    assert.equal(prior, undefined, `Duplicate migration prefix ${String(item.number).padStart(4, "0")}: ${prior} and ${item.file}`);
+    seen.set(item.number, item.file);
+  }
+  return numbered;
+}
+
+async function applyFiles(db, items) {
+  for (const { file } of items) {
+    const sql = await readFile(new URL(file, DRIZZLE_DIR), "utf8");
+    try {
+      db.exec(sql);
+    } catch (error) {
+      throw new Error(`Migration ${file} failed during upgrade gate: ${error.message}`);
+    }
+  }
+}
+
+function tableColumns(db, table) {
+  return db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name);
+}
+
+function indexNames(db, table) {
+  return db.prepare(`PRAGMA index_list(${table})`).all().map((row) => row.name);
+}
+
+test("production baseline through 0029 upgrades through 0032 without losing existing data", async () => {
+  const inventory = await migrationInventory();
+  const baseline = inventory.filter((item) => item.number <= 29);
+  const release = inventory.filter((item) => item.number >= 30 && item.number <= 32);
+  assert.deepEqual(release.map((item) => item.number), [30, 31, 32]);
+
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec("PRAGMA foreign_keys = ON;");
+    await applyFiles(db, baseline);
+
+    db.prepare(
+      `UPDATE pacs_settings
+       SET dicomweb_base_url = ?, viewer_base_url = ?, ae_title = ?, enabled = 1,
+           notes = ?, updated_by = ?
+       WHERE id = 1`,
+    ).run(
+      "https://legacy-pacs.example.test/dicom-web",
+      "https://legacy-viewer.example.test/viewer",
+      "LEGACYPACS",
+      "preserve this configuration",
+      "legacy-admin@example.test",
+    );
+
+    const bookingResult = db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized, date_of_birth,
+         service, service_code, equipment_id, desired_date, desired_time, status, comment)
+       VALUES (1, 'UPGRADE-001', 'Пацієнт До Міграції', '+380501112233', '380501112233',
+         '1985-06-07', 'КТ органів грудної клітки', '408', 'ct',
+         '2026-08-20', '10:00', 'confirmed', 'legacy booking must survive')`,
+    ).run();
+    const bookingId = Number(bookingResult.lastInsertRowid);
+
+    const imagingColumns = tableColumns(db, "imaging_studies");
+    if (imagingColumns.includes("organization_id")) {
+      db.prepare(
+        `INSERT INTO imaging_studies
+          (organization_id, booking_id, accession_number, study_instance_uid, modality,
+           study_status, source, updated_by)
+         VALUES (1, ?, 'LEGACY-ACC-001', '1.2.840.10008.5.1.4.1', 'CT',
+           'available', 'manual', 'legacy-radiographer@example.test')`,
+      ).run(bookingId);
+    } else {
+      db.prepare(
+        `INSERT INTO imaging_studies
+          (booking_id, accession_number, study_instance_uid, modality,
+           study_status, source, updated_by)
+         VALUES (?, 'LEGACY-ACC-001', '1.2.840.10008.5.1.4.1', 'CT',
+           'available', 'manual', 'legacy-radiographer@example.test')`,
+      ).run(bookingId);
+    }
+
+    const legacyPacs = db.prepare(
+      `SELECT dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
+        ae_title AS aeTitle, enabled, notes, updated_by AS updatedBy
+       FROM pacs_settings WHERE id = 1`,
+    ).get();
+    const legacyBooking = db.prepare(
+      "SELECT code, name, phone, service, status, comment FROM bookings WHERE id = ?",
+    ).get(bookingId);
+    const legacyImaging = db.prepare(
+      `SELECT accession_number AS accessionNumber, study_instance_uid AS studyInstanceUid,
+        modality, study_status AS studyStatus, source, updated_by AS updatedBy
+       FROM imaging_studies WHERE booking_id = ?`,
+    ).get(bookingId);
+
+    await applyFiles(db, release);
+
+    const upgradedPacs = db.prepare(
+      `SELECT organization_id AS organizationId, dicomweb_base_url AS dicomwebBaseUrl,
+        viewer_base_url AS viewerBaseUrl, ae_title AS aeTitle, enabled, notes,
+        updated_by AS updatedBy FROM pacs_settings WHERE id = 1`,
+    ).get();
+    assert.equal(upgradedPacs.organizationId, 1);
+    assert.deepEqual(
+      Object.fromEntries(Object.entries(upgradedPacs).filter(([key]) => key !== "organizationId")),
+      legacyPacs,
+    );
+
+    assert.deepEqual(
+      db.prepare("SELECT code, name, phone, service, status, comment FROM bookings WHERE id = ?").get(bookingId),
+      legacyBooking,
+    );
+    assert.deepEqual(
+      db.prepare(
+        `SELECT accession_number AS accessionNumber, study_instance_uid AS studyInstanceUid,
+          modality, study_status AS studyStatus, source, updated_by AS updatedBy
+         FROM imaging_studies WHERE booking_id = ?`,
+      ).get(bookingId),
+      legacyImaging,
+    );
+
+    assert.deepEqual(tableColumns(db, "analytics_events"), [
+      "id", "organization_id", "event_name", "journey_id", "service_code",
+      "patient_category", "page_key", "source", "occurred_at",
+    ]);
+    assert.ok(indexNames(db, "analytics_events").includes("analytics_events_org_event_time_idx"));
+
+    assert.ok(tableColumns(db, "pacs_settings").includes("organization_id"));
+    assert.ok(indexNames(db, "pacs_settings").includes("pacs_settings_organization_idx"));
+
+    assert.deepEqual(tableColumns(db, "mwl_bridge_tokens"), [
+      "organization_id", "token_hash", "active", "created_by", "created_at", "rotated_at", "last_used_at",
+    ]);
+    assert.deepEqual(tableColumns(db, "mwl_patient_ids"), [
+      "organization_id", "identity_key", "patient_id", "created_at",
+    ]);
+    assert.ok(indexNames(db, "mwl_bridge_tokens").includes("mwl_bridge_tokens_hash_idx"));
+    assert.ok(indexNames(db, "mwl_patient_ids").includes("mwl_patient_ids_org_patient_idx"));
+  } finally {
+    db.close();
+  }
+});

--- a/tests/migration-upgrade.test.mjs
+++ b/tests/migration-upgrade.test.mjs
@@ -47,6 +47,10 @@ function indexNames(db, table) {
   return db.prepare(`PRAGMA index_list(${table})`).all().map((row) => row.name);
 }
 
+function plainRow(row) {
+  return row == null ? row : Object.fromEntries(Object.entries(row));
+}
+
 test("production baseline through 0029 upgrades through 0032 without losing existing data", async () => {
   const inventory = await migrationInventory();
   const baseline = inventory.filter((item) => item.number <= 29);
@@ -100,27 +104,27 @@ test("production baseline through 0029 upgrades through 0032 without losing exis
       ).run(bookingId);
     }
 
-    const legacyPacs = db.prepare(
+    const legacyPacs = plainRow(db.prepare(
       `SELECT dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
         ae_title AS aeTitle, enabled, notes, updated_by AS updatedBy
        FROM pacs_settings WHERE id = 1`,
-    ).get();
-    const legacyBooking = db.prepare(
+    ).get());
+    const legacyBooking = plainRow(db.prepare(
       "SELECT code, name, phone, service, status, comment FROM bookings WHERE id = ?",
-    ).get(bookingId);
-    const legacyImaging = db.prepare(
+    ).get(bookingId));
+    const legacyImaging = plainRow(db.prepare(
       `SELECT accession_number AS accessionNumber, study_instance_uid AS studyInstanceUid,
         modality, study_status AS studyStatus, source, updated_by AS updatedBy
        FROM imaging_studies WHERE booking_id = ?`,
-    ).get(bookingId);
+    ).get(bookingId));
 
     await applyFiles(db, release);
 
-    const upgradedPacs = db.prepare(
+    const upgradedPacs = plainRow(db.prepare(
       `SELECT organization_id AS organizationId, dicomweb_base_url AS dicomwebBaseUrl,
         viewer_base_url AS viewerBaseUrl, ae_title AS aeTitle, enabled, notes,
         updated_by AS updatedBy FROM pacs_settings WHERE id = 1`,
-    ).get();
+    ).get());
     assert.equal(upgradedPacs.organizationId, 1);
     assert.deepEqual(
       Object.fromEntries(Object.entries(upgradedPacs).filter(([key]) => key !== "organizationId")),
@@ -128,15 +132,15 @@ test("production baseline through 0029 upgrades through 0032 without losing exis
     );
 
     assert.deepEqual(
-      db.prepare("SELECT code, name, phone, service, status, comment FROM bookings WHERE id = ?").get(bookingId),
+      plainRow(db.prepare("SELECT code, name, phone, service, status, comment FROM bookings WHERE id = ?").get(bookingId)),
       legacyBooking,
     );
     assert.deepEqual(
-      db.prepare(
+      plainRow(db.prepare(
         `SELECT accession_number AS accessionNumber, study_instance_uid AS studyInstanceUid,
           modality, study_status AS studyStatus, source, updated_by AS updatedBy
          FROM imaging_studies WHERE booking_id = ?`,
-      ).get(bookingId),
+      ).get(bookingId)),
       legacyImaging,
     );
 


### PR DESCRIPTION
Closes #181

Adds an explicit upgrade-path release gate for the accumulated database migrations 0030–0032.

Highlights:
- discovers SQL migrations by numeric prefix and rejects duplicate prefixes;
- builds a representative pre-release database through migrations <=0029;
- seeds the legacy global PACS configuration plus an existing booking and imaging linkage;
- applies 0030 analytics, 0031 PACS tenant scope and 0032 MWL bridge in order;
- verifies the old PACS configuration is preserved and assigned to organization 1;
- verifies existing booking/imaging data remains unchanged;
- verifies the new analytics, PACS tenant and MWL tables/indexes exist after upgrade;
- adds this test to `npm run test:production-gate` so future PRs cannot bypass the upgrade check.

No production deploy is performed by this PR.