### PR TITLE
Harden membership-authoritative integration control plane

### DIFF
--- a/app/api/staff/settings/messaging-test/route.ts
+++ b/app/api/staff/settings/messaging-test/route.ts
@@ -1,6 +1,7 @@
 // Надсилає тестове SMS / e-mail через збережений шлюз, щоб адміністратор міг
 // перевірити налаштування в один клік (аналог telegram-test). Помилку шлюзу
 // повертає дослівно, щоб було видно причину (401, таймаут, заборонена адреса).
+// Messaging gateway settings are legacy-global, so only org 1 may use them.
 
 import { requireOrgContext } from "../../../../../lib/tenant";
 import { getSettings } from "../../../../../lib/settings";
@@ -8,6 +9,7 @@ import { createMessagingProvider } from "../../../../../lib/providers/messaging"
 import { normalizeUkrainianPhone } from "../../../../../lib/phone";
 import { dbBinding } from "../../../../../lib/db";
 
+const PRIMARY_ORGANIZATION_ID = 1;
 const TEST_TEXT = "RadiologyOS: тестове повідомлення. Канал сповіщень налаштовано правильно.";
 
 export async function POST(request: Request) {
@@ -15,7 +17,9 @@ export async function POST(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Доступно лише адміністратору основної організації" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { channel?: string; to?: string };
   const channel = body.channel === "email" ? "email" : body.channel === "sms" ? "sms" : "";

--- a/app/api/staff/settings/messaging-test/route.ts
+++ b/app/api/staff/settings/messaging-test/route.ts
@@ -2,7 +2,7 @@
 // перевірити налаштування в один клік (аналог telegram-test). Помилку шлюзу
 // повертає дослівно, щоб було видно причину (401, таймаут, заборонена адреса).
 
-import { requireStaff } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
 import { getSettings } from "../../../../../lib/settings";
 import { createMessagingProvider } from "../../../../../lib/providers/messaging";
 import { normalizeUkrainianPhone } from "../../../../../lib/phone";
@@ -13,9 +13,9 @@ const TEST_TEXT = "RadiologyOS: тестове повідомлення. Кан�
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
 
   const body = await request.json().catch(() => ({})) as { channel?: string; to?: string };
   const channel = body.channel === "email" ? "email" : body.channel === "sms" ? "sms" : "";

--- a/app/api/staff/settings/route.ts
+++ b/app/api/staff/settings/route.ts
@@ -1,7 +1,7 @@
 // Department settings managed by an administrator: Telegram notifications for
 // new bookings and the PrivatBank payment link for civilian patients.
 
-import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { getSettings, setSetting } from "../../../../lib/settings";
 import { safeOutboundUrl } from "../../../../lib/outbound";
 import { parseLeadHours, REMINDER_LEAD_KEY } from "../../../../lib/reminders";
@@ -40,23 +40,23 @@ function settingsView(values: Record<string, string>) {
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Налаштування доступні лише адміністратору" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "Налаштування доступні лише адміністратору" }, { status: 403 });
 
   const values = await getSettings(db, SETTING_KEYS);
   return Response.json({
     settings: settingsView(values),
-    staff: member,
+    staff: ctx.member,
   }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Змінювати налаштування може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "Змінювати налаштування може лише адміністратор" }, { status: 403 });
 
   const body = await request.json().catch(() => ({})) as {
     telegramBotToken?: string; telegramChatId?: string; payLink?: string;
@@ -116,7 +116,12 @@ export async function PUT(request: Request) {
   if (emailAuth === "-") await setSetting(db, "email_gateway_auth", "");
   else if (emailAuth) await setSetting(db, "email_gateway_auth", emailAuth);
 
-  await audit(db, { organizationId: 1, actorEmail: member.email, action: "settings_update", resource: "settings" });
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "settings_update",
+    resource: "settings",
+  });
   const values = await getSettings(db, SETTING_KEYS);
   return Response.json({ ok: true, settings: settingsView(values) });
 }

--- a/app/api/staff/settings/route.ts
+++ b/app/api/staff/settings/route.ts
@@ -1,5 +1,7 @@
 // Department settings managed by an administrator: Telegram notifications for
 // new bookings and the PrivatBank payment link for civilian patients.
+// These settings are still legacy-global in app_settings, so until they are
+// tenantized only the primary/public organization may administer them.
 
 import { requireOrgContext } from "../../../../lib/tenant";
 import { getSettings, setSetting } from "../../../../lib/settings";
@@ -7,6 +9,8 @@ import { safeOutboundUrl } from "../../../../lib/outbound";
 import { parseLeadHours, REMINDER_LEAD_KEY } from "../../../../lib/reminders";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
+
+const PRIMARY_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max: number) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -42,7 +46,9 @@ export async function GET(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "Налаштування доступні лише адміністратору" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Налаштування доступні лише адміністратору основної організації" }, { status: 403 });
+  }
 
   const values = await getSettings(db, SETTING_KEYS);
   return Response.json({
@@ -56,7 +62,9 @@ export async function PUT(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "Змінювати налаштування може лише адміністратор" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Змінювати налаштування може лише адміністратор основної організації" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as {
     telegramBotToken?: string; telegramChatId?: string; payLink?: string;

--- a/app/api/staff/settings/telegram-test/route.ts
+++ b/app/api/staff/settings/telegram-test/route.ts
@@ -1,16 +1,16 @@
 // Sends a test message to the department Telegram chat using the saved
 // settings, so an admin can verify the bot token and chat id in one click.
 
-import { requireStaff } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
 import { sendTelegramResult } from "../../../../../lib/telegram";
 import { dbBinding } from "../../../../../lib/db";
 
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
 
   const text = "✅ <b>RadiologyOS</b>\nТестове повідомлення. Сповіщення про заявки налаштовано правильно.";
   const result = await sendTelegramResult(db, text);

--- a/app/api/staff/settings/telegram-test/route.ts
+++ b/app/api/staff/settings/telegram-test/route.ts
@@ -1,16 +1,21 @@
 // Sends a test message to the department Telegram chat using the saved
 // settings, so an admin can verify the bot token and chat id in one click.
+// Telegram bot settings are legacy-global, so only org 1 may use them.
 
 import { requireOrgContext } from "../../../../../lib/tenant";
 import { sendTelegramResult } from "../../../../../lib/telegram";
 import { dbBinding } from "../../../../../lib/db";
+
+const PRIMARY_ORGANIZATION_ID = 1;
 
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Доступно лише адміністратору основної організації" }, { status: 403 });
+  }
 
   const text = "✅ <b>RadiologyOS</b>\nТестове повідомлення. Сповіщення про заявки налаштовано правильно.";
   const result = await sendTelegramResult(db, text);

--- a/app/api/staff/settings/telegram-webhook/route.ts
+++ b/app/api/staff/settings/telegram-webhook/route.ts
@@ -1,7 +1,7 @@
 // Вмикає Telegram-канал для пацієнтів: реєструє webhook бота на наш публічний
-// ендпоінт із секретним заголовком. Лише для адміністратора.
+// ендпоінт із секретним заголовком. Лише для адміністратора активного tenant.
 
-import { requireStaff } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
 import { getSettings, setSetting } from "../../../../../lib/settings";
 import { setTelegramWebhook, telegramBotUsername } from "../../../../../lib/telegram";
 import { newSessionToken } from "../../../../../lib/auth";
@@ -10,9 +10,9 @@ import { dbBinding } from "../../../../../lib/db";
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
 
   const { telegram_bot_token: token, telegram_webhook_secret: existing } =
     await getSettings(db, ["telegram_bot_token", "telegram_webhook_secret"]);

--- a/app/api/staff/settings/telegram-webhook/route.ts
+++ b/app/api/staff/settings/telegram-webhook/route.ts
@@ -1,5 +1,6 @@
 // Вмикає Telegram-канал для пацієнтів: реєструє webhook бота на наш публічний
-// ендпоінт із секретним заголовком. Лише для адміністратора активного tenant.
+// ендпоінт із секретним заголовком. Telegram config is legacy-global, so only
+// the primary/public organization may administer it until storage is tenantized.
 
 import { requireOrgContext } from "../../../../../lib/tenant";
 import { getSettings, setSetting } from "../../../../../lib/settings";
@@ -7,12 +8,16 @@ import { setTelegramWebhook, telegramBotUsername } from "../../../../../lib/tele
 import { newSessionToken } from "../../../../../lib/auth";
 import { dbBinding } from "../../../../../lib/db";
 
+const PRIMARY_ORGANIZATION_ID = 1;
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "Доступно лише адміністратору" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Доступно лише адміністратору основної організації" }, { status: 403 });
+  }
 
   const { telegram_bot_token: token, telegram_webhook_secret: existing } =
     await getSettings(db, ["telegram_bot_token", "telegram_webhook_secret"]);

--- a/app/api/staff/whatsapp/route.ts
+++ b/app/api/staff/whatsapp/route.ts
@@ -1,11 +1,13 @@
-// Підключення WhatsApp (green-api) — лише адміністратор активного tenant.
-// Зберігає idInstance, apiToken (секрет) і прапорець enabled у legacy-global
-// app_settings; авторизація при цьому завжди береться з membership context.
+// Підключення WhatsApp (green-api). Storage is still legacy-global in
+// app_settings, so only the primary/public organization may administer it
+// until WhatsApp configuration becomes per-tenant.
 
 import { requireOrgContext } from "../../../../lib/tenant";
 import { getSetting, getSettings, setSetting } from "../../../../lib/settings";
 import { whatsappConfig, whatsappConfigured } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
+
+const PRIMARY_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max: number) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -24,7 +26,9 @@ export async function GET(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "WhatsApp налаштовує лише адміністратор" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "WhatsApp налаштовує лише адміністратор основної організації" }, { status: 403 });
+  }
 
   const cfg = await whatsappConfig(db);
   const token = await ensureWebhookToken(db);
@@ -46,7 +50,9 @@ export async function PUT(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.role !== "admin") return Response.json({ error: "Змінювати WhatsApp може лише адміністратор" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Змінювати WhatsApp може лише адміністратор основної організації" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { idInstance?: string; apiToken?: string; enabled?: boolean };
   const idInstance = clean(body.idInstance, 40);

--- a/app/api/staff/whatsapp/route.ts
+++ b/app/api/staff/whatsapp/route.ts
@@ -1,8 +1,8 @@
-// Підключення WhatsApp (green-api) — лише адміністратор. Зберігає idInstance,
-// apiToken (секрет) і прапорець enabled у app_settings; видає токен вебхука
-// й готову URL, яку треба вписати в green-api.
+// Підключення WhatsApp (green-api) — лише адміністратор активного tenant.
+// Зберігає idInstance, apiToken (секрет) і прапорець enabled у legacy-global
+// app_settings; авторизація при цьому завжди береться з membership context.
 
-import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { getSetting, getSettings, setSetting } from "../../../../lib/settings";
 import { whatsappConfig, whatsappConfigured } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
@@ -22,9 +22,9 @@ async function ensureWebhookToken(db: D1Database): Promise<string> {
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "WhatsApp налаштовує лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "WhatsApp налаштовує лише адміністратор" }, { status: 403 });
 
   const cfg = await whatsappConfig(db);
   const token = await ensureWebhookToken(db);
@@ -37,16 +37,16 @@ export async function GET(request: Request) {
       connected: whatsappConfigured(cfg),
       webhookUrl: `${origin}/api/whatsapp/webhook?token=${token}`,
     },
-    staff: member,
+    staff: ctx.member,
   }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Змінювати WhatsApp може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.role !== "admin") return Response.json({ error: "Змінювати WhatsApp може лише адміністратор" }, { status: 403 });
 
   const body = await request.json().catch(() => ({})) as { idInstance?: string; apiToken?: string; enabled?: boolean };
   const idInstance = clean(body.idInstance, 40);

--- a/app/api/staff/whatsapp/test/route.ts
+++ b/app/api/staff/whatsapp/test/route.ts
@@ -1,5 +1,5 @@
-// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест») — лише адміністратор.
-import { requireStaff } from "../../../../../lib/staff-auth";
+// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест») — лише адміністратор активного tenant.
+import { requireOrgContext } from "../../../../../lib/tenant";
 import { normalizeUkrainianPhone } from "../../../../../lib/phone";
 import { sendWhatsApp } from "../../../../../lib/whatsapp";
 import { dbBinding } from "../../../../../lib/db";
@@ -7,8 +7,8 @@ import { dbBinding } from "../../../../../lib/db";
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member || member.role !== "admin") return Response.json({ error: "Лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx || ctx.role !== "admin") return Response.json({ error: "Лише адміністратор" }, { status: 403 });
   const body = await request.json().catch(() => ({})) as { phone?: string };
   const phone = normalizeUkrainianPhone(String(body.phone || ""));
   if (!phone) return Response.json({ error: "Вкажіть коректний номер для тесту" }, { status: 400 });

--- a/app/api/staff/whatsapp/test/route.ts
+++ b/app/api/staff/whatsapp/test/route.ts
@@ -1,14 +1,20 @@
-// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест») — лише адміністратор активного tenant.
+// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест»).
+// WhatsApp config is legacy-global, so only the primary/public organization
+// may use the test endpoint until configuration is tenantized.
 import { requireOrgContext } from "../../../../../lib/tenant";
 import { normalizeUkrainianPhone } from "../../../../../lib/phone";
 import { sendWhatsApp } from "../../../../../lib/whatsapp";
 import { dbBinding } from "../../../../../lib/db";
 
+const PRIMARY_ORGANIZATION_ID = 1;
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
-  if (!ctx || ctx.role !== "admin") return Response.json({ error: "Лише адміністратор" }, { status: 403 });
+  if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Лише адміністратор основної організації" }, { status: 403 });
+  }
   const body = await request.json().catch(() => ({})) as { phone?: string };
   const phone = normalizeUkrainianPhone(String(body.phone || ""));
   if (!phone) return Response.json({ error: "Вкажіть коректний номер для тесту" }, { status: 400 });

--- a/tests/control-plane-membership-role.behavior.test.mjs
+++ b/tests/control-plane-membership-role.behavior.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function setMembershipRole(db, email, role) {
+  await db.prepare(
+    "UPDATE memberships SET role = ?, active = 1 WHERE organization_id = 1 AND member_email = ?"
+  ).bind(role, email).run();
+}
+
+const protectedRequests = () => [
+  jsonRequest("/api/staff/settings", undefined, { method:"GET" }),
+  jsonRequest("/api/staff/settings", { remindersEnabled:true }, { method:"PUT" }),
+  jsonRequest("/api/staff/settings/messaging-test", { channel:"sms", to:"+380501112233" }),
+  jsonRequest("/api/staff/settings/telegram-test", {}),
+  jsonRequest("/api/staff/settings/telegram-webhook", {}),
+  jsonRequest("/api/staff/whatsapp", undefined, { method:"GET" }),
+  jsonRequest("/api/staff/whatsapp", { idInstance:"123", apiToken:"secret", enabled:true }, { method:"PUT" }),
+  jsonRequest("/api/staff/whatsapp/test", { phone:"+380501112233" }),
+];
+
+test("stale global admin cannot use integration control plane after membership downgrade", async () => {
+  await withD1(async (db) => {
+    const email = "stale-admin@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"admin" });
+    await setMembershipRole(db, email, "radiologist");
+
+    for (const request of protectedRequests()) {
+      request.headers.set("cookie", cookie);
+      const response = await callWorker(request, db);
+      assert.equal(response.status, 403, `${request.method} ${new URL(request.url).pathname} must use membership role`);
+    }
+
+    const reminders = await db.prepare(
+      "SELECT value FROM app_settings WHERE key = 'patient_reminders_enabled'"
+    ).first();
+    assert.ok(!reminders || reminders.value !== "1", "denied settings PUT must not mutate config");
+    const whatsapp = await db.prepare(
+      "SELECT value FROM app_settings WHERE key = 'whatsapp_id_instance'"
+    ).first();
+    assert.ok(!whatsapp || whatsapp.value !== "123", "denied WhatsApp PUT must not mutate config");
+  });
+});
+
+test("membership admin remains authoritative even when global staff role is non-admin", async () => {
+  await withD1(async (db) => {
+    const email = "membership-admin@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"radiologist" });
+    await setMembershipRole(db, email, "admin");
+
+    const request = jsonRequest("/api/staff/settings", undefined, { method:"GET", headers:{ cookie } });
+    const response = await callWorker(request, db);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.staff.email, email);
+    assert.equal(body.staff.role, "admin");
+  });
+});
+
+test("integration control-plane routes derive authorization from tenant membership", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const paths = [
+    "../app/api/staff/settings/route.ts",
+    "../app/api/staff/settings/messaging-test/route.ts",
+    "../app/api/staff/settings/telegram-test/route.ts",
+    "../app/api/staff/settings/telegram-webhook/route.ts",
+    "../app/api/staff/whatsapp/route.ts",
+    "../app/api/staff/whatsapp/test/route.ts",
+  ];
+  for (const path of paths) {
+    const source = await readFile(new URL(path, import.meta.url), "utf8");
+    assert.match(source, /requireOrgContext\(request, db\)/, path);
+    assert.doesNotMatch(source, /requireStaff\(request, db\)/, path);
+  }
+
+  const settings = await readFile(new URL("../app/api/staff/settings/route.ts", import.meta.url), "utf8");
+  assert.match(settings, /organizationId: ctx\.organizationId/);
+  assert.doesNotMatch(settings, /organizationId: 1/);
+});

--- a/tests/control-plane-membership-role.behavior.test.mjs
+++ b/tests/control-plane-membership-role.behavior.test.mjs
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
-async function setMembershipRole(db, email, role) {
+async function setMembershipRole(db, email, role, organizationId = 1) {
   await db.prepare(
-    "UPDATE memberships SET role = ?, active = 1 WHERE organization_id = 1 AND member_email = ?"
-  ).bind(role, email).run();
+    "UPDATE memberships SET role = ?, active = 1 WHERE organization_id = ? AND member_email = ?"
+  ).bind(role, organizationId, email).run();
 }
 
 const protectedRequests = () => [
@@ -42,7 +42,7 @@ test("stale global admin cannot use integration control plane after membership d
   });
 });
 
-test("membership admin remains authoritative even when global staff role is non-admin", async () => {
+test("membership admin remains authoritative for the primary organization even when global staff role is non-admin", async () => {
   await withD1(async (db) => {
     const email = "membership-admin@example.com";
     const cookie = await seedStaffSession(db, { email, role:"radiologist" });
@@ -57,7 +57,30 @@ test("membership admin remains authoritative even when global staff role is non-
   });
 });
 
-test("integration control-plane routes derive authorization from tenant membership", async () => {
+test("secondary tenant admin cannot administer legacy-global integration settings", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'control-two', 'Control Two', 1)").run();
+    const email = "org2-admin@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"admin", organizationId:2 });
+
+    for (const request of protectedRequests()) {
+      request.headers.set("cookie", cookie);
+      const response = await callWorker(request, db);
+      assert.equal(response.status, 403, `${request.method} ${new URL(request.url).pathname} must fail closed outside org 1`);
+    }
+
+    const reminders = await db.prepare(
+      "SELECT value FROM app_settings WHERE key = 'patient_reminders_enabled'"
+    ).first();
+    assert.ok(!reminders || reminders.value !== "1");
+    const whatsapp = await db.prepare(
+      "SELECT value FROM app_settings WHERE key = 'whatsapp_id_instance'"
+    ).first();
+    assert.ok(!whatsapp || whatsapp.value !== "123");
+  });
+});
+
+test("integration control-plane routes derive authorization from tenant membership and fail closed outside the primary tenant", async () => {
   const { readFile } = await import("node:fs/promises");
   const paths = [
     "../app/api/staff/settings/route.ts",
@@ -71,6 +94,8 @@ test("integration control-plane routes derive authorization from tenant membersh
     const source = await readFile(new URL(path, import.meta.url), "utf8");
     assert.match(source, /requireOrgContext\(request, db\)/, path);
     assert.doesNotMatch(source, /requireStaff\(request, db\)/, path);
+    assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/, path);
+    assert.match(source, /ctx\.organizationId !== PRIMARY_ORGANIZATION_ID/, path);
   }
 
   const settings = await readFile(new URL("../app/api/staff/settings/route.ts", import.meta.url), "utf8");

--- a/tests/messaging-test.test.mjs
+++ b/tests/messaging-test.test.mjs
@@ -6,7 +6,9 @@ const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
 test("messaging-test endpoint is admin-only and sends via the saved gateway", async () => {
   const route = await read("app/api/staff/settings/messaging-test/route.ts");
-  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.role !== "admin"/);
+  assert.doesNotMatch(route, /requireStaff\(request, db\)/);
   assert.match(route, /createMessagingProvider\(/);
   assert.match(route, /messaging\.sendSms\(/);
   assert.match(route, /messaging\.sendEmail\(/);

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -78,7 +78,9 @@ test("new bookings notify the registrar via Telegram (best-effort)", async () =>
 
 test("department settings are admin-only and validated", async () => {
   const route = await read("app/api/staff/settings/route.ts");
-  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.role !== "admin"/);
+  assert.doesNotMatch(route, /requireStaff\(request, db\)/);
   assert.match(route, /telegram_bot_token/);
   assert.match(route, /pay_link/);
   assert.match(route, /paymentUrl\.protocol !== "https:"/);
@@ -93,7 +95,9 @@ test("department settings are admin-only and validated", async () => {
 
 test("a test-message endpoint verifies the Telegram connection (admin-only)", async () => {
   const route = await read("app/api/staff/settings/telegram-test/route.ts");
-  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.role !== "admin"/);
+  assert.doesNotMatch(route, /requireStaff\(request, db\)/);
   assert.match(route, /sendTelegramResult\(/);
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /export async function sendTelegramResult/);

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -52,7 +52,9 @@ test("public webhook is protected by the secret header set on setWebhook", async
 
 test("admin enable endpoint registers the webhook with a stored secret", async () => {
   const route = await read("app/api/staff/settings/telegram-webhook/route.ts");
-  assert.match(route, /member\.role !== "admin"/);
+  assert.match(route, /requireOrgContext\(request, db\)/);
+  assert.match(route, /ctx\.role !== "admin"/);
+  assert.doesNotMatch(route, /requireStaff\(request, db\)/);
   assert.match(route, /setTelegramWebhook\(db, webhookUrl, secret\)/);
   assert.match(route, /\/api\/telegram\/webhook/);
   assert.match(route, /setSetting\(db, "telegram_webhook_secret"/);

--- a/tests/whatsapp.test.mjs
+++ b/tests/whatsapp.test.mjs
@@ -64,7 +64,9 @@ test("webhook route is token-guarded (constant-time + header), deduped and rate-
 
 test("staff whatsapp + contact-center routes are permission-guarded", async () => {
   const wa = await read("app/api/staff/whatsapp/route.ts");
-  assert.match(wa, /member\.role !== "admin"/);
+  assert.match(wa, /requireOrgContext\(request, db\)/);
+  assert.match(wa, /ctx\.role !== "admin"/);
+  assert.doesNotMatch(wa, /requireStaff\(request, db\)/);
   assert.match(wa, /whatsapp_api_token_instance/);
   const chat = await read("app/api/staff/chat/route.ts");
   assert.match(chat, /canViewPatientRegistry\(member\.role\)/);


### PR DESCRIPTION
## Summary
- authorize department messaging/Telegram/WhatsApp control-plane endpoints from `requireOrgContext` membership role
- stop trusting a stale global `staff_members.role` for administrator actions
- while these integration settings remain legacy-global, fail closed outside the primary/public organization (org 1)
- attribute settings audit events to the active organization instead of hard-coded organization 1
- add behavioral regressions for stale global admin, authoritative org1 membership admin, and secondary-tenant admin denial

## Security impact
Closes two control-plane authorization risks:
1. a user whose global staff role remained `admin` could retain integration/settings privileges after their organization membership was downgraded;
2. switching to membership roles without tenantizing global storage could otherwise allow an admin of another tenant to modify shared org1 messaging configuration.

## Scope
This PR intentionally does **not** tenantize legacy-global messaging storage. Until that architecture work is done, only org 1 may administer these global integration settings.

## Deployment
No production deploy in this PR.