### PR TITLE
Audit staff medical-image access

### DIFF
--- a/app/api/staff/imaging/route.ts
+++ b/app/api/staff/imaging/route.ts
@@ -12,6 +12,7 @@ import {
 import { fetchLimited, readLimitedText, safeOutboundUrl } from "../../../../lib/outbound";
 import { requireOrgContext } from "../../../../lib/tenant";
 import { dbBinding } from "../../../../lib/db";
+import { audit } from "../../../../lib/audit";
 
 type PacsRow = {
   dicomwebBaseUrl:string; viewerBaseUrl:string; aeTitle:string; enabled:number;
@@ -89,6 +90,14 @@ export async function GET(request: Request) {
          WHERE booking_id = ? AND organization_id = ?`
       ).bind(series.length, instances, bookingId, ctx.organizationId).run();
     }
+    await audit(db, {
+      organizationId: ctx.organizationId,
+      actorEmail: member.email,
+      action: "imaging_study_viewed",
+      resource: "imaging",
+      targetId: bookingId,
+      details: { linked: !!study, seriesCount: series.length },
+    });
     return Response.json({
       booking,
       study:study || null,

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -29,6 +29,7 @@ export const AUDIT_LABELS: Record<string, string> = {
   settings_update: "Змінено налаштування",
   org_profile_update: "Змінено профіль організації",
   pacs_update: "Змінено налаштування PACS",
+  imaging_study_viewed: "Переглянуто медичні зображення",
   booking_confirm: "Підтверджено запис",
   booking_cancel: "Скасовано запис",
   booking_reschedule: "Перенесено запис",

--- a/tests/imaging-access-audit.behavior.test.mjs
+++ b/tests/imaging-access-audit.behavior.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addOrganization(db, id, slug) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (?, ?, ?, 1)"
+  ).bind(id, slug, `Organization ${id}`).run();
+}
+
+test("staff imaging detail access is security-audited in the active tenant without PHI or PACS identifiers", async () => {
+  await withD1(async (db) => {
+    await addOrganization(db, 2, "audit-imaging");
+    const cookie = await seedStaffSession(db, {
+      email: "imaging-auditor@example.com",
+      role: "admin",
+      organizationId: 2,
+    });
+    const bookingResult = await db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, service, service_code, equipment_id,
+         desired_date, desired_time, patient_category, status, performed_at)
+       VALUES (2, 'IMG-AUDIT-2', 'Sensitive Patient', '+380501112233', 'CT', '403', 'ct',
+         '2026-09-01', '10:00', 'civilian', 'completed', '2026-09-01T10:30:00')`
+    ).run();
+    const bookingId = Number(bookingResult.meta.last_row_id);
+    await db.prepare(
+      `INSERT INTO imaging_studies
+        (organization_id, booking_id, accession_number, study_instance_uid, modality,
+         study_status, source, updated_by)
+       VALUES (2, ?, 'SECRET-ACC-2', '1.2.840.113619.99.2', 'CT', 'available', 'manual', 'seed')`
+    ).bind(bookingId).run();
+    await db.prepare(
+      `INSERT INTO pacs_settings
+        (organization_id, dicomweb_base_url, viewer_base_url, ae_title, enabled)
+       VALUES (2, '', 'https://viewer.secret.example/viewer', 'RAD2', 1)
+       ON CONFLICT(organization_id) DO UPDATE SET
+         viewer_base_url = excluded.viewer_base_url, enabled = excluded.enabled`
+    ).run();
+
+    const response = await callWorker(jsonRequest(`/api/staff/imaging?bookingId=${bookingId}`, undefined, {
+      method: "GET",
+      headers: { cookie },
+    }), db);
+    assert.equal(response.status, 200);
+
+    const event = await db.prepare(
+      `SELECT organization_id AS organizationId, actor_email AS actorEmail,
+              action, resource, target_id AS targetId, details_json AS detailsJson
+       FROM security_audit_log
+       WHERE action = 'imaging_study_viewed' ORDER BY id DESC LIMIT 1`
+    ).first();
+    assert.equal(event.organizationId, 2);
+    assert.equal(event.actorEmail, "imaging-auditor@example.com");
+    assert.equal(event.resource, "imaging");
+    assert.equal(event.targetId, String(bookingId));
+    assert.deepEqual(JSON.parse(event.detailsJson), { linked: true, seriesCount: 0 });
+    assert.doesNotMatch(event.detailsJson, /Sensitive Patient|SECRET-ACC-2|1\.2\.840|viewer\.secret/i);
+  });
+});


### PR DESCRIPTION
Adds tenant-attributed security audit when authorized staff opens a specific imaging study/detail and receives PACS/viewer data. The event records organization, staff actor, action/resource, booking target, and only minimal non-PHI details (linked flag and returned series count); it does not log patient identity, accession number, Study Instance UID, PACS endpoints, or viewer URLs. Uses the safe audit wrapper so audit storage failure cannot break clinical image access. Includes an org2 behavioral test proving tenant attribution and absence of sensitive identifiers. No deployment changes.