### PR TITLE
Enforce clinician assignment scope across study workflows

### DIFF
--- a/app/api/staff/notify/route.ts
+++ b/app/api/staff/notify/route.ts
@@ -1,11 +1,12 @@
 import { sendPatientMessage, type ReminderBooking } from "../../../../lib/notify";
-import { canWriteNotes, type StaffRole } from "../../../../lib/staff-auth";
+import { canAccessBooking, canWriteNotes, type StaffRole } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
 import { dbBinding } from "../../../../lib/db";
 
 // Разове повідомлення пацієнту, ініційоване персоналом (результат готовий,
-// затримка, жива черга тощо) — окремо від автопідтвердження. Доступне всім
-// активним працівникам (canWriteNotes), зокрема лікарю-рентгенологу.
+// затримка, жива черга тощо) — окремо від автопідтвердження. Admin/registrar
+// можуть працювати з усією tenant-чергою; клінічні ролі — лише з призначеними
+// їм заявками через ту саму security primitive, що й протоколи/PACS.
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
@@ -23,6 +24,9 @@ export async function POST(request: Request) {
   }
   if (message.length < 3) {
     return Response.json({ error: "Введіть текст повідомлення" }, { status: 400 });
+  }
+  if (!(await canAccessBooking(db, ctx.member, bookingId, ctx.organizationId))) {
+    return Response.json({ error: "Заявку не знайдено або її не призначено вам" }, { status: 404 });
   }
 
   const booking = await db.prepare(

--- a/lib/tenant-repo.ts
+++ b/lib/tenant-repo.ts
@@ -66,10 +66,16 @@ export interface OrgStudyRow {
   assignedRadiographerEmail: string;
 }
 
-// Реєстр досліджень організації: заявки, збагачені прив'язкою до DICOM-студії
-// та призначеними виконавцями. Строго tenant-scoped — фільтр organization_id
-// зі серверного контексту.
+// Реєстр досліджень: tenant scope застосовується завжди, а клінічні ролі
+// додатково бачать лише записи, призначені саме їм. Admin/registrar можуть
+// бачити всю чергу своєї організації для диспетчеризації та призначення.
 export async function listOrgStudies(db: D1Database, ctx: OrgContext, limit = 500): Promise<OrgStudyRow[]> {
+  const assignment = ctx.role === "radiologist"
+    ? { sql: " AND b.assigned_radiologist_email = ?", binds: [ctx.member.email] }
+    : ctx.role === "radiographer"
+      ? { sql: " AND b.assigned_radiographer_email = ?", binds: [ctx.member.email] }
+      : { sql: "", binds: [] as string[] };
+
   const result = await db.prepare(
     `SELECT b.id AS id, b.code AS code, b.name AS name, b.service AS service,
        b.equipment_id AS equipmentId, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
@@ -79,10 +85,10 @@ export async function listOrgStudies(db: D1Database, ctx: OrgContext, limit = 50
        s.study_status AS studyStatus, s.accession_number AS accessionNumber
      FROM bookings b
      LEFT JOIN imaging_studies s ON s.booking_id = b.id AND s.organization_id = b.organization_id
-     WHERE b.organization_id = ?
+     WHERE b.organization_id = ?${assignment.sql}
      ORDER BY b.desired_date DESC, b.desired_time DESC
      LIMIT ?`
-  ).bind(ctx.organizationId, limit).all<OrgStudyRow>();
+  ).bind(ctx.organizationId, ...assignment.binds, limit).all<OrgStudyRow>();
   return result.results ?? [];
 }
 
@@ -92,9 +98,7 @@ export interface OrgClinician {
   role: string;
 }
 
-// Виконавці організації, яких можна призначати на дослідження: активні
-// лікарі-рентгенологи та рентгенолаборанти — учасники цього tenant.
-// Роль береться з memberships, бо саме tenant membership є authoritative.
+// Виконавці для призначення — лише активні учасники цього tenant.
 export async function listOrgClinicians(db: D1Database, ctx: OrgContext): Promise<OrgClinician[]> {
   const result = await db.prepare(
     `SELECT sm.email AS email, sm.display_name AS displayName, m.role AS role

--- a/tests/notify.behavior.test.mjs
+++ b/tests/notify.behavior.test.mjs
@@ -1,18 +1,27 @@
 // Поведінковий тест вибору каналів сповіщення через /api/staff/notify:
-// повага до «не турбувати», tenant-ізоляція, поведінка без налаштованих шлюзів.
-// Свідомо перевіряємо лише детерміновані гілки (без реальних мережевих викликів).
+// повага до «не турбувати», tenant-ізоляція, assignment scope і поведінка без
+// налаштованих шлюзів. Без реальних мережевих викликів.
 
 import assert from "node:assert/strict";
 import test from "node:test";
 import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
 
-async function seedBooking(db, { id = 1, phoneNormalized = "380971112233", orgId = 1, email = "" } = {}) {
+async function seedBooking(db, {
+  id = 1,
+  phoneNormalized = "380971112233",
+  orgId = 1,
+  email = "",
+  radiologist = "",
+  radiographer = "",
+} = {}) {
   await db.prepare(
     `INSERT INTO bookings (id, code, name, phone, phone_normalized, patient_email, service, service_code,
-       desired_date, desired_time, status, date_of_birth, patient_category, organization_id)
-     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+       desired_date, desired_time, status, date_of_birth, patient_category, organization_id,
+       assigned_radiologist_email, assigned_radiographer_email)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
   ).bind(id, `RD-NOTIFY${String(id).padStart(4, "0")}`, "Пацієнт", "+" + phoneNormalized, phoneNormalized,
-    email, "КТ", "CT-01", "2026-09-01", "10:00", "confirmed", "1990-05-05", "civilian", orgId).run();
+    email, "КТ", "CT-01", "2026-09-01", `${String(9 + id).padStart(2, "0")}:00`, "confirmed", "1990-05-05", "civilian", orgId,
+    radiologist, radiographer).run();
 }
 
 const notify = (db, cookie, bookingId, message = "Ваш результат готовий") =>
@@ -62,12 +71,20 @@ test("a message to a booking in another organization is not found (tenant isolat
   });
 });
 
-test("a clinical role may still send an ad-hoc message (canWriteNotes)", async () => {
+test("a clinical role may notify only a booking assigned to that clinician", async () => {
   await withD1(async (db) => {
-    await seedBooking(db, { id: 4, phoneNormalized: "380974445566" });
-    const cookie = await seedStaffSession(db, { email: "rad@likarnya.test", role: "radiologist" });
-    const res = await notify(db, cookie, 4);
-    assert.equal(res.status, 200);
+    const doctor = "rad@likarnya.test";
+    await seedBooking(db, { id: 4, phoneNormalized: "380974445566", radiologist: doctor });
+    await seedBooking(db, { id: 6, phoneNormalized: "380976667788", radiologist: "other-rad@likarnya.test" });
+    const cookie = await seedStaffSession(db, { email: doctor, role: "radiologist" });
+
+    const own = await notify(db, cookie, 4);
+    assert.equal(own.status, 200);
+
+    const foreignAssignment = await notify(db, cookie, 6);
+    assert.equal(foreignAssignment.status, 404);
+    const outbox = await db.prepare("SELECT COUNT(*) AS n FROM patient_notifications WHERE booking_id = 6").first("n");
+    assert.equal(outbox, 0);
   });
 });
 

--- a/tests/studies-assignment-scope.behavior.test.mjs
+++ b/tests/studies-assignment-scope.behavior.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { listOrgStudies } from "../lib/tenant-repo.ts";
+import { withD1 } from "./helpers/d1.mjs";
+
+function ctx(role, email, organizationId = 1) {
+  return {
+    organizationId,
+    slug: organizationId === 1 ? "org1" : `org${organizationId}`,
+    organizationName: `Org ${organizationId}`,
+    role,
+    member: { email, displayName: email, role },
+  };
+}
+
+async function addBooking(db, {
+  organizationId = 1,
+  code,
+  time,
+  radiologist = "",
+  radiographer = "",
+}) {
+  await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, service, service_code, equipment_id,
+       duration_minutes, desired_date, desired_time,
+       assigned_radiologist_email, assigned_radiographer_email)
+     VALUES (?, ?, ?, '+380500000000', 'CT', 'CT-HEAD', 'ct', 30, '2026-09-01', ?, ?, ?)`
+  ).bind(organizationId, code, `Patient ${code}`, time, radiologist, radiographer).run();
+}
+
+const codes = (rows) => rows.map((row) => row.code).sort();
+
+test("study registry exposes only assigned studies to radiologists and radiographers", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other-studies', 'Other', 1)").run();
+
+    await addBooking(db, { code:"ASSIGNED-A", time:"09:00", radiologist:"rad-a@example.com", radiographer:"lab-a@example.com" });
+    await addBooking(db, { code:"ASSIGNED-B", time:"10:00", radiologist:"rad-b@example.com", radiographer:"lab-b@example.com" });
+    await addBooking(db, { code:"UNASSIGNED", time:"11:00" });
+    await addBooking(db, { organizationId:2, code:"FOREIGN", time:"12:00", radiologist:"rad-a@example.com", radiographer:"lab-a@example.com" });
+
+    const radiologist = await listOrgStudies(db, ctx("radiologist", "rad-a@example.com"));
+    assert.deepEqual(codes(radiologist), ["ASSIGNED-A"]);
+
+    const radiographer = await listOrgStudies(db, ctx("radiographer", "lab-b@example.com"));
+    assert.deepEqual(codes(radiographer), ["ASSIGNED-B"]);
+
+    const admin = await listOrgStudies(db, ctx("admin", "admin@example.com"));
+    assert.deepEqual(codes(admin), ["ASSIGNED-A", "ASSIGNED-B", "UNASSIGNED"]);
+
+    const registrar = await listOrgStudies(db, ctx("registrar", "registrar@example.com"));
+    assert.deepEqual(codes(registrar), ["ASSIGNED-A", "ASSIGNED-B", "UNASSIGNED"]);
+  });
+});
+
+test("study repository source makes assignment scope part of the query", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(new URL("../lib/tenant-repo.ts", import.meta.url), "utf8");
+  assert.match(source, /ctx\.role === "radiologist"/);
+  assert.match(source, /b\.assigned_radiologist_email = \?/);
+  assert.match(source, /ctx\.role === "radiographer"/);
+  assert.match(source, /b\.assigned_radiographer_email = \?/);
+  assert.match(source, /WHERE b\.organization_id = \?\$\{assignment\.sql\}/);
+});


### PR DESCRIPTION
## Summary
- enforce assignment scope inside `listOrgStudies`
- radiologists see only studies assigned to their radiologist email
- radiographers see only studies assigned to their radiographer email
- admin/registrar retain the full tenant-scoped operational queue
- require the same booking assignment guard before `/api/staff/notify` reads patient contact data or sends a message
- add behavioral coverage for multiple clinicians, foreign tenant data, and blocked notification side effects

## Security impact
Closes two same-tenant authorization gaps where a clinician could enumerate other patients' studies or target an arbitrary booking for a patient notification despite not being assigned to that study.

## Deployment
No production deploy in this PR.