### PR TITLE
Tenant-scope schedule runtime

### DIFF
--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,8 +1,8 @@
 import { addMinutes, EQUIPMENT } from "../../../lib/catalog";
 import { isBookableDate } from "../../../lib/booking-rules";
 import { effectiveServiceByCode } from "../../../lib/effective-services";
-import { getSetting } from "../../../lib/settings";
-import { candidateTimesFor, hoursFor, isEquipmentDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../lib/schedule";
+import { candidateTimesFor, hoursFor, isEquipmentDayOpen } from "../../../lib/schedule";
+import { getOrganizationSchedule } from "../../../lib/tenant-schedule";
 import { requireOrgContext } from "../../../lib/tenant";
 import { dbBinding } from "../../../lib/db";
 
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
     return Response.json({ times: [] });
   }
 
-  const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+  const schedule = await getOrganizationSchedule(db, organizationId);
   if (!isEquipmentDayOpen(date, schedule, service.equipmentId)) {
     return Response.json({
       times: [],

--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -1,8 +1,8 @@
 import { addMinutes } from "../../../../lib/catalog";
 import { isBookableDate } from "../../../../lib/booking-rules";
 import { effectiveServiceByCode, serviceAvailableTo } from "../../../../lib/effective-services";
-import { candidateTimesFor, hoursFor, isEquipmentDayOpen, parseSchedule, SCHEDULE_KEY } from "../../../../lib/schedule";
-import { getSetting } from "../../../../lib/settings";
+import { candidateTimesFor, hoursFor, isEquipmentDayOpen } from "../../../../lib/schedule";
+import { getOrganizationSchedule } from "../../../../lib/tenant-schedule";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
 import { normalizeDob } from "../../../../lib/dob";
 import { sendPatientReminder, type ReminderBooking } from "../../../../lib/notify";
@@ -77,7 +77,7 @@ export async function POST(request: Request) {
   if (!serviceAvailableTo(service, category)) {
     return Response.json({ error: "Ця послуга зараз недоступна для обраної категорії пацієнтів" }, { status: 400 });
   }
-  const schedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+  const schedule = await getOrganizationSchedule(db, ctx.organizationId);
   radiologist ||= schedule.equipment[service.equipmentId]?.radiologistEmail || "";
   radiographer ||= schedule.equipment[service.equipmentId]?.radiographerEmail || "";
   if (!(await hasActiveTenantRole(db, ctx.organizationId, radiologist, "radiologist"))) {
@@ -298,7 +298,7 @@ export async function PATCH(request: Request) {
         return Response.json({ error: "Ця послуга зараз недоступна для обраної категорії пацієнтів" }, { status: 400 });
       }
       if (cur) {
-        const rSchedule = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+        const rSchedule = await getOrganizationSchedule(db, ctx.organizationId);
         const validTimes = candidateTimesFor(hoursFor(rSchedule, svc.equipmentId), svc.durationMinutes);
         const endTime = addMinutes(cur.t, svc.durationMinutes);
         const rejectReschedule = Response.json({ error: "Поточний час не підходить для нової послуги (апарат / тривалість / зайнятість) — спершу перенесіть заявку" }, { status: 409 });
@@ -525,7 +525,7 @@ export async function PATCH(request: Request) {
         name, phone, phone_normalized AS phoneNormalized, patient_email AS patientEmail, service
        FROM bookings WHERE organization_id = ? AND id = ?`
     ).bind(ctx.organizationId, body.id).first<{serviceCode:string;equipmentId:string;durationMinutes:number;name:string;phone:string;phoneNormalized:string;patientEmail:string;service:string}>();
-    const rSched = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+    const rSched = await getOrganizationSchedule(db, ctx.organizationId);
     if (!booking || !isBookableDate(body.desiredDate) || !isEquipmentDayOpen(body.desiredDate, rSched, booking.equipmentId)
         || !candidateTimesFor(hoursFor(rSched, booking.equipmentId), booking.durationMinutes).includes(body.desiredTime)) {
       return Response.json({ error: "Некоректні дата або час" }, { status: 400 });
@@ -569,7 +569,7 @@ export async function PATCH(request: Request) {
     if (booking.status === "cancelled" || booking.status === "completed") {
       return Response.json({ error: "Заявку вже закрито — підтвердження недоступне" }, { status: 400 });
     }
-    const cSched = parseSchedule(await getSetting(db, SCHEDULE_KEY));
+    const cSched = await getOrganizationSchedule(db, ctx.organizationId);
     if (!isBookableDate(booking.desiredDate) || !isEquipmentDayOpen(booking.desiredDate, cSched, booking.equipmentId)
         || !candidateTimesFor(hoursFor(cSched, booking.equipmentId), booking.durationMinutes).includes(booking.desiredTime)) {
       return Response.json({ error: "Бажаний час поза розкладом — перенесіть запис на вільний слот" }, { status: 400 });

--- a/app/api/staff/schedule/route.ts
+++ b/app/api/staff/schedule/route.ts
@@ -1,36 +1,49 @@
 // Графік прийому: години/крок слота по апаратах, робочі дні тижня та вихідні.
-// Лише адміністратор. Зберігається у app_settings (equipment_schedule).
+// Лише адміністратор поточної організації.
 
-import { requireStaff } from "../../../../lib/staff-auth";
-import { getSetting, setSetting } from "../../../../lib/settings";
-import { parseSchedule, sanitizeSchedule, SCHEDULE_KEY } from "../../../../lib/schedule";
+import { sanitizeSchedule } from "../../../../lib/schedule";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
+import { requireOrgContext } from "../../../../lib/tenant";
+import { getOrganizationSchedule, setOrganizationSchedule } from "../../../../lib/tenant-schedule";
 
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const [schedule, people] = await Promise.all([
-    getSetting(db, SCHEDULE_KEY).then(parseSchedule),
-    db.prepare(`SELECT email, display_name AS displayName, role, position_title AS positionTitle,
-      military_rank AS militaryRank FROM staff_members
-      WHERE active = 1 ORDER BY position_title, display_name`).all(),
+    getOrganizationSchedule(db, ctx.organizationId),
+    db.prepare(`SELECT s.email, s.display_name AS displayName, m.role AS role,
+      s.position_title AS positionTitle, s.military_rank AS militaryRank
+      FROM memberships m
+      JOIN staff_members s ON s.email = m.member_email
+      WHERE m.organization_id = ? AND m.active = 1 AND s.active = 1
+      ORDER BY s.position_title, s.display_name`).bind(ctx.organizationId).all(),
   ]);
-  return Response.json({ schedule, staff: member, people: people.results }, { headers: { "cache-control": "no-store" } });
+  return Response.json(
+    { schedule, staff: ctx.member, people: people.results },
+    { headers: { "cache-control": "no-store" } },
+  );
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Змінювати графік може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.member.role !== "admin") {
+    return Response.json({ error: "Змінювати графік може лише адміністратор" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { schedule?: unknown };
   const schedule = sanitizeSchedule(body.schedule);
-  await setSetting(db, SCHEDULE_KEY, JSON.stringify(schedule));
-  await audit(db, { organizationId: 1, actorEmail: member.email, action: "schedule_update", resource: "settings" });
+  await setOrganizationSchedule(db, ctx.organizationId, schedule);
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "schedule_update",
+    resource: "settings",
+  });
   return Response.json({ ok: true, schedule }, { headers: { "cache-control": "no-store" } });
 }

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -19,6 +19,10 @@ export type ScheduleConfig = {
 };
 
 export const SCHEDULE_KEY = "equipment_schedule";
+export function scheduleKey(organizationId: number): string {
+  const id = Number.isInteger(organizationId) && organizationId > 0 ? organizationId : 1;
+  return `${SCHEDULE_KEY}:org:${id}`;
+}
 export const EQUIP_KEYS = ["ct", "xray", "fluoro"] as const;
 export const EQUIP_LABELS: Record<string, string> = {
   ct: "Комп’ютерний томограф", xray: "Цифровий рентген", fluoro: "Флюорограф",

--- a/lib/tenant-schedule.ts
+++ b/lib/tenant-schedule.ts
@@ -1,0 +1,24 @@
+import { getSetting, setSetting } from "./settings";
+import { parseSchedule, SCHEDULE_KEY, scheduleKey, type ScheduleConfig } from "./schedule";
+
+export async function getOrganizationSchedule(
+  db: D1Database,
+  organizationId: number,
+): Promise<ScheduleConfig> {
+  const tenantStored = await getSetting(db, scheduleKey(organizationId));
+  if (tenantStored) return parseSchedule(tenantStored);
+  if (organizationId === 1) return parseSchedule(await getSetting(db, SCHEDULE_KEY));
+  return parseSchedule("");
+}
+
+export async function setOrganizationSchedule(
+  db: D1Database,
+  organizationId: number,
+  schedule: ScheduleConfig,
+): Promise<void> {
+  const serialized = JSON.stringify(schedule);
+  await setSetting(db, scheduleKey(organizationId), serialized);
+  // Public storefront remains org1-only for now and still reads the legacy key.
+  // Mirror org1 writes so public availability/site booking stay compatible.
+  if (organizationId === 1) await setSetting(db, SCHEDULE_KEY, serialized);
+}

--- a/tests/schedule.test.mjs
+++ b/tests/schedule.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
-  candidateTimesFor, isDayOpen, parseSchedule, sanitizeSchedule, SCHEDULE_DEFAULTS,
+  candidateTimesFor, isDayOpen, parseSchedule, sanitizeSchedule, scheduleKey, SCHEDULE_DEFAULTS,
 } from "../lib/schedule.ts";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
@@ -15,21 +15,17 @@ test("candidateTimesFor honours start/end/step and study duration", () => {
 });
 
 test("candidateTimesFor skips slots overlapping the lunch break", () => {
-  // Обід 13:00–14:00: слоти, що його перетинають, не пропонуються.
   const t = candidateTimesFor({ start: "12:30", end: "14:30", slotMinutes: 15, breakStart: "13:00", breakEnd: "14:00" }, 15);
   assert.deepEqual(t, ["12:30", "12:45", "14:00", "14:15"]);
-  // 30-хв дослідження: 12:45+30 перетинає обід → відкидається, 12:30 закінчується рівно о 13:00.
   const t30 = candidateTimesFor({ start: "12:30", end: "15:00", slotMinutes: 15, breakStart: "13:00", breakEnd: "14:00" }, 30);
   assert.deepEqual(t30, ["12:30", "14:00", "14:15", "14:30"]);
 });
 
 test("default schedule matches the real outpatient reception windows", () => {
-  // Флюорографія: 9:30–13:00 та 14:00–16:00.
   const fluoro = candidateTimesFor(SCHEDULE_DEFAULTS.equipment.fluoro, 15);
   assert.equal(fluoro[0], "09:30");
   assert.ok(fluoro.includes("12:45") && !fluoro.includes("13:00"));
   assert.ok(fluoro.includes("14:00") && fluoro.at(-1) === "15:45");
-  // Рентгенографія: 10:00–13:00 та 14:00–15:00.
   const xray = candidateTimesFor(SCHEDULE_DEFAULTS.equipment.xray, 15);
   assert.equal(xray[0], "10:00");
   assert.ok(xray.includes("12:45") && !xray.includes("13:00") && !xray.includes("13:30"));
@@ -40,30 +36,27 @@ test("sanitizeSchedule keeps a valid break, drops an out-of-range one, inherits 
   const kept = sanitizeSchedule({ equipment: { ct: { start: "08:00", end: "17:00", slotMinutes: 30, breakStart: "12:00", breakEnd: "13:00" } } });
   assert.equal(kept.equipment.ct.breakStart, "12:00");
   assert.equal(kept.equipment.ct.breakEnd, "13:00");
-  // Перерва поза межами робочих годин відкидається.
   const dropped = sanitizeSchedule({ equipment: { ct: { start: "08:00", end: "12:00", slotMinutes: 30, breakStart: "13:00", breakEnd: "14:00" } } });
   assert.equal(dropped.equipment.ct.breakStart, undefined);
-  // Явне очищення (порожні поля) прибирає перерву.
   const cleared = sanitizeSchedule({ equipment: { xray: { start: "10:00", end: "15:00", slotMinutes: 15, breakStart: "", breakEnd: "" } } });
   assert.equal(cleared.equipment.xray.breakStart, undefined);
-  // Без ключів перерви — успадковується типова.
   const inherited = sanitizeSchedule({ equipment: { fluoro: { start: "09:30", end: "16:00", slotMinutes: 15 } } });
   assert.equal(inherited.equipment.fluoro.breakStart, "13:00");
 });
 
 test("isDayOpen respects weekdays and specific days-off", () => {
   const cfg = sanitizeSchedule({ weekdays: [1, 2, 3, 4, 5], daysOff: ["2026-08-04"] });
-  assert.equal(isDayOpen("2026-08-02", cfg), false); // неділя
-  assert.equal(isDayOpen("2026-08-01", cfg), false); // субота вимкнена (лише 1-5)
-  assert.equal(isDayOpen("2026-08-03", cfg), true);  // понеділок
-  assert.equal(isDayOpen("2026-08-04", cfg), false); // вихідний зі списку
+  assert.equal(isDayOpen("2026-08-02", cfg), false);
+  assert.equal(isDayOpen("2026-08-01", cfg), false);
+  assert.equal(isDayOpen("2026-08-03", cfg), true);
+  assert.equal(isDayOpen("2026-08-04", cfg), false);
 });
 
 test("sanitizeSchedule clamps invalid input to safe defaults", () => {
   const c = sanitizeSchedule({ equipment: { ct: { start: "25:99", end: "08:00", slotMinutes: 9999 } }, weekdays: [0, 9], daysOff: ["bad", "2026-01-01"] });
-  for (const key of ["open", "close", "breakStart", "breakEnd", "slotStep"]) assert.equal(c.equipment.ct[key], SCHEDULE_DEFAULTS.equipment.ct[key]); // некоректні години → типові
-  assert.deepEqual(c.weekdays, SCHEDULE_DEFAULTS.weekdays); // 0/9 відкинуто → типові
-  assert.deepEqual(c.daysOff, ["2026-01-01"]); // лишилась лише валідна дата
+  for (const key of ["open", "close", "breakStart", "breakEnd", "slotStep"]) assert.equal(c.equipment.ct[key], SCHEDULE_DEFAULTS.equipment.ct[key]);
+  assert.deepEqual(c.weekdays, SCHEDULE_DEFAULTS.weekdays);
+  assert.deepEqual(c.daysOff, ["2026-01-01"]);
 });
 
 test("parseSchedule returns defaults for empty/invalid JSON", () => {
@@ -71,23 +64,33 @@ test("parseSchedule returns defaults for empty/invalid JSON", () => {
   assert.deepEqual(parseSchedule("{oops"), sanitizeSchedule({}));
 });
 
-test("availability and staff booking read the configurable schedule", async () => {
+test("schedule keys are namespaced by organization", () => {
+  assert.equal(scheduleKey(1), "equipment_schedule:org:1");
+  assert.equal(scheduleKey(2), "equipment_schedule:org:2");
+});
+
+test("availability and staff booking read the tenant schedule", async () => {
   const avail = await read("app/api/availability/route.ts");
-  assert.match(avail, /parseSchedule\(await getSetting\(db, SCHEDULE_KEY\)\)/);
+  assert.match(avail, /getOrganizationSchedule\(db, organizationId\)/);
   assert.match(avail, /isEquipmentDayOpen\(date, schedule, service\.equipmentId\)/);
   assert.match(avail, /candidateTimesFor\(hoursFor\(schedule/);
-  assert.match(avail, /equipment_blocks/); // збережено фільтр блокувань
+  assert.match(avail, /equipment_blocks/);
   assert.match(avail, /status IN \('new','confirmed','rescheduled'\)/);
   const book = await read("app/api/staff/bookings/route.ts");
+  assert.match(book, /getOrganizationSchedule\(db, ctx\.organizationId\)/);
+  assert.doesNotMatch(book, /getSetting\(db, SCHEDULE_KEY\)/);
   assert.match(book, /candidateTimesFor\(hoursFor\(schedule/);
   assert.match(book, /isEquipmentDayOpen\(desiredDate, schedule, service\.equipmentId\)/);
 });
 
-test("schedule editor and admin API are wired and guarded", async () => {
+test("schedule editor and admin API are tenant-scoped and guarded", async () => {
   const route = await read("app/api/staff/schedule/route.ts");
-  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.member\.role !== "admin"/);
   assert.match(route, /sanitizeSchedule\(body\.schedule\)/);
-  assert.match(route, /setSetting\(db, SCHEDULE_KEY/);
+  assert.match(route, /setOrganizationSchedule\(db, ctx\.organizationId, schedule\)/);
+  assert.match(route, /FROM memberships m/);
+  assert.match(route, /organizationId: ctx\.organizationId/);
   const page = await read("app/staff/schedule/page.tsx");
   assert.match(page, /active="schedule"/);
   assert.match(page, /Робочі дні/);

--- a/tests/tenant-schedule.behavior.test.mjs
+++ b/tests/tenant-schedule.behavior.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+import { sanitizeSchedule, scheduleKey, SCHEDULE_KEY } from "../lib/schedule.ts";
+
+async function addOrganization(db, id, slug) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (?, ?, ?, 1)"
+  ).bind(id, slug, `Organization ${id}`).run();
+}
+
+async function setRawSetting(db, key, value) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  ).bind(key, value).run();
+}
+
+const scheduleWithCtStart = (start, end = "17:00") => sanitizeSchedule({
+  equipment: {
+    ct: { start, end, slotMinutes: 30, breakStart: "", breakEnd: "" },
+  },
+});
+
+test("schedule admin stores per-tenant config, scopes people, and preserves org1 legacy settings", async () => {
+  await withD1(async (db) => {
+    await addOrganization(db, 2, "other-clinic");
+    const admin1 = await seedStaffSession(db, {
+      email: "schedule-one@example.com", role: "admin", organizationId: 1,
+    });
+    const admin2 = await seedStaffSession(db, {
+      email: "schedule-two@example.com", role: "admin", organizationId: 2,
+    });
+    await seedStaffSession(db, {
+      email: "org1-rad@example.com", role: "radiologist", organizationId: 1,
+    });
+    await seedStaffSession(db, {
+      email: "org2-rad@example.com", role: "radiologist", organizationId: 2,
+    });
+
+    const legacy = scheduleWithCtStart("08:00");
+    await setRawSetting(db, SCHEDULE_KEY, JSON.stringify(legacy));
+    const org2Schedule = scheduleWithCtStart("11:00", "13:00");
+
+    const put = await callWorker(jsonRequest("/api/staff/schedule", { schedule: org2Schedule }, {
+      method: "PUT", headers: { cookie: admin2 },
+    }), db);
+    assert.equal(put.status, 200);
+
+    const storedOrg2 = await db.prepare("SELECT value FROM app_settings WHERE key = ?")
+      .bind(scheduleKey(2)).first();
+    assert.ok(storedOrg2?.value);
+    const legacyAfter = await db.prepare("SELECT value FROM app_settings WHERE key = ?")
+      .bind(SCHEDULE_KEY).first();
+    assert.deepEqual(JSON.parse(legacyAfter.value), legacy);
+
+    const get2 = await callWorker(jsonRequest("/api/staff/schedule", undefined, {
+      method: "GET", headers: { cookie: admin2 },
+    }), db);
+    assert.equal(get2.status, 200);
+    const body2 = await get2.json();
+    assert.equal(body2.schedule.equipment.ct.start, "11:00");
+    assert.equal(body2.people.some((row) => row.email === "org2-rad@example.com"), true);
+    assert.equal(body2.people.some((row) => row.email === "org1-rad@example.com"), false);
+
+    const get1 = await callWorker(jsonRequest("/api/staff/schedule", undefined, {
+      method: "GET", headers: { cookie: admin1 },
+    }), db);
+    const body1 = await get1.json();
+    assert.equal(body1.schedule.equipment.ct.start, "08:00");
+  });
+});
+
+test("staff availability uses its tenant schedule while anonymous availability stays on org1", async () => {
+  await withD1(async (db) => {
+    await addOrganization(db, 2, "availability-clinic");
+    const staff2 = await seedStaffSession(db, {
+      email: "availability-two@example.com", role: "admin", organizationId: 2,
+    });
+    await setRawSetting(db, SCHEDULE_KEY, JSON.stringify(scheduleWithCtStart("08:00")));
+    await setRawSetting(db, scheduleKey(2), JSON.stringify(scheduleWithCtStart("11:00")));
+
+    const url = "/api/availability?date=2026-09-01&serviceCode=403";
+    const staffResponse = await callWorker(jsonRequest(url, undefined, {
+      method: "GET", headers: { cookie: staff2 },
+    }), db);
+    const publicResponse = await callWorker(jsonRequest(url, undefined, { method: "GET" }), db);
+    assert.equal(staffResponse.status, 200);
+    assert.equal(publicResponse.status, 200);
+    const staffBody = await staffResponse.json();
+    const publicBody = await publicResponse.json();
+    assert.equal(staffBody.times[0], "11:00");
+    assert.equal(publicBody.times[0], "08:00");
+  });
+});


### PR DESCRIPTION
Makes the configurable equipment schedule coherent across tenant-aware staff workflows. Schedules use namespaced app_settings keys per organization; org 1 reads legacy data when needed and mirrors writes to the legacy key so the intentionally org1-only public storefront remains compatible, while org >1 never falls back to org1 settings. The schedule editor now uses requireOrgContext, membership-role admin authorization, tenant-scoped staff choices, and tenant-attributed audit. Staff availability and every staff booking schedule validation use the current organization's schedule. Includes behavioral coverage proving org2 schedule isolation and anonymous org1 compatibility. No deployment changes.