### PR TITLE
Add read-only study workflow Kanban

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,3 +15,4 @@
 @import "./styles/12-design-system.css";
 @import "./styles/13-dashboard-monitor.css";
 @import "./styles/14-resource-planner.css";
+@import "./styles/15-study-kanban.css";

--- a/app/staff/board/page.tsx
+++ b/app/staff/board/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { stateLabel } from "../../../lib/study-state";
+
+type StaffInfo = { email:string; displayName:string; role:string };
+type Booking = {
+  id:number; code:string; name:string; phone:string; service:string; equipmentId:string;
+  desiredDate:string; desiredTime:string; status:string; patientCategory?:string;
+  paymentStatus?:string; assignedRadiologistEmail?:string;
+};
+
+type Column = {
+  key:string;
+  title:string;
+  hint:string;
+  states:string[];
+};
+
+const COLUMNS:Column[] = [
+  {
+    key:"planned",
+    title:"Заплановано",
+    hint:"Заявки та підтверджені записи",
+    states:["new","requested","needs_verification","scheduled","rescheduled","confirmed"],
+  },
+  {
+    key:"arrived",
+    title:"Прибув",
+    hint:"Пацієнт уже у відділенні",
+    states:["arrived"],
+  },
+  {
+    key:"inroom",
+    title:"У кабінеті",
+    hint:"Черга та виконання дослідження",
+    states:["queued","in_progress"],
+  },
+  {
+    key:"reporting",
+    title:"Очікує опису",
+    hint:"Знімки є, протокол ще не готовий",
+    states:["performed","images_ready","reporting"],
+  },
+  {
+    key:"ready",
+    title:"Готово / видано",
+    hint:"Протокол готовий або результат видано",
+    states:["protocol_ready","issued","completed"],
+  },
+];
+
+const EQUIPMENT:Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
+const isContrast = (service:string) => /контраст|ангіограф/i.test(service || "");
+
+function todayKyiv() {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone:"Europe/Kyiv", year:"numeric", month:"2-digit", day:"2-digit",
+  }).format(new Date());
+}
+
+function patientRoute(booking:Booking) {
+  if (["performed","images_ready","reporting","protocol_ready","issued","completed"].includes(booking.status)) {
+    return `/staff/protocols?open=${booking.id}`;
+  }
+  return `/staff/appointments?date=${encodeURIComponent(booking.desiredDate)}&view=list`;
+}
+
+export default function StudyBoardPage() {
+  const [bookings,setBookings] = useState<Booking[]>([]);
+  const [staff,setStaff] = useState<StaffInfo | null>(null);
+  const [date,setDate] = useState(todayKyiv());
+  const [query,setQuery] = useState("");
+  const [loaded,setLoaded] = useState(false);
+  const [error,setError] = useState("");
+
+  async function load() {
+    const res = await fetch("/api/staff/bookings", { cache:"no-store" });
+    const payload = await res.json().catch(()=>({})) as { bookings?:Booking[]; staff?:StaffInfo; error?:string };
+    if (!res.ok || !payload.staff) {
+      setError(payload.error || "Немає доступу");
+      setLoaded(true);
+      return;
+    }
+    setBookings(payload.bookings || []);
+    setStaff(payload.staff);
+    setError("");
+    setLoaded(true);
+  }
+
+  useEffect(()=>{
+    const timer = window.setTimeout(()=>{ void load(); },0);
+    return ()=>window.clearTimeout(timer);
+  },[]);
+
+  const scoped = useMemo(()=>{
+    const q = query.trim().toLowerCase();
+    return bookings
+      .filter((b)=>b.desiredDate === date)
+      .filter((b)=>!["cancelled","no_show"].includes(b.status))
+      .filter((b)=>!q || `${b.name} ${b.phone} ${b.code} ${b.service}`.toLowerCase().includes(q))
+      .sort((a,b)=>(a.desiredTime || "").localeCompare(b.desiredTime || ""));
+  },[bookings,date,query]);
+
+  const exceptions = useMemo(()=>bookings
+    .filter((b)=>b.desiredDate === date && ["cancelled","no_show"].includes(b.status))
+    .sort((a,b)=>(a.desiredTime || "").localeCompare(b.desiredTime || "")),
+  [bookings,date]);
+
+  return <StaffWorkspaceShell
+    active="board"
+    title="Дошка досліджень"
+    description="Операційний потік дня: від запису пацієнта до готового та виданого результату."
+    staffName={staff?.displayName || staff?.email}
+    staffRole={staff?.role}
+  >
+    {error ? <section className="accessDenied"><b>Захищений розділ</b><p>{error}</p><a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Fboard">Увійти</a></section>
+      : !loaded ? <p className="dashLoading">Завантаження дошки…</p>
+      : <section className="studyBoardShell">
+          <div className="studyBoardToolbar">
+            <label><span>Дата</span><input type="date" value={date} onChange={(e)=>setDate(e.target.value)} /></label>
+            <label className="studyBoardSearch"><span>Пошук</span><input type="search" value={query} onChange={(e)=>setQuery(e.target.value)} placeholder="Пацієнт, телефон, код, послуга" /></label>
+            <button type="button" onClick={()=>void load()}>Оновити</button>
+            <a href="/staff/appointments">Планувальник</a>
+          </div>
+
+          <div className="studyBoardSummary" aria-label="Стан потоку">
+            {COLUMNS.map((column)=>{
+              const count = scoped.filter((b)=>column.states.includes(b.status)).length;
+              return <span key={column.key}><b>{count}</b>{column.title}</span>;
+            })}
+          </div>
+
+          <div className="studyKanban" aria-label="Канбан досліджень">
+            {COLUMNS.map((column)=>{
+              const items = scoped.filter((b)=>column.states.includes(b.status));
+              return <section className={`studyKanbanColumn col-${column.key}`} key={column.key}>
+                <header>
+                  <div><h2>{column.title}</h2><p>{column.hint}</p></div>
+                  <span>{items.length}</span>
+                </header>
+                <div className="studyKanbanCards">
+                  {items.length === 0 ? <p className="studyKanbanEmpty">Немає записів</p> : items.map((booking)=><a className={`studyKanbanCard mod-${booking.equipmentId || "other"}`} href={patientRoute(booking)} key={booking.id}>
+                    <div className="studyKanbanCardTop">
+                      <time>{booking.desiredTime || "—"}</time>
+                      <span>{EQUIPMENT[booking.equipmentId] || booking.equipmentId || "Дослідження"}</span>
+                    </div>
+                    <b>{booking.name || "Без імені"}</b>
+                    <p>{booking.service}</p>
+                    <div className="studyKanbanTags">
+                      <span className={`studyStateTag st-${booking.status}`}>{stateLabel(booking.status)}</span>
+                      {isContrast(booking.service) && <span className="studyTag contrast">Контраст</span>}
+                      {booking.patientCategory === "civilian" && booking.paymentStatus !== "paid" && <span className="studyTag pay">Оплата</span>}
+                    </div>
+                    <small>{booking.code}</small>
+                  </a>)}
+                </div>
+              </section>;
+            })}
+          </div>
+
+          {exceptions.length > 0 && <details className="studyBoardExceptions">
+            <summary>Скасовані / неявка <span>{exceptions.length}</span></summary>
+            <div>{exceptions.map((b)=><a href={`/staff/appointments?date=${encodeURIComponent(b.desiredDate)}&view=list`} key={b.id}><time>{b.desiredTime}</time><b>{b.name || "Без імені"}</b><span>{stateLabel(b.status)}</span></a>)}</div>
+          </details>}
+        </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import CommandPalette from "./command-palette";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -16,25 +16,19 @@ type StaffWorkspaceShellProps = {
   children: ReactNode;
 };
 
-// Бічна панель: угорі «Огляд» — найчастіші екрани реєстратури; нижче
-// «Модулі» — робочі напрями, згруповані за призначенням. Кожен модуль
-// веде на головну сторінку напряму й розгортається у підпункти-екрани.
 type NavChild = { label:string; href:string };
 type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
-// section — головний розділ модуля; sections — усі розділи, що його підсвічують.
 type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
-// Меню за процесом роботи, а не за модулями системи: як думає відділення —
-// Прийом → Розклад → Опис → Видача. Пульт зверху як загальний огляд дня.
 const processRail: NavLink[] = [
   { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
   { label:"Прийом", href:"/staff/intake", section:"intake", icon:"📥" },
   { label:"Розклад", href:"/staff/appointments", section:"appointments", icon:"🗓️" },
+  { label:"Дошка", href:"/staff/board", section:"board", icon:"▦" },
   { label:"Опис", href:"/staff/protocols", section:"protocols", icon:"✍️" },
   { label:"Видача", href:"/staff/studies", section:"studies", icon:"✅" },
 ];
 
-// Модулі — усе, що поза щоденним потоком: довідники, фінанси, адміністрування.
 const systemModules: NavModule[] = [
   { label:"Пацієнти", href:"/staff/patients", sections:["patients","chat"], icon:"👥", items:[
     { label:"Картки пацієнтів", href:"/staff/patients" },
@@ -125,9 +119,7 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
-  // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
-  // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
-  const wide = active === "dashboard" || active === "appointments" || active === "intake";
+  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
     <aside className="workspaceSidebar">
@@ -149,8 +141,6 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = item.sections.includes(active);
-          // Акордеон: типово розгорнутий лише модуль поточного розділу, решта
-          // згорнуті в один рядок. Користувач може розгортати вручну.
           const isOpen = openModules[item.href] ?? isActive;
           return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">
@@ -218,14 +208,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "equipment" ? "Обладнання":active === "services" ? "Послуги кабінетів":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Публічний сайт":active === "schedule" ? "Графік кабінетів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "structure" ? "Структура відділення":active === "audit" ? "Журнал дій":active === "intake" ? "Дошка прийому":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "equipment" ? "Обладнання":active === "services" ? "Послуги кабінетів":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "board" ? "Дошка досліджень":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Публічний сайт":active === "schedule" ? "Графік кабінетів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "structure" ? "Структура відділення":active === "audit" ? "Журнал дій":active === "intake" ? "Дошка прийому":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "equipment" || active === "services" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "whatsapp" || active === "chat" || active === "schedule" || active === "structure" || active === "audit" || active === "intake"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "equipment" || active === "services" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "board" || active === "whatsapp" || active === "chat" || active === "schedule" || active === "structure" || active === "audit" || active === "intake"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -16,10 +16,16 @@ type StaffWorkspaceShellProps = {
   children: ReactNode;
 };
 
+// Бічна панель: угорі «Огляд» — найчастіші екрани реєстратури; нижче
+// «Модулі» — робочі напрями, згруповані за призначенням. Кожен модуль
+// веде на головну сторінку напряму й розгортається у підпункти-екрани.
 type NavChild = { label:string; href:string };
 type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
+// section — головний розділ модуля; sections — усі розділи, що його підсвічують.
 type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
+// Меню за процесом роботи, а не за модулями системи: як думає відділення —
+// Прийом → Розклад → Дошка → Опис → Видача. Пульт зверху як загальний огляд дня.
 const processRail: NavLink[] = [
   { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
   { label:"Прийом", href:"/staff/intake", section:"intake", icon:"📥" },
@@ -29,6 +35,7 @@ const processRail: NavLink[] = [
   { label:"Видача", href:"/staff/studies", section:"studies", icon:"✅" },
 ];
 
+// Модулі — усе, що поза щоденним потоком: довідники, фінанси, адміністрування.
 const systemModules: NavModule[] = [
   { label:"Пацієнти", href:"/staff/patients", sections:["patients","chat"], icon:"👥", items:[
     { label:"Картки пацієнтів", href:"/staff/patients" },
@@ -119,6 +126,8 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
+  // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
+  // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
   const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
@@ -141,6 +150,8 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = item.sections.includes(active);
+          // Акордеон: типово розгорнутий лише модуль поточного розділу, решта
+          // згорнуті в один рядок. Користувач може розгортати вручну.
           const isOpen = openModules[item.href] ?? isActive;
           return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">

--- a/app/styles/15-study-kanban.css
+++ b/app/styles/15-study-kanban.css
@@ -1,0 +1,423 @@
+/* Study workflow Kanban: operational, read-only view of the clinical lifecycle. */
+
+.workspaceShell .workspaceModuleLink[href="/staff/board"] {
+  --ws-nav-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='5' height='16' rx='1'/%3E%3Crect x='10' y='4' width='5' height='11' rx='1'/%3E%3Crect x='17' y='4' width='4' height='8' rx='1'/%3E%3C/svg%3E");
+}
+
+.workspaceShell .studyBoardShell {
+  display: grid;
+  gap: 12px;
+}
+
+.workspaceShell .studyBoardToolbar {
+  display: flex;
+  align-items: end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--ws-line);
+  border-radius: var(--ws-radius-md);
+  background: var(--ws-surface);
+  box-shadow: var(--ws-shadow-sm);
+}
+
+.workspaceShell .studyBoardToolbar label {
+  display: grid;
+  gap: 4px;
+}
+
+.workspaceShell .studyBoardToolbar label > span {
+  color: var(--ws-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.workspaceShell .studyBoardToolbar input,
+.workspaceShell .studyBoardToolbar button,
+.workspaceShell .studyBoardToolbar a {
+  min-height: 34px;
+  border-radius: var(--ws-radius-sm);
+}
+
+.workspaceShell .studyBoardToolbar input {
+  border: 1px solid var(--ws-line);
+  background: var(--ws-surface-subtle);
+  color: var(--ws-ink);
+}
+
+.workspaceShell .studyBoardSearch {
+  flex: 1 1 320px;
+}
+
+.workspaceShell .studyBoardSearch input {
+  width: 100%;
+}
+
+.workspaceShell .studyBoardToolbar button,
+.workspaceShell .studyBoardToolbar a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--ws-line);
+  background: var(--ws-surface-subtle);
+  color: var(--ws-ink);
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.workspaceShell .studyBoardToolbar button:hover,
+.workspaceShell .studyBoardToolbar a:hover {
+  border-color: rgba(37,99,235,.3);
+  background: var(--ws-accent-soft);
+  color: var(--ws-accent);
+}
+
+.workspaceShell .studyBoardSummary {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.workspaceShell .studyBoardSummary > span {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px 10px;
+  border: 1px solid var(--ws-line);
+  border-radius: 9px;
+  background: var(--ws-surface);
+  color: var(--ws-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.workspaceShell .studyBoardSummary b {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 26px;
+  padding: 0 7px;
+  border-radius: 8px;
+  background: var(--ws-surface-subtle);
+  color: var(--ws-ink);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+
+.workspaceShell .studyKanban {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(245px, 1fr));
+  gap: 9px;
+  align-items: start;
+  overflow-x: auto;
+  padding-bottom: 5px;
+  scrollbar-width: thin;
+}
+
+.workspaceShell .studyKanbanColumn {
+  min-width: 245px;
+  border: 1px solid var(--ws-line);
+  border-radius: var(--ws-radius-md);
+  background: var(--ws-surface-subtle);
+  overflow: hidden;
+}
+
+.workspaceShell .studyKanbanColumn > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 70px;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--ws-line);
+  background: var(--ws-surface);
+}
+
+.workspaceShell .studyKanbanColumn > header h2 {
+  margin: 0;
+  color: var(--ws-ink);
+  font-size: 13px;
+  line-height: 1.25;
+  letter-spacing: -.01em;
+}
+
+.workspaceShell .studyKanbanColumn > header p {
+  margin: 4px 0 0;
+  color: var(--ws-muted);
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.workspaceShell .studyKanbanColumn > header > span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 24px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--ws-accent-soft);
+  color: var(--ws-accent);
+  font-size: 11px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.workspaceShell .studyKanbanCards {
+  display: grid;
+  gap: 7px;
+  min-height: 132px;
+  max-height: calc(100vh - 330px);
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.workspaceShell .studyKanbanCard {
+  position: relative;
+  display: grid;
+  gap: 5px;
+  padding: 10px 10px 9px 13px;
+  border: 1px solid var(--ws-line);
+  border-radius: 9px;
+  background: var(--ws-surface);
+  color: var(--ws-ink);
+  text-decoration: none;
+  box-shadow: 0 1px 2px rgba(16,24,40,.035);
+  overflow: hidden;
+  transition: border-color .12s ease, box-shadow .12s ease, transform .12s ease;
+}
+
+.workspaceShell .studyKanbanCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: #94a3b8;
+}
+
+.workspaceShell .studyKanbanCard.mod-ct::before { background: #2563eb; }
+.workspaceShell .studyKanbanCard.mod-xray::before { background: #7c3aed; }
+.workspaceShell .studyKanbanCard.mod-fluoro::before { background: #0891b2; }
+
+.workspaceShell .studyKanbanCard:hover {
+  border-color: rgba(37,99,235,.35);
+  box-shadow: 0 5px 16px rgba(16,24,40,.09);
+  transform: translateY(-1px);
+}
+
+.workspaceShell .studyKanbanCardTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.workspaceShell .studyKanbanCardTop time {
+  color: var(--ws-ink);
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.workspaceShell .studyKanbanCardTop > span {
+  color: var(--ws-muted);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.workspaceShell .studyKanbanCard > b {
+  overflow: hidden;
+  color: var(--ws-ink);
+  font-size: 13px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspaceShell .studyKanbanCard > p {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  color: var(--ws-muted);
+  font-size: 11px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.workspaceShell .studyKanbanCard > small {
+  color: var(--ws-muted);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .03em;
+}
+
+.workspaceShell .studyKanbanTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.workspaceShell .studyStateTag,
+.workspaceShell .studyTag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  font-size: 9px;
+  line-height: 1;
+  font-weight: 800;
+}
+
+.workspaceShell .studyStateTag {
+  background: rgba(148,163,184,.12);
+  color: var(--ws-muted);
+}
+
+.workspaceShell .studyStateTag.st-arrived,
+.workspaceShell .studyStateTag.st-queued,
+.workspaceShell .studyStateTag.st-in_progress {
+  background: rgba(217,119,6,.11);
+  color: #b45309;
+}
+
+.workspaceShell .studyStateTag.st-performed,
+.workspaceShell .studyStateTag.st-images_ready,
+.workspaceShell .studyStateTag.st-reporting {
+  background: rgba(37,99,235,.11);
+  color: #2563eb;
+}
+
+.workspaceShell .studyStateTag.st-protocol_ready,
+.workspaceShell .studyStateTag.st-issued,
+.workspaceShell .studyStateTag.st-completed {
+  background: rgba(22,163,74,.11);
+  color: #15803d;
+}
+
+.workspaceShell .studyTag.contrast {
+  background: rgba(124,58,237,.1);
+  color: #7c3aed;
+}
+
+.workspaceShell .studyTag.pay {
+  background: rgba(220,38,38,.1);
+  color: #b91c1c;
+}
+
+.workspaceShell .studyKanbanEmpty {
+  margin: 14px 6px;
+  color: var(--ws-muted);
+  font-size: 11px;
+  text-align: center;
+}
+
+.workspaceShell .studyBoardExceptions {
+  border: 1px solid var(--ws-line);
+  border-radius: var(--ws-radius-md);
+  background: var(--ws-surface);
+  overflow: hidden;
+}
+
+.workspaceShell .studyBoardExceptions summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 12px;
+  color: var(--ws-muted);
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.workspaceShell .studyBoardExceptions summary span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 21px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(148,163,184,.12);
+}
+
+.workspaceShell .studyBoardExceptions > div {
+  border-top: 1px solid var(--ws-line);
+}
+
+.workspaceShell .studyBoardExceptions > div a {
+  display: grid;
+  grid-template-columns: 72px minmax(0,1fr) auto;
+  gap: 9px;
+  align-items: center;
+  min-height: 38px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--ws-line);
+  color: var(--ws-ink);
+  font-size: 11px;
+  text-decoration: none;
+}
+
+.workspaceShell .studyBoardExceptions > div a:last-child { border-bottom: 0; }
+.workspaceShell .studyBoardExceptions time { font-variant-numeric: tabular-nums; }
+.workspaceShell .studyBoardExceptions > div a span { color: var(--ws-muted); }
+
+.workspaceShell.themeDark .studyKanbanCard {
+  box-shadow: none;
+}
+
+.workspaceShell.themeDark .studyKanbanCard:hover {
+  box-shadow: 0 5px 16px rgba(0,0,0,.26);
+}
+
+.workspaceShell.themeDark .studyStateTag.st-arrived,
+.workspaceShell.themeDark .studyStateTag.st-queued,
+.workspaceShell.themeDark .studyStateTag.st-in_progress { color: #fbbf24; }
+.workspaceShell.themeDark .studyStateTag.st-performed,
+.workspaceShell.themeDark .studyStateTag.st-images_ready,
+.workspaceShell.themeDark .studyStateTag.st-reporting { color: #93c5fd; }
+.workspaceShell.themeDark .studyStateTag.st-protocol_ready,
+.workspaceShell.themeDark .studyStateTag.st-issued,
+.workspaceShell.themeDark .studyStateTag.st-completed { color: #86efac; }
+.workspaceShell.themeDark .studyTag.contrast { color: #c4b5fd; }
+.workspaceShell.themeDark .studyTag.pay { color: #fca5a5; }
+
+@media (max-width: 1120px) {
+  .workspaceShell .studyBoardSummary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .workspaceShell .studyKanban {
+    grid-template-columns: repeat(5, 260px);
+  }
+}
+
+@media (max-width: 700px) {
+  .workspaceShell .studyBoardSummary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .workspaceShell .studyBoardToolbar {
+    align-items: stretch;
+  }
+  .workspaceShell .studyBoardToolbar label,
+  .workspaceShell .studyBoardToolbar button,
+  .workspaceShell .studyBoardToolbar a {
+    width: 100%;
+  }
+  .workspaceShell .studyKanbanCards {
+    max-height: 60vh;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspaceShell .studyKanbanCard { transition: none; }
+  .workspaceShell .studyKanbanCard:hover { transform: none; }
+}

--- a/tests/study-kanban-design.test.mjs
+++ b/tests/study-kanban-design.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("study Kanban is a read-only projection of the existing booking workflow", async () => {
+  const page = await read("app/staff/board/page.tsx");
+
+  assert.match(page, /fetch\("\/api\/staff\/bookings", \{ cache:"no-store" \}\)/);
+  assert.doesNotMatch(page, /method\s*:\s*["']PATCH["']/);
+  assert.doesNotMatch(page, /onDrop|draggable\s*=|dragstart/i);
+  assert.match(page, /states:\["new","requested","needs_verification","scheduled","rescheduled","confirmed"\]/);
+  assert.match(page, /states:\["arrived"\]/);
+  assert.match(page, /states:\["queued","in_progress"\]/);
+  assert.match(page, /states:\["performed","images_ready","reporting"\]/);
+  assert.match(page, /states:\["protocol_ready","issued","completed"\]/);
+});
+
+test("study Kanban is integrated into the staff workspace and visual cascade", async () => {
+  const [shell, globals, css] = await Promise.all([
+    read("app/staff/workspace-shell.tsx"),
+    read("app/globals.css"),
+    read("app/styles/15-study-kanban.css"),
+  ]);
+
+  assert.match(shell, /"board"/);
+  assert.match(shell, /href:"\/staff\/board"/);
+  assert.match(shell, /active === "board"/);
+  const planner = globals.indexOf('@import "./styles/14-resource-planner.css";');
+  const kanban = globals.indexOf('@import "./styles/15-study-kanban.css";');
+  assert.notEqual(planner, -1);
+  assert.notEqual(kanban, -1);
+  assert.ok(kanban > planner);
+  assert.match(css, /workspaceModuleLink\[href="\/staff\/board"\]/);
+  assert.match(css, /grid-template-columns: repeat\(5, minmax\(245px, 1fr\)\)/);
+  assert.match(css, /prefers-reduced-motion/);
+});


### PR DESCRIPTION
Adds a BAS-inspired operational Kanban for the radiology study lifecycle while preserving the existing deny-by-default clinical state machine. The board projects current bookings into five workflow columns: planned, arrived, in room, awaiting report, and ready/issued. It supports date filtering, search, modality/status/payment/contrast indicators, and links into the existing planner/protocol workspaces. The initial board is intentionally read-only: it performs no PATCH, drag/drop, or status mutation. Adds the board to the staff process rail, a consistent line icon, responsive/dark styling, and regression tests that enforce the read-only safety property.