### PR TITLE
chore: sync PACS Drizzle tenant schema

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -284,6 +284,7 @@ export const imagingStudies = sqliteTable("imaging_studies", {
 
 export const pacsSettings = sqliteTable("pacs_settings", {
   id: integer("id").primaryKey(),
+  organizationId: integer("organization_id").notNull().default(1),
   dicomwebBaseUrl: text("dicomweb_base_url").notNull().default(""),
   viewerBaseUrl: text("viewer_base_url").notNull().default(""),
   aeTitle: text("ae_title").notNull().default(""),
@@ -291,7 +292,7 @@ export const pacsSettings = sqliteTable("pacs_settings", {
   notes: text("notes").notNull().default(""),
   updatedBy: text("updated_by").notNull().default(""),
   updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
-});
+}, table => [uniqueIndex("pacs_settings_organization_idx").on(table.organizationId)]);
 
 export const reportExports = sqliteTable("report_exports", {
   organizationId: integer("organization_id").notNull().default(1),

--- a/tests/migration-upgrade.test.mjs
+++ b/tests/migration-upgrade.test.mjs
@@ -5,6 +5,7 @@ import { readFile, readdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const DRIZZLE_DIR = new URL("../drizzle/", import.meta.url);
+const SCHEMA_URL = new URL("../db/schema.ts", import.meta.url);
 
 function migrationNumber(file) {
   const match = /^(\d{4})_[A-Za-z0-9_.-]+\.sql$/.exec(file);
@@ -54,6 +55,22 @@ function indexColumns(db, index) {
 function plainRow(row) {
   return row == null ? row : Object.fromEntries(Object.entries(row));
 }
+
+test("Drizzle PACS schema matches tenant migration contract", async () => {
+  const schema = await readFile(SCHEMA_URL, "utf8");
+  const pacsBlock = schema.match(/export const pacsSettings = sqliteTable\("pacs_settings", \{[\s\S]*?\n\}\s*,\s*table => \[[\s\S]*?\]\);/);
+  assert.ok(pacsBlock, "pacsSettings must declare a table-level tenant index");
+  assert.match(
+    pacsBlock[0],
+    /organizationId:\s*integer\("organization_id"\)\.notNull\(\)\.default\(1\)/,
+    "pacsSettings.organizationId must match migration 0031 nullability/default",
+  );
+  assert.match(
+    pacsBlock[0],
+    /uniqueIndex\("pacs_settings_organization_idx"\)\.on\(table\.organizationId\)/,
+    "pacsSettings must keep the one-row-per-organization uniqueness contract",
+  );
+});
 
 test("production baseline through 0029 upgrades through 0033 without losing existing data", async () => {
   const inventory = await migrationInventory();


### PR DESCRIPTION
Closes #196

Aligns the committed Drizzle `pacsSettings` model with the tenant-scoped D1 schema already introduced by migration 0031.

Changes:
- adds `organizationId` with the same NOT NULL/default(1) contract as D1;
- adds the unique `pacs_settings_organization_idx` contract to Drizzle;
- extends the production migration gate with a source/schema regression so Drizzle and migration semantics cannot silently drift again;
- intentionally adds no new D1 migration because production schema already contains the tenant column/index.

No production deploy is performed by this PR.