### PR TITLE
Preserve PBKDF2 literals in production admin guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,26 @@ jobs:
 
       - name: Verify a secure active administrator exists
         run: |
+          ADMIN_GUARD_SQL=$(cat <<'SQL'
+          WITH admins AS (
+            SELECT password_hash,
+                   substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations
+            FROM staff_members
+            WHERE role = 'admin' AND active = 1
+          )
+          SELECT COUNT(*) AS secure_admins
+          FROM admins
+          WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$'
+            AND length(password_hash) - length(replace(password_hash,'$','')) = 4
+            AND iterations <> ''
+            AND iterations NOT GLOB '*[^0-9]*'
+            AND CAST(iterations AS INTEGER) >= 1000
+            AND length(password_hash) >= 80
+            AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');
+          SQL
+          )
           npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-            --command "WITH admins AS (SELECT password_hash, substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations FROM staff_members WHERE role = 'admin' AND active = 1) SELECT COUNT(*) AS secure_admins FROM admins WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$' AND length(password_hash) - length(replace(password_hash,'$','')) = 4 AND iterations <> '' AND iterations NOT GLOB '*[^0-9]*' AND CAST(iterations AS INTEGER) >= 1000 AND length(password_hash) >= 80 AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');" \
+            --command "$ADMIN_GUARD_SQL" \
             > /tmp/radiologyos-secure-admin.json
           node -e '
             const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-secure-admin.json", "utf8"));

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -32,8 +32,26 @@ echo "[3/5] Applying D1 migrations to the remote database…"
 npx wrangler d1 migrations apply radiologyos --remote --config "${CONFIG}"
 
 echo "[4/5] Verifying a secure active administrator credential…"
+ADMIN_GUARD_SQL=$(cat <<'SQL'
+WITH admins AS (
+  SELECT password_hash,
+         substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations
+  FROM staff_members
+  WHERE role = 'admin' AND active = 1
+)
+SELECT COUNT(*) AS secure_admins
+FROM admins
+WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$'
+  AND length(password_hash) - length(replace(password_hash,'$','')) = 4
+  AND iterations <> ''
+  AND iterations NOT GLOB '*[^0-9]*'
+  AND CAST(iterations AS INTEGER) >= 1000
+  AND length(password_hash) >= 80
+  AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');
+SQL
+)
 npx wrangler d1 execute radiologyos --remote --config "${CONFIG}" --json \
-  --command "WITH admins AS (SELECT password_hash, substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations FROM staff_members WHERE role = 'admin' AND active = 1) SELECT COUNT(*) AS secure_admins FROM admins WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$' AND length(password_hash) - length(replace(password_hash,'$','')) = 4 AND iterations <> '' AND iterations NOT GLOB '*[^0-9]*' AND CAST(iterations AS INTEGER) >= 1000 AND length(password_hash) >= 80 AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');" \
+  --command "$ADMIN_GUARD_SQL" \
   > /tmp/radiologyos-secure-admin.json
 node -e '
   const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-secure-admin.json", "utf8"));

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
@@ -79,7 +80,24 @@ test("production deploy paths reject placeholder or malformed administrator hash
     assert.match(source, /CAST\(iterations AS INTEGER\) >= 1000/);
     assert.match(source, /length\(password_hash\) >= 80/);
     assert.match(source, /secure_admins/);
+    assert.match(source, /ADMIN_GUARD_SQL=\$\(cat <<'SQL'/);
+    assert.match(source, /--command \"\$ADMIN_GUARD_SQL\"/);
+    assert.doesNotMatch(source, /--command \"WITH admins AS/);
   }
+});
+
+test("quoted admin-guard heredoc preserves PBKDF2 dollar literals", () => {
+  const command = String.raw`ADMIN_GUARD_SQL=$(cat <<'SQL'
+SELECT 'pbkdf2$sha256$100000$seed';
+SQL
+)
+printf '%s' "$ADMIN_GUARD_SQL"`;
+  const result = spawnSync("bash", ["-c", command], {
+    encoding: "utf8",
+    env: { ...process.env, sha256: "BROKEN", seed: "BROKEN" },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "SELECT 'pbkdf2$sha256$100000$seed';");
 });
 
 test("GitHub production workflow migrates D1 before checking for an administrator", async () => {


### PR DESCRIPTION
Fixes deploy #129. The admin validation SQL was passed to Wrangler inside a double-quoted shell argument, so Bash expanded `$sha256`, `$100000`, and other PBKDF2 dollar-delimited literals before D1 saw the query. This caused a valid active admin credential to be counted as zero. Both GitHub Actions and the local deploy path now build the SQL through a single-quoted heredoc and pass it via a variable, preserving all `$` characters literally. Adds regression coverage that asserts the deploy paths use the quoted heredoc and a Bash behavioral test proving PBKDF2 literals survive even when similarly named environment variables exist.