### PR TITLE
Limit tenant auto-enrollment to first bootstrap

### DIFF
--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -53,11 +53,20 @@ export async function requireOrgContext(request: Request, db: D1Database): Promi
     role: string;
   }>();
 
-  // Legacy onboarding compatibility. This remains temporarily until the test
-  // and bootstrap paths can require explicit membership end-to-end.
+  // Legacy bootstrap compatibility is allowed only for a genuinely empty
+  // single-organization installation. Once any membership exists (or more than
+  // one active organization exists), tenant access becomes explicit and
+  // deny-by-default for identities without an active membership.
   if (!row) {
+    const bootstrap = await db.prepare(
+      `SELECT
+         (SELECT COUNT(*) FROM memberships) AS membershipCount,
+         (SELECT COUNT(*) FROM organizations WHERE active = 1) AS activeOrgCount`
+    ).first<{ membershipCount: number; activeOrgCount: number }>();
+    if (!bootstrap || Number(bootstrap.membershipCount) !== 0 || Number(bootstrap.activeOrgCount) !== 1) return null;
+
     const org = await db.prepare(
-      "SELECT id AS organizationId, slug, name AS organizationName FROM organizations WHERE active = 1 ORDER BY id ASC LIMIT 1"
+      "SELECT id AS organizationId, slug, name AS organizationName FROM organizations WHERE active = 1 LIMIT 1"
     ).first<{ organizationId: number; slug: string; organizationName: string }>();
     if (!org) return null;
     await db.prepare(

--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -109,11 +109,24 @@ function loadWorker() {
   return workerPromise;
 }
 
-export async function seedStaffSession(db, { email, role, displayName = "" }) {
+export async function seedStaffSession(db, {
+  email,
+  role,
+  displayName = "",
+  organizationId = 1,
+  withMembership = true,
+}) {
   await db.prepare(
     `INSERT INTO staff_members (email, display_name, role, active) VALUES (?, ?, ?, 1)
      ON CONFLICT(email) DO UPDATE SET role = excluded.role, active = 1`
   ).bind(email, displayName || email, role).run();
+  if (withMembership) {
+    await db.prepare(
+      `INSERT INTO memberships (organization_id, member_email, role, active)
+       VALUES (?, ?, ?, 1)
+       ON CONFLICT(organization_id, member_email) DO UPDATE SET role = excluded.role, active = 1`
+    ).bind(Number(organizationId) || 1, email, role).run();
+  }
   const rawToken = randomBytes(32).toString("hex");
   const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
   await db.prepare(


### PR DESCRIPTION
Superseded by merged PR #248, which implements the bootstrap-only tenant enrollment policy on current main with explicit-membership test fixtures and green CI/CodeQL. Do not merge this stale draft.