### PR TITLE
Fix production admin hash guard offsets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Verify a secure active administrator exists
         run: |
           npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-            --command "WITH admins AS (SELECT password_hash, substr(password_hash,16,instr(substr(password_hash,16),'$')-1) AS iterations FROM staff_members WHERE role = 'admin' AND active = 1) SELECT COUNT(*) AS secure_admins FROM admins WHERE substr(password_hash,1,15) = 'pbkdf2$sha256$' AND length(password_hash) - length(replace(password_hash,'$','')) = 4 AND iterations <> '' AND iterations NOT GLOB '*[^0-9]*' AND CAST(iterations AS INTEGER) >= 1000 AND length(password_hash) >= 80 AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');" \
+            --command "WITH admins AS (SELECT password_hash, substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations FROM staff_members WHERE role = 'admin' AND active = 1) SELECT COUNT(*) AS secure_admins FROM admins WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$' AND length(password_hash) - length(replace(password_hash,'$','')) = 4 AND iterations <> '' AND iterations NOT GLOB '*[^0-9]*' AND CAST(iterations AS INTEGER) >= 1000 AND length(password_hash) >= 80 AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');" \
             > /tmp/radiologyos-secure-admin.json
           node -e '
             const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-secure-admin.json", "utf8"));

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -33,7 +33,7 @@ npx wrangler d1 migrations apply radiologyos --remote --config "${CONFIG}"
 
 echo "[4/5] Verifying a secure active administrator credential…"
 npx wrangler d1 execute radiologyos --remote --config "${CONFIG}" --json \
-  --command "WITH admins AS (SELECT password_hash, substr(password_hash,16,instr(substr(password_hash,16),'$')-1) AS iterations FROM staff_members WHERE role = 'admin' AND active = 1) SELECT COUNT(*) AS secure_admins FROM admins WHERE substr(password_hash,1,15) = 'pbkdf2$sha256$' AND length(password_hash) - length(replace(password_hash,'$','')) = 4 AND iterations <> '' AND iterations NOT GLOB '*[^0-9]*' AND CAST(iterations AS INTEGER) >= 1000 AND length(password_hash) >= 80 AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');" \
+  --command "WITH admins AS (SELECT password_hash, substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations FROM staff_members WHERE role = 'admin' AND active = 1) SELECT COUNT(*) AS secure_admins FROM admins WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$' AND length(password_hash) - length(replace(password_hash,'$','')) = 4 AND iterations <> '' AND iterations NOT GLOB '*[^0-9]*' AND CAST(iterations AS INTEGER) >= 1000 AND length(password_hash) >= 80 AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');" \
   > /tmp/radiologyos-secure-admin.json
 node -e '
   const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-secure-admin.json", "utf8"));

--- a/tests/admin-hash-guard.behavior.test.mjs
+++ b/tests/admin-hash-guard.behavior.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+const COMPROMISED = "pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=";
+const VALID = "pbkdf2$sha256$100000$IWyZk/j3/iTwDlSzXLkzAw==$RokqUfcf533IH0DSwOBb0yLoQvd1qBQ6E0Pp5xCzE5A=";
+
+const SQL = `WITH admins AS (
+  SELECT password_hash,
+         substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations
+  FROM staff_members
+  WHERE role = 'admin' AND active = 1
+)
+SELECT COUNT(*) AS secure_admins
+FROM admins
+WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$'
+  AND length(password_hash) - length(replace(password_hash,'$','')) = 4
+  AND iterations <> ''
+  AND iterations NOT GLOB '*[^0-9]*'
+  AND CAST(iterations AS INTEGER) >= 1000
+  AND length(password_hash) >= 80
+  AND password_hash NOT IN (?);`;
+
+function secureCount(hash) {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE staff_members (role TEXT, active INTEGER, password_hash TEXT)");
+  db.prepare("INSERT INTO staff_members (role, active, password_hash) VALUES ('admin',1,?)").run(hash);
+  const row = db.prepare(SQL).get(COMPROMISED);
+  db.close();
+  return Number(row.secure_admins);
+}
+
+test("production admin hash guard accepts a valid PBKDF2 credential", () => {
+  assert.equal(secureCount(VALID), 1);
+});
+
+test("production admin hash guard rejects placeholders, malformed hashes, weak iterations and compromised seed", () => {
+  assert.equal(secureCount("ВСТАВТЕ_ТУТ_HASH"), 0);
+  assert.equal(secureCount("pbkdf2$sha256$abc$salt$key"), 0);
+  assert.equal(secureCount("pbkdf2$sha256$999$AAAAAAAAAAAAAAAAAAAAAA==$BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="), 0);
+  assert.equal(secureCount(COMPROMISED), 0);
+});

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -72,7 +72,8 @@ test("production deploy paths reject placeholder or malformed administrator hash
     read(".github/workflows/deploy.yml"),
   ]);
   for (const source of [script, workflow]) {
-    assert.match(source, /substr\(password_hash,1,15\) = 'pbkdf2\$sha256\$'/);
+    assert.match(source, /substr\(password_hash,15,instr\(substr\(password_hash,15\),'\$'\)-1\) AS iterations/);
+    assert.match(source, /substr\(password_hash,1,14\) = 'pbkdf2\$sha256\$'/);
     assert.match(source, /length\(password_hash\) - length\(replace\(password_hash,'\$',''\)\) = 4/);
     assert.match(source, /iterations NOT GLOB '\*\[\^0-9\]\*'/);
     assert.match(source, /CAST\(iterations AS INTEGER\) >= 1000/);


### PR DESCRIPTION
Fixes the production deploy guard introduced in #254. The PBKDF2 prefix is 14 characters (`pbkdf2$sha256$`) and the iteration field begins at SQLite position 15; the previous query used 15/16, so every valid administrator credential was rejected and deploy #127 was blocked. Updates both GitHub Actions and the local deploy script, strengthens the static deploy contract test, and adds an in-memory SQLite behavioral test that accepts a real valid PBKDF2 credential while rejecting placeholders, malformed/weak hashes, and the known compromised seed.