### PR TITLE
Tenant-scope manual notification events

### DIFF
--- a/app/api/staff/notify/route.ts
+++ b/app/api/staff/notify/route.ts
@@ -34,8 +34,9 @@ export async function POST(request: Request) {
 
   const summary = await sendPatientMessage(db, booking, message);
   await db.prepare(
-    "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'notified', ?, ?)"
-  ).bind(bookingId, `Повідомлення пацієнту: ${message}`.slice(0, 480), ctx.member.email).run();
+    `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+     VALUES (?, ?, 'notified', ?, ?)`
+  ).bind(ctx.organizationId, bookingId, `Повідомлення пацієнту: ${message}`.slice(0, 480), ctx.member.email).run();
 
   return Response.json({ ok: true, summary }, { headers: { "cache-control": "no-store" } });
 }

--- a/tests/notify-event-tenant-scope.behavior.test.mjs
+++ b/tests/notify-event-tenant-scope.behavior.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+
+test("manual notification event is attributed to the staff tenant", async () => {
+  await withD1(async (db) => {
+    await db.prepare(
+      "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'notify-org', 'Notify Org', 1)"
+    ).run();
+    const email = "notify-org2@example.com";
+    const cookie = await seedStaffSession(db, { email, role: "admin" });
+    await db.prepare(
+      `INSERT INTO memberships (organization_id, member_email, role, active)
+       VALUES (2, ?, 'admin', 1)`
+    ).bind(email).run();
+    const booking = await db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized, service, service_code,
+         desired_date, desired_time, status, patient_category)
+       VALUES (2, 'NOTIFY-ORG2', 'Patient', '+380501234567', '380501234567', 'CT', 'CT-01',
+         '2026-09-01', '10:00', 'confirmed', 'civilian')`
+    ).run();
+    const bookingId = Number(booking.meta.last_row_id);
+
+    const response = await callWorker(jsonRequest("/api/staff/notify", {
+      bookingId,
+      message: "Result is ready",
+    }, { headers: { cookie } }), db);
+    assert.equal(response.status, 200);
+
+    const event = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM booking_events WHERE booking_id = ? AND action = 'notified' ORDER BY id DESC LIMIT 1`
+    ).bind(bookingId).first();
+    assert.equal(event.organizationId, 2);
+  });
+});


### PR DESCRIPTION
Manual staff-to-patient notification events now write booking_events with the authenticated organization_id instead of relying on the org1 default. Booking lookup was already tenant-scoped; this aligns event attribution with it.