### PR TITLE
Tenant-scope AI draft audit events

### DIFF
--- a/app/api/staff/ai/protocol-draft/route.ts
+++ b/app/api/staff/ai/protocol-draft/route.ts
@@ -42,8 +42,8 @@ export async function POST(request: Request) {
   const draft = generateProtocolDraft(parsed.document, { priorStudies });
 
   await db.prepare(
-    "INSERT INTO booking_events (booking_id, action, details, actor) VALUES (?, 'ai_draft_generated', ?, ?)"
-  ).bind(bookingId, `${draft.engine} · відхилень: ${draft.deviations.length}`, member.email).run();
+    "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'ai_draft_generated', ?, ?)"
+  ).bind(ctx.organizationId, bookingId, `${draft.engine} · відхилень: ${draft.deviations.length}`, member.email).run();
 
   return Response.json({ ok: true, draft }, { headers: { "cache-control": "no-store" } });
 }

--- a/tests/ai-draft.test.mjs
+++ b/tests/ai-draft.test.mjs
@@ -23,6 +23,8 @@ test("AI draft API guards generation and audits it", async () => {
   assert.match(route, /canManageProtocols\(member\.role\)/);
   assert.match(route, /sanitizeDocument\(/);
   assert.match(route, /generateProtocolDraft\(/);
+  assert.match(route, /INSERT INTO booking_events \(organization_id, booking_id, action, details, actor\)/);
+  assert.match(route, /\.bind\(ctx\.organizationId, bookingId,/);
   assert.match(route, /ai_draft_generated/);
   assert.doesNotMatch(route, /CREATE\s+TABLE/i);
   assert.doesNotMatch(route, /ALTER\s+TABLE/i);


### PR DESCRIPTION
Final replay of the already-green AI draft audit fix on the latest main. The booking_events row for AI draft generation now carries the authenticated organization_id, with regression coverage. Supersedes #243 and #245.