### PR TITLE
Make patient identity tenant-composite

### DIFF
--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -1,5 +1,5 @@
 // Видає пацієнту (за активною сесією кабінету) deep-link для під'єднання
-// Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до його телефону.
+// Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до tenant + телефону.
 
 import { requirePatientSession } from "../../../lib/patient-auth";
 import { createTelegramLinkToken } from "../../../lib/telegram-link";
@@ -20,7 +20,7 @@ export async function POST(request: Request) {
   if (!username) {
     return Response.json({ error: "Telegram-канал ще не налаштований відділенням", botConfigured: false }, { status: 503 });
   }
-  const token = await createTelegramLinkToken(db, session.phoneNormalized);
+  const token = await createTelegramLinkToken(db, session.phoneNormalized, session.organizationId);
   const url = `https://t.me/${username}?start=${token}`;
   return Response.json({ url }, { headers: { "cache-control": "no-store" } });
 }

--- a/app/api/staff/patients/import/route.ts
+++ b/app/api/staff/patients/import/route.ts
@@ -35,15 +35,16 @@ export async function POST(request: Request) {
       `INSERT INTO patient_profiles
          (organization_id, phone_normalized, display_name, birth_year, birth_date, email, address, tags, notes, do_not_contact, updated_by, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-       ON CONFLICT(phone_normalized) DO UPDATE SET
+       ON CONFLICT(organization_id, phone_normalized) DO UPDATE SET
          display_name = CASE WHEN excluded.display_name != '' THEN excluded.display_name ELSE patient_profiles.display_name END,
          birth_year = CASE WHEN excluded.birth_year != 0 THEN excluded.birth_year ELSE patient_profiles.birth_year END,
          birth_date = CASE WHEN excluded.birth_date != '' THEN excluded.birth_date ELSE patient_profiles.birth_date END,
          email = CASE WHEN excluded.email != '' THEN excluded.email ELSE patient_profiles.email END,
          address = CASE WHEN excluded.address != '' THEN excluded.address ELSE patient_profiles.address END,
          notes = CASE WHEN excluded.notes != '' THEN excluded.notes ELSE patient_profiles.notes END,
-         updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP
-       WHERE patient_profiles.organization_id = excluded.organization_id`
+         tags = excluded.tags,
+         do_not_contact = excluded.do_not_contact,
+         updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
     ).bind(
       ctx.organizationId, p.phoneNormalized, p.displayName, p.birthYear, p.birthDate, p.email, p.address,
       p.tags, p.notes, p.doNotContact, member.email,
@@ -51,13 +52,10 @@ export async function POST(request: Request) {
   });
 
   let imported = 0;
-  // D1 batch по частинах, щоб не впертися в ліміт кількості операцій.
   for (let i = 0; i < statements.length; i += 50) {
     const results = await db.batch(statements.slice(i, i + 50));
     imported += results.reduce((sum, result) => sum + (Number(result.meta?.changes || 0) > 0 ? 1 : 0), 0);
   }
-  // Валідний рядок, що конфліктує з профілем іншого tenant, навмисно не
-  // змінює той профіль і рахується як skipped до composite-key migration.
   const skipped = errors.length + (statements.length - imported);
 
   await logSecurityEvent(db, {
@@ -67,6 +65,5 @@ export async function POST(request: Request) {
     resource: "patient_registry",
     details: { imported, skipped },
   });
-
   return Response.json({ ok: true, imported, skipped, errors: errors.slice(0, 50) });
 }

--- a/app/api/staff/patients/route.ts
+++ b/app/api/staff/patients/route.ts
@@ -11,7 +11,6 @@ import {
   sanitizeProfile,
 } from "../../../../lib/patients";
 
-
 const BOOKING_COLUMNS = `id, code, name, phone_normalized AS phoneNormalized, service,
   service_code AS serviceCode, equipment_id AS equipmentId, desired_date AS desiredDate,
   desired_time AS desiredTime, status, patient_category AS patientCategory,
@@ -37,38 +36,20 @@ export async function GET(request: Request) {
   }
 
   const phone = normalizeUkrainianPhone(new URL(request.url).searchParams.get("phone") || "");
-
   if (phone) {
     const [bookings, profileRow, communications] = await Promise.all([
-      db.prepare(
-        `SELECT ${BOOKING_COLUMNS} FROM bookings WHERE phone_normalized = ? AND organization_id = ? ORDER BY desired_date DESC, desired_time DESC`
-      ).bind(phone, orgId).all(),
+      db.prepare(`SELECT ${BOOKING_COLUMNS} FROM bookings WHERE phone_normalized = ? AND organization_id = ? ORDER BY desired_date DESC, desired_time DESC`).bind(phone, orgId).all(),
       db.prepare(`SELECT ${PROFILE_COLUMNS} FROM patient_profiles WHERE phone_normalized = ? AND organization_id = ? LIMIT 1`).bind(phone, orgId).first<PatientProfile>(),
-      db.prepare(
-        `SELECT id, channel, direction, summary, actor, created_at AS createdAt
-         FROM patient_communications WHERE phone_normalized = ? AND organization_id = ? ORDER BY created_at DESC LIMIT 200`
-      ).bind(phone, orgId).all(),
+      db.prepare(`SELECT id, channel, direction, summary, actor, created_at AS createdAt
+         FROM patient_communications WHERE phone_normalized = ? AND organization_id = ? ORDER BY created_at DESC LIMIT 200`).bind(phone, orgId).all(),
     ]);
     const rows = bookings.results as unknown as PatientBookingRow[];
     if (!rows.length && !profileRow) return Response.json({ error: "Пацієнта не знайдено" }, { status: 404 });
     const profiles = new Map<string, PatientProfile>();
     if (profileRow) profiles.set(phone, profileRow);
     const [summary] = buildPatientSummaries(rows, profiles);
-    await logSecurityEvent(db, {
-      organizationId: orgId,
-      actorEmail: member.email,
-      action: "patient_record_viewed",
-      resource: "patient",
-      targetId: phone,
-    });
-    return Response.json({
-      patient: summary || null,
-      phone,
-      profile: profileRow || null,
-      bookings: bookings.results,
-      communications: communications.results,
-      staff: member,
-    }, { headers: { "cache-control": "no-store" } });
+    await logSecurityEvent(db, { organizationId: orgId, actorEmail: member.email, action: "patient_record_viewed", resource: "patient", targetId: phone });
+    return Response.json({ patient: summary || null, phone, profile: profileRow || null, bookings: bookings.results, communications: communications.results, staff: member }, { headers: { "cache-control": "no-store" } });
   }
 
   const [bookings, profileRows] = await Promise.all([
@@ -78,13 +59,7 @@ export async function GET(request: Request) {
   const profiles = new Map<string, PatientProfile>();
   for (const row of profileRows.results as unknown as PatientProfile[]) profiles.set(row.phoneNormalized, row);
   const patients = buildPatientSummaries(bookings.results as unknown as PatientBookingRow[], profiles);
-  await logSecurityEvent(db, {
-    organizationId: orgId,
-    actorEmail: member.email,
-    action: "patient_registry_viewed",
-    resource: "patient_registry",
-    details: { rows: patients.length },
-  });
+  await logSecurityEvent(db, { organizationId: orgId, actorEmail: member.email, action: "patient_registry_viewed", resource: "patient_registry", details: { rows: patients.length } });
   return Response.json({ patients, staff: member }, { headers: { "cache-control": "no-store" } });
 }
 
@@ -94,9 +69,7 @@ export async function PUT(request: Request) {
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const member = ctx.member;
-  if (!canManageBookings(member.role)) {
-    return Response.json({ error: "Картку пацієнта може змінювати лише реєстратор або адміністратор" }, { status: 403 });
-  }
+  if (!canManageBookings(member.role)) return Response.json({ error: "Картку пацієнта може змінювати лише реєстратор або адміністратор" }, { status: 403 });
   const parsed = sanitizeProfile(await request.json());
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
   const { profile } = parsed;
@@ -105,18 +78,12 @@ export async function PUT(request: Request) {
     `INSERT INTO patient_profiles
        (organization_id, phone_normalized, display_name, birth_year, birth_date, email, address, tags, notes, do_not_contact, updated_by, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-     ON CONFLICT(phone_normalized) DO UPDATE SET
+     ON CONFLICT(organization_id, phone_normalized) DO UPDATE SET
        display_name = excluded.display_name, birth_year = excluded.birth_year,
        birth_date = excluded.birth_date, email = excluded.email, address = excluded.address,
        tags = excluded.tags, notes = excluded.notes, do_not_contact = excluded.do_not_contact,
-       updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP
-     WHERE patient_profiles.organization_id = excluded.organization_id`
-  ).bind(
-    ctx.organizationId, profile.phoneNormalized, profile.displayName, profile.birthYear,
-    profile.birthDate, profile.email, profile.address,
-    profile.tags, profile.notes, profile.doNotContact, member.email,
-  ).run();
-
+       updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
+  ).bind(ctx.organizationId, profile.phoneNormalized, profile.displayName, profile.birthYear, profile.birthDate, profile.email, profile.address, profile.tags, profile.notes, profile.doNotContact, member.email).run();
   return Response.json({ ok: true, profile: { ...profile, updatedBy: member.email } });
 }
 
@@ -126,24 +93,10 @@ export async function POST(request: Request) {
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const member = ctx.member;
-  if (!canViewPatientRegistry(member.role)) {
-    return Response.json({ error: "Комунікації доступні лише реєстратору або адміністратору" }, { status: 403 });
-  }
+  if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Комунікації доступні лише реєстратору або адміністратору" }, { status: 403 });
   const parsed = sanitizeCommunication(await request.json());
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
   const { communication } = parsed;
-
-  const inserted = await db.prepare(
-    `INSERT INTO patient_communications (organization_id, phone_normalized, channel, direction, summary, actor)
-     VALUES (?, ?, ?, ?, ?, ?)`
-  ).bind(ctx.organizationId, communication.phoneNormalized, communication.channel, communication.direction, communication.summary, member.email).run();
-
-  return Response.json({
-    ok: true,
-    communication: {
-      id: inserted.meta.last_row_id,
-      ...communication,
-      actor: member.email,
-    },
-  });
+  const inserted = await db.prepare(`INSERT INTO patient_communications (organization_id, phone_normalized, channel, direction, summary, actor) VALUES (?, ?, ?, ?, ?, ?)`).bind(ctx.organizationId, communication.phoneNormalized, communication.channel, communication.direction, communication.summary, member.email).run();
+  return Response.json({ ok: true, communication: { id: inserted.meta.last_row_id, ...communication, actor: member.email } });
 }

--- a/drizzle/0035_patient_composite_identity.sql
+++ b/drizzle/0035_patient_composite_identity.sql
@@ -1,0 +1,46 @@
+-- Patient identity is tenant-local: the same normalized phone may belong to
+-- independent patient profiles in different organizations.
+CREATE TABLE `patient_profiles_v2` (
+  `organization_id` integer NOT NULL DEFAULT 1,
+  `phone_normalized` text NOT NULL,
+  `display_name` text NOT NULL DEFAULT '',
+  `birth_year` integer NOT NULL DEFAULT 0,
+  `birth_date` text NOT NULL DEFAULT '',
+  `email` text NOT NULL DEFAULT '',
+  `address` text NOT NULL DEFAULT '',
+  `tags` text NOT NULL DEFAULT '',
+  `notes` text NOT NULL DEFAULT '',
+  `do_not_contact` integer NOT NULL DEFAULT 0,
+  `telegram_chat_id` text NOT NULL DEFAULT '',
+  `updated_by` text NOT NULL,
+  `updated_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`organization_id`, `phone_normalized`)
+);
+--> statement-breakpoint
+INSERT INTO `patient_profiles_v2` (
+  `organization_id`, `phone_normalized`, `display_name`, `birth_year`, `birth_date`,
+  `email`, `address`, `tags`, `notes`, `do_not_contact`, `telegram_chat_id`,
+  `updated_by`, `updated_at`
+)
+SELECT
+  `organization_id`, `phone_normalized`, `display_name`, `birth_year`, `birth_date`,
+  `email`, `address`, `tags`, `notes`, `do_not_contact`, `telegram_chat_id`,
+  `updated_by`, `updated_at`
+FROM `patient_profiles`;
+--> statement-breakpoint
+DROP TABLE `patient_profiles`;
+--> statement-breakpoint
+ALTER TABLE `patient_profiles_v2` RENAME TO `patient_profiles`;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_profiles_phone_idx`
+ON `patient_profiles` (`phone_normalized`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_profiles_org_updated_idx`
+ON `patient_profiles` (`organization_id`, `updated_at`);
+--> statement-breakpoint
+-- Telegram deep-link tokens must carry the tenant so consuming a token cannot
+-- attach a chat to another organization's profile with the same phone.
+ALTER TABLE `telegram_link_tokens` ADD COLUMN `organization_id` integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `telegram_link_tokens_org_phone_idx`
+ON `telegram_link_tokens` (`organization_id`, `phone_normalized`);

--- a/lib/telegram-link.ts
+++ b/lib/telegram-link.ts
@@ -1,47 +1,58 @@
 // Прив'язка Telegram пацієнта: короткоживучі токени для deep-link «Старт»
 // і обробник вхідних оновлень від бота (webhook). Пацієнт натискає «Старт»
-// у боті один раз — ми зіставляємо токен із його телефоном і зберігаємо chat_id.
+// у боті один раз — ми зіставляємо токен із tenant + телефоном і зберігаємо chat_id.
 
 import { hashToken, newSessionToken } from "./auth";
 
 export const TELEGRAM_LINK_TTL_SECONDS = 15 * 60;
 
-// Створює токен, прив'язаний до телефону пацієнта; повертає «сирий» токен для
-// параметра ?start=. У БД зберігаємо лише SHA-256 хеш (як і сесії).
-export async function createTelegramLinkToken(db: D1Database, phoneNormalized: string): Promise<string> {
+export async function createTelegramLinkToken(
+  db: D1Database,
+  phoneNormalized: string,
+  organizationId: number,
+): Promise<string> {
   const rawToken = newSessionToken();
   const tokenHash = await hashToken(rawToken);
   await db.prepare(
-    `INSERT INTO telegram_link_tokens (token_hash, phone_normalized, expires_at)
-     VALUES (?, ?, datetime('now', ?))`
-  ).bind(tokenHash, phoneNormalized, `+${TELEGRAM_LINK_TTL_SECONDS} seconds`).run();
+    `INSERT INTO telegram_link_tokens (token_hash, organization_id, phone_normalized, expires_at)
+     VALUES (?, ?, ?, datetime('now', ?))`
+  ).bind(tokenHash, organizationId, phoneNormalized, `+${TELEGRAM_LINK_TTL_SECONDS} seconds`).run();
   await db.prepare("DELETE FROM telegram_link_tokens WHERE expires_at <= CURRENT_TIMESTAMP").run();
   return rawToken;
 }
 
-// Одноразово споживає токен: повертає телефон і одразу видаляє запис.
-export async function consumeTelegramLinkToken(db: D1Database, rawToken: string): Promise<string> {
+export async function consumeTelegramLinkToken(
+  db: D1Database,
+  rawToken: string,
+): Promise<{ organizationId: number; phone: string } | null> {
   const token = String(rawToken || "").trim();
-  if (!/^[a-f0-9]{64}$/.test(token)) return "";
+  if (!/^[a-f0-9]{64}$/.test(token)) return null;
   const tokenHash = await hashToken(token);
   const row = await db.prepare(
-    `SELECT phone_normalized AS phone FROM telegram_link_tokens
+    `SELECT organization_id AS organizationId, phone_normalized AS phone
+     FROM telegram_link_tokens
      WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP LIMIT 1`
-  ).bind(tokenHash).first<{ phone: string }>().catch(() => null);
+  ).bind(tokenHash).first<{ organizationId: number; phone: string }>().catch(() => null);
   await db.prepare("DELETE FROM telegram_link_tokens WHERE token_hash = ?").bind(tokenHash).run();
-  return row?.phone || "";
+  return row || null;
 }
 
-// Зберігає chat_id у профілі пацієнта (upsert за нормалізованим телефоном).
-export async function linkPatientTelegram(db: D1Database, phoneNormalized: string, chatId: string): Promise<void> {
+export async function linkPatientTelegram(
+  db: D1Database,
+  organizationId: number,
+  phoneNormalized: string,
+  chatId: string,
+): Promise<void> {
   await db.prepare(
-    `INSERT INTO patient_profiles (phone_normalized, telegram_chat_id, updated_by, updated_at)
-     VALUES (?, ?, 'telegram', CURRENT_TIMESTAMP)
-     ON CONFLICT(phone_normalized) DO UPDATE SET telegram_chat_id = excluded.telegram_chat_id, updated_at = CURRENT_TIMESTAMP`
-  ).bind(phoneNormalized, chatId).run();
+    `INSERT INTO patient_profiles (organization_id, phone_normalized, telegram_chat_id, updated_by, updated_at)
+     VALUES (?, ?, ?, 'telegram', CURRENT_TIMESTAMP)
+     ON CONFLICT(organization_id, phone_normalized) DO UPDATE SET
+       telegram_chat_id = excluded.telegram_chat_id, updated_by = 'telegram', updated_at = CURRENT_TIMESTAMP`
+  ).bind(organizationId, phoneNormalized, chatId).run();
 }
 
-// Видаляє прив'язку (пацієнт написав /stop).
+// /stop is bot-wide consent revocation for this chat. If the same human linked
+// the same bot in more than one tenant, remove every matching link.
 export async function unlinkPatientTelegram(db: D1Database, chatId: string): Promise<void> {
   await db.prepare(
     "UPDATE patient_profiles SET telegram_chat_id = '', updated_at = CURRENT_TIMESTAMP WHERE telegram_chat_id = ?"
@@ -52,8 +63,6 @@ interface TelegramUpdate {
   message?: { chat?: { id?: number | string }; text?: string };
 }
 
-// Обробляє одне оновлення від бота. Повертає текст відповіді пацієнту або "".
-// Best-effort: не кидає винятків, невідомі команди ігнорує.
 export async function handleTelegramUpdate(db: D1Database, update: TelegramUpdate): Promise<{ chatId: string; reply: string }> {
   const chatId = update?.message?.chat?.id != null ? String(update.message.chat.id) : "";
   const text = (update?.message?.text || "").trim();
@@ -68,10 +77,10 @@ export async function handleTelegramUpdate(db: D1Database, update: TelegramUpdat
   if (!m) {
     return { chatId, reply: "Щоб підключити сповіщення, відкрийте кабінет на сайті й натисніть «Підключити Telegram»." };
   }
-  const phone = await consumeTelegramLinkToken(db, m[1]);
-  if (!phone) {
+  const target = await consumeTelegramLinkToken(db, m[1]);
+  if (!target) {
     return { chatId, reply: "Посилання застаріло. Відкрийте кабінет і натисніть «Підключити Telegram» ще раз." };
   }
-  await linkPatientTelegram(db, phone, chatId);
+  await linkPatientTelegram(db, target.organizationId, target.phone, chatId);
   return { chatId, reply: "✅ Готово! Сповіщення про ваші дослідження надходитимуть у цей чат." };
 }

--- a/tests/patient-import-guard.test.mjs
+++ b/tests/patient-import-guard.test.mjs
@@ -3,10 +3,6 @@ import { readFile, readdir } from "node:fs/promises";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
-// Регресія: повторний імпорт CSV лише з телефон+ПІБ раніше затирав раніше
-// введені поля картки (birth_date/email/address/birth_year). Тепер кожне
-// поле оновлюється лише коли нове значення непорожнє.
-
 async function freshDb() {
   const dir = new URL("../drizzle/", import.meta.url);
   const files = (await readdir(dir)).filter((f) => f.endsWith(".sql")).sort();
@@ -19,9 +15,9 @@ async function freshDb() {
 }
 
 const UPSERT_SQL = `INSERT INTO patient_profiles
-     (phone_normalized, display_name, birth_year, birth_date, email, address, tags, notes, do_not_contact, updated_by, updated_at)
-   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-   ON CONFLICT(phone_normalized) DO UPDATE SET
+     (organization_id, phone_normalized, display_name, birth_year, birth_date, email, address, tags, notes, do_not_contact, updated_by, updated_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+   ON CONFLICT(organization_id, phone_normalized) DO UPDATE SET
      display_name = CASE WHEN excluded.display_name != '' THEN excluded.display_name ELSE patient_profiles.display_name END,
      birth_year = CASE WHEN excluded.birth_year != 0 THEN excluded.birth_year ELSE patient_profiles.birth_year END,
      birth_date = CASE WHEN excluded.birth_date != '' THEN excluded.birth_date ELSE patient_profiles.birth_date END,
@@ -32,47 +28,29 @@ const UPSERT_SQL = `INSERT INTO patient_profiles
 
 test("re-import with only phone+name preserves existing card fields", async () => {
   const db = await freshDb();
-  // Перший імпорт — повна картка.
-  db.prepare(UPSERT_SQL).run(
-    "380971112233", "Іван Петренко", 1985, "1985-03-10", "ivan@example.com", "Київ, вул. Тестова 1",
-    "", "нотатка", 0, "admin@clinic",
-  );
-  // Повторний імпорт того ж телефону — лише ПІБ, решта порожня.
-  db.prepare(UPSERT_SQL).run(
-    "380971112233", "Іван Петренко", 0, "", "", "",
-    "", "", 0, "registrar@clinic",
-  );
-  const row = db.prepare("SELECT * FROM patient_profiles WHERE phone_normalized = ?").get("380971112233");
-  assert.equal(row.birth_date, "1985-03-10", "дата народження збережена");
-  assert.equal(row.birth_year, 1985, "рік народження збережений");
-  assert.equal(row.email, "ivan@example.com", "email збережений");
-  assert.equal(row.address, "Київ, вул. Тестова 1", "адреса збережена");
-  assert.equal(row.notes, "нотатка", "нотатка збережена");
-  assert.equal(row.display_name, "Іван Петренко");
+  db.prepare(UPSERT_SQL).run(1, "380971112233", "Іван Петренко", 1985, "1985-03-10", "ivan@example.com", "Київ, вул. Тестова 1", "", "нотатка", 0, "admin@clinic");
+  db.prepare(UPSERT_SQL).run(1, "380971112233", "Іван Петренко", 0, "", "", "", "", "", 0, "registrar@clinic");
+  const row = db.prepare("SELECT * FROM patient_profiles WHERE organization_id = 1 AND phone_normalized = ?").get("380971112233");
+  assert.equal(row.birth_date, "1985-03-10");
+  assert.equal(row.birth_year, 1985);
+  assert.equal(row.email, "ivan@example.com");
+  assert.equal(row.address, "Київ, вул. Тестова 1");
+  assert.equal(row.notes, "нотатка");
 });
 
-test("re-import with new non-empty values does overwrite", async () => {
+test("same phone can coexist independently in two tenants", async () => {
   const db = await freshDb();
-  db.prepare(UPSERT_SQL).run(
-    "380971112233", "Іван П.", 1985, "1985-03-10", "old@example.com", "Стара адреса",
-    "", "", 0, "admin@clinic",
-  );
-  db.prepare(UPSERT_SQL).run(
-    "380971112233", "Іван Петренко", 1986, "1986-04-11", "new@example.com", "Нова адреса",
-    "", "", 0, "admin@clinic",
-  );
-  const row = db.prepare("SELECT * FROM patient_profiles WHERE phone_normalized = ?").get("380971112233");
-  assert.equal(row.birth_date, "1986-04-11");
-  assert.equal(row.birth_year, 1986);
-  assert.equal(row.email, "new@example.com");
-  assert.equal(row.address, "Нова адреса");
-  assert.equal(row.display_name, "Іван Петренко");
+  db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'second', 'Second', 1)").run();
+  db.prepare(UPSERT_SQL).run(1, "380971112233", "Org One", 1985, "", "one@example.com", "", "", "", 0, "one@staff");
+  db.prepare(UPSERT_SQL).run(2, "380971112233", "Org Two", 1990, "", "two@example.com", "", "", "", 0, "two@staff");
+  const rows = db.prepare("SELECT organization_id, display_name, email FROM patient_profiles WHERE phone_normalized = ? ORDER BY organization_id").all("380971112233");
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows.map((r) => [r.organization_id, r.display_name, r.email]), [[1, "Org One", "one@example.com"], [2, "Org Two", "two@example.com"]]);
 });
 
-test("import route source guards each card field on conflict", async () => {
+test("import route uses the tenant composite conflict target", async () => {
   const route = await readFile(new URL("../app/api/staff/patients/import/route.ts", import.meta.url), "utf8");
-  for (const col of ["birth_date", "email", "address"]) {
-    assert.match(route, new RegExp(`${col} = CASE WHEN excluded.${col} != ''`), `${col} guarded`);
-  }
+  assert.match(route, /ON CONFLICT\(organization_id, phone_normalized\)/);
+  for (const col of ["birth_date", "email", "address"]) assert.match(route, new RegExp(`${col} = CASE WHEN excluded.${col} != ''`));
   assert.match(route, /birth_year = CASE WHEN excluded\.birth_year != 0/);
 });

--- a/tests/patient-registry-tenant-guard.test.mjs
+++ b/tests/patient-registry-tenant-guard.test.mjs
@@ -6,6 +6,8 @@ const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
 test("patient registry route scopes audit and upsert by organization", async () => {
   const route = await read("app/api/staff/patients/route.ts");
+  const migration = await read("drizzle/0035_patient_composite_identity.sql");
   assert.match(route, /organizationId: orgId/);
-  assert.match(route, /WHERE patient_profiles\.organization_id = excluded\.organization_id/);
+  assert.match(route, /ON CONFLICT\(organization_id, phone_normalized\) DO UPDATE SET/);
+  assert.match(migration, /PRIMARY KEY \(`organization_id`, `phone_normalized`\)/);
 });

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -4,33 +4,33 @@ import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-test("migration adds patient telegram_chat_id and link-token table", async () => {
-  const sql = await read("drizzle/0025_patient_telegram.sql");
-  assert.match(sql, /ALTER TABLE `patient_profiles` ADD COLUMN `telegram_chat_id`/);
-  assert.match(sql, /CREATE TABLE IF NOT EXISTS `telegram_link_tokens`/);
-  assert.match(sql, /`token_hash` text PRIMARY KEY/);
-  assert.match(sql, /`expires_at` text NOT NULL/);
+test("migrations add patient Telegram fields and tenant link tokens", async () => {
+  const base = await read("drizzle/0025_patient_telegram.sql");
+  const composite = await read("drizzle/0035_patient_composite_identity.sql");
+  assert.match(base, /ALTER TABLE `patient_profiles` ADD COLUMN `telegram_chat_id`/);
+  assert.match(base, /CREATE TABLE IF NOT EXISTS `telegram_link_tokens`/);
+  assert.match(base, /`token_hash` text PRIMARY KEY/);
+  assert.match(composite, /ALTER TABLE `telegram_link_tokens` ADD COLUMN `organization_id`/);
+  assert.match(composite, /PRIMARY KEY \(`organization_id`, `phone_normalized`\)/);
 });
 
-test("link lib: single-use hashed tokens + /start webhook handler", async () => {
+test("link lib: single-use hashed tenant tokens + /start webhook handler", async () => {
   const lib = await read("lib/telegram-link.ts");
   assert.match(lib, /export async function createTelegramLinkToken/);
+  assert.match(lib, /organization_id, phone_normalized/);
   assert.match(lib, /export async function consumeTelegramLinkToken/);
   assert.match(lib, /export async function linkPatientTelegram/);
   assert.match(lib, /export async function handleTelegramUpdate/);
-  // Токен зберігається лише як хеш.
   assert.match(lib, /hashToken\(/);
-  assert.match(lib, /DELETE FROM telegram_link_tokens WHERE token_hash = \?/); // одноразовість
-  // /start <token> прив'язує chat_id; /stop відписує.
-  assert.match(lib, /\/\^\\\/start\\s\+\(\[a-f0-9\]\{64\}\)\$\//);
+  assert.match(lib, /DELETE FROM telegram_link_tokens WHERE token_hash = \?/);
+  assert.match(lib, /ON CONFLICT\(organization_id, phone_normalized\) DO UPDATE SET/);
   assert.match(lib, /\/stop\\b/);
-  assert.match(lib, /ON CONFLICT\(phone_normalized\) DO UPDATE SET telegram_chat_id/);
 });
 
-test("patient link endpoint needs a verified session and returns a t.me deep link", async () => {
+test("patient link endpoint binds a deep link to the verified tenant session", async () => {
   const route = await read("app/api/my-telegram-link/route.ts");
   assert.match(route, /requirePatientSession\(/);
-  assert.match(route, /createTelegramLinkToken\(db, session\.phoneNormalized\)/);
+  assert.match(route, /createTelegramLinkToken\(db, session\.phoneNormalized, session\.organizationId\)/);
   assert.match(route, /https:\/\/t\.me\/\$\{username\}\?start=\$\{token\}/);
   assert.match(route, /isRateLimited\(/);
 });
@@ -64,7 +64,6 @@ test("notify sends via Telegram when a patient linked their chat", async () => {
   const notify = await read("lib/notify.ts");
   assert.match(notify, /import \{ sendTelegramTo \} from ".\/telegram"/);
   assert.match(notify, /telegram_chat_id AS tg/);
-  // Telegram-канал у обох шляхах (авто-нагадування і разове повідомлення).
   const pushes = notify.match(/channel: "telegram"/g) || [];
   assert.ok(pushes.length >= 2, "очікуємо Telegram-канал у reminder і message");
   assert.match(notify, /sendTelegramTo\(db, telegramChatId, body\)/);


### PR DESCRIPTION
Rebuilds patient_profiles with a composite primary key (organization_id, phone_normalized) so the same phone can belong to independent patient profiles in different tenants. Updates staff patient upserts and CSV import conflict targets, and carries organization_id through Telegram link tokens so a deep-link can only attach a chat to the profile in the verified patient session's tenant. Includes migration and regression coverage for same-phone coexistence across org1/org2. No deployment changes.