### PR TITLE
Harden protocol tenant scope and medical-result access audit

### DIFF
--- a/app/api/my-protocol/route.ts
+++ b/app/api/my-protocol/route.ts
@@ -1,3 +1,4 @@
+import { audit } from "../../../lib/audit";
 import { normalizeBookingCode, requirePatientSession } from "../../../lib/patient-auth";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { dbBinding } from "../../../lib/db";
@@ -34,6 +35,15 @@ export async function POST(request: Request) {
     number: string; method: string; findings: string; conclusion: string; recommendations: string;
   }>();
   if (!proto) return Response.json({ error: "Протокол ще не готовий" }, { status: 409 });
+
+  await audit(db, {
+    organizationId: session.organizationId,
+    actorEmail: "patient_session",
+    action: "patient_protocol_viewed",
+    resource: "protocol",
+    targetId: booking.id,
+    details: { channel: "patient_cabinet" },
+  });
 
   return Response.json({
     protocol: {

--- a/app/api/staff/protocols/route.ts
+++ b/app/api/staff/protocols/route.ts
@@ -1,5 +1,5 @@
 import { serviceByCode } from "../../../../lib/catalog";
-import { logSecurityEvent } from "../../../../lib/audit";
+import { audit } from "../../../../lib/audit";
 import { canAccessBooking, canManageProtocols } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
 import { dbBinding } from "../../../../lib/db";
@@ -19,7 +19,7 @@ const QUEUE_SQL = `SELECT b.id, b.code, b.name, b.service, b.service_code AS ser
     b.assigned_radiologist_email AS assignedRadiologistEmail,
     COALESCE(p.status, '') AS documentStatus, COALESCE(p.version, 0) AS documentVersion
   FROM bookings b
-  LEFT JOIN protocols p ON p.booking_id = b.id
+  LEFT JOIN protocols p ON p.booking_id = b.id AND p.organization_id = b.organization_id
   WHERE b.status != 'cancelled' AND (b.performed_at != '' OR b.protocol_status != 'not_started')
   ORDER BY (b.performed_at != '') DESC, b.desired_date DESC, b.desired_time DESC
   LIMIT 300`;
@@ -55,20 +55,20 @@ export async function GET(request: Request) {
         protocol_number AS protocolNumber, protocol_status AS protocolStatus,
         protocol_ready_at AS protocolReadyAt, protocol_issued_at AS protocolIssuedAt,
         assigned_radiologist_email AS assignedRadiologistEmail
-       FROM bookings WHERE id = ? LIMIT 1`
-    ).bind(bookingId).first<Record<string, unknown>>();
+       FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1`
+    ).bind(bookingId, ctx.organizationId).first<Record<string, unknown>>();
     if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
     const [row, revisions] = await Promise.all([
       db.prepare(
       `SELECT template_key AS templateKey, method, sections_json AS sectionsJson,
         findings, conclusion, recommendations, number, status, version,
         author_email AS authorEmail, updated_by AS updatedBy, updated_at AS updatedAt
-       FROM protocols WHERE booking_id = ? LIMIT 1`
-      ).bind(bookingId).first<Record<string, unknown>>(),
+       FROM protocols WHERE booking_id = ? AND organization_id = ? LIMIT 1`
+      ).bind(bookingId, ctx.organizationId).first<Record<string, unknown>>(),
       db.prepare(
         `SELECT version, number, status, saved_by AS savedBy, created_at AS createdAt
-         FROM protocol_revisions WHERE booking_id = ? ORDER BY version DESC LIMIT 20`
-      ).bind(bookingId).all(),
+         FROM protocol_revisions WHERE booking_id = ? AND organization_id = ? ORDER BY version DESC LIMIT 20`
+      ).bind(bookingId, ctx.organizationId).all(),
     ]);
     const protocol = row
       ? {
@@ -86,7 +86,8 @@ export async function GET(request: Request) {
           updatedAt: String(row.updatedAt || ""),
         }
       : null;
-    await logSecurityEvent(db, {
+    await audit(db, {
+      organizationId: ctx.organizationId,
       actorEmail: member.email,
       action: "protocol_viewed",
       resource: "protocol",
@@ -137,8 +138,8 @@ export async function PUT(request: Request) {
     return Response.json({ error: "Заявку не знайдено або її не призначено вам" }, { status: 404 });
   }
   const booking = await db.prepare(
-    "SELECT id, equipment_id AS equipmentId FROM bookings WHERE id = ? LIMIT 1"
-  ).bind(bookingId).first<{ id: number; equipmentId: string }>();
+    "SELECT id, equipment_id AS equipmentId FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1"
+  ).bind(bookingId, ctx.organizationId).first<{ id: number; equipmentId: string }>();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
   const template = protocolTemplateByKey(document.templateKey);
   if (document.templateKey !== "generic" && template.equipmentId !== booking.equipmentId) {
@@ -146,8 +147,8 @@ export async function PUT(request: Request) {
   }
 
   const existing = await db.prepare(
-    "SELECT version, author_email AS authorEmail, status FROM protocols WHERE booking_id = ? LIMIT 1"
-  ).bind(bookingId).first<{ version: number; authorEmail: string; status: string }>();
+    "SELECT version, author_email AS authorEmail, status FROM protocols WHERE booking_id = ? AND organization_id = ? LIMIT 1"
+  ).bind(bookingId, ctx.organizationId).first<{ version: number; authorEmail: string; status: string }>();
   const baseVersion = Number(body.baseVersion ?? existing?.version ?? 0);
   if (existing && baseVersion !== Number(existing.version)) {
     return Response.json({ error: "Протокол уже змінено в іншому вікні. Оновіть сторінку." }, { status: 409 });
@@ -164,8 +165,8 @@ export async function PUT(request: Request) {
   }
   if (document.number) {
     const duplicate = await db.prepare(
-      "SELECT booking_id AS bookingId FROM protocols WHERE number = ? AND booking_id != ? LIMIT 1"
-    ).bind(document.number, bookingId).first();
+      "SELECT booking_id AS bookingId FROM protocols WHERE organization_id = ? AND number = ? AND booking_id != ? LIMIT 1"
+    ).bind(ctx.organizationId, document.number, bookingId).first();
     if (duplicate) return Response.json({ error: "Такий номер протоколу вже використано" }, { status: 409 });
   }
   const version = existing ? Number(existing.version) + 1 : 1;
@@ -177,27 +178,28 @@ export async function PUT(request: Request) {
     await db.batch([
       db.prepare(
         `INSERT INTO protocols
-       (booking_id, template_key, method, sections_json, findings, conclusion, recommendations,
+       (organization_id, booking_id, template_key, method, sections_json, findings, conclusion, recommendations,
         number, status, version, author_email, updated_by, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
      ON CONFLICT(booking_id) DO UPDATE SET
+       organization_id = excluded.organization_id,
        template_key = excluded.template_key, method = excluded.method,
        sections_json = excluded.sections_json, findings = excluded.findings,
        conclusion = excluded.conclusion, recommendations = excluded.recommendations,
        number = excluded.number, status = excluded.status, version = excluded.version,
        updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
       ).bind(
-        bookingId, document.templateKey, document.method, sectionsJson, document.findings,
+        ctx.organizationId, bookingId, document.templateKey, document.method, sectionsJson, document.findings,
         document.conclusion, document.recommendations, document.number, document.status,
         version, authorEmail, member.email,
       ),
       db.prepare(
         `INSERT INTO protocol_revisions
-           (booking_id, version, template_key, method, sections_json, findings, conclusion,
+           (organization_id, booking_id, version, template_key, method, sections_json, findings, conclusion,
             recommendations, number, status, saved_by)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       ).bind(
-        bookingId, version, document.templateKey, document.method, sectionsJson,
+        ctx.organizationId, bookingId, version, document.templateKey, document.method, sectionsJson,
         document.findings, document.conclusion, document.recommendations,
         document.number, document.status, member.email,
       ),
@@ -210,11 +212,12 @@ export async function PUT(request: Request) {
        protocol_issued_at = CASE
          WHEN ? = 'issued' AND protocol_issued_at = '' THEN CURRENT_TIMESTAMP
          ELSE protocol_issued_at END
-         WHERE id = ?`
-      ).bind(document.number, legacyStatus, legacyStatus, legacyStatus, bookingId),
+         WHERE id = ? AND organization_id = ?`
+      ).bind(document.number, legacyStatus, legacyStatus, legacyStatus, bookingId, ctx.organizationId),
       db.prepare(
-        "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'protocol_document_saved', ?, ?)"
+        "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'protocol_document_saved', ?, ?)"
       ).bind(
+        ctx.organizationId,
         bookingId,
         `${document.status} · v${version}${document.number ? ` · ${document.number}` : ""}`,
         member.email,
@@ -224,9 +227,18 @@ export async function PUT(request: Request) {
     return Response.json({ error: "Конфлікт версій протоколу. Оновіть сторінку." }, { status: 409 });
   }
 
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: member.email,
+    action: document.status === "issued" ? "protocol_issued" : "protocol_saved",
+    resource: "protocol",
+    targetId: bookingId,
+    details: { version, status: document.status },
+  });
+
   const dates = await db.prepare(
-    "SELECT protocol_ready_at AS protocolReadyAt, protocol_issued_at AS protocolIssuedAt FROM bookings WHERE id = ?"
-  ).bind(bookingId).first<{ protocolReadyAt: string; protocolIssuedAt: string }>();
+    "SELECT protocol_ready_at AS protocolReadyAt, protocol_issued_at AS protocolIssuedAt FROM bookings WHERE id = ? AND organization_id = ?"
+  ).bind(bookingId, ctx.organizationId).first<{ protocolReadyAt: string; protocolIssuedAt: string }>();
 
   return Response.json({
     ok: true,

--- a/drizzle/0034_protocol_medical_access_scope.sql
+++ b/drizzle/0034_protocol_medical_access_scope.sql
@@ -1,0 +1,30 @@
+-- Protocol documents and their immutable revisions must follow the booking tenant.
+-- Historical rows may have inherited the legacy DEFAULT 1 even when their booking
+-- belongs to another organization, so repair ownership before adding scoped reads.
+UPDATE `protocols`
+SET `organization_id` = COALESCE(
+  (SELECT b.`organization_id` FROM `bookings` b WHERE b.`id` = `protocols`.`booking_id`),
+  `organization_id`
+);
+--> statement-breakpoint
+ALTER TABLE `protocol_revisions` ADD COLUMN `organization_id` integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+UPDATE `protocol_revisions`
+SET `organization_id` = COALESCE(
+  (SELECT b.`organization_id` FROM `bookings` b WHERE b.`id` = `protocol_revisions`.`booking_id`),
+  `organization_id`
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `protocol_revisions_org_booking_idx`
+ON `protocol_revisions` (`organization_id`, `booking_id`, `version`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `protocols_org_number_idx`
+ON `protocols` (`organization_id`, `number`);
+--> statement-breakpoint
+-- Repair legacy protocol event attribution. New writes explicitly carry the tenant.
+UPDATE `booking_events`
+SET `organization_id` = COALESCE(
+  (SELECT b.`organization_id` FROM `bookings` b WHERE b.`id` = `booking_events`.`booking_id`),
+  `organization_id`
+)
+WHERE `action` = 'protocol_document_saved';

--- a/tests/protocol-medical-access.test.mjs
+++ b/tests/protocol-medical-access.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("protocol document, revisions and booking mutations are tenant scoped", async () => {
+  const route = await read("app/api/staff/protocols/route.ts");
+  assert.match(route, /FROM bookings WHERE id = \? AND organization_id = \? LIMIT 1/);
+  assert.match(route, /FROM protocols WHERE booking_id = \? AND organization_id = \? LIMIT 1/);
+  assert.match(route, /FROM protocol_revisions WHERE booking_id = \? AND organization_id = \?/);
+  assert.match(route, /WHERE organization_id = \? AND number = \? AND booking_id != \?/);
+  assert.match(route, /\(organization_id, booking_id, template_key/);
+  assert.match(route, /INSERT INTO protocol_revisions[\s\S]*\(organization_id, booking_id, version/);
+  assert.match(route, /WHERE id = \? AND organization_id = \?/);
+  assert.match(route, /INSERT INTO booking_events \(organization_id, booking_id/);
+});
+
+test("protocol access and lifecycle writes are security audited with tenant attribution", async () => {
+  const route = await read("app/api/staff/protocols/route.ts");
+  assert.match(route, /organizationId: ctx\.organizationId,[\s\S]*action: "protocol_viewed"/);
+  assert.match(route, /action: document\.status === "issued" \? "protocol_issued" : "protocol_saved"/);
+});
+
+test("patient can only read an issued tenant protocol and the access is audited without PII actor data", async () => {
+  const route = await read("app/api/my-protocol/route.ts");
+  assert.match(route, /WHERE organization_id = \? AND code = \? AND phone_normalized = \?/);
+  assert.match(route, /WHERE organization_id = \? AND booking_id = \? AND status = 'issued'/);
+  assert.match(route, /actorEmail: "patient_session"/);
+  assert.match(route, /action: "patient_protocol_viewed"/);
+  assert.match(route, /organizationId: session\.organizationId/);
+});
+
+test("migration repairs protocol ownership and tenant-scopes immutable revisions", async () => {
+  const migration = await read("drizzle/0034_protocol_medical_access_scope.sql");
+  assert.match(migration, /UPDATE `protocols`[\s\S]*FROM `bookings`/);
+  assert.match(migration, /ALTER TABLE `protocol_revisions` ADD COLUMN `organization_id`/);
+  assert.match(migration, /protocol_revisions_org_booking_idx/);
+  assert.match(migration, /protocols_org_number_idx/);
+  assert.match(migration, /WHERE `action` = 'protocol_document_saved'/);
+});


### PR DESCRIPTION
## Production audit block
Protocols → DICOM/PACS → patient result delivery → revision history → medical-data access control.

### Fixed
- tenant-scope protocol detail reads and writes by `organization_id`
- tenant-scope protocol-number collision checks
- persist `organization_id` on protocols, protocol revisions, booking mutations, and booking events
- add migration to repair historical protocol ownership and add tenant scope to immutable revisions
- attribute protocol view/save/issue security-audit events to the active organization
- audit patient self-service access to issued protocols without storing patient PII as the audit actor
- add regression tests for protocol/revision tenant isolation and medical-result access auditing

### Audit notes
- DICOM/PACS study and settings queries are already tenant-scoped on current main.
- A remaining non-blocking follow-up is explicit security-audit logging for staff image/viewer access and PACS configuration changes; the attempted PACS settings write was not applied in this PR.

### Intentionally not included
- production deploy
- D1 first-admin/password bootstrap