### PR TITLE
Harden medical data access controls

### DIFF
--- a/drizzle/0048_security_audit_append_only.sql
+++ b/drizzle/0048_security_audit_append_only.sql
@@ -1,0 +1,13 @@
+-- Security audit rows are evidentiary records. Once written, application or
+-- ad-hoc SQL must not rewrite or delete the history of access to medical data.
+CREATE TRIGGER IF NOT EXISTS `security_audit_log_append_only_update`
+BEFORE UPDATE ON `security_audit_log`
+BEGIN
+  SELECT RAISE(ABORT, 'security audit log is append-only');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `security_audit_log_append_only_delete`
+BEFORE DELETE ON `security_audit_log`
+BEGIN
+  SELECT RAISE(ABORT, 'security audit log is append-only');
+END;

--- a/lib/staff-auth.ts
+++ b/lib/staff-auth.ts
@@ -73,27 +73,30 @@ export function canAccessAllBookings(role: StaffRole) {
   return role === "admin" || role === "registrar";
 }
 
-// Доступ до заявки. Коли передано organizationId — доступ обмежено ще й
-// організацією (tenant isolation): заявка іншої організації недосяжна навіть
-// для admin/registrar і навіть за прямим id.
+// Доступ до заявки завжди перевіряється всередині конкретної організації.
+// Tenant scope є обов'язковою частиною security primitive: навіть admin або
+// registrar не можуть викликати helper у режимі "усі організації".
 export async function canAccessBooking(
   db: D1Database,
   member: { email: string; role: StaffRole },
   bookingId: number,
-  organizationId?: number,
+  organizationId: number,
 ): Promise<boolean> {
-  const orgClause = organizationId != null ? " AND organization_id = ?" : "";
-  const orgBind = organizationId != null ? [organizationId] : [];
+  if (!Number.isInteger(bookingId) || bookingId <= 0) return false;
+  if (!Number.isInteger(organizationId) || organizationId <= 0) return false;
+
   if (canAccessAllBookings(member.role)) {
-    if (organizationId == null) return true;
-    const row = await db.prepare(`SELECT id FROM bookings WHERE id = ?${orgClause} LIMIT 1`)
-      .bind(bookingId, ...orgBind).first();
+    const row = await db.prepare(
+      "SELECT id FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1"
+    ).bind(bookingId, organizationId).first();
     return Boolean(row);
   }
+
   const column = member.role === "radiologist"
     ? "assigned_radiologist_email"
     : "assigned_radiographer_email";
-  const row = await db.prepare(`SELECT id FROM bookings WHERE id = ? AND ${column} = ?${orgClause} LIMIT 1`)
-    .bind(bookingId, member.email, ...orgBind).first();
+  const row = await db.prepare(
+    `SELECT id FROM bookings WHERE id = ? AND ${column} = ? AND organization_id = ? LIMIT 1`
+  ).bind(bookingId, member.email, organizationId).first();
   return Boolean(row);
 }

--- a/tests/audit-append-only.behavior.test.mjs
+++ b/tests/audit-append-only.behavior.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1 } from "./helpers/d1.mjs";
+
+test("security audit history is physically append-only in D1", async () => {
+  await withD1(async (db) => {
+    const inserted = await db.prepare(
+      `INSERT INTO security_audit_log
+        (organization_id, actor_email, action, resource, target_id, details_json)
+       VALUES (1, 'doctor@example.com', 'protocol_viewed', 'protocol', '42', '{"version":1}')`
+    ).run();
+    const id = Number(inserted.meta.last_row_id);
+    assert.ok(id > 0);
+
+    await assert.rejects(
+      db.prepare("UPDATE security_audit_log SET action='rewritten' WHERE id=?").bind(id).run(),
+      /append-only/i,
+    );
+    await assert.rejects(
+      db.prepare("DELETE FROM security_audit_log WHERE id=?").bind(id).run(),
+      /append-only/i,
+    );
+
+    const row = await db.prepare(
+      "SELECT organization_id AS organizationId, actor_email AS actorEmail, action, resource, target_id AS targetId, details_json AS detailsJson FROM security_audit_log WHERE id=?"
+    ).bind(id).first();
+    assert.equal(row.organizationId, 1);
+    assert.equal(row.actorEmail, "doctor@example.com");
+    assert.equal(row.action, "protocol_viewed");
+    assert.equal(row.resource, "protocol");
+    assert.equal(row.targetId, "42");
+    assert.equal(row.detailsJson, '{"version":1}');
+  });
+});
+
+test("0048 declares update and delete guards for the audit ledger", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const sql = await readFile(new URL("../drizzle/0048_security_audit_append_only.sql", import.meta.url), "utf8");
+  assert.match(sql, /BEFORE UPDATE ON `security_audit_log`/);
+  assert.match(sql, /BEFORE DELETE ON `security_audit_log`/);
+  assert.match(sql, /RAISE\(ABORT, 'security audit log is append-only'\)/);
+});

--- a/tests/tenant-hardening.test.mjs
+++ b/tests/tenant-hardening.test.mjs
@@ -64,11 +64,15 @@ test("bookings route derives tenant from session and org-scopes access", async (
   assert.doesNotMatch(route, /function bookingScope\(member: \{ email: string; role: StaffRole \}\)\s*\{/);
 });
 
-// canAccessBooking отримав необовʼязковий organizationId і застосовує його.
-test("canAccessBooking enforces organization when provided", async () => {
+// Security primitive вимагає tenant завжди: немає optional organizationId
+// і немає admin/registrar fast-path, який повертає true без перевірки заявки.
+test("canAccessBooking requires organization and fails closed", async () => {
   const src = await read("lib/staff-auth.ts");
-  assert.match(src, /organizationId\?: number/);
-  assert.match(src, /AND organization_id = \?/);
+  assert.match(src, /organizationId: number/);
+  assert.doesNotMatch(src, /organizationId\?: number/);
+  assert.match(src, /!Number\.isInteger\(organizationId\) \|\| organizationId <= 0/);
+  assert.match(src, /WHERE id = \? AND organization_id = \? LIMIT 1/);
+  assert.doesNotMatch(src, /organizationId == null\) return true/);
 });
 
 // Протоколи: доступ і черга org-scoped.


### PR DESCRIPTION
## Summary
- make `canAccessBooking` require an explicit tenant and fail closed for invalid booking/organization IDs
- make `security_audit_log` physically append-only in D1 with UPDATE/DELETE guards
- add regression tests for tenant-required booking access and immutable audit history

## Security impact
Prevents future callers from accidentally using a tenant-less booking access primitive and prevents direct SQL from rewriting or deleting the evidentiary medical-access audit trail.

## Deployment
No production deploy in this PR. Migration 0048 will only be applied during a later approved production rollout.