### PR TITLE
Audit PACS configuration changes

### DIFF
--- a/app/api/staff/imaging/settings/route.ts
+++ b/app/api/staff/imaging/settings/route.ts
@@ -1,6 +1,7 @@
 import { sanitizePacsSettings } from "../../../../../lib/dicom";
 import { safeOutboundUrl } from "../../../../../lib/outbound";
 import { requireOrgContext } from "../../../../../lib/tenant";
+import { audit } from "../../../../../lib/audit";
 import { dbBinding } from "../../../../../lib/db";
 
 const SETTINGS_COLUMNS = `dicomweb_base_url AS dicomwebBaseUrl, viewer_base_url AS viewerBaseUrl,
@@ -58,6 +59,14 @@ export async function PUT(request: Request) {
     settings.notes,
     ctx.member.email,
   ).run();
+
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "pacs_update",
+    resource: "pacs_settings",
+    details: { enabled: !!settings.enabled },
+  });
 
   return Response.json({ ok: true, settings: { ...settings, updatedBy: ctx.member.email } });
 }

--- a/tests/pacs-config-audit.test.mjs
+++ b/tests/pacs-config-audit.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("PACS configuration changes are audited to the signed-in tenant", async () => {
+  const route = await read("app/api/staff/imaging/settings/route.ts");
+  assert.match(route, /await audit\(db,/);
+  assert.match(route, /organizationId: ctx\.organizationId/);
+  assert.match(route, /action: "pacs_update"/);
+  assert.match(route, /resource: "pacs_settings"/);
+  assert.doesNotMatch(route, /details:[^}]*dicomwebBaseUrl|details:[^}]*viewerBaseUrl/s);
+});


### PR DESCRIPTION
Superseded by merged PR #237, which reapplied the PACS configuration audit change on the current main. Do not merge this stale PR.