### PR TITLE
Tenant-scope reminder notification records

### DIFF
--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -75,17 +75,17 @@ export async function runDueReminders(
       if (!b || !b.phoneNormalized) continue;
       const kind = `reminder_${due.hours}h`;
       if (dnc.has(b.phoneNormalized)) {
-        await record(db, b, kind, "skipped", "Пацієнт у списку «не турбувати»");
+        await record(db, organizationId, b, kind, "skipped", "Пацієнт у списку «не турбувати»");
         result.skipped += 1;
         continue;
       }
       const body = leadReminderText(b.service, b.desiredTime, due.hours);
       try {
         const r = await sendWhatsApp(db, b.phoneNormalized, body);
-        if (r.ok) { await record(db, b, kind, "sent", ""); result.sent += 1; }
-        else { await record(db, b, kind, "failed", r.error || "WhatsApp помилка"); result.failed += 1; }
+        if (r.ok) { await record(db, organizationId, b, kind, "sent", ""); result.sent += 1; }
+        else { await record(db, organizationId, b, kind, "failed", r.error || "WhatsApp помилка"); result.failed += 1; }
       } catch (error) {
-        await record(db, b, kind, "failed", error instanceof Error ? error.message : "Помилка");
+        await record(db, organizationId, b, kind, "failed", error instanceof Error ? error.message : "Помилка");
         result.failed += 1;
       }
     }
@@ -95,10 +95,18 @@ export async function runDueReminders(
   return result;
 }
 
-async function record(db: D1Database, b: ReminderRow, kind: string, status: string, error: string): Promise<void> {
+async function record(
+  db: D1Database,
+  organizationId: number,
+  b: ReminderRow,
+  kind: string,
+  status: string,
+  error: string,
+): Promise<void> {
   const body = leadReminderText(b.service, b.desiredTime, 0);
   await db.prepare(
-    `INSERT INTO patient_notifications (booking_id, kind, channel, recipient, body, status, error, sent_at)
-     VALUES (?, ?, 'whatsapp', ?, ?, ?, ?, ?)`
-  ).bind(b.id, kind, b.phone, body, status, error.slice(0, 240), status).run();
+    `INSERT INTO patient_notifications
+      (organization_id, booking_id, kind, channel, recipient, body, status, error, sent_at)
+     VALUES (?, ?, ?, 'whatsapp', ?, ?, ?, ?, ?)`
+  ).bind(organizationId, b.id, kind, b.phone, body, status, error.slice(0, 240), status).run();
 }

--- a/tests/reminders-tenant.behavior.test.mjs
+++ b/tests/reminders-tenant.behavior.test.mjs
@@ -20,6 +20,12 @@ test("scheduled reminder SQL isolates bookings, dedupe and do-not-contact by org
   assert.match(remindersSource, /WHERE organization_id = \? AND desired_date = \? AND status IN \('confirmed','rescheduled'\)/);
   assert.match(remindersSource, /JOIN bookings b ON b\.id = n\.booking_id[\s\S]*WHERE b\.organization_id = \?/);
   assert.match(remindersSource, /patient_profiles WHERE organization_id = \? AND do_not_contact = 1/);
+  assert.match(remindersSource, /record\(db, organizationId, b, kind/);
+  assert.match(
+    remindersSource,
+    /INSERT INTO patient_notifications[\s\S]*\(organization_id, booking_id, kind, channel, recipient, body, status, error, sent_at\)/,
+  );
+  assert.match(remindersSource, /\.bind\(organizationId, b\.id, kind/);
 
   await withD1(async (db) => {
     await db.prepare(


### PR DESCRIPTION
Scheduled reminder selection and DNC checks are already tenant-scoped. This change also records patient_notifications with the runner's explicit organization_id instead of relying on the org1 default. Existing tenant tests now guard the notification INSERT and organizationId propagation. Messaging credentials and the production org1-only scheduled handler are unchanged.