### PR TITLE
Fix Cloudflare root redirect loop

### DIFF
--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -113,5 +113,6 @@ test("Cloudflare deployment uses an apex custom domain, worker-first assets and 
   assert.match(config, /pattern = "radiologyos\.tech", custom_domain = true/);
   assert.doesNotMatch(config, /pattern = "www\.radiologyos\.tech", custom_domain = true/);
   assert.match(config, /\nrun_worker_first = true\n/);
+  assert.match(config, /\nhtml_handling = "none"\n/);
   assert.match(config, /\[triggers\][\s\S]*crons\s*=\s*\[\s*"\*\/15 \* \* \* \*"\s*\]/);
 });

--- a/wrangler.cloudflare.toml
+++ b/wrangler.cloudflare.toml
@@ -27,13 +27,16 @@ crons = ["*/15 * * * *"]
 
 # Static client bundle (JS/CSS, self-hosted fonts, favicon). The Worker must run
 # before asset matching so canonical redirects, security headers and access
-# rules apply consistently even to paths backed by HTML assets (for example
-# /site/ -> /site/index.html). The Worker explicitly delegates asset delivery
-# through env.ASSETS.fetch where appropriate.
+# rules apply consistently even to paths backed by HTML assets. HTML handling
+# is disabled because the Worker deliberately maps legacy /site aliases to `/`
+# and internally fetches `/site/index.html`; Cloudflare's default HTML
+# canonicalization would otherwise redirect that internal asset request back to
+# `/site/`, creating a `/` <-> `/site/` redirect loop.
 [assets]
 directory = "dist/client"
 binding = "ASSETS"
 run_worker_first = true
+html_handling = "none"
 
 # D1 database. Create it once (see HOSTING.md) and paste its id below.
 [[d1_databases]]


### PR DESCRIPTION
Disable Cloudflare static-asset HTML canonicalization for the RadiologyOS Worker. The Worker intentionally maps legacy `/site` aliases to `/` and internally fetches `/site/index.html`; Cloudflare's default HTML handling canonicalizes that asset path back to `/site/`, creating a `/` ↔ `/site/` redirect loop. Add a regression assertion for `html_handling = "none"`.