### PR TITLE
Fix Cloudflare custom domain redirect loop

### DIFF
--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -107,11 +107,11 @@ test("production deployment bootstraps schema before enforcing a secure active a
   assert.match(workflow, /count < 1/);
 });
 
-test("Cloudflare deployment uses custom domains, worker-first assets and safe reminder cron", async () => {
+test("Cloudflare deployment uses an apex custom domain, worker-first assets and safe reminder cron", async () => {
   const config = await read("wrangler.cloudflare.toml");
   assert.match(config, /\nworkers_dev = false\n/);
   assert.match(config, /pattern = "radiologyos\.tech", custom_domain = true/);
-  assert.match(config, /pattern = "www\.radiologyos\.tech", custom_domain = true/);
+  assert.doesNotMatch(config, /pattern = "www\.radiologyos\.tech", custom_domain = true/);
   assert.match(config, /\nrun_worker_first = true\n/);
   assert.match(config, /\[triggers\][\s\S]*crons\s*=\s*\[\s*"\*\/15 \* \* \* \*"\s*\]/);
 });

--- a/wrangler.cloudflare.toml
+++ b/wrangler.cloudflare.toml
@@ -12,11 +12,12 @@ compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
-# Custom domains. Keep routes at the TOML top level: placing this key after a
+# Custom domain. Keep routes at the TOML top level: placing this key after a
 # table header such as [triggers] would make it part of that table.
+# The Worker is bound only to the apex hostname. `www` is handled separately
+# by Cloudflare redirect/DNS configuration to avoid competing custom domains.
 routes = [
   { pattern = "radiologyos.tech", custom_domain = true },
-  { pattern = "www.radiologyos.tech", custom_domain = true },
 ]
 
 # Patient reminders are evaluated every 15 minutes. The handler itself remains


### PR DESCRIPTION
Bind the RadiologyOS Worker only to the apex custom domain `radiologyos.tech` and keep `www` outside Wrangler custom-domain ownership so it can be redirected separately at the Cloudflare zone level. Also update the security regression test to enforce apex-only deployment.