### PR TITLE
Limit tenant auto-enrollment to first bootstrap

### DIFF
--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -53,9 +53,17 @@ export async function requireOrgContext(request: Request, db: D1Database): Promi
     role: string;
   }>();
 
-  // Legacy onboarding compatibility. This remains temporarily until the test
-  // and bootstrap paths can require explicit membership end-to-end.
+  // Legacy bootstrap compatibility is allowed only for a genuinely empty
+  // single-organization installation. Once any membership exists (or more than
+  // one active organization exists), tenant access is explicit and deny-by-default.
   if (!row) {
+    const bootstrap = await db.prepare(
+      `SELECT
+         (SELECT COUNT(*) FROM memberships) AS membershipCount,
+         (SELECT COUNT(*) FROM organizations WHERE active = 1) AS activeOrgCount`
+    ).first<{ membershipCount: number; activeOrgCount: number }>();
+    if (!bootstrap || Number(bootstrap.membershipCount) !== 0 || Number(bootstrap.activeOrgCount) !== 1) return null;
+
     const org = await db.prepare(
       "SELECT id AS organizationId, slug, name AS organizationName FROM organizations WHERE active = 1 ORDER BY id ASC LIMIT 1"
     ).first<{ organizationId: number; slug: string; organizationName: string }>();

--- a/tests/dicom-accession.behavior.test.mjs
+++ b/tests/dicom-accession.behavior.test.mjs
@@ -6,7 +6,7 @@ const PACS_ENV = { OUTBOUND_ALLOWED_HOSTS: "pacs.example.com" };
 
 async function seedAdmin(db) {
   const email = "imaging-admin@example.com";
-  const cookie = await seedStaffSession(db, { email, role: "admin" });
+  const cookie = await seedStaffSession(db, { email, role: "admin", withMembership: false });
   await db.prepare(
     `INSERT INTO memberships (organization_id, member_email, role, active)
      VALUES (1, ?, 'admin', 1)`,

--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -109,11 +109,25 @@ function loadWorker() {
   return workerPromise;
 }
 
-export async function seedStaffSession(db, { email, role, displayName = "" }) {
+export async function seedStaffSession(db, {
+  email,
+  role,
+  displayName = "",
+  organizationId = 1,
+  withMembership = true,
+}) {
   await db.prepare(
     `INSERT INTO staff_members (email, display_name, role, active) VALUES (?, ?, ?, 1)
      ON CONFLICT(email) DO UPDATE SET role = excluded.role, active = 1`
   ).bind(email, displayName || email, role).run();
+  if (withMembership) {
+    await db.prepare(
+      `INSERT INTO memberships (organization_id, member_email, role, active)
+       VALUES (?, ?, ?, 1)
+       ON CONFLICT(organization_id, member_email)
+       DO UPDATE SET role = excluded.role, active = 1`
+    ).bind(organizationId, email, role).run();
+  }
   const rawToken = randomBytes(32).toString("hex");
   const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
   await db.prepare(

--- a/tests/imaging-tenant.behavior.test.mjs
+++ b/tests/imaging-tenant.behavior.test.mjs
@@ -30,8 +30,8 @@ test("PACS settings are isolated by organization", async () => {
   await withD1(async (db) => {
     await addOrganization(db, 2, "second-clinic", "Second Clinic");
 
-    const cookie1 = await seedStaffSession(db, { email: "admin-one@example.com", role: "admin" });
-    const cookie2 = await seedStaffSession(db, { email: "admin-two@example.com", role: "admin" });
+    const cookie1 = await seedStaffSession(db, { email: "admin-one@example.com", role: "admin", withMembership: false });
+    const cookie2 = await seedStaffSession(db, { email: "admin-two@example.com", role: "admin", withMembership: false });
     await addMembership(db, 1, "admin-one@example.com");
     await addMembership(db, 2, "admin-two@example.com");
 
@@ -82,8 +82,8 @@ test("PACS settings are isolated by organization", async () => {
 test("imaging linkage and audit events cannot cross tenant scope", async () => {
   await withD1(async (db) => {
     await addOrganization(db, 2, "second-clinic", "Second Clinic");
-    const cookie1 = await seedStaffSession(db, { email: "image-one@example.com", role: "admin" });
-    const cookie2 = await seedStaffSession(db, { email: "image-two@example.com", role: "admin" });
+    const cookie1 = await seedStaffSession(db, { email: "image-one@example.com", role: "admin", withMembership: false });
+    const cookie2 = await seedStaffSession(db, { email: "image-two@example.com", role: "admin", withMembership: false });
     await addMembership(db, 1, "image-one@example.com");
     await addMembership(db, 2, "image-two@example.com");
 

--- a/tests/mwl-bridge.behavior.test.mjs
+++ b/tests/mwl-bridge.behavior.test.mjs
@@ -8,7 +8,7 @@ async function addOrganization(db, id, slug, name) {
 }
 
 async function adminCookie(db, organizationId, email) {
-  const cookie = await seedStaffSession(db, { email, role: "admin" });
+  const cookie = await seedStaffSession(db, { email, role: "admin", withMembership: false });
   await db.prepare(
     `INSERT INTO memberships (organization_id, member_email, role, active)
      VALUES (?, ?, 'admin', 1)`,

--- a/tests/notify-event-tenant-scope.behavior.test.mjs
+++ b/tests/notify-event-tenant-scope.behavior.test.mjs
@@ -8,11 +8,7 @@ test("manual notification event is attributed to the staff tenant", async () => 
       "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'notify-org', 'Notify Org', 1)"
     ).run();
     const email = "notify-org2@example.com";
-    const cookie = await seedStaffSession(db, { email, role: "admin" });
-    await db.prepare(
-      `INSERT INTO memberships (organization_id, member_email, role, active)
-       VALUES (2, ?, 'admin', 1)`
-    ).bind(email).run();
+    const cookie = await seedStaffSession(db, { email, role: "admin", organizationId: 2 });
     const booking = await db.prepare(
       `INSERT INTO bookings
         (organization_id, code, name, phone, phone_normalized, service, service_code,

--- a/tests/tenant-bootstrap.test.mjs
+++ b/tests/tenant-bootstrap.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("../lib/tenant.ts", import.meta.url), "utf8");
+
+test("tenant auto-enrollment is limited to an empty single-organization bootstrap", () => {
+  assert.match(source, /SELECT COUNT\(\*\) FROM memberships/);
+  assert.match(source, /SELECT COUNT\(\*\) FROM organizations WHERE active = 1/);
+  assert.match(source, /Number\(bootstrap\.membershipCount\) !== 0/);
+  assert.match(source, /Number\(bootstrap\.activeOrgCount\) !== 1/);
+  assert.match(source, /ORDER BY id ASC LIMIT 1/);
+});


### PR DESCRIPTION
Restricts the legacy tenant auto-enrollment fallback to a genuinely empty single-organization installation: memberships must be empty and exactly one active organization must exist. Once any membership exists or multiple active organizations exist, staff without an explicit active membership are denied tenant context. Test helpers now seed explicit memberships by default, while multi-tenant fixtures can opt out and add memberships deliberately. Includes regression coverage for the bootstrap-only policy. No deployment changes.