### PR TITLE
security: tenant-scope report metadata and audit

### DIFF
--- a/app/api/staff/reports/export/route.ts
+++ b/app/api/staff/reports/export/route.ts
@@ -42,6 +42,7 @@ export async function GET(request:Request) {
     containsPersonalData
   ).run();
   await logSecurityEvent(db, {
+    organizationId: ctx.organizationId,
     actorEmail: member.email,
     action: "report_exported",
     resource: "report",

--- a/app/api/staff/reports/route.ts
+++ b/app/api/staff/reports/route.ts
@@ -11,7 +11,6 @@ import {
   reportPayload,
 } from "../../../../lib/reporting-server";
 
-
 export async function GET(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error:"База тимчасово недоступна" },{ status:503 });
@@ -81,8 +80,12 @@ export async function GET(request:Request) {
 
   const [{ results:staffOptions },{ results:exportHistory }] = await Promise.all([
     db.prepare(
-      "SELECT email, display_name AS displayName, role FROM staff_members WHERE active = 1 ORDER BY role, display_name"
-    ).all(),
+      `SELECT s.email, s.display_name AS displayName, m.role AS role
+       FROM memberships m
+       JOIN staff_members s ON s.email = m.member_email
+       WHERE m.organization_id = ? AND m.active = 1 AND s.active = 1
+       ORDER BY m.role, s.display_name`
+    ).bind(ctx.organizationId).all(),
     db.prepare(
       `SELECT e.id, e.requested_by AS requestedBy,
         COALESCE(NULLIF(s.display_name,''), e.requested_by) AS requestedByName,
@@ -91,11 +94,13 @@ export async function GET(request:Request) {
         e.created_at AS createdAt
        FROM report_exports e
        LEFT JOIN staff_members s ON s.email = e.requested_by
+       WHERE e.organization_id = ?
        ORDER BY e.created_at DESC LIMIT 20`
-    ).all(),
+    ).bind(ctx.organizationId).all(),
   ]);
   const report = reportPayload(filters,source);
   await logSecurityEvent(db, {
+    organizationId: ctx.organizationId,
     actorEmail: member.email,
     action: "report_viewed",
     resource: "report",

--- a/drizzle/0033_security_audit_tenant_scope.sql
+++ b/drizzle/0033_security_audit_tenant_scope.sql
@@ -1,0 +1,9 @@
+-- Repair migration shadowing from 0016/0023: 0016 created security_audit_log
+-- without organization_id, so 0023 CREATE TABLE IF NOT EXISTS could not upgrade it.
+ALTER TABLE `security_audit_log`
+ADD COLUMN `organization_id` integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `security_audit_created_idx`;
+--> statement-breakpoint
+CREATE INDEX `security_audit_created_idx`
+ON `security_audit_log` (`organization_id`, `created_at`, `actor_email`);

--- a/tests/migration-upgrade.test.mjs
+++ b/tests/migration-upgrade.test.mjs
@@ -47,15 +47,19 @@ function indexNames(db, table) {
   return db.prepare(`PRAGMA index_list(${table})`).all().map((row) => row.name);
 }
 
+function indexColumns(db, index) {
+  return db.prepare(`PRAGMA index_info(${index})`).all().map((row) => row.name);
+}
+
 function plainRow(row) {
   return row == null ? row : Object.fromEntries(Object.entries(row));
 }
 
-test("production baseline through 0029 upgrades through 0032 without losing existing data", async () => {
+test("production baseline through 0029 upgrades through 0033 without losing existing data", async () => {
   const inventory = await migrationInventory();
   const baseline = inventory.filter((item) => item.number <= 29);
-  const release = inventory.filter((item) => item.number >= 30 && item.number <= 32);
-  assert.deepEqual(release.map((item) => item.number), [30, 31, 32]);
+  const release = inventory.filter((item) => item.number >= 30 && item.number <= 33);
+  assert.deepEqual(release.map((item) => item.number), [30, 31, 32, 33]);
 
   const db = new DatabaseSync(":memory:");
   try {
@@ -103,6 +107,13 @@ test("production baseline through 0029 upgrades through 0032 without losing exis
            'available', 'manual', 'legacy-radiographer@example.test')`,
       ).run(bookingId);
     }
+
+    db.prepare(
+      `INSERT INTO security_audit_log
+        (actor_email, action, resource, target_id, details_json)
+       VALUES ('legacy-admin@example.test', 'legacy_event', 'system', 'legacy-1', '{"preserve":true}')`,
+    ).run();
+    assert.equal(tableColumns(db, "security_audit_log").includes("organization_id"), false);
 
     const legacyPacs = plainRow(db.prepare(
       `SELECT dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
@@ -161,6 +172,31 @@ test("production baseline through 0029 upgrades through 0032 without losing exis
     ]);
     assert.ok(indexNames(db, "mwl_bridge_tokens").includes("mwl_bridge_tokens_hash_idx"));
     assert.ok(indexNames(db, "mwl_patient_ids").includes("mwl_patient_ids_org_patient_idx"));
+
+    assert.ok(tableColumns(db, "security_audit_log").includes("organization_id"));
+    const legacyAudit = plainRow(db.prepare(
+      `SELECT organization_id AS organizationId, actor_email AS actorEmail, action, target_id AS targetId
+       FROM security_audit_log WHERE action = 'legacy_event'`,
+    ).get());
+    assert.deepEqual(legacyAudit, {
+      organizationId: 1,
+      actorEmail: "legacy-admin@example.test",
+      action: "legacy_event",
+      targetId: "legacy-1",
+    });
+    assert.ok(indexNames(db, "security_audit_log").includes("security_audit_created_idx"));
+    assert.deepEqual(indexColumns(db, "security_audit_created_idx"), ["organization_id", "created_at", "actor_email"]);
+
+    db.prepare(
+      `INSERT INTO security_audit_log
+        (organization_id, actor_email, action, resource, target_id, details_json)
+       VALUES (2, 'org2-admin@example.test', 'org2_event', 'report', 'org2-1', '{}')`,
+    ).run();
+    const org2Audit = plainRow(db.prepare(
+      `SELECT organization_id AS organizationId, actor_email AS actorEmail
+       FROM security_audit_log WHERE action = 'org2_event'`,
+    ).get());
+    assert.deepEqual(org2Audit, { organizationId: 2, actorEmail: "org2-admin@example.test" });
   } finally {
     db.close();
   }

--- a/tests/reports-tenant-isolation.behavior.test.mjs
+++ b/tests/reports-tenant-isolation.behavior.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+function reportsRequest(cookie, path = "/api/staff/reports") {
+  return new Request(`http://localhost${path}`, { headers:{ cookie } });
+}
+
+test("reports expose only current-tenant export history and staff options", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email:"org1-admin@reports.test", role:"admin", displayName:"Org One Admin" });
+    // Resolve the signed-in admin into org 1 before adding another tenant.
+    let response = await callWorker(reportsRequest(cookie), db);
+    assert.equal(response.status, 200);
+
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'reports-org2', 'Reports Org 2', 1)").run();
+    await db.prepare(
+      `INSERT INTO staff_members (email, display_name, role, active)
+       VALUES ('org2-secret@reports.test', 'ORG2 SECRET STAFF', 'admin', 1)`
+    ).run();
+    await db.prepare(
+      `INSERT INTO memberships (organization_id, member_email, role, active)
+       VALUES (2, 'org2-secret@reports.test', 'admin', 1)`
+    ).run();
+
+    await db.prepare(
+      `INSERT INTO report_exports
+        (organization_id, requested_by, report_type, filters_json, columns_json, format, row_count, contains_personal_data)
+       VALUES
+        (1, 'org1-admin@reports.test', 'summary', '{}', '[]', 'xlsx', 1, 0),
+        (2, 'org2-secret@reports.test', 'ORG2-SECRET-REPORT', '{}', '[]', 'xlsx', 999, 1)`
+    ).run();
+
+    response = await callWorker(reportsRequest(cookie), db);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    const serialized = JSON.stringify(body);
+
+    assert.equal(body.exportHistory.length, 1);
+    assert.equal(body.exportHistory[0].requestedBy, "org1-admin@reports.test");
+    assert.equal(body.filterOptions.staff.some((row) => row.email === "org1-admin@reports.test"), true);
+    assert.equal(body.filterOptions.staff.some((row) => row.email === "org2-secret@reports.test"), false);
+    for (const forbidden of ["ORG2 SECRET STAFF", "ORG2-SECRET-REPORT", "org2-secret@reports.test"]) {
+      assert.equal(serialized.includes(forbidden), false, `reports leaked ${forbidden}`);
+    }
+
+    const audit = await db.prepare(
+      `SELECT organization_id AS organizationId FROM security_audit_log
+       WHERE action = 'report_viewed' AND actor_email = ? ORDER BY id DESC LIMIT 1`
+    ).bind("org1-admin@reports.test").first();
+    assert.equal(Number(audit?.organizationId), 1);
+  });
+});
+
+test("report export audit is owned by the signed-in organization", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email:"export-admin@reports.test", role:"admin" });
+    // Establish org 1 membership through the normal server path.
+    const initial = await callWorker(reportsRequest(cookie), db);
+    assert.equal(initial.status, 200);
+
+    const response = await callWorker(reportsRequest(cookie, "/api/staff/reports/export"), db);
+    assert.equal(response.status, 200);
+
+    const audit = await db.prepare(
+      `SELECT organization_id AS organizationId FROM security_audit_log
+       WHERE action = 'report_exported' AND actor_email = ? ORDER BY id DESC LIMIT 1`
+    ).bind("export-admin@reports.test").first();
+    assert.equal(Number(audit?.organizationId), 1);
+
+    const exportRow = await db.prepare(
+      `SELECT organization_id AS organizationId FROM report_exports
+       WHERE requested_by = ? ORDER BY id DESC LIMIT 1`
+    ).bind("export-admin@reports.test").first();
+    assert.equal(Number(exportRow?.organizationId), 1);
+  });
+});


### PR DESCRIPTION
Closes #194
Closes #197

Go-live blocker fixes for report metadata isolation and the underlying security-audit migration defect.

Changes:
- tenant-scopes report export history by the signed-in organization;
- limits report staff filter options to active memberships in the current organization;
- attributes `report_viewed` and `report_exported` security audit events to the correct organization instead of defaulting to org 1;
- adds `0033_security_audit_tenant_scope.sql` to repair migration shadowing from 0016/0023 by adding `organization_id`, preserving legacy rows as org 1, and rebuilding the tenant-aware audit index;
- extends the production migration upgrade test through 0033, including legacy audit preservation and org2 audit writes;
- adds behavior tests proving org2 staff/export metadata cannot appear in org1 reports and that view/export audit rows are owned by the signed-in tenant.

No production deploy is performed by this PR.