### PR TITLE
Tenant-scope private calendar subscriptions

### DIFF
--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -7,12 +7,27 @@ import { buildIcs, type CalendarBooking } from "../../../lib/calendar-ics";
 import { hashToken } from "../../../lib/auth";
 import { dbBinding } from "../../../lib/db";
 
+const tokenKey = (organizationId: number) => `calendar_token_hash:org:${organizationId}`;
+
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return new Response("Service unavailable", { status: 503 });
 
-  const token = new URL(request.url).searchParams.get("token") || "";
-  const expected = await getSetting(db, "calendar_token_hash");
+  const presented = new URL(request.url).searchParams.get("token") || "";
+  let organizationId = 1;
+  let token = presented;
+  const scoped = presented.match(/^(\d+)\.([a-f0-9]{48})$/);
+  if (scoped) {
+    organizationId = Number(scoped[1]);
+    token = scoped[2];
+  }
+  if (!Number.isInteger(organizationId) || organizationId < 1) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const expected = organizationId === 1
+    ? await getSetting(db, "calendar_token_hash")
+    : await getSetting(db, tokenKey(organizationId));
   if (!expected || !token || await hashToken(token) !== expected) {
     return new Response("Not found", { status: 404 });
   }
@@ -21,11 +36,12 @@ export async function GET(request: Request) {
     `SELECT code, service, desired_date AS desiredDate, desired_time AS desiredTime,
        duration_minutes AS durationMinutes, status
      FROM bookings
-     WHERE status IN ('new','confirmed','rescheduled')
+     WHERE organization_id = ?
+       AND status IN ('new','confirmed','rescheduled')
        AND desired_date >= date('now','-1 day')
      ORDER BY desired_date, desired_time
      LIMIT 1000`
-  ).all<CalendarBooking>();
+  ).bind(organizationId).all<CalendarBooking>();
 
   const ics = buildIcs(rows.results || []);
   return new Response(ics, {

--- a/app/api/staff/settings/calendar/route.ts
+++ b/app/api/staff/settings/calendar/route.ts
@@ -1,20 +1,28 @@
 // Generates (or rotates) the private calendar subscription token. Admin only.
 // Rotating it invalidates any previously shared subscription link.
 
-import { requireStaff } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
 import { setSetting } from "../../../../../lib/settings";
 import { hashToken } from "../../../../../lib/auth";
 import { dbBinding } from "../../../../../lib/db";
 
+const tokenKey = (organizationId: number) => `calendar_token_hash:org:${organizationId}`;
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
   if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
 
   const bytes = crypto.getRandomValues(new Uint8Array(24));
   const token = Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
-  await setSetting(db, "calendar_token_hash", await hashToken(token));
-  return Response.json({ ok: true, calendarToken: token });
+  const tokenHash = await hashToken(token);
+  await setSetting(db, tokenKey(ctx.organizationId), tokenHash);
+  if (ctx.organizationId === 1) {
+    await setSetting(db, "calendar_token_hash", await hashToken(token));
+  }
+  const calendarToken = ctx.organizationId === 1 ? token : `${ctx.organizationId}.${token}`;
+  return Response.json({ ok: true, calendarToken });
 }

--- a/tests/calendar-tenant-scope.test.mjs
+++ b/tests/calendar-tenant-scope.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("private calendar token resolves a tenant and scopes booking rows", async () => {
+  const route = await read("app/api/calendar/route.ts");
+  assert.match(route, /calendar_token_hash:org:/);
+  assert.match(route, /organizationId = Number\(scoped\[1\]\)/);
+  assert.match(route, /WHERE organization_id = \?/);
+  assert.match(route, /\.bind\(organizationId\)\.all<CalendarBooking>/);
+});
+
+test("calendar token rotation derives the tenant from staff membership", async () => {
+  const route = await read("app/api/staff/settings/calendar/route.ts");
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /tokenKey\(ctx\.organizationId\)/);
+  assert.match(route, /ctx\.organizationId === 1/);
+  assert.match(route, /`\$\{ctx\.organizationId\}\.\$\{token\}`/);
+});


### PR DESCRIPTION
Scopes private iCal subscription tokens and booking feeds to the authenticated organization. Organization 1 keeps the legacy token key and raw-token format for backward compatibility; additional tenants use namespaced hashes and an org-prefixed disclosed token. Adds regression coverage. No deployment changes.