### PR TITLE
Add personal saved study views

### DIFF
--- a/app/api/staff/saved-views/route.ts
+++ b/app/api/staff/saved-views/route.ts
@@ -22,6 +22,10 @@ function sanitizeConfig(surface:string,value:unknown):SavedConfig|null{
   if(!STUDY_STATES.has(filter)||!EQUIPMENT.has(equipment))return null;
   return {filter,equipment};
 }
+function parseConfig(surface:string,value:string):SavedConfig{
+  try{return sanitizeConfig(surface,JSON.parse(value||"{}"))||{filter:"all",equipment:"all"}}
+  catch{return {filter:"all",equipment:"all"}}
+}
 
 export async function GET(request:Request){
   const db=dbBinding(); if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
@@ -33,8 +37,7 @@ export async function GET(request:Request){
     WHERE organization_id=? AND member_email=? AND surface=?
     ORDER BY name COLLATE NOCASE,id`).bind(ctx.organizationId,ctx.member.email,surface).all<{id:number;name:string;configJson:string;updatedAt:string}>();
   const views=(rows.results||[]).map(row=>({
-    id:row.id,name:row.name,updatedAt:row.updatedAt,
-    config:sanitizeConfig(surface,JSON.parse(row.configJson||"{}"))||{filter:"all",equipment:"all"},
+    id:row.id,name:row.name,updatedAt:row.updatedAt,config:parseConfig(surface,row.configJson),
   }));
   return Response.json({views},{headers:{"cache-control":"no-store"}});
 }

--- a/app/api/staff/saved-views/route.ts
+++ b/app/api/staff/saved-views/route.ts
@@ -1,0 +1,70 @@
+import { audit } from "../../../../lib/audit";
+import { dbBinding } from "../../../../lib/db";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+const SURFACES = new Set(["studies"]);
+const STUDY_STATES = new Set([
+  "all","new","requested","needs_verification","scheduled","confirmed","rescheduled",
+  "arrived","queued","in_progress","performed","images_ready","reporting","protocol_ready",
+  "issued","completed","cancelled","no_show",
+]);
+const EQUIPMENT = new Set(["all","ct","xray","fluoro"]);
+
+type SavedConfig = { filter:string; equipment:string };
+
+function clean(value:unknown,max:number){return String(value||"").trim().slice(0,max)}
+function sanitizeSurface(value:unknown){const v=clean(value,32);return SURFACES.has(v)?v:""}
+function sanitizeConfig(surface:string,value:unknown):SavedConfig|null{
+  if(surface!=="studies"||!value||typeof value!=="object")return null;
+  const raw=value as Record<string,unknown>;
+  const filter=clean(raw.filter,40)||"all";
+  const equipment=clean(raw.equipment,20)||"all";
+  if(!STUDY_STATES.has(filter)||!EQUIPMENT.has(equipment))return null;
+  return {filter,equipment};
+}
+
+export async function GET(request:Request){
+  const db=dbBinding(); if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db); if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const surface=sanitizeSurface(new URL(request.url).searchParams.get("surface"));
+  if(!surface)return Response.json({error:"Некоректний розділ"},{status:400});
+  const rows=await db.prepare(`SELECT id,name,config_json AS configJson,updated_at AS updatedAt
+    FROM staff_saved_views
+    WHERE organization_id=? AND member_email=? AND surface=?
+    ORDER BY name COLLATE NOCASE,id`).bind(ctx.organizationId,ctx.member.email,surface).all<{id:number;name:string;configJson:string;updatedAt:string}>();
+  const views=(rows.results||[]).map(row=>({
+    id:row.id,name:row.name,updatedAt:row.updatedAt,
+    config:sanitizeConfig(surface,JSON.parse(row.configJson||"{}"))||{filter:"all",equipment:"all"},
+  }));
+  return Response.json({views},{headers:{"cache-control":"no-store"}});
+}
+
+export async function POST(request:Request){
+  const db=dbBinding(); if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db); if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const surface=sanitizeSurface(body.surface),name=clean(body.name,48),config=sanitizeConfig(surface,body.config);
+  if(!surface||!name||!config)return Response.json({error:"Некоректний варіант списку"},{status:400});
+  await db.prepare(`INSERT INTO staff_saved_views (organization_id,member_email,surface,name,config_json)
+    VALUES (?,?,?,?,?)
+    ON CONFLICT(organization_id,member_email,surface,name)
+    DO UPDATE SET config_json=excluded.config_json,updated_at=CURRENT_TIMESTAMP`)
+    .bind(ctx.organizationId,ctx.member.email,surface,name,JSON.stringify(config)).run();
+  const row=await db.prepare(`SELECT id FROM staff_saved_views WHERE organization_id=? AND member_email=? AND surface=? AND name=? LIMIT 1`)
+    .bind(ctx.organizationId,ctx.member.email,surface,name).first<{id:number}>();
+  await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"saved_view_saved",resource:"staff_saved_view",targetId:row?.id||0,details:{surface}});
+  return Response.json({ok:true,id:row?.id||0});
+}
+
+export async function DELETE(request:Request){
+  const db=dbBinding(); if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db); if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const id=Number(body.id),surface=sanitizeSurface(body.surface);
+  if(!Number.isInteger(id)||id<1||!surface)return Response.json({error:"Некоректний варіант"},{status:400});
+  const result=await db.prepare(`DELETE FROM staff_saved_views WHERE id=? AND organization_id=? AND member_email=? AND surface=?`)
+    .bind(id,ctx.organizationId,ctx.member.email,surface).run();
+  if(Number(result.meta.changes||0)<1)return Response.json({error:"Варіант не знайдено"},{status:404});
+  await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"saved_view_deleted",resource:"staff_saved_view",targetId:id,details:{surface}});
+  return Response.json({ok:true});
+}

--- a/app/staff/studies/page.tsx
+++ b/app/staff/studies/page.tsx
@@ -22,6 +22,7 @@ type Data = {
   profile:{ type:string; label:string };
   features:{ dicomPacs:boolean };
 };
+type SavedView = { id:number; name:string; config:{ filter:string; equipment:string } };
 
 const roleLabels: Record<StaffRole,string> = {
   admin:"Адміністратор", registrar:"Реєстратор",
@@ -29,7 +30,6 @@ const roleLabels: Record<StaffRole,string> = {
 };
 const equipmentNames: Record<string,string> = { ct:"КТ", xray:"Рентген", fluoro:"Флюорограф" };
 
-// Клінічні групи станів — для кольору бейджа й логічного порядку черги.
 const STATE_GROUP: Record<string,"intake"|"active"|"reporting"|"done"|"stopped"> = {
   new:"intake", requested:"intake", needs_verification:"intake", scheduled:"intake",
   confirmed:"intake", rescheduled:"intake",
@@ -48,6 +48,10 @@ export default function StudiesPage() {
   const [query,setQuery] = useState("");
   const [notice,setNotice] = useState("");
   const [busy,setBusy] = useState(0);
+  const [savedViews,setSavedViews] = useState<SavedView[]>([]);
+  const [selectedViewId,setSelectedViewId] = useState(0);
+  const [viewName,setViewName] = useState("");
+  const [viewBusy,setViewBusy] = useState(false);
 
   async function load() {
     const response = await fetch("/api/staff/studies", { cache:"no-store" });
@@ -58,8 +62,15 @@ export default function StudiesPage() {
     setError("");
   }
 
+  async function loadSavedViews() {
+    const response = await fetch("/api/staff/saved-views?surface=studies", { cache:"no-store" });
+    if (!response.ok) return;
+    const payload = await response.json() as { views?:SavedView[] };
+    setSavedViews(payload.views || []);
+  }
+
   useEffect(() => {
-    const timer = window.setTimeout(() => { void load(); }, 0);
+    const timer = window.setTimeout(() => { void load(); void loadSavedViews(); }, 0);
     return () => window.clearTimeout(timer);
   }, []);
 
@@ -84,8 +95,6 @@ export default function StudiesPage() {
     }
   }
 
-  // Призначення виконавця: reg/admin шлють оновлення на той самий PATCH
-  // /api/staff/bookings, що валідує роль виконавця й фіксує подію.
   async function assign(study:Study, field:"radiologist"|"radiographer", email:string) {
     setBusy(study.id); setNotice("");
     try {
@@ -107,6 +116,54 @@ export default function StudiesPage() {
     } finally {
       setBusy(0);
     }
+  }
+
+  async function saveView() {
+    const name=viewName.trim();
+    if (!name) { setNotice("Вкажіть назву варіанта"); return; }
+    setViewBusy(true); setNotice("");
+    try {
+      const response=await fetch("/api/staff/saved-views",{
+        method:"POST",headers:{"content-type":"application/json"},
+        body:JSON.stringify({surface:"studies",name,config:{filter,equipment}}),
+      });
+      const payload=await response.json().catch(()=>({})) as {error?:string;id?:number};
+      if(!response.ok){setNotice(payload.error||"Не вдалося зберегти варіант");return;}
+      setViewName("");
+      await loadSavedViews();
+      if(payload.id)setSelectedViewId(payload.id);
+      setNotice("Варіант списку збережено");
+    } catch {
+      setNotice("Помилка мережі — не вдалося зберегти варіант");
+    } finally { setViewBusy(false); }
+  }
+
+  function applyView(id:number) {
+    setSelectedViewId(id);
+    const view=savedViews.find(v=>v.id===id);
+    if(!view)return;
+    setFilter(view.config.filter||"all");
+    setEquipment(view.config.equipment||"all");
+    setQuery("");
+    setNotice("");
+  }
+
+  async function deleteView() {
+    if(!selectedViewId)return;
+    setViewBusy(true); setNotice("");
+    try {
+      const response=await fetch("/api/staff/saved-views",{
+        method:"DELETE",headers:{"content-type":"application/json"},
+        body:JSON.stringify({surface:"studies",id:selectedViewId}),
+      });
+      const payload=await response.json().catch(()=>({})) as {error?:string};
+      if(!response.ok){setNotice(payload.error||"Не вдалося видалити варіант");return;}
+      setSelectedViewId(0);
+      await loadSavedViews();
+      setNotice("Варіант списку видалено");
+    } catch {
+      setNotice("Помилка мережі — не вдалося видалити варіант");
+    } finally { setViewBusy(false); }
   }
 
   const visible = useMemo(() => {
@@ -143,25 +200,36 @@ export default function StudiesPage() {
         <small>{data.profile?.label ? `${data.profile.label} · ` : ""}{data.studies.length} досліджень · роль: {roleLabels[data.role]}{data.canManage ? "" : " · лише перегляд"}</small>
       </div>
 
-      {notice && <p className="staffError" role="alert" onClick={()=>setNotice("")}>{notice}</p>}
+      {notice && <p className="staffError" role="status" onClick={()=>setNotice("")}>{notice}</p>}
+
+      <div className="studiesToolbar" aria-label="Варіанти списку">
+        <select value={selectedViewId||""} onChange={(e)=>applyView(Number(e.target.value))} aria-label="Мої варіанти списку">
+          <option value="">Мої варіанти…</option>
+          {savedViews.map(v=><option key={v.id} value={v.id}>{v.name}</option>)}
+        </select>
+        <input value={viewName} maxLength={48} onChange={(e)=>setViewName(e.target.value)} placeholder="Назва нового варіанта" aria-label="Назва нового варіанта"/>
+        <button type="button" className="studiesClear" disabled={viewBusy} onClick={()=>void saveView()}>Зберегти варіант</button>
+        {selectedViewId ? <button type="button" className="studiesClear" disabled={viewBusy} onClick={()=>void deleteView()}>Видалити</button> : null}
+        <small>Зберігаються стан і апарат; текст пошуку не зберігається.</small>
+      </div>
 
       <div className="studiesToolbar">
-        <input type="search" className="studiesSearch" value={query} onChange={(e)=>setQuery(e.target.value)} placeholder="Пошук: код, пацієнт, дослідження" aria-label="Пошук досліджень"/>
-        <select value={equipment} onChange={(e)=>setEquipment(e.target.value)} aria-label="Апарат">
+        <input type="search" className="studiesSearch" value={query} onChange={(e)=>{setQuery(e.target.value);setSelectedViewId(0);}} placeholder="Пошук: код, пацієнт, дослідження" aria-label="Пошук досліджень"/>
+        <select value={equipment} onChange={(e)=>{setEquipment(e.target.value);setSelectedViewId(0);}} aria-label="Апарат">
           <option value="all">Усі апарати</option>
           <option value="ct">КТ</option><option value="xray">Рентген</option><option value="fluoro">Флюорограф</option>
         </select>
-        {(query || equipment!=="all" || filter!=="all") && <button type="button" className="studiesClear" onClick={()=>{setQuery("");setEquipment("all");setFilter("all");}}>Скинути</button>}
+        {(query || equipment!=="all" || filter!=="all") && <button type="button" className="studiesClear" onClick={()=>{setQuery("");setEquipment("all");setFilter("all");setSelectedViewId(0);}}>Скинути</button>}
         <span className="studiesResultCount">Показано: {visible.length}</span>
       </div>
 
       <div className="studiesTabs" role="tablist" aria-label="Фільтр за станом">
         <button type="button" role="tab" aria-selected={filter==="all"}
-          className={filter==="all"?"active":""} onClick={()=>setFilter("all")}>
+          className={filter==="all"?"active":""} onClick={()=>{setFilter("all");setSelectedViewId(0);}}>
           Усі <b>{data.studies.length}</b>
         </button>
         {activeStates.map((s)=><button key={s.v} type="button" role="tab" aria-selected={filter===s.v}
-          className={filter===s.v?"active":""} onClick={()=>setFilter(s.v)}>
+          className={filter===s.v?"active":""} onClick={()=>{setFilter(s.v);setSelectedViewId(0);}}>
           {s.l} <b>{s.count}</b>
         </button>)}
       </div>

--- a/drizzle/0039_staff_saved_views.sql
+++ b/drizzle/0039_staff_saved_views.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS staff_saved_views (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  organization_id INTEGER NOT NULL,
+  member_email TEXT NOT NULL,
+  surface TEXT NOT NULL,
+  name TEXT NOT NULL,
+  config_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+  FOREIGN KEY (member_email) REFERENCES staff_members(email) ON DELETE CASCADE,
+  UNIQUE (organization_id, member_email, surface, name)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS staff_saved_views_owner_surface_idx
+  ON staff_saved_views (organization_id, member_email, surface, updated_at DESC);

--- a/tests/staff-saved-views.behavior.test.mjs
+++ b/tests/staff-saved-views.behavior.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+
+const read=(p)=>readFile(new URL(`../${p}`,import.meta.url),"utf8");
+const call=(db,cookie,url,body,method="GET")=>callWorker(jsonRequest(url,body,{method,headers:{cookie}}),db);
+
+test("saved-view migration keys variants by tenant, member and surface",async()=>{
+  const sql=await read("drizzle/0039_staff_saved_views.sql");
+  assert.match(sql,/CREATE TABLE IF NOT EXISTS staff_saved_views/);
+  assert.match(sql,/organization_id INTEGER NOT NULL/);
+  assert.match(sql,/member_email TEXT NOT NULL/);
+  assert.match(sql,/UNIQUE \(organization_id, member_email, surface, name\)/);
+  assert.match(sql,/staff_saved_views_owner_surface_idx/);
+});
+
+test("staff saved views are personal and tenant scoped",async()=>{
+  await withD1(async(db)=>{
+    await db.prepare("INSERT INTO organizations (id,slug,name,active) VALUES (2,'other','Інша',1)").run();
+    const owner=await seedStaffSession(db,{email:"owner@clinic.test",role:"radiologist",organizationId:1});
+    const colleague=await seedStaffSession(db,{email:"colleague@clinic.test",role:"radiologist",organizationId:1});
+    const otherTenant=await seedStaffSession(db,{email:"other@clinic.test",role:"radiologist",organizationId:2});
+
+    const saved=await call(db,owner,"/api/staff/saved-views",{
+      surface:"studies",name:"КТ очікує опису",config:{filter:"reporting",equipment:"ct",query:"Іваненко"},
+    },"POST");
+    assert.equal(saved.status,200);
+
+    const ownData=await (await call(db,owner,"/api/staff/saved-views?surface=studies",undefined,"GET")).json();
+    assert.equal(ownData.views.length,1);
+    assert.deepEqual(ownData.views[0].config,{filter:"reporting",equipment:"ct"});
+
+    const colleagueData=await (await call(db,colleague,"/api/staff/saved-views?surface=studies",undefined,"GET")).json();
+    assert.equal(colleagueData.views.length,0);
+    const tenantData=await (await call(db,otherTenant,"/api/staff/saved-views?surface=studies",undefined,"GET")).json();
+    assert.equal(tenantData.views.length,0);
+
+    const raw=await db.prepare("SELECT config_json AS configJson FROM staff_saved_views WHERE organization_id=1 AND member_email='owner@clinic.test'").first();
+    assert.equal(raw.configJson,'{"filter":"reporting","equipment":"ct"}');
+  });
+});
+
+test("a staff member cannot delete another member's saved view",async()=>{
+  await withD1(async(db)=>{
+    const owner=await seedStaffSession(db,{email:"owner-delete@clinic.test",role:"registrar"});
+    const other=await seedStaffSession(db,{email:"other-delete@clinic.test",role:"registrar"});
+    const saved=await (await call(db,owner,"/api/staff/saved-views",{
+      surface:"studies",name:"Рентген готові",config:{filter:"completed",equipment:"xray"},
+    },"POST")).json();
+    const denied=await call(db,other,"/api/staff/saved-views",{surface:"studies",id:saved.id},"DELETE");
+    assert.equal(denied.status,404);
+    const stillThere=await db.prepare("SELECT COUNT(*) AS n FROM staff_saved_views WHERE id=?").bind(saved.id).first();
+    assert.equal(stillThere.n,1);
+  });
+});
+
+test("saved views API is deny-by-default and stores no free-text study search",async()=>{
+  const route=await read("app/api/staff/saved-views/route.ts");
+  assert.match(route,/requireOrgContext\(request,db\)/);
+  assert.match(route,/WHERE organization_id=\? AND member_email=\? AND surface=\?/);
+  assert.match(route,/DELETE FROM staff_saved_views WHERE id=\? AND organization_id=\? AND member_email=\? AND surface=\?/);
+  assert.match(route,/type SavedConfig = \{ filter:string; equipment:string \}/);
+  assert.doesNotMatch(route,/query:string/);
+});
+
+test("studies registry can save, apply and delete personal variants without persisting search text",async()=>{
+  const page=await read("app/staff/studies/page.tsx");
+  assert.match(page,/Мої варіанти…/);
+  assert.match(page,/Зберегти варіант/);
+  assert.match(page,/Видалити/);
+  assert.match(page,/config:\{filter,equipment\}/);
+  assert.match(page,/setQuery\(""\)/);
+  assert.match(page,/текст пошуку не зберігається/);
+  assert.doesNotMatch(page,/config:\{filter,equipment,query\}/);
+});


### PR DESCRIPTION
Adds BAS-style personal saved list variants to the studies registry. Staff can save, apply and delete named study views containing only workflow state and equipment filters. Saved views persist in D1 and are scoped by organization, member email and surface, so they never cross tenants or staff accounts. The free-text study search is deliberately not stored. The API validates allowed states/equipment, safely handles malformed stored JSON, audits save/delete actions without persisting filter text in audit details, and delete operations are owner-scoped. Includes migration 0039 and behavioral tests for tenant isolation, staff isolation, PHI-minimized config and UI wiring. No auth, PIN, credential or deployment changes.