### PR TITLE
fix: keep local Cloudflare deploy Time Travel command valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "22.19.19",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.6",
+    "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "@vitejs/plugin-rsc": "0.5.26",
     "drizzle-kit": "0.31.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "bash scripts/build-verified.sh",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
     "test": "npm run build && node --experimental-strip-types --test tests/*.test.mjs",
-    "test:production-gate": "npm run build && node --experimental-strip-types --test tests/canonical-public-url.test.mjs tests/hosting-headers.test.mjs tests/site-booking.behavior.test.mjs tests/booking-capacity.test.mjs tests/staff-confirm-reschedule.behavior.test.mjs tests/staff-rbac.behavior.test.mjs tests/patient-otp.behavior.test.mjs tests/patient-cabinet-tenant.test.mjs tests/my-bookings.behavior.test.mjs tests/payment-api.behavior.test.mjs tests/payment-ledger.behavior.test.mjs tests/payment-settlement.behavior.test.mjs tests/study-state.test.mjs tests/protocol-builder.test.mjs tests/dashboard.test.mjs tests/security-hardening.test.mjs tests/tenant-hardening.test.mjs tests/migration-upgrade.test.mjs",
+    "test:production-gate": "npm run build && node --experimental-strip-types --test tests/canonical-public-url.test.mjs tests/hosting-headers.test.mjs tests/deploy-config.test.mjs tests/site-booking.behavior.test.mjs tests/booking-capacity.test.mjs tests/staff-confirm-reschedule.behavior.test.mjs tests/staff-rbac.behavior.test.mjs tests/patient-otp.behavior.test.mjs tests/patient-cabinet-tenant.test.mjs tests/my-bookings.behavior.test.mjs tests/payment-api.behavior.test.mjs tests/payment-ledger.behavior.test.mjs tests/payment-settlement.behavior.test.mjs tests/study-state.test.mjs tests/protocol-builder.test.mjs tests/dashboard.test.mjs tests/security-hardening.test.mjs tests/tenant-hardening.test.mjs tests/migration-upgrade.test.mjs",
     "validate:artifact": "bash scripts/validate-artifact.sh",
     "lint": "bash scripts/sites-env.sh -- eslint . --ignore-pattern dist --ignore-pattern .next --ignore-pattern public",
     "db:generate": "bash scripts/sites-env.sh -- drizzle-kit generate"
@@ -28,7 +28,7 @@
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "22.19.19",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
+    "@types/react-dom": "19.2.6",
     "@vitejs/plugin-react": "6.0.2",
     "@vitejs/plugin-rsc": "0.5.26",
     "drizzle-kit": "0.31.10",

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -26,7 +26,7 @@ echo "[1/4] Building the artifact (dist/server + dist/client)…"
 npm run build
 
 echo "[2/4] Recording the current D1 recovery bookmark…"
-npx wrangler d1 time-travel info radiologyos --remote --config "${CONFIG}"
+npx wrangler d1 time-travel info radiologyos --config "${CONFIG}"
 
 echo "[3/4] Applying D1 migrations to the remote database…"
 npx wrangler d1 migrations apply radiologyos --remote --config "${CONFIG}"

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("local deploy uses valid remote D1 command contracts", async () => {
+  const script = await read("scripts/deploy-cloudflare.sh");
+
+  assert.match(
+    script,
+    /wrangler d1 time-travel info radiologyos --config \"\$\{CONFIG\}\"/,
+    "Time Travel info is remote-only and must not receive --remote",
+  );
+  assert.doesNotMatch(
+    script,
+    /wrangler d1 time-travel info[^\n]*--remote/,
+    "Do not reintroduce the unsupported --remote option on Time Travel info",
+  );
+  assert.match(
+    script,
+    /wrangler d1 migrations apply radiologyos --remote --config \"\$\{CONFIG\}\"/,
+    "Migration application must remain explicitly remote",
+  );
+});
+
+test("GitHub production workflow uses the same Time Travel command contract", async () => {
+  const workflow = await read(".github/workflows/deploy.yml");
+  assert.match(workflow, /wrangler d1 time-travel info radiologyos --config wrangler\.cloudflare\.toml/);
+  assert.doesNotMatch(workflow, /wrangler d1 time-travel info[^\n]*--remote/);
+});


### PR DESCRIPTION
Closes #200

Fixes the documented local production deployment path so its D1 Time Travel bookmark command matches current Wrangler semantics.

Changes:
- removes the unsupported `--remote` option from `wrangler d1 time-travel info` in the local deploy script;
- keeps `wrangler d1 migrations apply ... --remote` explicit for production migrations;
- adds `tests/deploy-config.test.mjs` to guard both local script and GitHub production workflow command contracts;
- includes the deployment command regression test in the production release gate.

No production deploy is performed by this PR.