### PR TITLE
fix: preserve production Worker vars during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy Worker and assets
-        run: npx wrangler deploy --config wrangler.cloudflare.toml
+        # Preserve runtime Worker vars managed outside source control, including
+        # OUTBOUND_ALLOWED_HOSTS used by PACS/ICS outbound policy.
+        run: npx wrangler deploy --keep-vars --config wrangler.cloudflare.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -32,6 +32,8 @@ echo "[3/4] Applying D1 migrations to the remote database…"
 npx wrangler d1 migrations apply radiologyos --remote --config "${CONFIG}"
 
 echo "[4/4] Deploying the Worker and static assets…"
-npx wrangler deploy --config "${CONFIG}"
+# Runtime configuration such as OUTBOUND_ALLOWED_HOSTS may be managed in the
+# Cloudflare Worker environment rather than committed to source control.
+npx wrangler deploy --keep-vars --config "${CONFIG}"
 
 echo "✓ Deployed to the custom domains configured in ${CONFIG}."

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -24,6 +24,23 @@ test("local deploy uses valid remote D1 command contracts", async () => {
   );
 });
 
+test("deployment paths preserve runtime Worker vars", async () => {
+  const [script, workflow] = await Promise.all([
+    read("scripts/deploy-cloudflare.sh"),
+    read(".github/workflows/deploy.yml"),
+  ]);
+  assert.match(
+    script,
+    /wrangler deploy --keep-vars --config \"\$\{CONFIG\}\"/,
+    "Local deploy must preserve remote Worker vars such as OUTBOUND_ALLOWED_HOSTS",
+  );
+  assert.match(
+    workflow,
+    /wrangler deploy --keep-vars --config wrangler\.cloudflare\.toml/,
+    "Production workflow must preserve remote Worker vars such as OUTBOUND_ALLOWED_HOSTS",
+  );
+});
+
 test("GitHub production workflow uses the same Time Travel command contract", async () => {
   const workflow = await read(".github/workflows/deploy.yml");
   assert.match(workflow, /wrangler d1 time-travel info radiologyos --config wrangler\.cloudflare\.toml/);


### PR DESCRIPTION
Closes #206

Wrangler removes remote plaintext Worker vars that are absent from local config unless `--keep-vars` is used. RadiologyOS intentionally keeps deployment-specific runtime configuration such as `OUTBOUND_ALLOWED_HOSTS` outside source control.

Changes:
- add `--keep-vars` to the GitHub Actions production deploy command;
- add `--keep-vars` to the local Cloudflare deploy script;
- extend `tests/deploy-config.test.mjs` so both deployment paths must preserve remote Worker vars.

No runtime hostnames are committed and no production deploy is performed by this PR.