### PR TITLE
Scope legacy public editor to primary tenant

### DIFF
--- a/app/api/staff/site/route.ts
+++ b/app/api/staff/site/route.ts
@@ -14,12 +14,13 @@ export async function GET(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+  const member = ctx.member;
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || member.role !== "admin") {
     return Response.json({ error: "Сайт клініки редагує лише адміністратор основної організації" }, { status: 403 });
   }
 
   const content = parseSiteContent(await getSetting(db, SITE_CONTENT_KEY));
-  return Response.json({ content, staff: ctx.member }, { headers: { "cache-control": "no-store" } });
+  return Response.json({ content, staff: member }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
@@ -27,7 +28,8 @@ export async function PUT(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+  const member = ctx.member;
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || member.role !== "admin") {
     return Response.json({ error: "Змінювати сайт може лише адміністратор основної організації" }, { status: 403 });
   }
 

--- a/app/api/staff/site/route.ts
+++ b/app/api/staff/site/route.ts
@@ -1,28 +1,35 @@
-// Редактор вітрини (сайту клініки) — лише адміністратор. Читає й зберігає
-// налаштовуваний контент публічної сторінки у app_settings (ключ site_content).
+// Редактор вітрини (сайту клініки). `site_content` поки зберігається у
+// legacy-global app_settings, тому службовий editor fail-closed доступний лише
+// membership-admin основної/публічної організації до per-tenant міграції.
 
-import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { getSetting, setSetting } from "../../../../lib/settings";
 import { SITE_CONTENT_KEY, parseSiteContent, sanitizeSiteContent } from "../../../../lib/site-content";
 import { dbBinding } from "../../../../lib/db";
 
+const PRIMARY_ORGANIZATION_ID = 1;
+
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Сайт клініки редагує лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Сайт клініки редагує лише адміністратор основної організації" }, { status: 403 });
+  }
 
   const content = parseSiteContent(await getSetting(db, SITE_CONTENT_KEY));
-  return Response.json({ content, staff: member }, { headers: { "cache-control": "no-store" } });
+  return Response.json({ content, staff: ctx.member }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Змінювати сайт може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Змінювати сайт може лише адміністратор основної організації" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { content?: unknown };
   const content = sanitizeSiteContent(body.content);

--- a/app/api/staff/structure/route.ts
+++ b/app/api/staff/structure/route.ts
@@ -5,14 +5,21 @@ import {
   sanitizeDepartmentStructure,
 } from "../../../../lib/department-structure";
 import { SITE_CONTENT_KEY, parseSiteContent, sanitizeSiteContent } from "../../../../lib/site-content";
-import { requireStaff } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
 import { getSetting, setSetting } from "../../../../lib/settings";
+
+// Department structure and site content are still legacy-global settings tied
+// to the public organization. Until storage is tenantized, deny staff from any
+// secondary tenant rather than showing/editing org 1's editor data.
+const PRIMARY_ORGANIZATION_ID = 1;
 
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID) {
+    return Response.json({ error: "Розділ доступний лише персоналу основної організації" }, { status: 403 });
+  }
 
   const [structureStored, siteStored] = await Promise.all([
     getSetting(db, DEPARTMENT_STRUCTURE_KEY),
@@ -21,17 +28,18 @@ export async function GET(request: Request) {
   return Response.json({
     structure: parseDepartmentStructure(structureStored),
     siteContent: parseSiteContent(siteStored),
-    staff: member,
-    canEdit: member.role === "admin",
+    staff: ctx.member,
+    canEdit: ctx.role === "admin",
   }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const member = await requireStaff(request, db);
-  if (!member) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (member.role !== "admin") return Response.json({ error: "Редагувати структуру може лише адміністратор" }, { status: 403 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
+    return Response.json({ error: "Редагувати структуру може лише адміністратор основної організації" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { structure?: unknown; siteContent?: unknown };
   const structure = sanitizeDepartmentStructure(body.structure);

--- a/app/api/staff/structure/route.ts
+++ b/app/api/staff/structure/route.ts
@@ -20,6 +20,7 @@ export async function GET(request: Request) {
   if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID) {
     return Response.json({ error: "Розділ доступний лише персоналу основної організації" }, { status: 403 });
   }
+  const member = ctx.member;
 
   const [structureStored, siteStored] = await Promise.all([
     getSetting(db, DEPARTMENT_STRUCTURE_KEY),
@@ -28,8 +29,8 @@ export async function GET(request: Request) {
   return Response.json({
     structure: parseDepartmentStructure(structureStored),
     siteContent: parseSiteContent(siteStored),
-    staff: ctx.member,
-    canEdit: ctx.role === "admin",
+    staff: member,
+    canEdit: member.role === "admin",
   }, { headers: { "cache-control": "no-store" } });
 }
 
@@ -37,9 +38,11 @@ export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireOrgContext(request, db);
-  if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "Редагувати структуру може лише адміністратор основної організації" }, { status: 403 });
+  if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID) {
+    return Response.json({ error: "Розділ доступний лише персоналу основної організації" }, { status: 403 });
   }
+  const member = ctx.member;
+  if (member.role !== "admin") return Response.json({ error: "Редагувати структуру може лише адміністратор" }, { status: 403 });
 
   const body = await request.json().catch(() => ({})) as { structure?: unknown; siteContent?: unknown };
   const structure = sanitizeDepartmentStructure(body.structure);

--- a/tests/public-editor-tenant-role.behavior.test.mjs
+++ b/tests/public-editor-tenant-role.behavior.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function setMembershipRole(db, email, role, organizationId = 1) {
+  await db.prepare(
+    "UPDATE memberships SET role = ?, active = 1 WHERE organization_id = ? AND member_email = ?"
+  ).bind(role, organizationId, email).run();
+}
+
+const siteGet = (cookie) => jsonRequest("/api/staff/site", undefined, { method:"GET", headers:{ cookie } });
+const sitePut = (cookie, brandTitle = "Updated") => jsonRequest(
+  "/api/staff/site",
+  { content:{ brandTitle } },
+  { method:"PUT", headers:{ cookie } },
+);
+const structureGet = (cookie) => jsonRequest("/api/staff/structure", undefined, { method:"GET", headers:{ cookie } });
+const structurePut = (cookie) => jsonRequest(
+  "/api/staff/structure",
+  { structure:{}, siteContent:{ brandTitle:"Structure update" } },
+  { method:"PUT", headers:{ cookie } },
+);
+
+test("stale global admin cannot edit public content after membership downgrade", async () => {
+  await withD1(async (db) => {
+    const email = "stale-site-admin@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"admin" });
+    await setMembershipRole(db, email, "radiologist");
+
+    assert.equal((await callWorker(siteGet(cookie), db)).status, 403);
+    assert.equal((await callWorker(sitePut(cookie, "Denied stale admin"), db)).status, 403);
+
+    const structure = await callWorker(structureGet(cookie), db);
+    assert.equal(structure.status, 200, "org1 staff may read the shared structure editor");
+    assert.equal((await structure.json()).canEdit, false);
+    assert.equal((await callWorker(structurePut(cookie), db)).status, 403);
+
+    const saved = await db.prepare("SELECT value FROM app_settings WHERE key = 'site_content'").first();
+    assert.doesNotMatch(String(saved?.value || ""), /Denied stale admin/);
+  });
+});
+
+test("secondary tenant staff cannot read or mutate the legacy-global public editor", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'public-two', 'Public Two', 1)").run();
+    const email = "org2-site-admin@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"admin", organizationId:2 });
+
+    assert.equal((await callWorker(siteGet(cookie), db)).status, 403);
+    assert.equal((await callWorker(sitePut(cookie, "Denied org2"), db)).status, 403);
+    assert.equal((await callWorker(structureGet(cookie), db)).status, 403);
+    assert.equal((await callWorker(structurePut(cookie), db)).status, 403);
+
+    const saved = await db.prepare("SELECT value FROM app_settings WHERE key = 'site_content'").first();
+    assert.doesNotMatch(String(saved?.value || ""), /Denied org2/);
+  });
+});
+
+test("org1 membership admin is authoritative even when global staff role is non-admin", async () => {
+  await withD1(async (db) => {
+    const email = "membership-site-admin@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"radiologist" });
+    await setMembershipRole(db, email, "admin");
+
+    const site = await callWorker(siteGet(cookie), db);
+    assert.equal(site.status, 200);
+    assert.equal((await site.json()).staff.role, "admin");
+
+    const structure = await callWorker(structureGet(cookie), db);
+    assert.equal(structure.status, 200);
+    const body = await structure.json();
+    assert.equal(body.staff.role, "admin");
+    assert.equal(body.canEdit, true);
+  });
+});
+
+test("public editor routes use tenant membership and explicit primary-tenant guards", async () => {
+  const { readFile } = await import("node:fs/promises");
+  for (const path of ["../app/api/staff/site/route.ts", "../app/api/staff/structure/route.ts"]) {
+    const source = await readFile(new URL(path, import.meta.url), "utf8");
+    assert.match(source, /requireOrgContext\(request, db\)/, path);
+    assert.doesNotMatch(source, /requireStaff\(request, db\)/, path);
+    assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/, path);
+    assert.match(source, /ctx\.organizationId !== PRIMARY_ORGANIZATION_ID/, path);
+  }
+});


### PR DESCRIPTION
## Summary
- make `/api/staff/site` and `/api/staff/structure` derive authorization from active tenant membership
- while `site_content` and `department_structure` remain legacy-global, fail closed outside the primary/public organization (org 1)
- preserve read-only structure access for org1 staff while editing remains membership-admin only
- add behavioral regressions for stale global admin, secondary-tenant denial, and authoritative org1 membership admin

## Security impact
Closes the remaining stale-global-role and cross-tenant editor gap for public site/department structure configuration without pretending the underlying global storage is per-tenant.

## Deployment
No production deploy in this PR.