### PR TITLE
Add idempotent operational task automation

### DIFF
--- a/app/api/staff/tasks/route.ts
+++ b/app/api/staff/tasks/route.ts
@@ -16,6 +16,10 @@ type TaskRow = {
   completedAt:string;
   createdAt:string;
   updatedAt:string;
+  source:"manual"|"automation";
+  automationKey:string;
+  sourceEntityType:string;
+  sourceEntityId:string;
 };
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -58,7 +62,9 @@ export async function GET(request:Request) {
             due_date AS dueDate, booking_id AS bookingId,
             assigned_email AS assignedEmail, created_by AS createdBy,
             completed_by AS completedBy, completed_at AS completedAt,
-            created_at AS createdAt, updated_at AS updatedAt
+            created_at AS createdAt, updated_at AS updatedAt,
+            source, automation_key AS automationKey,
+            source_entity_type AS sourceEntityType, source_entity_id AS sourceEntityId
      FROM staff_tasks
      WHERE ${where.join(" AND ")}
      ORDER BY CASE status WHEN 'open' THEN 0 ELSE 1 END,
@@ -100,8 +106,8 @@ export async function POST(request:Request) {
 
   const result = await db.prepare(
     `INSERT INTO staff_tasks
-      (organization_id,title,details,status,priority,due_date,booking_id,assigned_email,created_by)
-     VALUES (?,?,?,'open',?,?,?,?,?)`
+      (organization_id,title,details,status,priority,due_date,booking_id,assigned_email,created_by,source)
+     VALUES (?,?,?,'open',?,?,?,?,?,'manual')`
   ).bind(ctx.organizationId,title,details,priority,dueDate,bookingId,assignedEmail,ctx.member.email).run();
   const id = Number(result.meta.last_row_id || 0);
   await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"task_created", resource:"task", targetId:id, details:{ priority, assigned:!!assignedEmail, linkedBooking:!!bookingId } });
@@ -119,12 +125,15 @@ export async function PATCH(request:Request) {
   if (!Number.isInteger(id) || id < 1) return Response.json({ error:"Некоректне завдання" }, { status:400 });
 
   const existing = await db.prepare(
-    `SELECT id, status, assigned_email AS assignedEmail, created_by AS createdBy
+    `SELECT id, status, assigned_email AS assignedEmail, created_by AS createdBy, source
      FROM staff_tasks WHERE organization_id = ? AND id = ? LIMIT 1`
-  ).bind(ctx.organizationId,id).first<{id:number;status:string;assignedEmail:string;createdBy:string}>();
+  ).bind(ctx.organizationId,id).first<{id:number;status:string;assignedEmail:string;createdBy:string;source:string}>();
   if (!existing) return Response.json({ error:"Завдання не знайдено" }, { status:404 });
-  const canEdit = ctx.role === "admin" || existing.assignedEmail === ctx.member.email || existing.createdBy === ctx.member.email;
+  const canEdit = ctx.member.role === "admin" || existing.assignedEmail === ctx.member.email || existing.createdBy === ctx.member.email;
   if (!canEdit) return Response.json({ error:"Немає прав змінювати це завдання" }, { status:403 });
+  if (existing.source === "automation" && existing.status === "done" && body.status === "open") {
+    return Response.json({ error:"Автоматичне завдання буде створено знову, якщо проблема все ще актуальна" }, { status:409 });
+  }
 
   const status = body.status === "done" ? "done" : body.status === "open" ? "open" : existing.status;
   const assignedEmail = body.assignedEmail === undefined ? existing.assignedEmail : String(body.assignedEmail || "").trim().toLowerCase().slice(0,254);
@@ -144,6 +153,6 @@ export async function PATCH(request:Request) {
      WHERE organization_id = ? AND id = ?`
   ).bind(status,assignedEmail,priority,dueDate,status,ctx.member.email,status,ctx.organizationId,id).run();
 
-  await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:status === "done" && existing.status !== "done" ? "task_completed" : "task_updated", resource:"task", targetId:id, details:{ status } });
+  await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:status === "done" && existing.status !== "done" ? "task_completed" : "task_updated", resource:"task", targetId:id, details:{ status, automatic:existing.source === "automation" } });
   return Response.json({ ok:true });
 }

--- a/app/staff/tasks/page.tsx
+++ b/app/staff/tasks/page.tsx
@@ -6,16 +6,26 @@ import StaffWorkspaceShell from "../workspace-shell";
 type Task = {
   id:number;title:string;details:string;status:"open"|"done";priority:"low"|"normal"|"high";
   dueDate:string;bookingId:number|null;assignedEmail:string;createdBy:string;completedBy:string;
-  completedAt:string;createdAt:string;updatedAt:string;
+  completedAt:string;createdAt:string;updatedAt:string;source:"manual"|"automation";
+  automationKey:string;sourceEntityType:string;sourceEntityId:string;
 };
 type Member = { email:string;displayName:string;role:string };
 type Staff = { email:string;displayName:string;role:string };
-
 type Payload = { tasks:Task[];members:Member[];staff:Staff };
 const priorityLabel:Record<Task["priority"],string> = { high:"Високий",normal:"Звичайний",low:"Низький" };
 
 function todayKyiv() {
   return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+function sourceHref(task:Task) {
+  if(task.sourceEntityType==="inventory_item") return "/staff/inventory";
+  if(task.sourceEntityType==="equipment_maintenance") return "/staff/maintenance";
+  return "";
+}
+function sourceLabel(task:Task) {
+  if(task.sourceEntityType==="inventory_item") return "Відкрити склад";
+  if(task.sourceEntityType==="equipment_maintenance") return "Відкрити ТО";
+  return "";
 }
 
 export default function TasksPage() {
@@ -63,7 +73,7 @@ export default function TasksPage() {
     } finally {setBusy(null);}
   }
 
-  return <StaffWorkspaceShell active="tasks" title="Завдання" description="Особисті й командні задачі відділення: відповідальний, термін, пріоритет і контроль виконання." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
+  return <StaffWorkspaceShell active="tasks" title="Завдання" description="Особисті, командні й автоматичні задачі відділення: відповідальний, термін, пріоритет і контроль виконання." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
     {error && <p className="notice error" role="alert">{error}</p>}
     {!loaded ? <p className="dashLoading">Завантаження завдань…</p> : !data ? null : <section className="taskWorkspace">
       <div className="taskToolbar">
@@ -95,17 +105,22 @@ export default function TasksPage() {
       <div className="taskList">
         {tasks.length===0 ? <p className="taskEmpty">Завдань у цьому списку немає.</p> : tasks.map(t=><article className={`taskCard priority-${t.priority}${overdue(t)?" overdue":""}`} key={t.id}>
           <div className="taskCardMain">
-            <div className="taskCardTop"><span className={`taskPriority ${t.priority}`}>{priorityLabel[t.priority]}</span>{overdue(t)&&<span className="taskOverdue">Прострочено</span>}</div>
+            <div className="taskCardTop">
+              <span className={`taskPriority ${t.priority}`}>{priorityLabel[t.priority]}</span>
+              {t.source==="automation"&&<span className="taskAuto">Автоматично</span>}
+              {overdue(t)&&<span className="taskOverdue">Прострочено</span>}
+            </div>
             <h2>{t.title}</h2>
             {t.details&&<p>{t.details}</p>}
             <div className="taskMeta">
               {t.assignedEmail?<span>Виконавець: <b>{nameByEmail[t.assignedEmail]||t.assignedEmail}</b></span>:<span>Без виконавця</span>}
               {t.dueDate&&<span>До: <b>{t.dueDate}</b></span>}
               {t.bookingId&&<a href={`/staff/protocols?open=${t.bookingId}`}>Дослідження #{t.bookingId}</a>}
+              {sourceHref(t)&&<a href={sourceHref(t)}>{sourceLabel(t)}</a>}
             </div>
           </div>
           <div className="taskActions">
-            {t.status==="open"?<button disabled={busy===t.id} onClick={()=>void patchTask(t.id,{status:"done"})}>{busy===t.id?"…":"✓ Виконано"}</button>:<button disabled={busy===t.id} onClick={()=>void patchTask(t.id,{status:"open"})}>Повернути в роботу</button>}
+            {t.status==="open"?<button disabled={busy===t.id} onClick={()=>void patchTask(t.id,{status:"done"})}>{busy===t.id?"…":"✓ Виконано"}</button>:t.source==="automation"?<span className="taskAutoDone">Керується системою</span>:<button disabled={busy===t.id} onClick={()=>void patchTask(t.id,{status:"open"})}>Повернути в роботу</button>}
           </div>
         </article>)}
       </div>

--- a/app/styles/16-tasks.css
+++ b/app/styles/16-tasks.css
@@ -43,12 +43,14 @@
 .workspaceShell .taskCard.priority-normal::before { background:#2563eb; }
 .workspaceShell .taskCard.priority-low::before { background:#64748b; }
 .workspaceShell .taskCard.overdue { border-color:rgba(217,119,6,.34); }
-.workspaceShell .taskCardTop { display:flex; align-items:center; gap:5px; }
-.workspaceShell .taskPriority,.workspaceShell .taskOverdue { display:inline-flex; align-items:center; min-height:20px; padding:0 7px; border-radius:999px; font-size:9px; font-weight:800; }
+.workspaceShell .taskCardTop { display:flex; align-items:center; gap:5px; flex-wrap:wrap; }
+.workspaceShell .taskPriority,.workspaceShell .taskOverdue,.workspaceShell .taskAuto { display:inline-flex; align-items:center; min-height:20px; padding:0 7px; border-radius:999px; font-size:9px; font-weight:800; }
 .workspaceShell .taskPriority { background:rgba(148,163,184,.12); color:var(--ws-muted); }
 .workspaceShell .taskPriority.high { background:rgba(220,38,38,.1); color:#b91c1c; }
 .workspaceShell .taskPriority.normal { background:rgba(37,99,235,.1); color:#2563eb; }
 .workspaceShell .taskOverdue { background:rgba(217,119,6,.11); color:#b45309; }
+.workspaceShell .taskAuto { background:rgba(8,145,178,.11); color:#0e7490; }
+.workspaceShell .taskAutoDone { color:var(--ws-muted); font-size:10px; font-weight:700; white-space:nowrap; }
 .workspaceShell .taskCard h2 { margin:5px 0 0; color:var(--ws-ink); font-size:14px; letter-spacing:-.01em; }
 .workspaceShell .taskCard p { margin:5px 0 0; color:var(--ws-muted); font-size:11px; line-height:1.45; white-space:pre-wrap; }
 .workspaceShell .taskMeta { display:flex; gap:12px; flex-wrap:wrap; margin-top:8px; color:var(--ws-muted); font-size:10px; }
@@ -60,6 +62,7 @@
 .workspaceShell.themeDark .taskPriority.high { color:#fca5a5; }
 .workspaceShell.themeDark .taskPriority.normal { color:#93c5fd; }
 .workspaceShell.themeDark .taskOverdue { color:#fbbf24; }
+.workspaceShell.themeDark .taskAuto { color:#67e8f9; background:rgba(8,145,178,.2); }
 
 @media(max-width:760px){
   .workspaceShell .taskCreateRow,.workspaceShell .taskSummary{grid-template-columns:1fr;}

--- a/drizzle/0041_operational_task_automation.sql
+++ b/drizzle/0041_operational_task_automation.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `staff_tasks` ADD COLUMN `source` text DEFAULT 'manual' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `staff_tasks` ADD COLUMN `automation_key` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `staff_tasks` ADD COLUMN `source_entity_type` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `staff_tasks` ADD COLUMN `source_entity_id` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `staff_tasks_org_open_automation_idx`
+  ON `staff_tasks` (`organization_id`, `automation_key`)
+  WHERE `status` = 'open' AND `automation_key` <> '';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_tasks_org_source_idx`
+  ON `staff_tasks` (`organization_id`, `source`, `source_entity_type`, `source_entity_id`);

--- a/lib/operational-tasks.ts
+++ b/lib/operational-tasks.ts
@@ -1,5 +1,3 @@
-import { audit } from "./audit";
-
 type Candidate = {
   organizationId:number;
   key:string;
@@ -16,6 +14,25 @@ function kyivDate(now:number) {
   return new Intl.DateTimeFormat("en-CA",{
     timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit",
   }).format(new Date(now));
+}
+
+async function auditAutomation(
+  db:D1Database,
+  organizationId:number,
+  action:"task_auto_created"|"task_auto_resolved",
+  targetId:number,
+  source:string,
+  sourceId:string,
+) {
+  try {
+    const details=JSON.stringify({source,sourceId}).slice(0,4000);
+    await db.prepare(`INSERT INTO security_audit_log
+      (organization_id,actor_email,action,resource,target_id,details_json)
+      VALUES (?,'system:automation',?,'task',?,?)`)
+      .bind(organizationId,action,String(targetId),details).run();
+  } catch {
+    // Audit must never block the operational task run.
+  }
 }
 
 async function activeAssignee(db:D1Database,organizationId:number,email:string) {
@@ -93,7 +110,7 @@ export async function runOperationalTasks(db:D1Database,now=Date.now()):Promise<
       if(Number(result.meta.changes||0)>0) {
         created++;
         const id=Number(result.meta.last_row_id||0);
-        await audit(db,{organizationId:task.organizationId,actorEmail:"system:automation",action:"task_auto_created",resource:"task",targetId:id,details:{source:task.sourceEntityType,sourceId:task.sourceEntityId}});
+        await auditAutomation(db,task.organizationId,"task_auto_created",id,task.sourceEntityType,task.sourceEntityId);
       }
     }
 
@@ -107,7 +124,7 @@ export async function runOperationalTasks(db:D1Database,now=Date.now()):Promise<
         .bind(org.id,task.id).run();
       if(Number(result.meta.changes||0)>0) {
         resolved++;
-        await audit(db,{organizationId:org.id,actorEmail:"system:automation",action:"task_auto_resolved",resource:"task",targetId:task.id,details:{source:task.sourceType,sourceId:task.sourceId}});
+        await auditAutomation(db,org.id,"task_auto_resolved",task.id,task.sourceType,task.sourceId);
       }
     }
   }

--- a/lib/operational-tasks.ts
+++ b/lib/operational-tasks.ts
@@ -1,0 +1,115 @@
+import { audit } from "./audit";
+
+type Candidate = {
+  organizationId:number;
+  key:string;
+  title:string;
+  details:string;
+  priority:"normal"|"high";
+  dueDate:string;
+  assignedEmail:string;
+  sourceEntityType:"inventory_item"|"equipment_maintenance";
+  sourceEntityId:string;
+};
+
+function kyivDate(now:number) {
+  return new Intl.DateTimeFormat("en-CA",{
+    timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit",
+  }).format(new Date(now));
+}
+
+async function activeAssignee(db:D1Database,organizationId:number,email:string) {
+  if(!email)return "";
+  const row=await db.prepare(`SELECT 1 AS ok FROM memberships m
+    JOIN staff_members s ON s.email=m.member_email AND s.active=1
+    WHERE m.organization_id=? AND m.member_email=? AND m.active=1 LIMIT 1`)
+    .bind(organizationId,email).first<{ok:number}>();
+  return row?.ok?email:"";
+}
+
+async function candidatesForOrg(db:D1Database,organizationId:number,today:string):Promise<Candidate[]> {
+  const [inventory,maintenance]=await Promise.all([
+    db.prepare(`SELECT i.id,i.name,i.unit,i.min_stock AS minStock,
+        COALESCE(SUM(m.quantity_delta),0) AS stock
+      FROM inventory_items i
+      LEFT JOIN inventory_lots l ON l.organization_id=i.organization_id AND l.item_id=i.id
+      LEFT JOIN inventory_movements m ON m.organization_id=i.organization_id AND m.item_id=i.id AND m.lot_id=l.id
+      WHERE i.organization_id=? AND i.active=1 AND i.min_stock>0
+      GROUP BY i.id
+      HAVING stock <= i.min_stock + 0.000001`)
+      .bind(organizationId).all<{id:number;name:string;unit:string;minStock:number;stock:number}>(),
+    db.prepare(`SELECT id,equipment_id AS equipmentId,event_type AS eventType,title,
+        assigned_email AS assignedEmail,due_date AS dueDate,downtime_start AS downtimeStart
+      FROM equipment_maintenance
+      WHERE organization_id=? AND status IN ('open','in_progress')
+        AND ((due_date<>'' AND due_date<?)
+          OR (event_type IN ('fault','repair') AND downtime_start<>'' AND downtime_end=''))
+      ORDER BY id`)
+      .bind(organizationId,today).all<{id:number;equipmentId:string;eventType:string;title:string;assignedEmail:string;dueDate:string;downtimeStart:string}>(),
+  ]);
+
+  const out:Candidate[]=[];
+  for(const item of inventory.results||[]) {
+    out.push({
+      organizationId,key:`inventory:low:${item.id}`,
+      title:`Поповнити запас: ${item.name}`,
+      details:`Поточний залишок: ${Number(item.stock)} ${item.unit}. Мінімальний запас: ${Number(item.minStock)} ${item.unit}.`,
+      priority:"high",dueDate:today,assignedEmail:"",
+      sourceEntityType:"inventory_item",sourceEntityId:String(item.id),
+    });
+  }
+  for(const event of maintenance.results||[]) {
+    const overdue=!!event.dueDate&&event.dueDate<today;
+    const assignedEmail=await activeAssignee(db,organizationId,event.assignedEmail||"");
+    out.push({
+      organizationId,key:`maintenance:attention:${event.id}`,
+      title:`Контроль обладнання: ${event.title}`,
+      details:overdue
+        ? `Обладнання: ${event.equipmentId}. Строк ${event.dueDate} прострочено.`
+        : `Обладнання: ${event.equipmentId}. Зафіксований активний простій з ${event.downtimeStart}.`,
+      priority:"high",dueDate:event.dueDate||today,assignedEmail,
+      sourceEntityType:"equipment_maintenance",sourceEntityId:String(event.id),
+    });
+  }
+  return out;
+}
+
+export async function runOperationalTasks(db:D1Database,now=Date.now()):Promise<{created:number;resolved:number}> {
+  const today=kyivDate(now);
+  const organizations=await db.prepare("SELECT id FROM organizations WHERE active=1 ORDER BY id").all<{id:number}>();
+  let created=0,resolved=0;
+
+  for(const org of organizations.results||[]) {
+    const candidates=await candidatesForOrg(db,org.id,today);
+    const activeKeys=new Set(candidates.map(c=>c.key));
+
+    for(const task of candidates) {
+      const result=await db.prepare(`INSERT OR IGNORE INTO staff_tasks
+        (organization_id,title,details,status,priority,due_date,assigned_email,created_by,
+         source,automation_key,source_entity_type,source_entity_id)
+        VALUES (?,?,?,'open',?,?,?,'system:automation','automation',?,?,?)`)
+        .bind(task.organizationId,task.title,task.details,task.priority,task.dueDate,task.assignedEmail,
+          task.key,task.sourceEntityType,task.sourceEntityId).run();
+      if(Number(result.meta.changes||0)>0) {
+        created++;
+        const id=Number(result.meta.last_row_id||0);
+        await audit(db,{organizationId:task.organizationId,actorEmail:"system:automation",action:"task_auto_created",resource:"task",targetId:id,details:{source:task.sourceEntityType,sourceId:task.sourceEntityId}});
+      }
+    }
+
+    const open=await db.prepare(`SELECT id,automation_key AS automationKey,source_entity_type AS sourceType,source_entity_id AS sourceId
+      FROM staff_tasks WHERE organization_id=? AND status='open' AND source='automation' AND automation_key<>''`)
+      .bind(org.id).all<{id:number;automationKey:string;sourceType:string;sourceId:string}>();
+    for(const task of open.results||[]) {
+      if(activeKeys.has(task.automationKey))continue;
+      const result=await db.prepare(`UPDATE staff_tasks SET status='done',completed_by='system:automation',completed_at=CURRENT_TIMESTAMP,updated_at=CURRENT_TIMESTAMP
+        WHERE organization_id=? AND id=? AND status='open' AND source='automation'`)
+        .bind(org.id,task.id).run();
+      if(Number(result.meta.changes||0)>0) {
+        resolved++;
+        await audit(db,{organizationId:org.id,actorEmail:"system:automation",action:"task_auto_resolved",resource:"task",targetId:task.id,details:{source:task.sourceType,sourceId:task.sourceId}});
+      }
+    }
+  }
+  return {created,resolved};
+}

--- a/tests/operational-auto-tasks.behavior.test.mjs
+++ b/tests/operational-auto-tasks.behavior.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1 } from "./helpers/d1.mjs";
+import { runOperationalTasks } from "../lib/operational-tasks.ts";
+
+const NOW = Date.parse("2026-08-14T12:00:00Z");
+
+test("operational automation is tenant-safe, idempotent and resolves stale tasks", async () => {
+  await withD1(async (db,raw) => {
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Org 2','org-2',1)");
+
+    raw.exec(`INSERT INTO inventory_items (id,organization_id,sku,name,category,unit,min_stock,active)
+      VALUES (101,1,'I-1','Контраст 350','contrast','фл',5,1),
+             (201,2,'I-2','Катетер','catheter','шт',3,1)`);
+    raw.exec(`INSERT INTO equipment_maintenance
+      (id,organization_id,equipment_id,event_type,status,title,due_date,downtime_start,created_by)
+      VALUES (301,1,'ct','maintenance','open','Планове ТО КТ','2026-08-10','','admin@example.com')`);
+
+    const first=await runOperationalTasks(db,NOW);
+    assert.equal(first.created,3);
+    assert.equal(first.resolved,0);
+
+    const open1=raw.prepare("SELECT organization_id,automation_key,status FROM staff_tasks WHERE source='automation' ORDER BY organization_id,automation_key").all();
+    assert.equal(open1.length,3);
+    assert.deepEqual(open1.map(r=>r.organization_id),[1,1,2]);
+    assert.equal(new Set(open1.map(r=>`${r.organization_id}:${r.automation_key}`)).size,3);
+
+    const second=await runOperationalTasks(db,NOW);
+    assert.equal(second.created,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_tasks WHERE source='automation'").get().n,3);
+
+    raw.exec("INSERT INTO inventory_lots (id,organization_id,item_id,lot_number) VALUES (401,1,101,'LOT-1')");
+    raw.exec("INSERT INTO inventory_movements (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,actor_email) VALUES (1,101,401,'receipt',10,'Поповнення','admin@example.com')");
+    raw.exec("UPDATE equipment_maintenance SET status='done',completed_by='admin@example.com',completed_at=CURRENT_TIMESTAMP WHERE id=301 AND organization_id=1");
+
+    const resolved=await runOperationalTasks(db,NOW);
+    assert.equal(resolved.resolved,2);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_tasks WHERE organization_id=1 AND source='automation' AND status='open'").get().n,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_tasks WHERE organization_id=2 AND source='automation' AND status='open'").get().n,1);
+
+    raw.exec("UPDATE staff_tasks SET status='done',completed_by='user@example.com',completed_at=CURRENT_TIMESTAMP WHERE organization_id=2 AND automation_key='inventory:low:201' AND status='open'");
+    const reappeared=await runOperationalTasks(db,NOW);
+    assert.equal(reappeared.created,1);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_tasks WHERE organization_id=2 AND automation_key='inventory:low:201' AND status='open'").get().n,1);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_tasks WHERE organization_id=2 AND automation_key='inventory:low:201'").get().n,2);
+  });
+});
+
+test("automatic task audit never stores inventory or maintenance free-text details", async () => {
+  await withD1(async (db,raw) => {
+    raw.exec(`INSERT INTO inventory_items (id,organization_id,sku,name,category,unit,min_stock,active)
+      VALUES (501,1,'SAFE','Секретна службова назва','other','шт',2,1)`);
+    await runOperationalTasks(db,NOW);
+    const audit=raw.prepare("SELECT details_json AS details FROM security_audit_log WHERE action='task_auto_created' ORDER BY id DESC LIMIT 1").get();
+    assert.ok(audit);
+    assert.match(audit.details,/inventory_item/);
+    assert.doesNotMatch(audit.details,/Секретна службова назва/);
+  });
+});

--- a/tests/reminders-tenant.behavior.test.mjs
+++ b/tests/reminders-tenant.behavior.test.mjs
@@ -66,11 +66,14 @@ test("scheduled reminder SQL isolates bookings, dedupe and do-not-contact by org
   });
 });
 
-test("production scheduled handler is explicitly limited to the initial organization", () => {
+test("production scheduled handler keeps patient reminders on org1 and operational jobs isolated", () => {
   assert.match(workerSource, /const INITIAL_ORGANIZATION_ID = 1/);
+  assert.match(workerSource, /const now=Date\.now\(\)/);
   assert.match(
     workerSource,
-    /runDueReminders\(env\.DB,\s*Date\.now\(\),\s*INITIAL_ORGANIZATION_ID\)/,
+    /runDueReminders\(env\.DB,\s*now,\s*INITIAL_ORGANIZATION_ID\)/,
   );
+  assert.match(workerSource, /runOperationalTasks\(env\.DB,\s*now\)/);
+  assert.match(workerSource, /Promise\.allSettled\(\[/);
   assert.match(workerSource, /async scheduled\s*\(/);
 });

--- a/tests/reminders.test.mjs
+++ b/tests/reminders.test.mjs
@@ -52,10 +52,13 @@ test("kyivNow converts a UTC instant to Kyiv date and minutes", () => {
   assert.equal(minutes, 15 * 60);
 });
 
-test("worker schedules tenant-limited reminder support every 15 minutes", async () => {
+test("worker schedules tenant-limited reminders and internal operational tasks every 15 minutes", async () => {
   const worker = await read("worker/index.ts");
   assert.match(worker, /async scheduled\(/);
-  assert.match(worker, /runDueReminders\(env\.DB, Date\.now\(\), INITIAL_ORGANIZATION_ID\)/);
+  assert.match(worker, /const now=Date\.now\(\)/);
+  assert.match(worker, /runDueReminders\(env\.DB,\s*now,\s*INITIAL_ORGANIZATION_ID\)/);
+  assert.match(worker, /runOperationalTasks\(env\.DB,\s*now\)/);
+  assert.match(worker, /Promise\.allSettled\(\[/);
   assert.match(worker, /const INITIAL_ORGANIZATION_ID = 1/);
   assert.match(worker, /ctx\.waitUntil/);
   const wrangler = await read("wrangler.cloudflare.toml");

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -4,6 +4,7 @@ import handler from "vinext/server/app-router-entry";
 import { getSetting } from "../lib/settings";
 import { parseSiteContent, SITE_CONTENT_KEY } from "../lib/site-content";
 import { runDueReminders } from "../lib/reminders";
+import { runOperationalTasks } from "../lib/operational-tasks";
 
 interface Env {
   ASSETS: Fetcher;
@@ -63,16 +64,12 @@ function secure(response: Response, request?: Request): Response {
   if (request) {
     const url = new URL(request.url);
     const pathname = url.pathname;
-    // Canonical headers cover the static pages that do not all have HTML
-    // metadata. The patient cabinet is intentionally excluded from indexing.
     if (PUBLIC_CANONICAL_PATHS.has(pathname)) {
       headers.set("link", `<${new URL(pathname, url.origin).toString()}>; rel="canonical"`);
     }
     if (pathname === "/site/cabinet.html" || pathname === "/cabinet") {
       headers.set("x-robots-tag", "noindex, nofollow");
     }
-    // /api/site-content — публічний контент вітрини, кешується самим маршрутом
-    // (short max-age); решта /api та /staff лишаються no-store.
     const publicCacheable = pathname === "/api/site-content";
     if (!publicCacheable && (pathname.startsWith("/api/") || pathname.startsWith("/staff"))) {
       headers.set("cache-control", "no-store");
@@ -85,9 +82,6 @@ function isStaticAssetPath(pathname: string): boolean {
   return STATIC_ASSET_PATHS.has(pathname) || STATIC_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
-// Чи вітрина в режимі «лише платні»: читаємо site_content з D1. Помилка/
-// відсутність налаштування = типовий режим (paid_and_free), тож військова
-// сторінка лишається доступною за замовчуванням.
 async function storefrontPaidOnly(db: D1Database): Promise<boolean> {
   try {
     return parseSiteContent(await getSetting(db, SITE_CONTENT_KEY)).storefrontType === "paid_only";
@@ -110,16 +104,8 @@ function unsafeCrossSiteRequest(request: Request): boolean {
   }
 }
 
-// Image security config. SVG sources with .svg extension auto-skip the
-// optimization endpoint on the client side (served directly, no proxy).
-// To route SVGs through the optimizer (with security headers), set
-// dangerouslyAllowSVG: true in next.config.js and uncomment below:
-// const imageConfig: ImageConfig = { dangerouslyAllowSVG: true };
-
 const worker = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    // Make the site-owned D1 binding available to server route modules without
-    // importing the runtime-only `cloudflare:workers` module into the artifact.
     (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__ = env.DB;
     (globalThis as typeof globalThis & {
       __RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__?: string;
@@ -130,40 +116,27 @@ const worker = {
       return secure(Response.json({ error: "Cross-site request blocked" }, { status: 403 }), request);
     }
 
-    // With run_worker_first=true every request reaches this Worker before the
-    // static-asset service. Delegate generated Vite/vinext bundles and public
-    // files explicitly; otherwise the app router can return HTML/404 for CSS
-    // and JS requests, leaving the staff UI unstyled and unhydrated.
     if ((request.method === "GET" || request.method === "HEAD") && isStaticAssetPath(url.pathname)) {
       return secure(await env.ASSETS.fetch(request), request);
     }
 
-    // There is exactly one indexable public home. Old URLs shared with patients
-    // keep working but permanently consolidate to the domain root, preserving
-    // query parameters such as campaign attribution.
     if ((request.method === "GET" || request.method === "HEAD") && LEGACY_HOME_PATHS.has(url.pathname)) {
       const canonicalHome = new URL("/", url);
       canonicalHome.search = url.search;
       return secure(Response.redirect(canonicalHome.toString(), 308), request);
     }
 
-    // The tested teal storefront remains the source document for the canonical
-    // domain root; only its legacy URL aliases redirect above.
     if (url.pathname === "/") {
       const storefrontRequest = new Request(new URL("/site/index.html", request.url), request);
       return secure(await env.ASSETS.fetch(storefrontRequest), request);
     }
 
-    // Режим вітрини «лише платні»: сторінка військових недоступна — і прямий
-    // вхід на military.html, і /booking?category=military ведуть на прайс.
     const wantsMilitary = url.pathname === "/site/military.html"
       || (url.pathname === "/booking" && url.searchParams.get("category") === "military");
     if (wantsMilitary && await storefrontPaidOnly(env.DB)) {
       return secure(Response.redirect(new URL("/site/price.html", request.url).toString(), 302), request);
     }
 
-    // Legacy Next public routes → v22 static pages, so nobody lands on the old
-    // card-grid booking screen. Civilian price list / military free list / cabinet.
     if (url.pathname === "/booking") {
       const target = url.searchParams.get("category") === "military" ? "/site/military.html" : "/site/price.html";
       return secure(Response.redirect(new URL(target, request.url).toString(), 302), request);
@@ -186,12 +159,15 @@ const worker = {
     return secure(await handler.fetch(request, env, ctx), request);
   },
 
-  // Messaging credentials still live in global app_settings. Until they become
-  // per-organization, cron is deliberately limited to the initial tenant so a
-  // second organization can never receive reminders through the wrong channel.
   async scheduled(_event: unknown, env: Env, ctx: ExecutionContext): Promise<void> {
     (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__ = env.DB;
-    ctx.waitUntil(runDueReminders(env.DB, Date.now(), INITIAL_ORGANIZATION_ID));
+    const now=Date.now();
+    ctx.waitUntil(Promise.allSettled([
+      // Patient messaging remains limited to org1 until credentials are tenant-scoped.
+      runDueReminders(env.DB, now, INITIAL_ORGANIZATION_ID),
+      // Internal operational tasks use no external credentials and are safe for all active tenants.
+      runOperationalTasks(env.DB, now),
+    ]));
   },
 };
 


### PR DESCRIPTION
Adds BAS-style automatic operational tasks on top of the existing staff_tasks module. Every 15-minute Cloudflare cron run now evaluates internal conditions independently from patient messaging: active inventory items at/below min_stock and overdue equipment maintenance or active fault/repair downtime. Generated tasks are tenant-scoped and idempotent through an automation_key unique only among open tasks; resolved underlying conditions automatically close stale automation tasks, while a still-active condition can reappear after a user completes the task. Migration 0041 adds task source/automation metadata and indexes. The Tasks UI marks automatic tasks and links back to Inventory or Maintenance. Automatic task audits store only source type/id, never task free-text details. Existing manual tasks remain unchanged. Includes behavioral tests for multi-tenant isolation, deduplication, auto-resolution, resurfacing, and audit minimization. No auth/PIN/credential or external messaging changes.