### PR TITLE
Add tenant-scoped staff tasks

### DIFF
--- a/app/api/staff/tasks/route.ts
+++ b/app/api/staff/tasks/route.ts
@@ -1,0 +1,149 @@
+import { audit } from "../../../../lib/audit";
+import { dbBinding } from "../../../../lib/db";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+type TaskRow = {
+  id:number;
+  title:string;
+  details:string;
+  status:"open"|"done";
+  priority:"low"|"normal"|"high";
+  dueDate:string;
+  bookingId:number|null;
+  assignedEmail:string;
+  createdBy:string;
+  completedBy:string;
+  completedAt:string;
+  createdAt:string;
+  updatedAt:string;
+};
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const PRIORITIES = new Set(["low","normal","high"]);
+
+async function activeMember(db:D1Database, organizationId:number, email:string) {
+  if (!email) return true;
+  const row = await db.prepare(
+    `SELECT 1 AS ok FROM memberships m
+     JOIN staff_members s ON s.email = m.member_email
+     WHERE m.organization_id = ? AND m.member_email = ? AND m.active = 1 AND s.active = 1
+     LIMIT 1`
+  ).bind(organizationId,email).first<{ok:number}>();
+  return !!row?.ok;
+}
+
+async function bookingBelongsToOrg(db:D1Database, organizationId:number, bookingId:number|null) {
+  if (!bookingId) return true;
+  const row = await db.prepare("SELECT 1 AS ok FROM bookings WHERE organization_id = ? AND id = ? LIMIT 1")
+    .bind(organizationId,bookingId).first<{ok:number}>();
+  return !!row?.ok;
+}
+
+export async function GET(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+
+  const url = new URL(request.url);
+  const status = url.searchParams.get("status");
+  const mine = url.searchParams.get("mine") === "1";
+  const where = ["organization_id = ?"];
+  const binds:(string|number)[] = [ctx.organizationId];
+  if (status === "open" || status === "done") { where.push("status = ?"); binds.push(status); }
+  if (mine) { where.push("assigned_email = ?"); binds.push(ctx.member.email); }
+
+  const rows = await db.prepare(
+    `SELECT id, title, details, status, priority,
+            due_date AS dueDate, booking_id AS bookingId,
+            assigned_email AS assignedEmail, created_by AS createdBy,
+            completed_by AS completedBy, completed_at AS completedAt,
+            created_at AS createdAt, updated_at AS updatedAt
+     FROM staff_tasks
+     WHERE ${where.join(" AND ")}
+     ORDER BY CASE status WHEN 'open' THEN 0 ELSE 1 END,
+              CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+              CASE WHEN due_date = '' THEN 1 ELSE 0 END, due_date, id DESC
+     LIMIT 500`
+  ).bind(...binds).all<TaskRow>();
+
+  const members = await db.prepare(
+    `SELECT s.email, s.display_name AS displayName, m.role
+     FROM memberships m JOIN staff_members s ON s.email = m.member_email
+     WHERE m.organization_id = ? AND m.active = 1 AND s.active = 1
+     ORDER BY s.display_name, s.email`
+  ).bind(ctx.organizationId).all<{email:string;displayName:string;role:string}>();
+
+  return Response.json({ tasks:rows.results, members:members.results, staff:ctx.member });
+}
+
+export async function POST(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+
+  const body = await request.json().catch(()=>({})) as {
+    title?:string;details?:string;priority?:string;dueDate?:string;assignedEmail?:string;bookingId?:number|null;
+  };
+  const title = String(body.title || "").trim().slice(0,180);
+  const details = String(body.details || "").trim().slice(0,4000);
+  const priority = PRIORITIES.has(String(body.priority)) ? String(body.priority) : "normal";
+  const dueDate = String(body.dueDate || "").trim();
+  const assignedEmail = String(body.assignedEmail || "").trim().toLowerCase().slice(0,254);
+  const bookingId = Number.isInteger(Number(body.bookingId)) && Number(body.bookingId) > 0 ? Number(body.bookingId) : null;
+
+  if (!title) return Response.json({ error:"Вкажіть назву завдання" }, { status:400 });
+  if (dueDate && !DATE_RE.test(dueDate)) return Response.json({ error:"Некоректна дата виконання" }, { status:400 });
+  if (!(await activeMember(db,ctx.organizationId,assignedEmail))) return Response.json({ error:"Виконавець не належить до цієї організації" }, { status:400 });
+  if (!(await bookingBelongsToOrg(db,ctx.organizationId,bookingId))) return Response.json({ error:"Дослідження не належить до цієї організації" }, { status:400 });
+
+  const result = await db.prepare(
+    `INSERT INTO staff_tasks
+      (organization_id,title,details,status,priority,due_date,booking_id,assigned_email,created_by)
+     VALUES (?,?,?,'open',?,?,?,?,?)`
+  ).bind(ctx.organizationId,title,details,priority,dueDate,bookingId,assignedEmail,ctx.member.email).run();
+  const id = Number(result.meta.last_row_id || 0);
+  await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"task_created", resource:"task", targetId:id, details:{ priority, assigned:!!assignedEmail, linkedBooking:!!bookingId } });
+  return Response.json({ ok:true,id }, { status:201 });
+}
+
+export async function PATCH(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request,db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+
+  const body = await request.json().catch(()=>({})) as { id?:number;status?:string;assignedEmail?:string;priority?:string;dueDate?:string };
+  const id = Number(body.id);
+  if (!Number.isInteger(id) || id < 1) return Response.json({ error:"Некоректне завдання" }, { status:400 });
+
+  const existing = await db.prepare(
+    `SELECT id, status, assigned_email AS assignedEmail, created_by AS createdBy
+     FROM staff_tasks WHERE organization_id = ? AND id = ? LIMIT 1`
+  ).bind(ctx.organizationId,id).first<{id:number;status:string;assignedEmail:string;createdBy:string}>();
+  if (!existing) return Response.json({ error:"Завдання не знайдено" }, { status:404 });
+  const canEdit = ctx.role === "admin" || existing.assignedEmail === ctx.member.email || existing.createdBy === ctx.member.email;
+  if (!canEdit) return Response.json({ error:"Немає прав змінювати це завдання" }, { status:403 });
+
+  const status = body.status === "done" ? "done" : body.status === "open" ? "open" : existing.status;
+  const assignedEmail = body.assignedEmail === undefined ? existing.assignedEmail : String(body.assignedEmail || "").trim().toLowerCase().slice(0,254);
+  const priority = body.priority === undefined ? null : PRIORITIES.has(String(body.priority)) ? String(body.priority) : null;
+  const dueDate = body.dueDate === undefined ? null : String(body.dueDate || "").trim();
+  if (body.priority !== undefined && !priority) return Response.json({ error:"Некоректний пріоритет" }, { status:400 });
+  if (dueDate !== null && dueDate && !DATE_RE.test(dueDate)) return Response.json({ error:"Некоректна дата" }, { status:400 });
+  if (!(await activeMember(db,ctx.organizationId,assignedEmail))) return Response.json({ error:"Виконавець не належить до цієї організації" }, { status:400 });
+
+  await db.prepare(
+    `UPDATE staff_tasks SET
+       status = ?, assigned_email = ?,
+       priority = COALESCE(?, priority), due_date = COALESCE(?, due_date),
+       completed_by = CASE WHEN ? = 'done' THEN ? ELSE '' END,
+       completed_at = CASE WHEN ? = 'done' THEN CURRENT_TIMESTAMP ELSE '' END,
+       updated_at = CURRENT_TIMESTAMP
+     WHERE organization_id = ? AND id = ?`
+  ).bind(status,assignedEmail,priority,dueDate,status,ctx.member.email,status,ctx.organizationId,id).run();
+
+  await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:status === "done" && existing.status !== "done" ? "task_completed" : "task_updated", resource:"task", targetId:id, details:{ status } });
+  return Response.json({ ok:true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,3 +16,4 @@
 @import "./styles/13-dashboard-monitor.css";
 @import "./styles/14-resource-planner.css";
 @import "./styles/15-study-kanban.css";
+@import "./styles/16-tasks.css";

--- a/app/staff/tasks/page.tsx
+++ b/app/staff/tasks/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type Task = {
+  id:number;title:string;details:string;status:"open"|"done";priority:"low"|"normal"|"high";
+  dueDate:string;bookingId:number|null;assignedEmail:string;createdBy:string;completedBy:string;
+  completedAt:string;createdAt:string;updatedAt:string;
+};
+type Member = { email:string;displayName:string;role:string };
+type Staff = { email:string;displayName:string;role:string };
+
+type Payload = { tasks:Task[];members:Member[];staff:Staff };
+const priorityLabel:Record<Task["priority"],string> = { high:"Високий",normal:"Звичайний",low:"Низький" };
+
+function todayKyiv() {
+  return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+
+export default function TasksPage() {
+  const [data,setData] = useState<Payload|null>(null);
+  const [error,setError] = useState("");
+  const [loaded,setLoaded] = useState(false);
+  const [mode,setMode] = useState<"open"|"done">("open");
+  const [mine,setMine] = useState(false);
+  const [busy,setBusy] = useState<number|null>(null);
+  const [creating,setCreating] = useState(false);
+  const [form,setForm] = useState({ title:"",details:"",priority:"normal",dueDate:"",assignedEmail:"" });
+
+  async function load() {
+    const res = await fetch("/api/staff/tasks",{cache:"no-store"});
+    const payload = await res.json().catch(()=>({})) as Payload & {error?:string};
+    if (!res.ok || !payload.staff) { setError(payload.error || "Не вдалося завантажити завдання"); setLoaded(true); return; }
+    setData(payload); setError(""); setLoaded(true);
+  }
+  useEffect(()=>{ const t=window.setTimeout(()=>void load(),0); return()=>window.clearTimeout(t); },[]);
+
+  const nameByEmail = useMemo(()=>Object.fromEntries((data?.members||[]).map(m=>[m.email,m.displayName||m.email])),[data]);
+  const tasks = useMemo(()=>{
+    let list=(data?.tasks||[]).filter(t=>t.status===mode);
+    if(mine) list=list.filter(t=>t.assignedEmail===data?.staff.email);
+    return list;
+  },[data,mode,mine]);
+  const today=todayKyiv();
+  const overdue=(t:Task)=>t.status==="open" && !!t.dueDate && t.dueDate<today;
+
+  async function createTask() {
+    if(!form.title.trim()) return;
+    const res=await fetch("/api/staff/tasks",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(form)});
+    const payload=await res.json().catch(()=>({})) as {error?:string};
+    if(!res.ok){setError(payload.error||"Не вдалося створити завдання");return;}
+    setCreating(false);setForm({title:"",details:"",priority:"normal",dueDate:"",assignedEmail:""});await load();
+  }
+
+  async function patchTask(id:number,body:Record<string,unknown>) {
+    setBusy(id);
+    try {
+      const res=await fetch("/api/staff/tasks",{method:"PATCH",headers:{"content-type":"application/json"},body:JSON.stringify({id,...body})});
+      const payload=await res.json().catch(()=>({})) as {error?:string};
+      if(!res.ok){setError(payload.error||"Не вдалося змінити завдання");return;}
+      await load();
+    } finally {setBusy(null);}
+  }
+
+  return <StaffWorkspaceShell active="tasks" title="Завдання" description="Особисті й командні задачі відділення: відповідальний, термін, пріоритет і контроль виконання." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
+    {error && <p className="notice error" role="alert">{error}</p>}
+    {!loaded ? <p className="dashLoading">Завантаження завдань…</p> : !data ? null : <section className="taskWorkspace">
+      <div className="taskToolbar">
+        <div className="taskSegments">
+          <button className={mode==="open"?"on":""} onClick={()=>setMode("open")}>В роботі</button>
+          <button className={mode==="done"?"on":""} onClick={()=>setMode("done")}>Виконані</button>
+        </div>
+        <label className="taskMine"><input type="checkbox" checked={mine} onChange={e=>setMine(e.target.checked)}/> Тільки мої</label>
+        <button className="taskNew" onClick={()=>setCreating(v=>!v)}>{creating?"Закрити":"+ Нове завдання"}</button>
+      </div>
+
+      {creating && <div className="taskCreate">
+        <label><span>Назва</span><input value={form.title} onChange={e=>setForm(f=>({...f,title:e.target.value}))} maxLength={180} placeholder="Що потрібно зробити"/></label>
+        <label><span>Деталі</span><textarea value={form.details} onChange={e=>setForm(f=>({...f,details:e.target.value}))} rows={3} placeholder="Контекст, результат, примітки"/></label>
+        <div className="taskCreateRow">
+          <label><span>Пріоритет</span><select value={form.priority} onChange={e=>setForm(f=>({...f,priority:e.target.value}))}><option value="high">Високий</option><option value="normal">Звичайний</option><option value="low">Низький</option></select></label>
+          <label><span>До дати</span><input type="date" value={form.dueDate} onChange={e=>setForm(f=>({...f,dueDate:e.target.value}))}/></label>
+          <label><span>Виконавець</span><select value={form.assignedEmail} onChange={e=>setForm(f=>({...f,assignedEmail:e.target.value}))}><option value="">Без виконавця</option>{data.members.map(m=><option key={m.email} value={m.email}>{m.displayName||m.email}</option>)}</select></label>
+        </div>
+        <button className="taskSave" disabled={!form.title.trim()} onClick={()=>void createTask()}>Створити завдання</button>
+      </div>}
+
+      <div className="taskSummary">
+        <span><b>{(data.tasks||[]).filter(t=>t.status==="open").length}</b>В роботі</span>
+        <span className="warn"><b>{(data.tasks||[]).filter(overdue).length}</b>Прострочено</span>
+        <span><b>{(data.tasks||[]).filter(t=>t.status==="open"&&t.assignedEmail===data.staff.email).length}</b>Мої</span>
+      </div>
+
+      <div className="taskList">
+        {tasks.length===0 ? <p className="taskEmpty">Завдань у цьому списку немає.</p> : tasks.map(t=><article className={`taskCard priority-${t.priority}${overdue(t)?" overdue":""}`} key={t.id}>
+          <div className="taskCardMain">
+            <div className="taskCardTop"><span className={`taskPriority ${t.priority}`}>{priorityLabel[t.priority]}</span>{overdue(t)&&<span className="taskOverdue">Прострочено</span>}</div>
+            <h2>{t.title}</h2>
+            {t.details&&<p>{t.details}</p>}
+            <div className="taskMeta">
+              {t.assignedEmail?<span>Виконавець: <b>{nameByEmail[t.assignedEmail]||t.assignedEmail}</b></span>:<span>Без виконавця</span>}
+              {t.dueDate&&<span>До: <b>{t.dueDate}</b></span>}
+              {t.bookingId&&<a href={`/staff/protocols?open=${t.bookingId}`}>Дослідження #{t.bookingId}</a>}
+            </div>
+          </div>
+          <div className="taskActions">
+            {t.status==="open"?<button disabled={busy===t.id} onClick={()=>void patchTask(t.id,{status:"done"})}>{busy===t.id?"…":"✓ Виконано"}</button>:<button disabled={busy===t.id} onClick={()=>void patchTask(t.id,{status:"open"})}>Повернути в роботу</button>}
+          </div>
+        </article>)}
+      </div>
+    </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import CommandPalette from "./command-palette";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -25,12 +25,13 @@ type NavLink = { label:string; href:string; section:WorkspaceSection; icon:strin
 type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
 // Меню за процесом роботи, а не за модулями системи: як думає відділення —
-// Прийом → Розклад → Дошка → Опис → Видача. Пульт зверху як загальний огляд дня.
+// Прийом → Розклад → Дошка → Завдання → Опис → Видача. Пульт зверху як загальний огляд дня.
 const processRail: NavLink[] = [
   { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
   { label:"Прийом", href:"/staff/intake", section:"intake", icon:"📥" },
   { label:"Розклад", href:"/staff/appointments", section:"appointments", icon:"🗓️" },
   { label:"Дошка", href:"/staff/board", section:"board", icon:"▦" },
+  { label:"Завдання", href:"/staff/tasks", section:"tasks", icon:"☑" },
   { label:"Опис", href:"/staff/protocols", section:"protocols", icon:"✍️" },
   { label:"Видача", href:"/staff/studies", section:"studies", icon:"✅" },
 ];
@@ -128,7 +129,7 @@ export default function StaffWorkspaceShell({
 
   // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
   // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
-  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board";
+  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board" || active === "tasks";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
     <aside className="workspaceSidebar">
@@ -219,14 +220,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "equipment" ? "Обладнання":active === "services" ? "Послуги кабінетів":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "board" ? "Дошка досліджень":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Публічний сайт":active === "schedule" ? "Графік кабінетів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "structure" ? "Структура відділення":active === "audit" ? "Журнал дій":active === "intake" ? "Дошка прийому":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "equipment" ? "Обладнання":active === "services" ? "Послуги кабінетів":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "board" ? "Дошка досліджень":active === "tasks" ? "Завдання":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Публічний сайт":active === "schedule" ? "Графік кабінетів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "structure" ? "Структура відділення":active === "audit" ? "Журнал дій":active === "intake" ? "Дошка прийому":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "equipment" || active === "services" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "board" || active === "whatsapp" || active === "chat" || active === "schedule" || active === "structure" || active === "audit" || active === "intake"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "equipment" || active === "services" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "board" || active === "tasks" || active === "whatsapp" || active === "chat" || active === "schedule" || active === "structure" || active === "audit" || active === "intake"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/app/styles/16-tasks.css
+++ b/app/styles/16-tasks.css
@@ -1,0 +1,69 @@
+/* Staff tasks: compact operational follow-up workspace. */
+.workspaceShell .workspaceModuleLink[href="/staff/tasks"] {
+  --ws-nav-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 11l3 3L22 4'/%3E%3Cpath d='M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11'/%3E%3C/svg%3E");
+}
+
+.workspaceShell .taskWorkspace { display:grid; gap:12px; }
+.workspaceShell .taskToolbar {
+  display:flex; align-items:center; gap:9px; flex-wrap:wrap;
+  padding:10px 12px; border:1px solid var(--ws-line); border-radius:var(--ws-radius-md);
+  background:var(--ws-surface); box-shadow:var(--ws-shadow-sm);
+}
+.workspaceShell .taskSegments { display:inline-flex; gap:3px; padding:3px; border:1px solid var(--ws-line); border-radius:10px; background:var(--ws-surface-subtle); }
+.workspaceShell .taskSegments button,.workspaceShell .taskNew,.workspaceShell .taskSave,.workspaceShell .taskActions button {
+  min-height:32px; border-radius:var(--ws-radius-sm); font-weight:700;
+}
+.workspaceShell .taskSegments button { border:0; background:transparent; color:var(--ws-muted); padding:0 11px; }
+.workspaceShell .taskSegments button.on { background:var(--ws-accent-soft); color:var(--ws-accent); }
+.workspaceShell .taskMine { display:inline-flex; align-items:center; gap:6px; color:var(--ws-muted); font-size:12px; font-weight:700; }
+.workspaceShell .taskNew { margin-left:auto; }
+
+.workspaceShell .taskCreate {
+  display:grid; gap:10px; padding:14px; border:1px solid rgba(37,99,235,.22); border-radius:var(--ws-radius-md);
+  background:color-mix(in srgb,var(--ws-accent-soft) 45%,var(--ws-surface));
+}
+.workspaceShell .taskCreate label { display:grid; gap:4px; }
+.workspaceShell .taskCreate label>span { color:var(--ws-muted); font-size:10px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; }
+.workspaceShell .taskCreate :where(input,select,textarea) { width:100%; border:1px solid var(--ws-line); background:var(--ws-surface); color:var(--ws-ink); }
+.workspaceShell .taskCreateRow { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:9px; }
+.workspaceShell .taskSave { justify-self:start; }
+
+.workspaceShell .taskSummary { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; }
+.workspaceShell .taskSummary span { display:flex; align-items:center; gap:9px; min-height:46px; padding:8px 11px; border:1px solid var(--ws-line); border-radius:9px; background:var(--ws-surface); color:var(--ws-muted); font-size:11px; font-weight:700; }
+.workspaceShell .taskSummary b { font-size:20px; color:var(--ws-ink); font-variant-numeric:tabular-nums; }
+.workspaceShell .taskSummary .warn b { color:#b45309; }
+
+.workspaceShell .taskList { display:grid; gap:7px; }
+.workspaceShell .taskCard {
+  position:relative; display:grid; grid-template-columns:minmax(0,1fr) auto; gap:12px; align-items:center;
+  padding:12px 13px 12px 16px; border:1px solid var(--ws-line); border-radius:10px; background:var(--ws-surface); box-shadow:var(--ws-shadow-sm); overflow:hidden;
+}
+.workspaceShell .taskCard::before { content:""; position:absolute; inset:0 auto 0 0; width:4px; background:#94a3b8; }
+.workspaceShell .taskCard.priority-high::before { background:#dc2626; }
+.workspaceShell .taskCard.priority-normal::before { background:#2563eb; }
+.workspaceShell .taskCard.priority-low::before { background:#64748b; }
+.workspaceShell .taskCard.overdue { border-color:rgba(217,119,6,.34); }
+.workspaceShell .taskCardTop { display:flex; align-items:center; gap:5px; }
+.workspaceShell .taskPriority,.workspaceShell .taskOverdue { display:inline-flex; align-items:center; min-height:20px; padding:0 7px; border-radius:999px; font-size:9px; font-weight:800; }
+.workspaceShell .taskPriority { background:rgba(148,163,184,.12); color:var(--ws-muted); }
+.workspaceShell .taskPriority.high { background:rgba(220,38,38,.1); color:#b91c1c; }
+.workspaceShell .taskPriority.normal { background:rgba(37,99,235,.1); color:#2563eb; }
+.workspaceShell .taskOverdue { background:rgba(217,119,6,.11); color:#b45309; }
+.workspaceShell .taskCard h2 { margin:5px 0 0; color:var(--ws-ink); font-size:14px; letter-spacing:-.01em; }
+.workspaceShell .taskCard p { margin:5px 0 0; color:var(--ws-muted); font-size:11px; line-height:1.45; white-space:pre-wrap; }
+.workspaceShell .taskMeta { display:flex; gap:12px; flex-wrap:wrap; margin-top:8px; color:var(--ws-muted); font-size:10px; }
+.workspaceShell .taskMeta a { color:var(--ws-accent); font-weight:700; }
+.workspaceShell .taskActions button { white-space:nowrap; }
+.workspaceShell .taskEmpty { padding:36px 14px; border:1px dashed var(--ws-line); border-radius:var(--ws-radius-md); color:var(--ws-muted); text-align:center; }
+
+.workspaceShell.themeDark .taskCard { box-shadow:none; }
+.workspaceShell.themeDark .taskPriority.high { color:#fca5a5; }
+.workspaceShell.themeDark .taskPriority.normal { color:#93c5fd; }
+.workspaceShell.themeDark .taskOverdue { color:#fbbf24; }
+
+@media(max-width:760px){
+  .workspaceShell .taskCreateRow,.workspaceShell .taskSummary{grid-template-columns:1fr;}
+  .workspaceShell .taskCard{grid-template-columns:1fr;}
+  .workspaceShell .taskActions button{width:100%;}
+  .workspaceShell .taskNew{margin-left:0;}
+}

--- a/drizzle/0036_staff_tasks.sql
+++ b/drizzle/0036_staff_tasks.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS staff_tasks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  organization_id INTEGER NOT NULL DEFAULT 1,
+  title TEXT NOT NULL,
+  details TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','done')),
+  priority TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('low','normal','high')),
+  due_date TEXT NOT NULL DEFAULT '',
+  booking_id INTEGER,
+  assigned_email TEXT NOT NULL DEFAULT '',
+  created_by TEXT NOT NULL,
+  completed_by TEXT NOT NULL DEFAULT '',
+  completed_at TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS staff_tasks_org_status_due_idx
+ON staff_tasks (organization_id, status, due_date, id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS staff_tasks_org_assignee_idx
+ON staff_tasks (organization_id, assigned_email, status, id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS staff_tasks_org_booking_idx
+ON staff_tasks (organization_id, booking_id, id);

--- a/tests/staff-tasks.behavior.test.mjs
+++ b/tests/staff-tasks.behavior.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+test("staff tasks are tenant scoped and assignees must be active tenant members", async () => {
+  await withD1(async (db, raw) => {
+    raw.exec("INSERT OR IGNORE INTO organizations (id, name, slug, active) VALUES (2, 'Org 2', 'org-2', 1)");
+
+    const org1Cookie = await seedStaffSession(db, { email:"one@example.com", role:"admin", organizationId:1 });
+    const org2Cookie = await seedStaffSession(db, { email:"two@example.com", role:"admin", organizationId:2 });
+    await seedStaffSession(db, { email:"worker2@example.com", role:"radiologist", organizationId:2 });
+
+    const create = await callWorker(jsonRequest("/api/staff/tasks", {
+      title:"Описати контрольне КТ",
+      details:"До кінця зміни",
+      priority:"high",
+      dueDate:"2026-08-15",
+      assignedEmail:"worker2@example.com",
+    }, { headers:{ cookie:org2Cookie } }), db);
+    assert.equal(create.status, 201);
+    const created = await create.json();
+    assert.ok(created.id > 0);
+
+    const org2Row = raw.prepare("SELECT organization_id, assigned_email, title FROM staff_tasks WHERE id = ?").get(created.id);
+    assert.equal(org2Row.organization_id, 2);
+    assert.equal(org2Row.assigned_email, "worker2@example.com");
+
+    const org1List = await callWorker(new Request("http://localhost/api/staff/tasks", { headers:{ cookie:org1Cookie } }), db);
+    assert.equal(org1List.status, 200);
+    const org1Payload = await org1List.json();
+    assert.equal(org1Payload.tasks.some((t) => t.id === created.id), false);
+
+    const crossAssign = await callWorker(jsonRequest("/api/staff/tasks", {
+      title:"Не повинно створитися",
+      assignedEmail:"worker2@example.com",
+    }, { headers:{ cookie:org1Cookie } }), db);
+    assert.equal(crossAssign.status, 400);
+
+    const auditRow = raw.prepare("SELECT organization_id, action, target_id FROM security_audit_log WHERE action = 'task_created' ORDER BY id DESC LIMIT 1").get();
+    assert.equal(auditRow.organization_id, 2);
+    assert.equal(auditRow.target_id, String(created.id));
+  });
+});
+
+test("task completion is limited to admin, creator, or assignee", async () => {
+  await withD1(async (db, raw) => {
+    const creatorCookie = await seedStaffSession(db, { email:"creator@example.com", role:"registrar", organizationId:1 });
+    const assigneeCookie = await seedStaffSession(db, { email:"doctor@example.com", role:"radiologist", organizationId:1 });
+    const strangerCookie = await seedStaffSession(db, { email:"other@example.com", role:"radiographer", organizationId:1 });
+
+    const create = await callWorker(jsonRequest("/api/staff/tasks", {
+      title:"Перевірити протокол",
+      assignedEmail:"doctor@example.com",
+    }, { headers:{ cookie:creatorCookie } }), db);
+    const { id } = await create.json();
+
+    const forbidden = await callWorker(jsonRequest("/api/staff/tasks", { id, status:"done" }, {
+      method:"PATCH", headers:{ cookie:strangerCookie },
+    }), db);
+    assert.equal(forbidden.status, 403);
+
+    const complete = await callWorker(jsonRequest("/api/staff/tasks", { id, status:"done" }, {
+      method:"PATCH", headers:{ cookie:assigneeCookie },
+    }), db);
+    assert.equal(complete.status, 200);
+
+    const row = raw.prepare("SELECT status, completed_by, organization_id FROM staff_tasks WHERE id = ?").get(id);
+    assert.equal(row.status, "done");
+    assert.equal(row.completed_by, "doctor@example.com");
+    assert.equal(row.organization_id, 1);
+  });
+});


### PR DESCRIPTION
Adds the BAS-inspired Tasks/Reminders foundation as a real tenant-scoped operational module rather than a decorative screen. Introduces migration 0036 with organization-scoped staff_tasks, a membership-aware API, tenant-scoped assignee and booking validation, creator/assignee/admin update authorization, security audit events, and a staff workspace for priorities, due dates, assignees, overdue indicators and completion. Adds the Tasks step to the process rail with the shared line-icon system and regression/behavioral tests for cross-tenant isolation and task authorization.