### PR TITLE
Add role-aware global search

### DIFF
--- a/app/api/staff/search/route.ts
+++ b/app/api/staff/search/route.ts
@@ -1,18 +1,28 @@
-// Швидкий пошук для командної палітри (⌘K): заявки за ПІБ, телефоном або
-// кодом RD у межах організації персоналу. Лише для активного співробітника.
+// Global staff search for the command palette. Every data source is tenant-scoped;
+// clinical sources additionally honor the caller's authoritative membership role.
 
 import { requireOrgContext } from "../../../../lib/tenant";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
 import { stateLabel } from "../../../../lib/study-state";
+import { canManageImaging, canManageProtocols, type StaffRole } from "../../../../lib/staff-auth";
 import { dbBinding } from "../../../../lib/db";
+import { getSetting } from "../../../../lib/settings";
+import { EQUIPMENT_REGISTRY_KEY, parseEquipmentRegistry } from "../../../../lib/equipment-registry";
 
-// SQLite LOWER() не чіпає кирилицю, тож регістронезалежність по імені робимо
-// через варіанти запиту (як є / нижній / з великої) — toLowerCase/Upper у JS
-// кирилицю обробляють правильно.
 function nameVariants(q: string): string[] {
   const lower = q.toLowerCase();
   const title = q.replace(/\S+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
   return [...new Set([q, lower, title])];
+}
+
+function bookingAssignment(alias:string, role:StaffRole, email:string) {
+  if (role === "radiologist") return { sql:` AND ${alias}.assigned_radiologist_email = ?`, binds:[email] };
+  if (role === "radiographer") return { sql:` AND ${alias}.assigned_radiographer_email = ?`, binds:[email] };
+  return { sql:"", binds:[] as string[] };
+}
+
+function registryKey(organizationId:number) {
+  return organizationId === 1 ? EQUIPMENT_REGISTRY_KEY : `org:${organizationId}:${EQUIPMENT_REGISTRY_KEY}`;
 }
 
 export async function GET(request: Request) {
@@ -21,32 +31,110 @@ export async function GET(request: Request) {
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
 
-  const q = (new URL(request.url).searchParams.get("q") || "").trim().slice(0, 60);
+  const q = (new URL(request.url).searchParams.get("q") || "").trim().slice(0, 80);
   if (q.length < 2) return Response.json({ results: [] }, { headers: { "cache-control": "no-store" } });
 
-  // Динамічний WHERE: додаємо лише релевантні умови (без «нічого не матчить»
-  // сентинелів, які ламаються при мініфікації).
-  const conds: string[] = [];
-  const binds: (string | number)[] = [ctx.organizationId];
-  for (const v of nameVariants(q)) { conds.push("name LIKE ?"); binds.push(`%${v}%`); }
-  conds.push("UPPER(code) LIKE ?"); binds.push(`%${q.toUpperCase()}%`);
+  const role = ctx.role as StaffRole;
+  const variants = nameVariants(q);
+  const assignment = bookingAssignment("b", role, ctx.member.email);
+  const bookingConds:string[] = [];
+  const bookingBinds:(string|number)[] = [ctx.organizationId, ...assignment.binds];
+  for (const v of variants) { bookingConds.push("b.name LIKE ?"); bookingBinds.push(`%${v}%`); }
+  bookingConds.push("UPPER(b.code) LIKE ?"); bookingBinds.push(`%${q.toUpperCase()}%`);
   const phoneDigits = q.replace(/\D/g, "");
-  if (phoneDigits.length >= 3) { conds.push("phone_normalized LIKE ?"); binds.push(`%${normalizeUkrainianPhone(q) || phoneDigits}%`); }
+  if (phoneDigits.length >= 3) {
+    bookingConds.push("b.phone_normalized LIKE ?");
+    bookingBinds.push(`%${normalizeUkrainianPhone(q) || phoneDigits}%`);
+  }
 
-  const rows = await db.prepare(
-    `SELECT id, code, name, phone, service, desired_date AS desiredDate, desired_time AS desiredTime, status
-       FROM bookings
-      WHERE organization_id = ? AND (${conds.join(" OR ")})
-      ORDER BY created_at DESC, id DESC
-      LIMIT 12`
-  ).bind(...binds).all<{
-    id: number; code: string; name: string; phone: string;
-    desiredDate: string; desiredTime: string; status: string;
+  const bookings = await db.prepare(
+    `SELECT b.id, b.code, b.name, b.phone, b.service, b.desired_date AS desiredDate,
+            b.desired_time AS desiredTime, b.status
+       FROM bookings b
+      WHERE b.organization_id = ?${assignment.sql} AND (${bookingConds.join(" OR ")})
+      ORDER BY b.created_at DESC, b.id DESC LIMIT 10`
+  ).bind(...bookingBinds).all<{
+    id:number;code:string;name:string;phone:string;service:string;desiredDate:string;desiredTime:string;status:string;
   }>();
 
-  const results = (rows.results || []).map((r) => ({
-    ...r,
-    statusLabel: stateLabel(String(r.status)),
+  const results:Array<Record<string,unknown>> = (bookings.results || []).map((r) => ({
+    type:"booking", key:`booking:${r.id}`, id:r.id, bookingId:r.id, code:r.code, name:r.name,
+    phone:r.phone, service:r.service, desiredDate:r.desiredDate, desiredTime:r.desiredTime,
+    statusLabel:stateLabel(String(r.status)),
+    title:`${r.name || "Без імені"} · ${r.code}`,
+    subtitle:`${r.service} · ${r.desiredDate}${r.desiredTime ? ` ${r.desiredTime}` : ""} · ${stateLabel(String(r.status))}`,
+    href:`/staff?open=${r.id}`,
   }));
-  return Response.json({ results }, { headers: { "cache-control": "no-store" } });
+
+  if (canManageImaging(role)) {
+    const imagingAssignment = bookingAssignment("b", role, ctx.member.email);
+    const imaging = await db.prepare(
+      `SELECT b.id AS bookingId, b.code, b.name, s.accession_number AS accessionNumber,
+              s.modality, s.study_datetime AS studyDatetime, s.study_status AS studyStatus
+         FROM imaging_studies s JOIN bookings b ON b.id = s.booking_id
+        WHERE b.organization_id = ?${imagingAssignment.sql}
+          AND (UPPER(s.accession_number) LIKE ? OR UPPER(b.code) LIKE ? OR UPPER(s.modality) LIKE ?)
+        ORDER BY s.updated_at DESC LIMIT 6`
+    ).bind(ctx.organizationId,...imagingAssignment.binds,`%${q.toUpperCase()}%`,`%${q.toUpperCase()}%`,`%${q.toUpperCase()}%`).all<{
+      bookingId:number;code:string;name:string;accessionNumber:string;modality:string;studyDatetime:string;studyStatus:string;
+    }>();
+    for (const r of imaging.results || []) results.push({
+      type:"imaging", key:`imaging:${r.bookingId}`, bookingId:r.bookingId,
+      title:`${r.accessionNumber || r.code} · ${r.modality || "DICOM"}`,
+      subtitle:`${r.name || "Пацієнт"} · ${r.studyDatetime || "дата не вказана"}`,
+      href:`/staff/imaging?booking=${r.bookingId}`,
+    });
+  }
+
+  if (canManageProtocols(role)) {
+    const protocolAssignment = bookingAssignment("b", role, ctx.member.email);
+    const textConds:string[] = ["UPPER(p.number) LIKE ?"];
+    const textBinds:(string|number)[] = [`%${q.toUpperCase()}%`];
+    for (const v of variants) {
+      textConds.push("p.findings LIKE ?","p.conclusion LIKE ?","b.name LIKE ?");
+      textBinds.push(`%${v}%`,`%${v}%`,`%${v}%`);
+    }
+    const protocols = await db.prepare(
+      `SELECT b.id AS bookingId, b.code, b.name, b.service, p.number, p.status
+         FROM protocols p JOIN bookings b ON b.id = p.booking_id
+        WHERE b.organization_id = ?${protocolAssignment.sql} AND (${textConds.join(" OR ")})
+        ORDER BY p.updated_at DESC LIMIT 6`
+    ).bind(ctx.organizationId,...protocolAssignment.binds,...textBinds).all<{
+      bookingId:number;code:string;name:string;service:string;number:string;status:string;
+    }>();
+    for (const r of protocols.results || []) results.push({
+      type:"protocol", key:`protocol:${r.bookingId}`, bookingId:r.bookingId,
+      title:`Протокол ${r.number || r.code}`,
+      subtitle:`${r.name || "Пацієнт"} · ${r.service} · ${r.status}`,
+      href:`/staff/protocols?booking=${r.bookingId}`,
+    });
+  }
+
+  const equipment = parseEquipmentRegistry(await getSetting(db,registryKey(ctx.organizationId)));
+  const qLower = q.toLowerCase();
+  for (const item of equipment.filter((e)=>`${e.type} ${e.manufacturer} ${e.model} ${e.room} ${e.serialNumber}`.toLowerCase().includes(qLower)).slice(0,6)) {
+    results.push({
+      type:"equipment", key:`equipment:${item.id}`,
+      title:[item.manufacturer,item.model].filter(Boolean).join(" ") || item.type,
+      subtitle:`${item.type} · ${item.room}${item.serialNumber ? ` · № ${item.serialNumber}` : ""}`,
+      href:"/staff/equipment",
+    });
+  }
+
+  const maintenance = await db.prepare(
+    `SELECT id, equipment_id AS equipmentId, event_type AS eventType, status, title, vendor, due_date AS dueDate
+       FROM equipment_maintenance_events
+      WHERE organization_id = ? AND (title LIKE ? OR details LIKE ? OR vendor LIKE ?)
+      ORDER BY updated_at DESC LIMIT 6`
+  ).bind(ctx.organizationId,`%${q}%`,`%${q}%`,`%${q}%`).all<{
+    id:number;equipmentId:string;eventType:string;status:string;title:string;vendor:string;dueDate:string;
+  }>();
+  for (const r of maintenance.results || []) results.push({
+    type:"maintenance", key:`maintenance:${r.id}`,
+    title:r.title,
+    subtitle:`ТО/сервіс · ${r.eventType} · ${r.status}${r.dueDate ? ` · до ${r.dueDate}` : ""}`,
+    href:"/staff/maintenance",
+  });
+
+  return Response.json({ results:results.slice(0,30) }, { headers: { "cache-control": "no-store" } });
 }

--- a/app/api/staff/search/route.ts
+++ b/app/api/staff/search/route.ts
@@ -123,7 +123,7 @@ export async function GET(request: Request) {
 
   const maintenance = await db.prepare(
     `SELECT id, equipment_id AS equipmentId, event_type AS eventType, status, title, vendor, due_date AS dueDate
-       FROM equipment_maintenance_events
+       FROM equipment_maintenance
       WHERE organization_id = ? AND (title LIKE ? OR details LIKE ? OR vendor LIKE ?)
       ORDER BY updated_at DESC LIMIT 6`
   ).bind(ctx.organizationId,`%${q}%`,`%${q}%`,`%${q}%`).all<{

--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-// Командна палітра (⌘K / Ctrl+K): миттєвий пошук пацієнта/заявки за ПІБ,
-// телефоном чи кодом + швидка навігація. Керування лише клавіатурою.
-// Монтується один раз у Workspace-shell, доступна на всіх staff-сторінках.
+// Command palette (⌘K / Ctrl+K): global role-aware search plus fast navigation.
 
 import { useEffect, useRef, useState } from "react";
 
-type Booking = {
-  id: number; code: string; name: string; phone: string;
-  service: string; desiredDate: string; desiredTime: string; statusLabel: string;
+type SearchResult = {
+  key: string;
+  type: "booking" | "imaging" | "protocol" | "equipment" | "maintenance";
+  title: string;
+  subtitle: string;
+  href: string;
 };
 
 const COMMANDS: { label: string; hint: string; href: string }[] = [
@@ -18,19 +19,29 @@ const COMMANDS: { label: string; hint: string; href: string }[] = [
   { label: "Нова заявка", hint: "записати пацієнта", href: "/staff/book" },
   { label: "Пацієнти", hint: "картки / CRM", href: "/staff/patients" },
   { label: "Протоколи", hint: "опис досліджень", href: "/staff/protocols" },
+  { label: "DICOM", hint: "знімки та PACS", href: "/staff/imaging" },
+  { label: "Склад", hint: "витратні матеріали", href: "/staff/inventory" },
+  { label: "ТО та несправності", hint: "обладнання / сервіс", href: "/staff/maintenance" },
   { label: "Звіти", hint: "аналітика", href: "/staff/reports" },
   { label: "Стан системи", hint: "health / production", href: "/staff/system/health" },
   { label: "Налаштування", hint: "адміністрування", href: "/staff/settings" },
 ];
 
+const TYPE_LABEL:Record<SearchResult["type"],string> = {
+  booking:"Пацієнт / заявка",
+  imaging:"DICOM",
+  protocol:"Протокол",
+  equipment:"Обладнання",
+  maintenance:"ТО / сервіс",
+};
+
 export default function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
-  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [results, setResults] = useState<SearchResult[]>([]);
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Глобальний хоткей ⌘K / Ctrl+K.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
@@ -44,23 +55,22 @@ export default function CommandPalette() {
   useEffect(() => {
     const t = window.setTimeout(() => {
       if (open) { setActive(0); inputRef.current?.focus(); }
-      else { setQ(""); setBookings([]); }
+      else { setQ(""); setResults([]); }
     }, 20);
     return () => window.clearTimeout(t);
   }, [open]);
 
-  // Пошук заявок із дебаунсом; збіг за ПІБ / телефоном / кодом RD.
   useEffect(() => {
     if (!open) return;
     if (q.trim().length < 2) {
-      const t0 = window.setTimeout(() => setBookings([]), 0);
+      const t0 = window.setTimeout(() => setResults([]), 0);
       return () => window.clearTimeout(t0);
     }
     const ctrl = new AbortController();
     const t = window.setTimeout(() => {
       fetch(`/api/staff/search?q=${encodeURIComponent(q.trim())}`, { signal: ctrl.signal, cache: "no-store" })
         .then((r) => (r.ok ? r.json() : { results: [] }))
-        .then((d) => setBookings(Array.isArray(d.results) ? d.results : []))
+        .then((d) => setResults(Array.isArray(d.results) ? d.results : []))
         .catch(() => {});
     }, 180);
     return () => { ctrl.abort(); window.clearTimeout(t); };
@@ -73,10 +83,10 @@ export default function CommandPalette() {
       go: () => window.location.assign(c.href),
       render: () => <><span className="cmdkIcon">→</span><span className="cmdkMain">{c.label}</span><span className="cmdkHint">{c.hint}</span></>,
     })),
-    ...bookings.map((b) => ({
-      key: `bk-${b.id}`,
-      go: () => window.location.assign(`/staff?open=${b.id}`),
-      render: () => <><span className="cmdkIcon">🔖</span><span className="cmdkMain">{b.name || "Без імені"} · {b.code}</span><span className="cmdkHint">{b.service} · {b.desiredDate}{b.desiredTime ? ` ${b.desiredTime}` : ""} · {b.statusLabel}</span></>,
+    ...results.map((r) => ({
+      key: r.key,
+      go: () => window.location.assign(r.href),
+      render: () => <><span className={`cmdkType cmdkType-${r.type}`}>{TYPE_LABEL[r.type]}</span><span className="cmdkMain">{r.title}</span><span className="cmdkHint">{r.subtitle}</span></>,
     })),
   ];
 
@@ -98,8 +108,8 @@ export default function CommandPalette() {
           value={q}
           onChange={(e) => { setQ(e.target.value); setActive(0); }}
           onKeyDown={onKeyDown}
-          placeholder="Пошук пацієнта, коду RD, телефону… або команда"
-          aria-label="Пошук"
+          placeholder="ПІБ, телефон, RD, accession, протокол, обладнання…"
+          aria-label="Глобальний пошук"
         />
         <ul className="cmdkList">
           {items.length === 0

--- a/app/styles/11-command-palette.css
+++ b/app/styles/11-command-palette.css
@@ -1,13 +1,17 @@
 /* ================= Командна палітра (⌘K) ================= */
 .cmdkOverlay{position:fixed;inset:0;z-index:1000;display:flex;align-items:flex-start;justify-content:center;padding:12vh 16px 16px;background:rgba(14,26,24,.44);backdrop-filter:blur(2px)}
-.cmdkBox{width:min(620px,100%);background:#fff;border:1px solid #d7e0dd;border-radius:14px;box-shadow:0 24px 64px rgba(12,30,24,.28);overflow:hidden;display:flex;flex-direction:column;max-height:70vh}
+.cmdkBox{width:min(680px,100%);background:#fff;border:1px solid #d7e0dd;border-radius:14px;box-shadow:0 24px 64px rgba(12,30,24,.28);overflow:hidden;display:flex;flex-direction:column;max-height:72vh}
 .cmdkInput{width:100%;border:0;border-bottom:1px solid #e7ecea;padding:16px 18px;font:inherit;font-size:16px;color:var(--ink,#18302f);outline:none}
 .cmdkList{list-style:none;margin:0;padding:6px;overflow:auto}
 .cmdkItem{display:flex;align-items:baseline;gap:10px;padding:10px 12px;border-radius:9px;cursor:pointer;color:#18302f}
 .cmdkItem.on{background:#eef7f8}
 .cmdkIcon{flex:0 0 auto;color:#6c8b86;font-size:13px;width:18px;text-align:center}
+.cmdkType{flex:0 0 auto;min-width:78px;padding:2px 7px;border:1px solid #dbe5e2;border-radius:999px;background:#f5f8f7;color:#607571;font-size:9px;font-weight:800;text-align:center;text-transform:uppercase;letter-spacing:.03em;white-space:nowrap}
+.cmdkType-imaging{border-color:#c7d8f4;background:#eef4ff;color:#365f9d}
+.cmdkType-protocol{border-color:#d8c9ee;background:#f5f0fb;color:#6a4a96}
+.cmdkType-equipment,.cmdkType-maintenance{border-color:#f0d9ad;background:#fff8e8;color:#8a6220}
 .cmdkMain{flex:1 1 auto;font-size:14px;font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.cmdkHint{flex:0 0 auto;color:#7a8b88;font-size:12px;max-width:55%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cmdkHint{flex:0 0 auto;color:#7a8b88;font-size:12px;max-width:45%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .cmdkEmpty{padding:22px 14px;text-align:center;color:#8a9994;font-size:13px}
 .cmdkFoot{border-top:1px solid #eef2f0;padding:9px 14px;color:#8a9994;font-size:11px;display:flex;gap:8px;flex-wrap:wrap}
 .cmdkFoot kbd{background:#f1f5f3;border:1px solid #dde5e2;border-radius:5px;padding:1px 6px;font:inherit;font-size:11px;color:#5a6c68}
@@ -15,5 +19,7 @@
 .themeDark .cmdkInput{color:#eaf2f3;border-bottom-color:#223a41;background:#132a31}
 .themeDark .cmdkItem{color:#dfe9ec}
 .themeDark .cmdkItem.on{background:#1c3a42}
+.themeDark .cmdkType{border-color:#334b53;background:#19333a;color:#b6c7ca}
 .themeDark .cmdkFoot{border-top-color:#223a41}
 .themeDark .cmdkFoot kbd{background:#1c3a42;border-color:#2b4048;color:#aebfc2}
+@media(max-width:680px){.cmdkHint{display:none}.cmdkType{min-width:68px}.cmdkOverlay{padding-top:7vh}}

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -70,8 +70,8 @@ test("search never leaks bookings from another organization", async () => {
 
 test("clinician search is limited to bookings assigned to that membership", async () => {
   await withD1(async (db) => {
-    await seed(db, { id: 6, code: "RD-OWNRAD01", name: "Контрольний Пацієнт", phone: "+380971110006", phoneNorm: "380971110006" });
-    await seed(db, { id: 7, code: "RD-OTHERRAD", name: "Контрольний Інший", phone: "+380971110007", phoneNorm: "380971110007" });
+    await seed(db, { id: 6, code: "RD-OWNRAD01", name: "Контрольний Пацієнт", phone: "+380971110006", phoneNorm: "380971110006", time: "10:00" });
+    await seed(db, { id: 7, code: "RD-OTHERRAD", name: "Контрольний Інший", phone: "+380971110007", phoneNorm: "380971110007", time: "10:30" });
     const radEmail = "rad@likarnya.test";
     const cookie = await seedStaffSession(db, { email: radEmail, role: "radiologist" });
     await db.prepare("UPDATE bookings SET assigned_radiologist_email = ? WHERE id = 6").bind(radEmail).run();
@@ -89,7 +89,7 @@ test("global search includes accession, protocol, equipment and maintenance for 
       VALUES (10,'ACC-XYZ-999','CT','linked','2026-09-01 10:00','admin@test')`).run();
     await db.prepare(`INSERT INTO protocols (booking_id, findings, conclusion, number, status, updated_by)
       VALUES (10,'Без особливостей','Унікальний висновок глобального пошуку','PR-777','issued','admin@test')`).run();
-    await db.prepare(`INSERT INTO equipment_maintenance_events
+    await db.prepare(`INSERT INTO equipment_maintenance
       (organization_id,equipment_id,event_type,status,title,details,created_by)
       VALUES (1,'siemens-somatom','fault','open','Помилка E09 стабілізатора','Перевірити живлення','admin@test')`).run();
     const cookie = await seedStaffSession(db, { email: "admin-global@likarnya.test", role: "admin" });
@@ -114,6 +114,7 @@ test("global search source enforces role scopes and never searches Study Instanc
   assert.match(route, /assigned_radiographer_email = \?/);
   assert.match(route, /canManageProtocols\(role\)/);
   assert.match(route, /canManageImaging\(role\)/);
+  assert.match(route, /FROM equipment_maintenance/);
   assert.doesNotMatch(route, /study_instance_uid\s+LIKE/i);
 });
 

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -1,4 +1,4 @@
-// Командна палітра (⌘K): пошуковий API проти живої схеми + монтаж у shell.
+// Command palette (⌘K): global search against the live schema + workspace mount.
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
@@ -18,6 +18,8 @@ async function seed(db, { id, code, name, phone, phoneNorm, org = 1, time = "10:
 const search = (db, cookie, q) =>
   callWorker(jsonRequest(`/api/staff/search?q=${encodeURIComponent(q)}`, undefined, { method: "GET", headers: { cookie } }), db);
 
+const bookingsOnly = (data) => data.results.filter((r) => r.type === "booking");
+
 test("search is staff-only", async () => {
   await withD1(async (db) => {
     const res = await callWorker(jsonRequest("/api/staff/search?q=іван", undefined, { method: "GET" }), db);
@@ -25,24 +27,23 @@ test("search is staff-only", async () => {
   });
 });
 
-test("search matches by name, phone and RD code", async () => {
+test("search matches booking by name, phone and RD code", async () => {
   await withD1(async (db) => {
     await seed(db, { id: 1, code: "RD-AAAA1111", name: "Іваненко Іван", phone: "+380971112233", phoneNorm: "380971112233", time: "10:00" });
     await seed(db, { id: 2, code: "RD-BBBB2222", name: "Петренко Петро", phone: "+380975556677", phoneNorm: "380975556677", time: "10:30" });
     const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
 
     const byName = await (await search(db, cookie, "іваненко")).json();
-    assert.equal(byName.results.length, 1);
-    assert.equal(byName.results[0].code, "RD-AAAA1111");
+    assert.equal(bookingsOnly(byName).length, 1);
+    assert.equal(bookingsOnly(byName)[0].code, "RD-AAAA1111");
 
     const byCode = await (await search(db, cookie, "bbbb2222")).json();
-    assert.equal(byCode.results.length, 1);
-    assert.equal(byCode.results[0].code, "RD-BBBB2222");
+    assert.equal(bookingsOnly(byCode).length, 1);
+    assert.equal(bookingsOnly(byCode)[0].code, "RD-BBBB2222");
 
     const byPhone = await (await search(db, cookie, "0971112233")).json();
-    assert.ok(byPhone.results.some((r) => r.code === "RD-AAAA1111"));
-    // Людський підпис статусу присутній.
-    assert.ok(byPhone.results[0].statusLabel);
+    assert.ok(bookingsOnly(byPhone).some((r) => r.code === "RD-AAAA1111"));
+    assert.ok(bookingsOnly(byPhone)[0].statusLabel);
   });
 });
 
@@ -50,8 +51,7 @@ test("a query shorter than 2 chars returns nothing (no full-table dump)", async 
   await withD1(async (db) => {
     await seed(db, { id: 3, code: "RD-CCCC3333", name: "Сидоренко", phone: "+380971110000", phoneNorm: "380971110000" });
     const cookie = await seedStaffSession(db, { email: "reg@likarnya.test", role: "registrar" });
-    const res = await search(db, cookie, "і");
-    const data = await res.json();
+    const data = await (await search(db, cookie, "і")).json();
     assert.equal(data.results.length, 0);
   });
 });
@@ -61,19 +61,70 @@ test("search never leaks bookings from another organization", async () => {
     await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2,'other','Інша',1)").run();
     await seed(db, { id: 4, code: "RD-OWN00001", name: "Шевченко", phone: "+380971110001", phoneNorm: "380971110001", org: 1 });
     await seed(db, { id: 5, code: "RD-OTHER0001", name: "Шевченко", phone: "+380971110002", phoneNorm: "380971110002", org: 2 });
-    const cookie = await seedStaffSession(db, { email: "admin@likarnya.test", role: "admin" }); // авто-онбординг у org 1
+    const cookie = await seedStaffSession(db, { email: "admin@likarnya.test", role: "admin" });
     const data = await (await search(db, cookie, "шевченко")).json();
-    assert.equal(data.results.length, 1);
-    assert.equal(data.results[0].code, "RD-OWN00001");
+    assert.equal(bookingsOnly(data).length, 1);
+    assert.equal(bookingsOnly(data)[0].code, "RD-OWN00001");
   });
 });
 
-test("the palette is mounted in the workspace shell and opens on Ctrl/⌘+K", async () => {
+test("clinician search is limited to bookings assigned to that membership", async () => {
+  await withD1(async (db) => {
+    await seed(db, { id: 6, code: "RD-OWNRAD01", name: "Контрольний Пацієнт", phone: "+380971110006", phoneNorm: "380971110006" });
+    await seed(db, { id: 7, code: "RD-OTHERRAD", name: "Контрольний Інший", phone: "+380971110007", phoneNorm: "380971110007" });
+    const radEmail = "rad@likarnya.test";
+    const cookie = await seedStaffSession(db, { email: radEmail, role: "radiologist" });
+    await db.prepare("UPDATE bookings SET assigned_radiologist_email = ? WHERE id = 6").bind(radEmail).run();
+    await db.prepare("UPDATE bookings SET assigned_radiologist_email = 'someone-else@likarnya.test' WHERE id = 7").run();
+
+    const data = await (await search(db, cookie, "контрольний")).json();
+    assert.deepEqual(bookingsOnly(data).map((r) => r.bookingId), [6]);
+  });
+});
+
+test("global search includes accession, protocol, equipment and maintenance for authorized staff", async () => {
+  await withD1(async (db) => {
+    await seed(db, { id: 10, code: "RD-GLOBAL10", name: "Глобальний Тест", phone: "+380971110010", phoneNorm: "380971110010" });
+    await db.prepare(`INSERT INTO imaging_studies (booking_id, accession_number, modality, study_status, study_datetime, updated_by)
+      VALUES (10,'ACC-XYZ-999','CT','linked','2026-09-01 10:00','admin@test')`).run();
+    await db.prepare(`INSERT INTO protocols (booking_id, findings, conclusion, number, status, updated_by)
+      VALUES (10,'Без особливостей','Унікальний висновок глобального пошуку','PR-777','issued','admin@test')`).run();
+    await db.prepare(`INSERT INTO equipment_maintenance_events
+      (organization_id,equipment_id,event_type,status,title,details,created_by)
+      VALUES (1,'siemens-somatom','fault','open','Помилка E09 стабілізатора','Перевірити живлення','admin@test')`).run();
+    const cookie = await seedStaffSession(db, { email: "admin-global@likarnya.test", role: "admin" });
+
+    const imaging = await (await search(db, cookie, "ACC-XYZ")).json();
+    assert.ok(imaging.results.some((r) => r.type === "imaging" && r.bookingId === 10));
+
+    const protocol = await (await search(db, cookie, "унікальний")).json();
+    assert.ok(protocol.results.some((r) => r.type === "protocol" && r.bookingId === 10));
+
+    const equipment = await (await search(db, cookie, "somatom")).json();
+    assert.ok(equipment.results.some((r) => r.type === "equipment"));
+
+    const maintenance = await (await search(db, cookie, "E09")).json();
+    assert.ok(maintenance.results.some((r) => r.type === "maintenance"));
+  });
+});
+
+test("global search source enforces role scopes and never searches Study Instance UID", async () => {
+  const route = await read("app/api/staff/search/route.ts");
+  assert.match(route, /assigned_radiologist_email = \?/);
+  assert.match(route, /assigned_radiographer_email = \?/);
+  assert.match(route, /canManageProtocols\(role\)/);
+  assert.match(route, /canManageImaging\(role\)/);
+  assert.doesNotMatch(route, /study_instance_uid\s+LIKE/i);
+});
+
+test("the palette is mounted in the workspace shell and renders typed global results", async () => {
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /import CommandPalette from "\.\/command-palette"/);
   assert.match(shell, /<CommandPalette \/>/);
   const cp = await read("app/staff/command-palette.tsx");
   assert.match(cp, /e\.metaKey \|\| e\.ctrlKey/);
   assert.match(cp, /\/api\/staff\/search/);
-  assert.match(cp, /\/staff\?open=\$\{b\.id\}/); // заявка → повна картка
+  assert.match(cp, /TYPE_LABEL/);
+  assert.match(cp, /accession, протокол, обладнання/);
+  assert.match(cp, /window\.location\.assign\(r\.href\)/);
 });


### PR DESCRIPTION
Expands the existing Ctrl/Cmd+K command palette into a BAS-style global search instead of creating a parallel search screen. The API now returns typed booking, DICOM/accession, protocol, equipment and maintenance results, all tenant-scoped. Booking-derived clinical results additionally honor authoritative membership assignment: admin/registrar can search all tenant bookings, radiologists only their assigned bookings, and radiographers only theirs. Protocol results are restricted to admin/radiologist; imaging results to admin/radiologist/radiographer. Equipment is resolved from the tenant registry and maintenance from the tenant-scoped service log. The search deliberately does not match Study Instance UID. UI adds typed result badges and broader navigation commands. Regression/behavioral tests cover tenant isolation, clinician assignment isolation and the new result sources. No migration, auth, PIN, credential or deployment changes.