### PR TITLE
feat: add PACS/MWL integration health dashboard

### DIFF
--- a/app/api/staff/integrations/health/route.ts
+++ b/app/api/staff/integrations/health/route.ts
@@ -1,0 +1,76 @@
+import { dbBinding } from "../../../../../lib/db";
+import { fetchLimited, safeOutboundUrl } from "../../../../../lib/outbound";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+function probeUrl(base:string):URL | null {
+  const normalized = base.trim().replace(/\/+$/, "");
+  return normalized ? safeOutboundUrl(`${normalized}/studies?limit=1`) : null;
+}
+
+async function pacsReachable(base:string):Promise<boolean> {
+  const url = probeUrl(base);
+  if (!url) return false;
+  try {
+    const response = await fetchLimited(url, { headers:{ accept:"application/dicom+json" } }, 3000);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function GET(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+  if (ctx.member.role !== "admin") {
+    return Response.json({ error:"Стан інтеграцій доступний лише адміністратору" }, { status:403 });
+  }
+
+  const [pacs, mwl] = await Promise.all([
+    db.prepare(
+      `SELECT dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
+        ae_title AS aeTitle, enabled, updated_at AS updatedAt
+       FROM pacs_settings WHERE organization_id = ? LIMIT 1`,
+    ).bind(ctx.organizationId).first<Record<string, unknown>>(),
+    db.prepare(
+      `SELECT active, created_at AS createdAt, rotated_at AS rotatedAt, last_used_at AS lastUsedAt
+       FROM mwl_bridge_tokens WHERE organization_id = ? LIMIT 1`,
+    ).bind(ctx.organizationId).first<Record<string, unknown>>(),
+  ]);
+
+  const pacsConfigured = !!String(pacs?.dicomwebBaseUrl || "").trim();
+  const pacsEnabled = !!Number(pacs?.enabled || 0);
+  const reachable = pacsConfigured && pacsEnabled
+    ? await pacsReachable(String(pacs?.dicomwebBaseUrl || ""))
+    : false;
+  const mwlConfigured = !!mwl;
+  const mwlActive = !!Number(mwl?.active || 0);
+  const lastUsedAt = String(mwl?.lastUsedAt || "");
+
+  const pacsState = !pacsConfigured ? "not_configured" : !pacsEnabled ? "disabled" : reachable ? "operational" : "unreachable";
+  const mwlState = !mwlConfigured ? "not_configured" : !mwlActive ? "disabled" : lastUsedAt ? "operational" : "awaiting_first_use";
+
+  return Response.json({
+    pacs:{
+      state:pacsState,
+      configured:pacsConfigured,
+      enabled:pacsEnabled,
+      reachable,
+      viewerConfigured:!!String(pacs?.viewerBaseUrl || "").trim(),
+      aeTitleConfigured:!!String(pacs?.aeTitle || "").trim(),
+      updatedAt:String(pacs?.updatedAt || ""),
+      autoLinkReady:pacsEnabled && reachable,
+    },
+    mwl:{
+      state:mwlState,
+      configured:mwlConfigured,
+      active:mwlActive,
+      createdAt:String(mwl?.createdAt || ""),
+      rotatedAt:String(mwl?.rotatedAt || ""),
+      lastUsedAt,
+      ready:mwlActive,
+    },
+    overall: (pacsEnabled && reachable && mwlActive) ? "operational" : "attention_required",
+  }, { headers:{ "cache-control":"no-store" } });
+}

--- a/app/staff/integrations/health/page.tsx
+++ b/app/staff/integrations/health/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type Health = {
+  pacs:{ state:string; configured:boolean; enabled:boolean; reachable:boolean; viewerConfigured:boolean; aeTitleConfigured:boolean; updatedAt:string; autoLinkReady:boolean };
+  mwl:{ state:string; configured:boolean; active:boolean; createdAt:string; rotatedAt:string; lastUsedAt:string; ready:boolean };
+  overall:string;
+};
+
+const LABELS:Record<string,string> = {
+  operational:"Працює",
+  attention_required:"Потрібна увага",
+  not_configured:"Не налаштовано",
+  disabled:"Вимкнено",
+  unreachable:"PACS недоступний",
+  awaiting_first_use:"Очікує першого підключення",
+};
+
+export default function IntegrationHealthPage() {
+  const [data,setData] = useState<Health | null>(null);
+  const [error,setError] = useState("");
+  const [busy,setBusy] = useState(false);
+
+  async function load() {
+    setBusy(true); setError("");
+    try {
+      const response = await fetch("/api/staff/integrations/health", { cache:"no-store" });
+      const payload = await response.json() as Health & { error?:string };
+      if (!response.ok) { setError(payload.error || "Не вдалося перевірити інтеграції"); return; }
+      setData(payload);
+    } catch {
+      setError("Не вдалося перевірити інтеграції");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void load(); }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return <StaffWorkspaceShell
+    active="imaging"
+    title="Стан PACS / MWL"
+    description="Операційна перевірка інтеграцій без показу токенів, паролів або інших секретів."
+  >
+    <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12,flexWrap:"wrap"}}>
+      <p><b>Загальний стан:</b> {data ? (LABELS[data.overall] || data.overall) : "—"}</p>
+      <button type="button" disabled={busy} onClick={()=>void load()}>{busy ? "Перевіряю…" : "Перевірити зараз"}</button>
+    </div>
+    {error && <p className="staffError" role="alert">{error}</p>}
+
+    <div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(280px,1fr))",gap:16,marginTop:16}}>
+      <section className="pacsSettings" style={{display:"block"}}>
+        <h2>PACS / DICOMweb</h2>
+        <p><b>Стан:</b> {data ? (LABELS[data.pacs.state] || data.pacs.state) : "—"}</p>
+        <p><b>Auto-link:</b> {data?.pacs.autoLinkReady ? "готовий" : "не готовий"}</p>
+        <p><b>Viewer:</b> {data?.pacs.viewerConfigured ? "налаштований" : "не налаштований"}</p>
+        <p><b>AE Title:</b> {data?.pacs.aeTitleConfigured ? "налаштований" : "не налаштований"}</p>
+        {data?.pacs.updatedAt && <p><b>Оновлено:</b> {data.pacs.updatedAt}</p>}
+        {!data?.pacs.configured && <p>Додайте DICOMweb URL у налаштуваннях PACS.</p>}
+        {data?.pacs.configured && data?.pacs.enabled && !data?.pacs.reachable && <p>Перевірте мережеву доступність PACS та allowlist вихідних хостів.</p>}
+      </section>
+
+      <section className="pacsSettings" style={{display:"block"}}>
+        <h2>Modality Worklist bridge</h2>
+        <p><b>Стан:</b> {data ? (LABELS[data.mwl.state] || data.mwl.state) : "—"}</p>
+        <p><b>Токен:</b> {data?.mwl.active ? "активний" : data?.mwl.configured ? "вимкнений" : "не створений"}</p>
+        {data?.mwl.rotatedAt && <p><b>Остання ротація:</b> {data.mwl.rotatedAt}</p>}
+        {data?.mwl.lastUsedAt && <p><b>Останнє використання:</b> {data.mwl.lastUsedAt}</p>}
+        {data?.mwl.active && !data?.mwl.lastUsedAt && <p>Bridge готовий, але локальний сервіс ще не звертався до feed.</p>}
+        {!data?.mwl.active && <p>Створіть або активуйте bridge token у розділі Modality Worklist.</p>}
+      </section>
+    </div>
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -16,10 +16,16 @@ type StaffWorkspaceShellProps = {
   children: ReactNode;
 };
 
+// Бічна панель: угорі «Огляд» — найчастіші екрани реєстратури; нижче
+// «Модулі» — робочі напрями, згруповані за призначенням. Кожен модуль
+// веде на головну сторінку напряму й розгортається у підпункти-екрани.
 type NavChild = { label:string; href:string };
 type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
+// section — головний розділ модуля; sections — усі розділи, що його підсвічують.
 type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
+// Меню за процесом роботи, а не за модулями системи: як думає відділення —
+// Прийом → Розклад → Опис → Видача. Пульт зверху як загальний огляд дня.
 const processRail: NavLink[] = [
   { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
   { label:"Прийом", href:"/staff/intake", section:"intake", icon:"📥" },
@@ -28,6 +34,7 @@ const processRail: NavLink[] = [
   { label:"Видача", href:"/staff/studies", section:"studies", icon:"✅" },
 ];
 
+// Модулі — усе, що поза щоденним потоком: довідники, фінанси, адміністрування.
 const systemModules: NavModule[] = [
   { label:"Пацієнти", href:"/staff/patients", sections:["patients","chat"], icon:"👥", items:[
     { label:"Картки пацієнтів", href:"/staff/patients" },
@@ -105,7 +112,7 @@ export default function StaffWorkspaceShell({
   function toggleTheme() {
     setDark((value)=>{
       const next = !value;
-      window.localStorage.setItem("ws-theme", next ? "dark":"light");
+      window.localStorage.setItem("ws-theme", next ? "dark" : "light");
       return next;
     });
   }
@@ -118,6 +125,8 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
+  // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
+  // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
   const wide = active === "dashboard" || active === "appointments" || active === "intake";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
@@ -140,6 +149,8 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = item.sections.includes(active);
+          // Акордеон: типово розгорнутий лише модуль поточного розділу, решта
+          // згорнуті в один рядок. Користувач може розгортати вручну.
           const isOpen = openModules[item.href] ?? isActive;
           return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -16,16 +16,10 @@ type StaffWorkspaceShellProps = {
   children: ReactNode;
 };
 
-// Бічна панель: угорі «Огляд» — найчастіші екрани реєстратури; нижче
-// «Модулі» — робочі напрями, згруповані за призначенням. Кожен модуль
-// веде на головну сторінку напряму й розгортається у підпункти-екрани.
 type NavChild = { label:string; href:string };
 type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
-// section — головний розділ модуля; sections — усі розділи, що його підсвічують.
 type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
-// Меню за процесом роботи, а не за модулями системи: як думає відділення —
-// Прийом → Розклад → Опис → Видача. Пульт зверху як загальний огляд дня.
 const processRail: NavLink[] = [
   { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
   { label:"Прийом", href:"/staff/intake", section:"intake", icon:"📥" },
@@ -34,13 +28,16 @@ const processRail: NavLink[] = [
   { label:"Видача", href:"/staff/studies", section:"studies", icon:"✅" },
 ];
 
-// Модулі — усе, що поза щоденним потоком: довідники, фінанси, адміністрування.
 const systemModules: NavModule[] = [
   { label:"Пацієнти", href:"/staff/patients", sections:["patients","chat"], icon:"👥", items:[
     { label:"Картки пацієнтів", href:"/staff/patients" },
     { label:"Чат із пацієнтами", href:"/staff/chat" },
   ]},
-  { label:"Знімки DICOM", href:"/staff/imaging", sections:["imaging"], icon:"🩻", items:[] },
+  { label:"Знімки DICOM", href:"/staff/imaging", sections:["imaging"], icon:"🩻", items:[
+    { label:"Список досліджень", href:"/staff/imaging" },
+    { label:"Стан PACS / MWL", href:"/staff/integrations/health" },
+    { label:"Modality Worklist", href:"/staff/integrations/mwl" },
+  ]},
   { label:"Кабінети й обладнання", href:"/staff/schedule", sections:["schedule","equipment","services"], icon:"🛠️", items:[
     { label:"Графік і слоти кабінетів", href:"/staff/schedule" },
     { label:"Обладнання", href:"/staff/equipment" },
@@ -108,7 +105,7 @@ export default function StaffWorkspaceShell({
   function toggleTheme() {
     setDark((value)=>{
       const next = !value;
-      window.localStorage.setItem("ws-theme", next ? "dark" : "light");
+      window.localStorage.setItem("ws-theme", next ? "dark":"light");
       return next;
     });
   }
@@ -121,8 +118,6 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
-  // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
-  // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
   const wide = active === "dashboard" || active === "appointments" || active === "intake";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
@@ -145,8 +140,6 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = item.sections.includes(active);
-          // Акордеон: типово розгорнутий лише модуль поточного розділу, решта
-          // згорнуті в один рядок. Користувач може розгортати вручну.
           const isOpen = openModules[item.href] ?? isActive;
           return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">

--- a/tests/integration-health.behavior.test.mjs
+++ b/tests/integration-health.behavior.test.mjs
@@ -12,9 +12,10 @@ test("integration health reports readiness without exposing PACS or MWL secrets"
   await withD1(async (db) => {
     const cookie = await seedStaffSession(db, { email:"admin@health.test", role:"admin" });
     await db.prepare(
-      `INSERT INTO pacs_settings
-        (organization_id, dicomweb_base_url, viewer_base_url, ae_title, enabled, notes, updated_by)
-       VALUES (1, ?, ?, 'RADIOLOGY', 1, 'secret operational note', 'admin@health.test')`
+      `UPDATE pacs_settings SET
+        dicomweb_base_url = ?, viewer_base_url = ?, ae_title = 'RADIOLOGY', enabled = 1,
+        notes = 'secret operational note', updated_by = 'admin@health.test', updated_at = CURRENT_TIMESTAMP
+       WHERE organization_id = 1`
     ).bind("https://pacs.example.test/dicomweb", "https://viewer.example.test/ohif").run();
     await db.prepare(
       `INSERT INTO mwl_bridge_tokens
@@ -54,8 +55,10 @@ test("integration health degrades PACS safely when the remote endpoint is unreac
   await withD1(async (db) => {
     const cookie = await seedStaffSession(db, { email:"admin2@health.test", role:"admin" });
     await db.prepare(
-      `INSERT INTO pacs_settings (organization_id, dicomweb_base_url, enabled, updated_by)
-       VALUES (1, 'https://pacs.example.test/dicomweb', 1, 'admin2@health.test')`
+      `UPDATE pacs_settings SET
+        dicomweb_base_url = 'https://pacs.example.test/dicomweb', enabled = 1,
+        updated_by = 'admin2@health.test', updated_at = CURRENT_TIMESTAMP
+       WHERE organization_id = 1`
     ).run();
 
     const previousFetch = globalThis.fetch;

--- a/tests/integration-health.behavior.test.mjs
+++ b/tests/integration-health.behavior.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+function request(cookie) {
+  return new Request("http://localhost/api/staff/integrations/health", {
+    headers:{ cookie },
+  });
+}
+
+test("integration health reports readiness without exposing PACS or MWL secrets", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email:"admin@health.test", role:"admin" });
+    await db.prepare(
+      `INSERT INTO pacs_settings
+        (organization_id, dicomweb_base_url, viewer_base_url, ae_title, enabled, notes, updated_by)
+       VALUES (1, ?, ?, 'RADIOLOGY', 1, 'secret operational note', 'admin@health.test')`
+    ).bind("https://pacs.example.test/dicomweb", "https://viewer.example.test/ohif").run();
+    await db.prepare(
+      `INSERT INTO mwl_bridge_tokens
+        (organization_id, token_hash, active, created_by, created_at, rotated_at, last_used_at)
+       VALUES (1, 'super-secret-token-hash', 1, 'admin@health.test', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+    ).run();
+
+    const previousFetch = globalThis.fetch;
+    const previousAllowlist = globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
+    globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = "pacs.example.test";
+    globalThis.fetch = async (url) => {
+      assert.match(String(url), /^https:\/\/pacs\.example\.test\/dicomweb\/studies\?limit=1$/);
+      return new Response("[]", { status:200, headers:{ "content-type":"application/dicom+json" } });
+    };
+    try {
+      const response = await callWorker(request(cookie), db);
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.overall, "operational");
+      assert.equal(body.pacs.state, "operational");
+      assert.equal(body.pacs.autoLinkReady, true);
+      assert.equal(body.mwl.state, "operational");
+      assert.equal(body.mwl.ready, true);
+      const serialized = JSON.stringify(body);
+      for (const forbidden of [
+        "pacs.example.test", "viewer.example.test", "super-secret-token-hash", "secret operational note",
+      ]) assert.equal(serialized.includes(forbidden), false);
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousAllowlist === undefined) delete globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
+      else globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = previousAllowlist;
+    }
+  });
+});
+
+test("integration health degrades PACS safely when the remote endpoint is unreachable", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email:"admin2@health.test", role:"admin" });
+    await db.prepare(
+      `INSERT INTO pacs_settings (organization_id, dicomweb_base_url, enabled, updated_by)
+       VALUES (1, 'https://pacs.example.test/dicomweb', 1, 'admin2@health.test')`
+    ).run();
+
+    const previousFetch = globalThis.fetch;
+    const previousAllowlist = globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
+    globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = "pacs.example.test";
+    globalThis.fetch = async () => { throw new Error("offline"); };
+    try {
+      const response = await callWorker(request(cookie), db);
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.pacs.state, "unreachable");
+      assert.equal(body.pacs.autoLinkReady, false);
+      assert.equal(body.overall, "attention_required");
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousAllowlist === undefined) delete globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
+      else globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = previousAllowlist;
+    }
+  });
+});


### PR DESCRIPTION
Closes #185

Adds a tenant-scoped operational health view for imaging integrations.

Highlights:
- admin-only `/api/staff/integrations/health` endpoint;
- bounded PACS DICOMweb probe through existing outbound SSRF protections;
- reports PACS configured/enabled/reachable/auto-link readiness without returning URLs or notes;
- reports MWL configured/active/last-used state without returning bearer token/hash;
- new `/staff/integrations/health` dashboard with actionable readiness messages;
- behavior tests for reachable/unreachable PACS and no-secret responses.

No production deploy is performed by this PR.