### PR TITLE
Add self-service staff profile and PIN security

### DIFF
--- a/app/api/staff/profile/route.ts
+++ b/app/api/staff/profile/route.ts
@@ -1,0 +1,121 @@
+import { requireStaff } from "../../../../lib/staff-auth";
+import { hashPassword, verifyPassword } from "../../../../lib/auth";
+import { passwordProblem } from "../../../../lib/staff-accounts";
+import { normalizeUkrainianPhone } from "../../../../lib/phone";
+import { dbBinding } from "../../../../lib/db";
+import { audit } from "../../../../lib/audit";
+
+function clean(value: unknown, max = 120) {
+  return String(value || "").trim().replace(/\s+/g, " ").slice(0, max);
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const staff = await requireStaff(request, db);
+  if (!staff) return Response.json({ error: "Потрібно увійти" }, { status: 401 });
+
+  const profile = await db.prepare(
+    `SELECT email, phone, display_name AS displayName, last_name AS lastName,
+       first_name AS firstName, patronymic, contact_email AS contactEmail,
+       military_rank AS militaryRank, position_title AS positionTitle,
+       role, active
+     FROM staff_members WHERE email = ? AND active = 1 LIMIT 1`
+  ).bind(staff.email).first();
+
+  if (!profile) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
+  return Response.json({ profile });
+}
+
+export async function PATCH(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const staff = await requireStaff(request, db);
+  if (!staff) return Response.json({ error: "Потрібно увійти" }, { status: 401 });
+
+  const body = await request.json().catch(() => ({})) as {
+    phone?: string;
+    firstName?: string;
+    lastName?: string;
+    patronymic?: string;
+    contactEmail?: string;
+    militaryRank?: string;
+    positionTitle?: string;
+    currentPin?: string;
+    newPin?: string;
+  };
+
+  const current = await db.prepare(
+    `SELECT email, password_hash AS passwordHash FROM staff_members
+     WHERE email = ? AND active = 1 LIMIT 1`
+  ).bind(staff.email).first<{ email: string; passwordHash: string }>();
+  if (!current) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
+
+  const phone = body.phone == null ? null : normalizeUkrainianPhone(body.phone);
+  if (body.phone != null && !phone) return Response.json({ error: "Перевірте номер телефону" }, { status: 400 });
+
+  const firstName = body.firstName == null ? null : clean(body.firstName, 60);
+  const lastName = body.lastName == null ? null : clean(body.lastName, 60);
+  const patronymic = body.patronymic == null ? null : clean(body.patronymic, 60);
+  const contactEmail = body.contactEmail == null ? null : clean(body.contactEmail, 254).toLowerCase();
+  const militaryRank = body.militaryRank == null ? null : clean(body.militaryRank, 80);
+  const positionTitle = body.positionTitle == null ? null : clean(body.positionTitle, 120);
+  if (contactEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactEmail)) {
+    return Response.json({ error: "Перевірте e-mail" }, { status: 400 });
+  }
+
+  if (phone) {
+    const duplicate = await db.prepare(
+      "SELECT email FROM staff_members WHERE phone = ? AND email <> ? LIMIT 1"
+    ).bind(phone, staff.email).first();
+    if (duplicate) return Response.json({ error: "Цей номер вже використовується іншим працівником" }, { status: 409 });
+  }
+
+  const wantsPinChange = typeof body.newPin === "string" && body.newPin.length > 0;
+  if (wantsPinChange) {
+    const problem = passwordProblem(body.newPin || "");
+    if (problem) return Response.json({ error: problem }, { status: 400 });
+    if (!body.currentPin || !(await verifyPassword(body.currentPin, current.passwordHash))) {
+      return Response.json({ error: "Поточний PIN-код невірний" }, { status: 401 });
+    }
+  }
+
+  const existingProfile = await db.prepare(
+    `SELECT last_name AS lastName, first_name AS firstName, patronymic
+     FROM staff_members WHERE email = ? LIMIT 1`
+  ).bind(staff.email).first<{ lastName: string; firstName: string; patronymic: string }>();
+  const finalLastName = lastName ?? existingProfile?.lastName ?? "";
+  const finalFirstName = firstName ?? existingProfile?.firstName ?? "";
+  const finalPatronymic = patronymic ?? existingProfile?.patronymic ?? "";
+  const displayName = [finalLastName, finalFirstName, finalPatronymic].filter(Boolean).join(" ").slice(0, 180);
+
+  await db.prepare(
+    `UPDATE staff_members SET
+       phone = COALESCE(?, phone),
+       last_name = COALESCE(?, last_name),
+       first_name = COALESCE(?, first_name),
+       patronymic = COALESCE(?, patronymic),
+       contact_email = COALESCE(?, contact_email),
+       military_rank = COALESCE(?, military_rank),
+       position_title = COALESCE(?, position_title),
+       display_name = CASE WHEN ? <> '' THEN ? ELSE display_name END
+     WHERE email = ?`
+  ).bind(phone, lastName, firstName, patronymic, contactEmail, militaryRank, positionTitle, displayName, displayName, staff.email).run();
+
+  if (wantsPinChange) {
+    await db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")
+      .bind(await hashPassword(body.newPin || ""), staff.email).run();
+    await db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(staff.email).run();
+  }
+
+  await audit(db, {
+    organizationId: 1,
+    actorEmail: staff.email,
+    action: wantsPinChange ? "profile_security_update" : "profile_update",
+    resource: "staff",
+    targetId: staff.email,
+    details: { phoneChanged: body.phone != null, pinChanged: wantsPinChange },
+  });
+
+  return Response.json({ ok: true, signedOut: wantsPinChange });
+}

--- a/app/staff/organization/page.tsx
+++ b/app/staff/organization/page.tsx
@@ -53,6 +53,12 @@ export default function OrganizationPage() {
       </div>
 
       <section className="orgProfileCard">
+        <h3>Мій робочий профіль</h3>
+        <p className="orgProfileHint">Контактні дані, посада, звання та зміна PIN-коду без роботи напряму з базою даних.</p>
+        <a className="button compact" href="/staff/profile">Відкрити мій профіль</a>
+      </section>
+
+      <section className="orgProfileCard">
         <h3>Заклад</h3>
         <dl className="structMeta">
           <div><dt>Назва</dt><dd>{data.organization.name}</dd></div>

--- a/app/staff/profile/page.tsx
+++ b/app/staff/profile/page.tsx
@@ -23,7 +23,27 @@ export default function StaffProfilePage() {
     setError("");
   }
 
-  useEffect(()=>{ void load(); },[]);
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/staff/profile", { cache:"no-store" })
+      .then(async (response) => ({
+        response,
+        data: await response.json().catch(()=>({})) as { profile?:Profile; error?:string },
+      }))
+      .then(({ response, data }) => {
+        if (cancelled) return;
+        if (!response.ok) {
+          setError(data.error || "Не вдалося завантажити профіль");
+          return;
+        }
+        setProfile(data.profile || null);
+        setError("");
+      })
+      .catch(() => {
+        if (!cancelled) setError("Не вдалося завантажити профіль");
+      });
+    return () => { cancelled = true; };
+  },[]);
 
   async function saveProfile(event:FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/app/staff/profile/page.tsx
+++ b/app/staff/profile/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { roleLabelUk } from "../../../lib/labels";
+
+type Profile = {
+  email:string; phone:string; displayName:string; lastName:string; firstName:string; patronymic:string;
+  contactEmail:string; militaryRank:string; positionTitle:string; role:string; active:number;
+};
+
+export default function StaffProfilePage() {
+  const [profile,setProfile] = useState<Profile|null>(null);
+  const [error,setError] = useState("");
+  const [success,setSuccess] = useState("");
+  const [saving,setSaving] = useState(false);
+
+  async function load() {
+    const response = await fetch("/api/staff/profile", { cache:"no-store" });
+    const data = await response.json().catch(()=>({})) as { profile?:Profile; error?:string };
+    if (!response.ok) { setError(data.error || "Не вдалося завантажити профіль"); return; }
+    setProfile(data.profile || null);
+    setError("");
+  }
+
+  useEffect(()=>{ void load(); },[]);
+
+  async function saveProfile(event:FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    setSaving(true); setError(""); setSuccess("");
+    const response = await fetch("/api/staff/profile", {
+      method:"PATCH",
+      headers:{ "content-type":"application/json" },
+      body:JSON.stringify({
+        phone:String(form.get("phone") || ""),
+        lastName:String(form.get("lastName") || ""),
+        firstName:String(form.get("firstName") || ""),
+        patronymic:String(form.get("patronymic") || ""),
+        contactEmail:String(form.get("contactEmail") || ""),
+        militaryRank:String(form.get("militaryRank") || ""),
+        positionTitle:String(form.get("positionTitle") || ""),
+      }),
+    });
+    const data = await response.json().catch(()=>({})) as { error?:string };
+    setSaving(false);
+    if (!response.ok) { setError(data.error || "Не вдалося зберегти профіль"); return; }
+    setSuccess("Профіль оновлено");
+    await load();
+  }
+
+  async function changePin(event:FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const currentPin = String(form.get("currentPin") || "");
+    const newPin = String(form.get("newPin") || "");
+    const confirmPin = String(form.get("confirmPin") || "");
+    if (newPin !== confirmPin) { setError("Новий PIN і підтвердження не збігаються"); return; }
+    setSaving(true); setError(""); setSuccess("");
+    const response = await fetch("/api/staff/profile", {
+      method:"PATCH",
+      headers:{ "content-type":"application/json" },
+      body:JSON.stringify({ currentPin, newPin }),
+    });
+    const data = await response.json().catch(()=>({})) as { error?:string; signedOut?:boolean };
+    setSaving(false);
+    if (!response.ok) { setError(data.error || "Не вдалося змінити PIN"); return; }
+    if (data.signedOut) {
+      window.location.assign("/staff/login?returnTo=%2Fstaff%2Fprofile&changed=1");
+      return;
+    }
+    setSuccess("PIN-код змінено");
+    event.currentTarget.reset();
+  }
+
+  return <StaffWorkspaceShell
+    active="organization"
+    title="Мій профіль"
+    description="Контактні дані, посада та безпека робочого облікового запису."
+    staffName={profile?.displayName}
+    staffRole={roleLabelUk(profile?.role)}
+  >
+    {error && <p className="notice bad">{error}</p>}
+    {success && <p className="notice good">{success}</p>}
+    {!profile ? <p className="dashLoading">Завантаження…</p> : <div className="orgProfile">
+      <section className="orgProfileCard">
+        <h3>Профіль працівника</h3>
+        <form onSubmit={saveProfile} className="formGrid">
+          <label>Прізвище<input name="lastName" defaultValue={profile.lastName || ""}/></label>
+          <label>Ім’я<input name="firstName" defaultValue={profile.firstName || ""}/></label>
+          <label>По батькові<input name="patronymic" defaultValue={profile.patronymic || ""}/></label>
+          <label>Телефон<input name="phone" inputMode="tel" defaultValue={profile.phone || ""}/></label>
+          <label>Контактний e-mail<input name="contactEmail" type="email" defaultValue={profile.contactEmail || ""}/></label>
+          <label>Військове звання<input name="militaryRank" defaultValue={profile.militaryRank || ""}/></label>
+          <label>Посада<input name="positionTitle" defaultValue={profile.positionTitle || ""}/></label>
+          <div><small>Роль у системі: <b>{roleLabelUk(profile.role)}</b></small></div>
+          <div><button className="button" type="submit" disabled={saving}>{saving ? "Зберігаємо…":"Зберегти профіль"}</button></div>
+        </form>
+      </section>
+
+      <section className="orgProfileCard">
+        <h3>Змінити PIN-код</h3>
+        <p className="orgProfileHint">Після зміни PIN усі активні сеанси буде завершено. Увійдіть знову вже з новим кодом.</p>
+        <form onSubmit={changePin} className="formGrid">
+          <label>Поточний PIN<input name="currentPin" type="password" inputMode="numeric" autoComplete="current-password" required/></label>
+          <label>Новий PIN<input name="newPin" type="password" inputMode="numeric" autoComplete="new-password" minLength={6} required/></label>
+          <label>Повторіть новий PIN<input name="confirmPin" type="password" inputMode="numeric" autoComplete="new-password" minLength={6} required/></label>
+          <div><button className="button" type="submit" disabled={saving}>{saving ? "Змінюємо…":"Змінити PIN"}</button></div>
+        </form>
+      </section>
+    </div>}
+  </StaffWorkspaceShell>;
+}


### PR DESCRIPTION
Adds a protected `/staff/profile` screen and API so authenticated staff can update their own profile and rotate their PIN without manual D1 edits. PIN changes verify the current PIN, use the existing PBKDF2 hash function, revoke active sessions, and write an audit event. The Organization screen links to the new profile page.