### PR TITLE
ci: use deterministic install in production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,8 @@ jobs:
           node-version: 22.13.0
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install dependencies deterministically
+        run: npm run install:ci
 
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high

--- a/tests/production-release-gate.test.mjs
+++ b/tests/production-release-gate.test.mjs
@@ -34,12 +34,15 @@ test("package exposes a deterministic production release gate manifest", async (
   }
 });
 
-test("CI and production deploy both run the release gate", async () => {
+test("CI and production deploy use hardened install and run the release gate", async () => {
   const ci = await read(".github/workflows/ci.yml");
   const deploy = await read(".github/workflows/deploy.yml");
 
-  assert.match(ci, /name: Production release gate\s+run: npm run test:production-gate/);
-  assert.match(deploy, /name: Production release gate\s+run: npm run test:production-gate/);
+  for (const [name, workflow] of [["CI", ci], ["deploy", deploy]]) {
+    assert.match(workflow, /name: Install dependencies deterministically\s+run: npm run install:ci/, `${name} must use the hardened installer`);
+    assert.doesNotMatch(workflow, /run: npm ci(?:\s|$)/, `${name} must not bypass install:ci with raw npm ci`);
+    assert.match(workflow, /name: Production release gate\s+run: npm run test:production-gate/);
+  }
 
   const gatePosition = deploy.indexOf("name: Production release gate");
   const migrationsPosition = deploy.indexOf("name: Apply D1 migrations");


### PR DESCRIPTION
Closes #187

Keeps CI and production deployment on the same hardened dependency-install path.

Changes:
- replaces raw `npm ci` in `deploy.yml` with `npm run install:ci`;
- extends the release-gate regression test to require the hardened installer in both CI and deploy workflows;
- explicitly rejects direct raw `npm ci` in those workflows.

No dependency versions or production runtime behavior are changed. No production deploy is performed by this PR.