### PR TITLE
Fix Cloudflare static asset delivery

### DIFF
--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -19,6 +19,13 @@ test("worker applies browser security headers and rejects cross-site API mutatio
   assert.match(worker, /new URL\(origin\)\.origin !== url\.origin/);
 });
 
+test("worker delegates generated and public static assets to the Cloudflare ASSETS binding", async () => {
+  const worker = await read("worker/index.ts");
+  assert.match(worker, /STATIC_ASSET_PREFIXES = \["\/assets\/", "\/fonts\/", "\/site\/assets\/"\]/);
+  assert.match(worker, /isStaticAssetPath\(url\.pathname\)/);
+  assert.match(worker, /env\.ASSETS\.fetch\(request\)/);
+});
+
 test("patient data requires a short-lived OTP-backed tenant-scoped server session", async () => {
   const auth = await read("lib/patient-auth.ts");
   const otp = await read("app/api/patient-otp/route.ts");

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -47,6 +47,14 @@ const SECURITY_HEADERS: Record<string, string> = {
 
 const LEGACY_HOME_PATHS = new Set(["/index.html", "/site", "/site/", "/site/index.html"]);
 const PUBLIC_CANONICAL_PATHS = new Set(["/", "/site/price.html", "/site/military.html"]);
+const STATIC_ASSET_PREFIXES = ["/assets/", "/fonts/", "/site/assets/"];
+const STATIC_ASSET_PATHS = new Set([
+  "/favicon.svg",
+  "/file.svg",
+  "/globe.svg",
+  "/hospital-emblem.jpg",
+  "/window.svg",
+]);
 const INITIAL_ORGANIZATION_ID = 1;
 
 function secure(response: Response, request?: Request): Response {
@@ -71,6 +79,10 @@ function secure(response: Response, request?: Request): Response {
     }
   }
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+function isStaticAssetPath(pathname: string): boolean {
+  return STATIC_ASSET_PATHS.has(pathname) || STATIC_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
 // Чи вітрина в режимі «лише платні»: читаємо site_content з D1. Помилка/
@@ -116,6 +128,14 @@ const worker = {
 
     if (unsafeCrossSiteRequest(request)) {
       return secure(Response.json({ error: "Cross-site request blocked" }, { status: 403 }), request);
+    }
+
+    // With run_worker_first=true every request reaches this Worker before the
+    // static-asset service. Delegate generated Vite/vinext bundles and public
+    // files explicitly; otherwise the app router can return HTML/404 for CSS
+    // and JS requests, leaving the staff UI unstyled and unhydrated.
+    if ((request.method === "GET" || request.method === "HEAD") && isStaticAssetPath(url.pathname)) {
+      return secure(await env.ASSETS.fetch(request), request);
     }
 
     // There is exactly one indexable public home. Old URLs shared with patients


### PR DESCRIPTION
Serve generated Vite/vinext bundles and public static assets directly from the Cloudflare ASSETS binding when `run_worker_first = true`. Without this delegation, CSS/JS requests can fall through to the app router and return HTML/404 responses, leaving `/staff/*` pages unstyled and unhydrated. Adds a regression test for the asset prefixes and ASSETS delegation.