### PR TITLE
Require explicit tenant membership

### DIFF
--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -39,7 +39,7 @@ export async function requireOrgContext(request: Request, db: D1Database): Promi
   const identity = await requireStaff(request, db);
   if (!identity) return null;
 
-  let row = await db.prepare(
+  const row = await db.prepare(
     `SELECT o.id AS organizationId, o.slug AS slug, o.name AS organizationName, m.role AS role
      FROM memberships m
      JOIN organizations o ON o.id = m.organization_id AND o.active = 1
@@ -53,21 +53,9 @@ export async function requireOrgContext(request: Request, db: D1Database): Promi
     role: string;
   }>();
 
-  // Legacy onboarding compatibility. This remains temporarily until the test
-  // and bootstrap paths can require explicit membership end-to-end.
-  if (!row) {
-    const org = await db.prepare(
-      "SELECT id AS organizationId, slug, name AS organizationName FROM organizations WHERE active = 1 ORDER BY id ASC LIMIT 1"
-    ).first<{ organizationId: number; slug: string; organizationName: string }>();
-    if (!org) return null;
-    await db.prepare(
-      `INSERT INTO memberships (organization_id, member_email, role, active) VALUES (?, ?, ?, 1)
-       ON CONFLICT(organization_id, member_email) DO UPDATE SET active = 1`
-    ).bind(org.organizationId, identity.email, identity.role).run();
-    row = { ...org, role: identity.role };
-  }
-
-  if (!ACTIVE_STAFF_ROLES.has(row.role as StaffRole)) return null;
+  // Tenant access is deny-by-default: an authenticated global identity does not
+  // gain access to any organization unless an explicit active membership exists.
+  if (!row || !ACTIVE_STAFF_ROLES.has(row.role as StaffRole)) return null;
   const role = row.role as StaffRole;
   return {
     organizationId: row.organizationId,

--- a/tests/analytics.behavior.test.mjs
+++ b/tests/analytics.behavior.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { recordAnalyticsEvent } from "../lib/analytics.ts";
-import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+import { callWorker, jsonRequest, withD1 } from "./helpers/d1.mjs";
+import { seedTenantStaffSession } from "./helpers/tenant-staff.mjs";
 
 test("public analytics accepts only anonymous allowlisted funnel fields", async () => {
   await withD1(async (db) => {
@@ -103,7 +104,7 @@ test("staff funnel report is tenant-scoped and derives clinical milestones from 
               (1, ?, 'status_changed', 'completed', 'test', '2026-08-20 10:30:00')`,
     ).bind(bookingId, bookingId).run();
 
-    const cookie = await seedStaffSession(db, { email: "admin@example.com", role: "admin", organizationId: 1 });
+    const cookie = await seedTenantStaffSession(db, { email: "admin@example.com", role: "admin", organizationId: 1 });
     const response = await callWorker(new Request(
       "https://radiologyos.test/api/staff/analytics?from=2026-08-01&to=2026-08-31",
       { headers: { cookie } },

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -3,7 +3,8 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+import { withD1, jsonRequest, callWorker } from "./helpers/d1.mjs";
+import { seedTenantStaffSession } from "./helpers/tenant-staff.mjs";
 
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
 
@@ -29,7 +30,7 @@ test("search matches by name, phone and RD code", async () => {
   await withD1(async (db) => {
     await seed(db, { id: 1, code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNorm: "380971112233", time: "10:00" });
     await seed(db, { id: 2, code: "RD-BBBB2222", name: "Петренко Петро", phone: "+380975556677", phoneNorm: "380975556677", time: "10:30" });
-    const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
+    const cookie = await seedTenantStaffSession(db, { email: "reg@likarnya.test", role: "registrar", organizationId: 1 });
 
     const byName = await (await search(db, cookie, "іваненко")).json();
     assert.equal(byName.results.length, 1);
@@ -41,7 +42,6 @@ test("search matches by name, phone and RD code", async () => {
 
     const byPhone = await (await search(db, cookie, "0971112233")).json();
     assert.ok(byPhone.results.some((r) => r.code === "RD-AAAA1111"));
-    // Людський підпис статусу присутній.
     assert.ok(byPhone.results[0].statusLabel);
   });
 });
@@ -49,7 +49,7 @@ test("search matches by name, phone and RD code", async () => {
 test("a query shorter than 2 chars returns nothing (no full-table dump)", async () => {
   await withD1(async (db) => {
     await seed(db, { id: 3, code: "RD-CCCC3333", name: "Сидоренко", phone: "+380971110000", phoneNorm: "380971110000" });
-    const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
+    const cookie = await seedTenantStaffSession(db, { email: "reg@likarnya.test", role: "registrar", organizationId: 1 });
     const res = await search(db, cookie, "і");
     const data = await res.json();
     assert.equal(data.results.length, 0);
@@ -61,7 +61,7 @@ test("search never leaks bookings from another organization", async () => {
     await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2,'other','Інша',1)").run();
     await seed(db, { id: 4, code: "RD-OWN00001", name: "Шевченко", phone: "+380971110001", phoneNorm: "380971110001", org: 1 });
     await seed(db, { id: 5, code: "RD-OTHER0001", name: "Шевченко", phone: "+380971110002", phoneNorm: "380971110002", org: 2 });
-    const cookie = await seedStaffSession(db, { email: "admin@likarnya.test", role: "admin" }); // авто-онбординг у org 1
+    const cookie = await seedTenantStaffSession(db, { email: "admin@likarnya.test", role: "admin", organizationId: 1 });
     const data = await (await search(db, cookie, "шевченко")).json();
     assert.equal(data.results.length, 1);
     assert.equal(data.results[0].code, "RD-OWN00001");
@@ -75,5 +75,5 @@ test("the palette is mounted in the workspace shell and opens on Ctrl/⌘+K", as
   const cp = await read("app/staff/command-palette.tsx");
   assert.match(cp, /e\.metaKey \|\| e\.ctrlKey/);
   assert.match(cp, /\/api\/staff\/search/);
-  assert.match(cp, /\/staff\?open=\$\{b\.id\}/); // заявка → повна картка
+  assert.match(cp, /\/staff\?open=\$\{b\.id\}/);
 });

--- a/tests/integration-health.behavior.test.mjs
+++ b/tests/integration-health.behavior.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { callWorker, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+import { callWorker, withD1 } from "./helpers/d1.mjs";
+import { seedTenantStaffSession } from "./helpers/tenant-staff.mjs";
 
 const PACS_ENV = { OUTBOUND_ALLOWED_HOSTS: "pacs.example.test" };
 
@@ -12,7 +13,7 @@ function request(cookie) {
 
 test("integration health reports readiness without exposing PACS or MWL secrets", async () => {
   await withD1(async (db) => {
-    const cookie = await seedStaffSession(db, { email:"admin@health.test", role:"admin" });
+    const cookie = await seedTenantStaffSession(db, { email:"admin@health.test", role:"admin", organizationId:1 });
     await db.prepare(
       `UPDATE pacs_settings SET
         dicomweb_base_url = ?, viewer_base_url = ?, ae_title = 'RADIOLOGY', enabled = 1,
@@ -51,7 +52,7 @@ test("integration health reports readiness without exposing PACS or MWL secrets"
 
 test("integration health degrades PACS safely when the remote endpoint is unreachable", async () => {
   await withD1(async (db) => {
-    const cookie = await seedStaffSession(db, { email:"admin2@health.test", role:"admin" });
+    const cookie = await seedTenantStaffSession(db, { email:"admin2@health.test", role:"admin", organizationId:1 });
     await db.prepare(
       `UPDATE pacs_settings SET
         dicomweb_base_url = 'https://pacs.example.test/dicomweb', enabled = 1,


### PR DESCRIPTION
Superseded by the bootstrap-compatible tenant membership work in PR #236. This older draft removed legacy bootstrap entirely and is no longer the intended approach. Do not merge.