### PR TITLE
feat: add critical system health dashboard

### DIFF
--- a/app/api/staff/system/health/route.ts
+++ b/app/api/staff/system/health/route.ts
@@ -1,0 +1,87 @@
+import { dbBinding } from "../../../../../lib/db";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+type Check = { state:"operational" | "attention_required"; detail:string };
+
+async function probe(db: ReturnType<typeof dbBinding>, sql:string, ...bind:unknown[]):Promise<boolean> {
+  if (!db) return false;
+  try {
+    await db.prepare(sql).bind(...bind).first();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function GET(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+  if (ctx.member.role !== "admin") {
+    return Response.json({ error:"Стан системи доступний лише адміністратору" }, { status:403 });
+  }
+
+  const orgId = ctx.organizationId;
+  const [databaseOk, bookingsOk, paymentsOk, pacs, mwl] = await Promise.all([
+    probe(db, "SELECT 1 AS ok"),
+    probe(db, "SELECT organization_id FROM bookings WHERE organization_id = ? LIMIT 1", orgId),
+    probe(db, "SELECT organization_id FROM payment_transactions WHERE organization_id = ? LIMIT 1", orgId),
+    db.prepare(
+      `SELECT enabled, dicomweb_base_url AS dicomwebBaseUrl
+       FROM pacs_settings WHERE organization_id = ? LIMIT 1`,
+    ).bind(orgId).first<Record<string, unknown>>().catch(() => null),
+    db.prepare(
+      `SELECT active, last_used_at AS lastUsedAt
+       FROM mwl_bridge_tokens WHERE organization_id = ? LIMIT 1`,
+    ).bind(orgId).first<Record<string, unknown>>().catch(() => null),
+  ]);
+
+  const pacsConfigured = !!String(pacs?.dicomwebBaseUrl || "").trim();
+  const pacsEnabled = !!Number(pacs?.enabled || 0);
+  const mwlConfigured = !!mwl;
+  const mwlActive = !!Number(mwl?.active || 0);
+
+  const checks:Record<string, Check> = {
+    database:{
+      state:databaseOk ? "operational":"attention_required",
+      detail:databaseOk ? "D1 відповідає на read-only запит":"D1 read probe не пройдено",
+    },
+    authentication:{
+      state:"operational",
+      detail:"Staff session та tenant context визначено",
+    },
+    bookings:{
+      state:bookingsOk ? "operational":"attention_required",
+      detail:bookingsOk ? "Booking schema доступна":"Booking schema недоступна",
+    },
+    payments:{
+      state:paymentsOk ? "operational":"attention_required",
+      detail:paymentsOk ? "Payment ledger schema доступна":"Payment ledger schema недоступна",
+    },
+    imaging:{
+      state:(pacsConfigured && pacsEnabled && mwlActive) ? "operational":"attention_required",
+      detail:(pacsConfigured && pacsEnabled && mwlActive)
+        ? "PACS налаштований, MWL token активний"
+        : "Перевірте конфігурацію PACS/MWL у спеціалізованому health-екрані",
+    },
+  };
+
+  const overall = Object.values(checks).every((check)=>check.state === "operational")
+    ? "operational"
+    : "attention_required";
+
+  return Response.json({
+    overall,
+    checkedAt:new Date().toISOString(),
+    checks,
+    imaging:{
+      pacsConfigured,
+      pacsEnabled,
+      mwlConfigured,
+      mwlActive,
+      mwlUsed:!!String(mwl?.lastUsedAt || ""),
+    },
+  }, { headers:{ "cache-control":"no-store" } });
+}

--- a/app/staff/system/health/page.tsx
+++ b/app/staff/system/health/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type State = "operational" | "attention_required";
+type Payload = {
+  overall:State;
+  checkedAt:string;
+  checks:Record<string,{ state:State; detail:string }>;
+  imaging:{ pacsConfigured:boolean; pacsEnabled:boolean; mwlConfigured:boolean; mwlActive:boolean; mwlUsed:boolean };
+};
+
+const LABELS:Record<string,string> = {
+  database:"База даних D1",
+  authentication:"Авторизація і tenant",
+  bookings:"Запис пацієнтів",
+  payments:"Платежі",
+  imaging:"PACS / MWL",
+};
+
+const STATE_LABELS:Record<State,string> = {
+  operational:"Працює",
+  attention_required:"Потрібна увага",
+};
+
+export default function SystemHealthPage() {
+  const [data,setData] = useState<Payload | null>(null);
+  const [error,setError] = useState("");
+  const [busy,setBusy] = useState(false);
+
+  async function load() {
+    setBusy(true); setError("");
+    try {
+      const response = await fetch("/api/staff/system/health", { cache:"no-store" });
+      const payload = await response.json() as Payload & { error?:string };
+      if (!response.ok) { setError(payload.error || "Не вдалося перевірити стан системи"); return; }
+      setData(payload);
+    } catch {
+      setError("Не вдалося перевірити стан системи");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(()=>{
+    const timer = window.setTimeout(()=>{ void load(); },0);
+    return ()=>window.clearTimeout(timer);
+  },[]);
+
+  return <StaffWorkspaceShell
+    active="settings"
+    title="Стан системи"
+    description="Read-only перевірка критичних production-потоків без даних пацієнтів і без секретів."
+  >
+    <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12,flexWrap:"wrap"}}>
+      <p><b>Загальний стан:</b> {data ? STATE_LABELS[data.overall] : "—"}</p>
+      <button type="button" disabled={busy} onClick={()=>void load()}>{busy ? "Перевіряю…":"Перевірити зараз"}</button>
+    </div>
+    {error && <p className="staffError" role="alert">{error}</p>}
+    {data?.checkedAt && <p><small>Остання перевірка: {new Date(data.checkedAt).toLocaleString("uk-UA")}</small></p>}
+
+    <div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(260px,1fr))",gap:16,marginTop:16}}>
+      {data && Object.entries(data.checks).map(([key,check])=><section className="pacsSettings" style={{display:"block"}} key={key}>
+        <h2>{LABELS[key] || key}</h2>
+        <p><b>Стан:</b> {STATE_LABELS[check.state]}</p>
+        <p>{check.detail}</p>
+        {key === "imaging" && <p><Link href="/staff/integrations/health">Відкрити детальну перевірку PACS / MWL</Link></p>}
+      </section>)}
+    </div>
+  </StaffWorkspaceShell>;
+}

--- a/tests/system-health.behavior.test.mjs
+++ b/tests/system-health.behavior.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+function request(cookie) {
+  return new Request("http://localhost/api/staff/system/health", { headers:{ cookie } });
+}
+
+test("system health is admin-only and returns no PHI or integration secrets", async () => {
+  await withD1(async (db) => {
+    const adminCookie = await seedStaffSession(db, { email:"admin@system-health.test", role:"admin" });
+    const staffCookie = await seedStaffSession(db, { email:"staff@system-health.test", role:"doctor" });
+
+    await db.prepare(
+      `UPDATE pacs_settings SET dicomweb_base_url = ?, enabled = 1 WHERE organization_id = 1`,
+    ).bind("https://secret-pacs.example.test/dicomweb").run();
+    await db.prepare(
+      `INSERT INTO mwl_bridge_tokens
+        (organization_id, token_hash, active, created_by, created_at, last_used_at)
+       VALUES (1, 'secret-mwl-hash', 1, 'admin@system-health.test', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+    ).run();
+
+    const denied = await callWorker(request(staffCookie), db);
+    assert.equal(denied.status, 403);
+
+    const response = await callWorker(request(adminCookie), db);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.checks.database.state, "operational");
+    assert.equal(body.checks.authentication.state, "operational");
+    assert.equal(body.checks.bookings.state, "operational");
+    assert.equal(body.checks.payments.state, "operational");
+    assert.equal(body.imaging.pacsConfigured, true);
+    assert.equal(body.imaging.pacsEnabled, true);
+    assert.equal(body.imaging.mwlActive, true);
+
+    const serialized = JSON.stringify(body);
+    for (const forbidden of [
+      "secret-pacs.example.test",
+      "secret-mwl-hash",
+      "admin@system-health.test",
+      "staff@system-health.test",
+    ]) assert.equal(serialized.includes(forbidden), false);
+  });
+});
+
+test("system health probes only the signed-in tenant and never returns row data", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email:"tenant-admin@health.test", role:"admin" });
+
+    await db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized, service_code, desired_date, desired_time, status)
+       VALUES (2, 'OTHER-TENANT-SECRET', 'Other Tenant Patient', '+380000000000', '+380000000000', 'ct_brain', '2026-08-11', '10:00', 'new')`,
+    ).run();
+    await db.prepare(
+      `INSERT INTO payment_transactions
+        (organization_id, booking_id, amount, currency, provider, provider_reference, status)
+       VALUES (2, 999999, 100, 'UAH', 'test-provider', 'OTHER-TENANT-PAYMENT-SECRET', 'pending')`,
+    ).run();
+
+    const response = await callWorker(request(cookie), db);
+    assert.equal(response.status, 200);
+    const serialized = JSON.stringify(await response.json());
+    for (const forbidden of [
+      "OTHER-TENANT-SECRET",
+      "Other Tenant Patient",
+      "+380000000000",
+      "OTHER-TENANT-PAYMENT-SECRET",
+      "test-provider",
+    ]) assert.equal(serialized.includes(forbidden), false);
+  });
+});

--- a/tests/system-health.behavior.test.mjs
+++ b/tests/system-health.behavior.test.mjs
@@ -44,30 +44,37 @@ test("system health is admin-only and returns no PHI or integration secrets", as
   });
 });
 
-test("system health probes only the signed-in tenant and never returns row data", async () => {
+test("system health reads imaging readiness only from the signed-in tenant", async () => {
   await withD1(async (db) => {
     const cookie = await seedStaffSession(db, { email:"tenant-admin@health.test", role:"admin" });
 
     await db.prepare(
-      `INSERT INTO bookings
-        (organization_id, code, name, phone, phone_normalized, service_code, desired_date, desired_time, status)
-       VALUES (2, 'OTHER-TENANT-SECRET', 'Other Tenant Patient', '+380000000000', '+380000000000', 'ct_brain', '2026-08-11', '10:00', 'new')`,
+      `UPDATE pacs_settings SET dicomweb_base_url = '', enabled = 0 WHERE organization_id = 1`,
     ).run();
     await db.prepare(
-      `INSERT INTO payment_transactions
-        (organization_id, booking_id, amount, currency, provider, provider_reference, status)
-       VALUES (2, 999999, 100, 'UAH', 'test-provider', 'OTHER-TENANT-PAYMENT-SECRET', 'pending')`,
+      `INSERT INTO pacs_settings
+        (organization_id, dicomweb_base_url, enabled, updated_by, updated_at)
+       VALUES (2, 'https://other-tenant-pacs.example.test/dicomweb', 1, 'other-admin', CURRENT_TIMESTAMP)`,
+    ).run();
+    await db.prepare(
+      `INSERT INTO mwl_bridge_tokens
+        (organization_id, token_hash, active, created_by, created_at, last_used_at)
+       VALUES (2, 'other-tenant-secret-hash', 1, 'other-admin', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
     ).run();
 
     const response = await callWorker(request(cookie), db);
     assert.equal(response.status, 200);
-    const serialized = JSON.stringify(await response.json());
+    const body = await response.json();
+    assert.equal(body.imaging.pacsConfigured, false);
+    assert.equal(body.imaging.pacsEnabled, false);
+    assert.equal(body.imaging.mwlConfigured, false);
+    assert.equal(body.imaging.mwlActive, false);
+
+    const serialized = JSON.stringify(body);
     for (const forbidden of [
-      "OTHER-TENANT-SECRET",
-      "Other Tenant Patient",
-      "+380000000000",
-      "OTHER-TENANT-PAYMENT-SECRET",
-      "test-provider",
+      "other-tenant-pacs.example.test",
+      "other-tenant-secret-hash",
+      "other-admin",
     ]) assert.equal(serialized.includes(forbidden), false);
   });
 });


### PR DESCRIPTION
Closes #189

Adds a PHI-free, admin-only operational health view for critical RadiologyOS production paths.

Highlights:
- tenant-scoped `/api/staff/system/health` endpoint;
- read-only D1, booking-schema and payment-ledger probes;
- verifies staff session + tenant context through the real auth path;
- summarizes PACS/MWL configured state without returning URLs, tokens or hashes;
- new `/staff/system/health` dashboard with actionable status cards;
- behavior tests for admin-only access, no-secret responses and cross-tenant imaging isolation.

No synthetic writes are performed by the health endpoint. No production deploy is performed by this PR.