### PR TITLE
Tenant-scope operational registry settings

### DIFF
--- a/app/api/staff/equipment-registry/route.ts
+++ b/app/api/staff/equipment-registry/route.ts
@@ -1,26 +1,31 @@
-import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { audit } from "../../../../lib/audit";
 import { dbBinding } from "../../../../lib/db";
 import { getSetting, setSetting } from "../../../../lib/settings";
 import { EQUIPMENT_REGISTRY_KEY, parseEquipmentRegistry, sanitizeEquipmentRegistry } from "../../../../lib/equipment-registry";
 
+function registryKey(organizationId:number) {
+  return organizationId === 1 ? EQUIPMENT_REGISTRY_KEY : `org:${organizationId}:${EQUIPMENT_REGISTRY_KEY}`;
+}
+
 export async function GET(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
-  const member = await requireStaff(request,db);
-  if (!member) return Response.json({error:"Доступ лише для персоналу"},{status:403});
-  const equipment = parseEquipmentRegistry(await getSetting(db,EQUIPMENT_REGISTRY_KEY));
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const member = { ...ctx.member, role: ctx.role };
+  const equipment = parseEquipmentRegistry(await getSetting(db,registryKey(ctx.organizationId)));
   return Response.json({equipment,staff:member},{headers:{"cache-control":"no-store"}});
 }
 
 export async function PUT(request:Request) {
   const db = dbBinding();
   if (!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
-  const member = await requireStaff(request,db);
-  if (!member || member.role !== "admin") return Response.json({error:"Редагувати обладнання може лише адміністратор"},{status:403});
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx || ctx.role !== "admin") return Response.json({error:"Редагувати обладнання може лише адміністратор"},{status:403});
   const body = await request.json().catch(()=>({})) as {equipment?:unknown};
   const equipment = sanitizeEquipmentRegistry(body.equipment);
-  await setSetting(db,EQUIPMENT_REGISTRY_KEY,JSON.stringify(equipment));
-  await audit(db,{organizationId:1,actorEmail:member.email,action:"equipment_registry_update",resource:"equipment"});
+  await setSetting(db,registryKey(ctx.organizationId),JSON.stringify(equipment));
+  await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"equipment_registry_update",resource:"equipment"});
   return Response.json({ok:true,equipment});
 }


### PR DESCRIPTION
Supersedes #231 on the current main branch. The staff equipment registry now derives organization from requireOrgContext, keeps the legacy key only for organization 1, uses namespaced settings for other tenants, and records audit events under the actual organization. No deployment changes.