### PR TITLE
Make inventory migration compatible with D1

### DIFF
--- a/app/api/staff/inventory/route.ts
+++ b/app/api/staff/inventory/route.ts
@@ -158,15 +158,24 @@ export async function POST(request:Request) {
     const lot = await lotForOrg(db,ctx.organizationId,lotId);
     if (!lot) return Response.json({ error:"Партію не знайдено" }, { status:404 });
     if (!(await bookingForOrg(db,ctx.organizationId,bookingId))) return Response.json({ error:"Дослідження не належить до цієї організації" }, { status:400 });
-    try {
-      await db.prepare(
-        `INSERT INTO inventory_movements (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,booking_id,actor_email)
-         VALUES (?,?,?,'writeoff',-?,?,?,?)`
-      ).bind(ctx.organizationId,lot.itemId,lotId,quantity,reason,bookingId,ctx.member.email).run();
-    } catch (e) {
-      if (String(e).includes("insufficient_stock")) return Response.json({ error:"Недостатній залишок у цій партії" }, { status:409 });
-      throw e;
+
+    const result = await db.prepare(
+      `INSERT INTO inventory_movements
+        (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,booking_id,actor_email)
+       SELECT ?,?,?,'writeoff',-?,?,?,?
+       WHERE COALESCE((
+         SELECT SUM(quantity_delta)
+         FROM inventory_movements
+         WHERE organization_id = ? AND lot_id = ?
+       ),0) + 0.000001 >= ?`
+    ).bind(
+      ctx.organizationId,lot.itemId,lotId,quantity,reason,bookingId,ctx.member.email,
+      ctx.organizationId,lotId,quantity,
+    ).run();
+    if (Number(result.meta.changes || 0) < 1) {
+      return Response.json({ error:"Недостатній залишок у цій партії" }, { status:409 });
     }
+
     await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"inventory_written_off", resource:"inventory", targetId:lot.itemId, details:{ lotId, quantity, linkedBooking:!!bookingId } });
     return Response.json({ ok:true });
   }

--- a/drizzle/0037_inventory_stock.sql
+++ b/drizzle/0037_inventory_stock.sql
@@ -55,16 +55,3 @@ CREATE INDEX IF NOT EXISTS `inventory_movements_org_item_idx`
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS `inventory_movements_org_lot_idx`
   ON `inventory_movements` (`organization_id`, `lot_id`, `id` DESC);
---> statement-breakpoint
-
--- Atomic guard: a write-off can never make a lot balance negative.
-CREATE TRIGGER IF NOT EXISTS `inventory_no_negative_stock`
-BEFORE INSERT ON `inventory_movements`
-WHEN NEW.`quantity_delta` < 0
-BEGIN
-  SELECT CASE WHEN (
-    COALESCE((SELECT SUM(`quantity_delta`) FROM `inventory_movements`
-      WHERE `organization_id` = NEW.`organization_id` AND `lot_id` = NEW.`lot_id`), 0)
-      + NEW.`quantity_delta`
-  ) < -0.000001 THEN RAISE(ABORT, 'insufficient_stock') END;
-END;

--- a/tests/inventory-d1-migration.test.mjs
+++ b/tests/inventory-d1-migration.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("inventory migration avoids trigger bodies that Wrangler splits as incomplete input", async () => {
+  const migration = await read("drizzle/0037_inventory_stock.sql");
+  assert.doesNotMatch(migration, /CREATE\s+TRIGGER/i);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS `inventory_movements`/);
+});
+
+test("inventory write-off uses one conditional insert and checks whether a row was inserted", async () => {
+  const route = await read("app/api/staff/inventory/route.ts");
+  assert.match(route, /INSERT INTO inventory_movements[\s\S]*SELECT \?,\?,\?,'writeoff'/);
+  assert.match(route, /SELECT SUM\(quantity_delta\)[\s\S]*organization_id = \? AND lot_id = \?/);
+  assert.match(route, /result\.meta\.changes/);
+  assert.match(route, /Недостатній залишок у цій партії/);
+});


### PR DESCRIPTION
Fixes deploy #128, where `0037_inventory_stock.sql` failed on remote D1 with `incomplete input`. Removes the SQLite trigger body that Wrangler split incorrectly and preserves negative-stock protection with a single atomic conditional `INSERT ... SELECT` in the inventory write-off API. The write-off only inserts when the tenant-scoped lot balance is sufficient and returns 409 when no row is inserted. Adds a regression test asserting the migration remains trigger-free for Wrangler/D1 and that the API keeps the conditional-insert contract.