### PR TITLE
Scope PACS provider diagnostics to tenant

### DIFF
--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,9 +1,8 @@
 // Резолвер провайдерів — добирає реалізації інтеграцій у tenant-контексті.
 //
-// Наразі конфігурація інтеграцій зберігається глобально (app_settings /
-// pacs_settings), але резолвер — це єдиний шов, куди згодом зайде per-org
-// конфігурація. Профіль організації (feature flags) вже впливає на доступність
-// (напр. PACS вимкнено прапорцем dicom_pacs → provider.enabled = false).
+// Messaging/calendar конфігурація поки зберігається глобально в app_settings;
+// PACS та payment вже мають per-org джерела. Резолвер не повинен підміняти
+// tenant-specific PACS readiness даними першої організації.
 
 import { getSettings } from "../settings";
 import { getOrgProfile } from "../org-profile";
@@ -32,8 +31,9 @@ export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise
       "email_gateway_url", "email_gateway_auth", "email_gateway_from",
     ]),
     getOrgProfile(db, ctx),
-    db.prepare("SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE id = 1")
-      .first<{ enabled: number; viewer: string; dicomweb: string }>().catch(() => null),
+    db.prepare(
+      "SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE organization_id = ? LIMIT 1"
+    ).bind(ctx.organizationId).first<{ enabled: number; viewer: string; dicomweb: string }>().catch(() => null),
     getSettings(db, ["external_ics_url"]).then((s) => s.external_ics_url || "").catch(() => ""),
   ]);
 
@@ -42,7 +42,7 @@ export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise
     email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
   });
 
-  // PACS доступний, коли його увімкнено в налаштуваннях PACS.
+  // PACS доступний, коли його увімкнено в налаштуваннях саме цього tenant.
   const pacsEnabled = Boolean(pacsRow?.enabled);
   const pacs: PacsProvider = {
     name: pacsEnabled ? "dicomweb" : "none",

--- a/tests/provider-pacs-tenant.behavior.test.mjs
+++ b/tests/provider-pacs-tenant.behavior.test.mjs
@@ -1,19 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveProviders } from "../lib/providers/index.ts";
 import { withD1 } from "./helpers/d1.mjs";
 
-function ctx(organizationId) {
-  return {
-    organizationId,
-    slug: `org-${organizationId}`,
-    organizationName: `Org ${organizationId}`,
-    role: "admin",
-    member: { email:`admin${organizationId}@example.com`, displayName:`Admin ${organizationId}`, role:"admin" },
-  };
-}
+const PACS_QUERY =
+  "SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE organization_id = ? LIMIT 1";
 
-test("provider PACS readiness is resolved from the active tenant only", async () => {
+test("PACS settings query isolates readiness by organization", async () => {
   await withD1(async (db) => {
     await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'provider-two', 'Provider Two', 1)").run();
     await db.prepare("DELETE FROM pacs_settings").run();
@@ -25,25 +17,19 @@ test("provider PACS readiness is resolved from the active tenant only", async ()
         (2, '', '', 'ORG2', 0, '', 'test')`
     ).run();
 
-    const one = await resolveProviders(db, ctx(1));
-    assert.equal(one.pacs.enabled, true);
-    assert.deepEqual(one.pacs.describe(), {
-      enabled:true,
-      viewerConfigured:true,
-      dicomwebConfigured:true,
-    });
+    const one = await db.prepare(PACS_QUERY).bind(1).first();
+    assert.equal(one.enabled, 1);
+    assert.equal(one.viewer, "https://pacs-one.example/viewer");
+    assert.equal(one.dicomweb, "https://pacs-one.example/dicomweb");
 
-    const two = await resolveProviders(db, ctx(2));
-    assert.equal(two.pacs.enabled, false);
-    assert.deepEqual(two.pacs.describe(), {
-      enabled:false,
-      viewerConfigured:false,
-      dicomwebConfigured:false,
-    });
+    const two = await db.prepare(PACS_QUERY).bind(2).first();
+    assert.equal(two.enabled, 0);
+    assert.equal(two.viewer, "");
+    assert.equal(two.dicomweb, "");
   });
 });
 
-test("provider resolver never hard-codes the first PACS row", async () => {
+test("provider resolver uses the tenant-scoped PACS query", async () => {
   const { readFile } = await import("node:fs/promises");
   const source = await readFile(new URL("../lib/providers/index.ts", import.meta.url), "utf8");
   assert.match(source, /FROM pacs_settings WHERE organization_id = \? LIMIT 1/);

--- a/tests/provider-pacs-tenant.behavior.test.mjs
+++ b/tests/provider-pacs-tenant.behavior.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveProviders } from "../lib/providers/index.ts";
+import { withD1 } from "./helpers/d1.mjs";
+
+function ctx(organizationId) {
+  return {
+    organizationId,
+    slug: `org-${organizationId}`,
+    organizationName: `Org ${organizationId}`,
+    role: "admin",
+    member: { email:`admin${organizationId}@example.com`, displayName:`Admin ${organizationId}`, role:"admin" },
+  };
+}
+
+test("provider PACS readiness is resolved from the active tenant only", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'provider-two', 'Provider Two', 1)").run();
+    await db.prepare("DELETE FROM pacs_settings").run();
+    await db.prepare(
+      `INSERT INTO pacs_settings
+        (organization_id, dicomweb_base_url, viewer_base_url, ae_title, enabled, notes, updated_by)
+       VALUES
+        (1, 'https://pacs-one.example/dicomweb', 'https://pacs-one.example/viewer', 'ORG1', 1, '', 'test'),
+        (2, '', '', 'ORG2', 0, '', 'test')`
+    ).run();
+
+    const one = await resolveProviders(db, ctx(1));
+    assert.equal(one.pacs.enabled, true);
+    assert.deepEqual(one.pacs.describe(), {
+      enabled:true,
+      viewerConfigured:true,
+      dicomwebConfigured:true,
+    });
+
+    const two = await resolveProviders(db, ctx(2));
+    assert.equal(two.pacs.enabled, false);
+    assert.deepEqual(two.pacs.describe(), {
+      enabled:false,
+      viewerConfigured:false,
+      dicomwebConfigured:false,
+    });
+  });
+});
+
+test("provider resolver never hard-codes the first PACS row", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(new URL("../lib/providers/index.ts", import.meta.url), "utf8");
+  assert.match(source, /FROM pacs_settings WHERE organization_id = \? LIMIT 1/);
+  assert.match(source, /\.bind\(ctx\.organizationId\)/);
+  assert.doesNotMatch(source, /FROM pacs_settings WHERE id = 1/);
+});


### PR DESCRIPTION
## Summary
- make provider diagnostics resolve PACS settings by `organization_id`
- remove the legacy `WHERE id = 1` lookup from the provider resolver
- add behavioral coverage with two organizations that have different PACS readiness

## Impact
This fixes operational tenant isolation in the provider-status layer. The primary imaging/PACS runtime path was already tenant-scoped; this prevents an administrator of another tenant from seeing readiness derived from the first tenant.

## Deployment
No production deploy in this PR.