### PR TITLE
Tenant-scope patient messaging data

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -46,8 +46,17 @@ function truthy(value: string): boolean {
   return ["1", "true", "on", "yes"].includes(value.trim().toLowerCase());
 }
 
+async function bookingOrganizationId(db: D1Database, bookingId: number): Promise<number> {
+  const row = await db.prepare(
+    "SELECT organization_id AS organizationId FROM bookings WHERE id = ? LIMIT 1"
+  ).bind(bookingId).first<{ organizationId: number }>().catch(() => null);
+  const id = Number(row?.organizationId || 0);
+  return Number.isInteger(id) && id > 0 ? id : 0;
+}
+
 async function record(
   db: D1Database,
+  organizationId: number,
   booking: ReminderBooking,
   kind: string,
   channel: Channel,
@@ -57,18 +66,33 @@ async function record(
   error: string,
 ): Promise<void> {
   await db.prepare(
-    `INSERT INTO patient_notifications (booking_id, kind, channel, recipient, body, status, error, sent_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, CASE WHEN ? = 'sent' THEN CURRENT_TIMESTAMP ELSE '' END)`
-  ).bind(booking.id, kind, channel, recipient, body, status, error.slice(0, 240), status).run();
+    `INSERT INTO patient_notifications
+       (organization_id, booking_id, kind, channel, recipient, body, status, error, sent_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, CASE WHEN ? = 'sent' THEN CURRENT_TIMESTAMP ELSE '' END)`
+  ).bind(organizationId, booking.id, kind, channel, recipient, body, status, error.slice(0, 240), status).run();
   if (status === "sent" && booking.phoneNormalized) {
     const label = kind === "confirmed" ? "Автонагадування (підтвердження)"
       : kind === "rescheduled" ? "Автонагадування (перенесення)"
         : "Повідомлення персоналу";
     await db.prepare(
-      `INSERT INTO patient_communications (phone_normalized, channel, direction, summary, actor)
-       VALUES (?, ?, 'outbound', ?, 'system')`
-    ).bind(booking.phoneNormalized, channel, `${label}: ${body}`.slice(0, 500)).run();
+      `INSERT INTO patient_communications
+         (organization_id, phone_normalized, channel, direction, summary, actor)
+       VALUES (?, ?, ?, 'outbound', ?, 'system')`
+    ).bind(organizationId, booking.phoneNormalized, channel, `${label}: ${body}`.slice(0, 500)).run();
   }
+}
+
+async function patientMessagingProfile(
+  db: D1Database,
+  organizationId: number,
+  phoneNormalized: string,
+): Promise<{ dnc: number; tg: string } | null> {
+  if (!phoneNormalized || !organizationId) return null;
+  return db.prepare(
+    `SELECT do_not_contact AS dnc, telegram_chat_id AS tg
+     FROM patient_profiles
+     WHERE organization_id = ? AND phone_normalized = ? LIMIT 1`
+  ).bind(organizationId, phoneNormalized).first<{ dnc: number; tg: string }>().catch(() => null);
 }
 
 // Ставить нагадування в чергу і намагається відправити наявними каналами.
@@ -79,6 +103,8 @@ export async function sendPatientReminder(
   booking: ReminderBooking,
 ): Promise<ReminderSummary> {
   const summary: ReminderSummary = { sent: 0, skipped: 0, failed: 0 };
+  const organizationId = await bookingOrganizationId(db, booking.id);
+  if (!organizationId) return summary;
   const body = reminderText(kind, booking);
 
   const cfg = await getSettings(db, [
@@ -88,20 +114,16 @@ export async function sendPatientReminder(
   ]);
   const enabled = truthy(cfg.patient_reminders_enabled || "");
 
-  // Доставлення абстраговане месенджинг-провайдером (див. lib/providers).
   const messaging = createMessagingProvider({
     sms: { url: cfg.sms_gateway_url || "", auth: cfg.sms_gateway_auth || "" },
     email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
   });
 
-  // Повага до позначки «не турбувати» у картці пацієнта + chat_id для Telegram.
   let telegramChatId = "";
   if (booking.phoneNormalized) {
-    const profile = await db.prepare(
-      "SELECT do_not_contact AS dnc, telegram_chat_id AS tg FROM patient_profiles WHERE phone_normalized = ?"
-    ).bind(booking.phoneNormalized).first<{ dnc: number; tg: string }>().catch(() => null);
+    const profile = await patientMessagingProfile(db, organizationId, booking.phoneNormalized);
     if (profile?.dnc) {
-      await record(db, booking, kind, "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
+      await record(db, organizationId, booking, kind, "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
       summary.skipped += 1;
       return summary;
     }
@@ -141,21 +163,21 @@ export async function sendPatientReminder(
 
   for (const ch of channels) {
     if (!enabled) {
-      await record(db, booking, kind, ch.channel, ch.recipient, body, "skipped", "Нагадування вимкнено в налаштуваннях");
+      await record(db, organizationId, booking, kind, ch.channel, ch.recipient, body, "skipped", "Нагадування вимкнено в налаштуваннях");
       summary.skipped += 1;
       continue;
     }
     if (!ch.url) {
-      await record(db, booking, kind, ch.channel, ch.recipient, body, "skipped", `Шлюз ${ch.channel.toUpperCase()} не налаштовано`);
+      await record(db, organizationId, booking, kind, ch.channel, ch.recipient, body, "skipped", `Шлюз ${ch.channel.toUpperCase()} не налаштовано`);
       summary.skipped += 1;
       continue;
     }
     try {
       await ch.send();
-      await record(db, booking, kind, ch.channel, ch.recipient, body, "sent", "");
+      await record(db, organizationId, booking, kind, ch.channel, ch.recipient, body, "sent", "");
       summary.sent += 1;
     } catch (error) {
-      await record(db, booking, kind, ch.channel, ch.recipient, body, "failed", error instanceof Error ? error.message : "Помилка відправлення");
+      await record(db, organizationId, booking, kind, ch.channel, ch.recipient, body, "failed", error instanceof Error ? error.message : "Помилка відправлення");
       summary.failed += 1;
     }
   }
@@ -171,6 +193,8 @@ export async function sendPatientMessage(
   text: string,
 ): Promise<ReminderSummary> {
   const summary: ReminderSummary = { sent: 0, skipped: 0, failed: 0 };
+  const organizationId = await bookingOrganizationId(db, booking.id);
+  if (!organizationId) return summary;
   const body = (text || "").trim();
   if (!body) return summary;
 
@@ -186,11 +210,9 @@ export async function sendPatientMessage(
 
   let telegramChatId = "";
   if (booking.phoneNormalized) {
-    const profile = await db.prepare(
-      "SELECT do_not_contact AS dnc, telegram_chat_id AS tg FROM patient_profiles WHERE phone_normalized = ?"
-    ).bind(booking.phoneNormalized).first<{ dnc: number; tg: string }>().catch(() => null);
+    const profile = await patientMessagingProfile(db, organizationId, booking.phoneNormalized);
     if (profile?.dnc) {
-      await record(db, booking, "custom", "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
+      await record(db, organizationId, booking, "custom", "sms", booking.phone, body, "skipped", "Пацієнт у списку «не турбувати»");
       summary.skipped += 1;
       return summary;
     }
@@ -220,16 +242,16 @@ export async function sendPatientMessage(
 
   for (const ch of channels) {
     if (!ch.url) {
-      await record(db, booking, "custom", ch.channel, ch.recipient, body, "skipped", `Шлюз ${ch.channel.toUpperCase()} не налаштовано`);
+      await record(db, organizationId, booking, "custom", ch.channel, ch.recipient, body, "skipped", `Шлюз ${ch.channel.toUpperCase()} не налаштовано`);
       summary.skipped += 1;
       continue;
     }
     try {
       await ch.send();
-      await record(db, booking, "custom", ch.channel, ch.recipient, body, "sent", "");
+      await record(db, organizationId, booking, "custom", ch.channel, ch.recipient, body, "sent", "");
       summary.sent += 1;
     } catch (error) {
-      await record(db, booking, "custom", ch.channel, ch.recipient, body, "failed", error instanceof Error ? error.message : "Помилка відправлення");
+      await record(db, organizationId, booking, "custom", ch.channel, ch.recipient, body, "failed", error instanceof Error ? error.message : "Помилка відправлення");
       summary.failed += 1;
     }
   }

--- a/tests/notify.behavior.test.mjs
+++ b/tests/notify.behavior.test.mjs
@@ -22,7 +22,7 @@ test("do-not-contact is respected: message is skipped, nothing sent", async () =
   await withD1(async (db) => {
     await seedBooking(db, { id: 1, phoneNormalized: "380971112233" });
     await db.prepare(
-      "INSERT INTO patient_profiles (phone_normalized, do_not_contact, updated_by) VALUES (?, 1, 'test')"
+      "INSERT INTO patient_profiles (organization_id, phone_normalized, do_not_contact, updated_by) VALUES (1, ?, 1, 'test')"
     ).bind("380971112233").run();
     const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
     const res = await notify(db, cookie, 1);
@@ -30,7 +30,6 @@ test("do-not-contact is respected: message is skipped, nothing sent", async () =
     const { summary } = await res.json();
     assert.equal(summary.sent, 0);
     assert.ok(summary.skipped >= 1, "має бути пропущено через «не турбувати»");
-    // У журналі — саме skipped, без жодного sent.
     const sent = await db.prepare("SELECT COUNT(*) AS n FROM patient_notifications WHERE status = 'sent'").first("n");
     assert.equal(sent, 0);
     const skipped = await db.prepare("SELECT COUNT(*) AS n FROM patient_notifications WHERE status = 'skipped'").first("n");
@@ -45,23 +44,21 @@ test("with no gateways configured nothing is sent (channel gated on config)", as
     const res = await notify(db, cookie, 2);
     assert.equal(res.status, 200);
     const { summary } = await res.json();
-    assert.equal(summary.sent, 0);       // SMS-шлюз не налаштований → нічого не відправлено
-    assert.equal(summary.failed, 0);     // і не «провал» — саме «пропущено»
+    assert.equal(summary.sent, 0);
+    assert.equal(summary.failed, 0);
     assert.ok(summary.skipped >= 1);
   });
 });
 
 test("a message to a booking in another organization is not found (tenant isolation)", async () => {
   await withD1(async (db) => {
-    // Друга організація + її заявка.
     await db.prepare(
       "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Інша', 1)"
     ).run();
     await seedBooking(db, { id: 3, phoneNormalized: "380973334455", orgId: 2 });
-    // Адмін автоматично прив'язується до організації з найменшим id (=1).
     const cookie = await seedStaffSession(db, { email: "admin2@likarnya.test", role: "admin" });
     const res = await notify(db, cookie, 3);
-    assert.equal(res.status, 404); // заявка чужої організації недосяжна
+    assert.equal(res.status, 404);
   });
 });
 
@@ -70,6 +67,33 @@ test("a clinical role may still send an ad-hoc message (canWriteNotes)", async (
     await seedBooking(db, { id: 4, phoneNormalized: "380974445566" });
     const cookie = await seedStaffSession(db, { email: "rad@likarnya.test", role: "radiologist" });
     const res = await notify(db, cookie, 4);
-    assert.equal(res.status, 200); // лікар-рентгенолог має право повідомляти
+    assert.equal(res.status, 200);
+  });
+});
+
+test("same phone in another tenant does not inherit DNC and outbox stays in booking tenant", async () => {
+  await withD1(async (db) => {
+    const phone = "380975556677";
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'notify-two', 'Notify Two', 1)").run();
+    await db.prepare(
+      `INSERT INTO patient_profiles (organization_id, phone_normalized, display_name, do_not_contact, updated_by)
+       VALUES (1, ?, 'Org1 Patient', 1, 'test'), (2, ?, 'Org2 Patient', 0, 'test')`
+    ).bind(phone, phone).run();
+    await seedBooking(db, { id: 5, phoneNormalized: phone, orgId: 2 });
+    const cookie = await seedStaffSession(db, { email: "reg-org2@likarnya.test", role: "registrar", organizationId: 2 });
+
+    const res = await notify(db, cookie, 5);
+    assert.equal(res.status, 200);
+    const { summary } = await res.json();
+    assert.equal(summary.sent, 0);
+    assert.ok(summary.skipped >= 1);
+
+    const rows = await db.prepare(
+      `SELECT organization_id AS organizationId, error
+       FROM patient_notifications WHERE booking_id = 5 ORDER BY id`
+    ).all();
+    assert.ok(rows.results.length >= 1);
+    assert.ok(rows.results.every((row) => row.organizationId === 2));
+    assert.ok(rows.results.every((row) => !String(row.error).includes("не турбувати")));
   });
 });


### PR DESCRIPTION
Tenant-scopes patient messaging data without changing booking callers. The notify engine derives the authoritative organization from the booking row, then uses it for patient profile/DNC/Telegram lookup and explicitly writes organization_id to patient_notifications and patient_communications. Includes a behavioral regression where the same phone exists in org1 and org2: org1 DNC must not suppress org2 messaging, and all outbox rows remain in org2. Messaging credentials remain unchanged in this PR and are handled separately. No deployment changes.