### PR TITLE
Tenant-scope operational equipment registry

### DIFF
--- a/app/api/staff/equipment-registry/route.ts
+++ b/app/api/staff/equipment-registry/route.ts
@@ -1,26 +1,31 @@
-import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { audit } from "../../../../lib/audit";
 import { dbBinding } from "../../../../lib/db";
 import { getSetting, setSetting } from "../../../../lib/settings";
 import { EQUIPMENT_REGISTRY_KEY, parseEquipmentRegistry, sanitizeEquipmentRegistry } from "../../../../lib/equipment-registry";
 
+function registryKey(organizationId:number) {
+  return organizationId === 1 ? EQUIPMENT_REGISTRY_KEY : `org:${organizationId}:${EQUIPMENT_REGISTRY_KEY}`;
+}
+
 export async function GET(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
-  const member = await requireStaff(request,db);
-  if (!member) return Response.json({error:"Доступ лише для персоналу"},{status:403});
-  const equipment = parseEquipmentRegistry(await getSetting(db,EQUIPMENT_REGISTRY_KEY));
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const member = { ...ctx.member, role: ctx.role };
+  const equipment = parseEquipmentRegistry(await getSetting(db,registryKey(ctx.organizationId)));
   return Response.json({equipment,staff:member},{headers:{"cache-control":"no-store"}});
 }
 
 export async function PUT(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
-  const member = await requireStaff(request,db);
-  if (!member || member.role !== "admin") return Response.json({error:"Редагувати обладнання може лише адміністратор"},{status:403});
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx || ctx.role !== "admin") return Response.json({error:"Редагувати обладнання може лише адміністратор"},{status:403});
   const body = await request.json().catch(()=>({})) as {equipment?:unknown};
   const equipment = sanitizeEquipmentRegistry(body.equipment);
-  await setSetting(db,EQUIPMENT_REGISTRY_KEY,JSON.stringify(equipment));
-  await audit(db,{organizationId:1,actorEmail:member.email,action:"equipment_registry_update",resource:"equipment"});
+  await setSetting(db,registryKey(ctx.organizationId),JSON.stringify(equipment));
+  await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"equipment_registry_update",resource:"equipment"});
   return Response.json({ok:true,equipment});
 }

--- a/tests/equipment-registry-tenant-scope.test.mjs
+++ b/tests/equipment-registry-tenant-scope.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("equipment registry settings derive tenant from org context", async () => {
+  const route = await read("app/api/staff/equipment-registry/route.ts");
+  assert.match(route, /requireOrgContext\(request,db\)/);
+  assert.match(route, /registryKey\(ctx\.organizationId\)/);
+  assert.match(route, /organizationId:ctx\.organizationId/);
+  assert.doesNotMatch(route, /organizationId:1/);
+  assert.doesNotMatch(route, /requireStaff\(/);
+});


### PR DESCRIPTION
Superseded by merged PR #233, which reapplied the tenant-scoped equipment registry change on a fresh current-main branch. Do not merge this stale duplicate.