### PR TITLE
test: verify Worker and D1 after production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,3 +92,12 @@ jobs:
           curl --fail --silent --show-error --retry 5 --retry-all-errors https://radiologyos.tech/ > /dev/null
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' https://radiologyos.tech/site/)" = "308"
           curl --fail --silent --show-error https://radiologyos.tech/robots.txt > /dev/null
+          curl --fail --silent --show-error --retry 5 --retry-all-errors \
+            https://radiologyos.tech/api/public-services > /tmp/radiologyos-public-services.json
+          node -e '
+            const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-public-services.json", "utf8"));
+            if (!Array.isArray(payload?.services)) {
+              console.error("Production smoke test failed: /api/public-services did not return a services array.");
+              process.exit(1);
+            }
+          '

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -29,3 +29,12 @@ test("GitHub production workflow uses the same Time Travel command contract", as
   assert.match(workflow, /wrangler d1 time-travel info radiologyos --config wrangler\.cloudflare\.toml/);
   assert.doesNotMatch(workflow, /wrangler d1 time-travel info[^\n]*--remote/);
 });
+
+test("GitHub production smoke test verifies a Worker + D1 read", async () => {
+  const workflow = await read(".github/workflows/deploy.yml");
+  assert.match(
+    workflow,
+    /https:\/\/radiologyos\.tech\/api\/public-services > \/tmp\/radiologyos-public-services\.json/,
+  );
+  assert.match(workflow, /Array\.isArray\(payload\?\.services\)/);
+});


### PR DESCRIPTION
Closes #202

Strengthens the post-deploy production smoke test so it verifies a real Worker + D1 read, not only static/public files.

Changes:
- requests `/api/public-services` after deployment with retries and `curl --fail`;
- parses the response and requires a JSON `services` array without depending on any specific service count/content;
- extends `tests/deploy-config.test.mjs` so the production release gate guards this runtime smoke check.

No production deploy is performed by this PR.