### PR TITLE
chore: expose system health in command palette

### DIFF
--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -19,6 +19,7 @@ const COMMANDS: { label: string; hint: string; href: string }[] = [
   { label: "Пацієнти", hint: "картки / CRM", href: "/staff/patients" },
   { label: "Протоколи", hint: "опис досліджень", href: "/staff/protocols" },
   { label: "Звіти", hint: "аналітика", href: "/staff/reports" },
+  { label: "Стан системи", hint: "health / production", href: "/staff/system/health" },
   { label: "Налаштування", hint: "адміністрування", href: "/staff/settings" },
 ];
 


### PR DESCRIPTION
Follow-up to #190.

Adds a direct command-palette entry for `/staff/system/health` so administrators can reach the new operational health dashboard with Ctrl/Cmd+K.

No runtime health logic or production configuration changes. No production deploy is performed by this PR.