### PR TITLE
Isolate legacy external calendar by primary tenant

### DIFF
--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,8 +1,9 @@
 // Резолвер провайдерів — добирає реалізації інтеграцій у tenant-контексті.
 //
-// Messaging/calendar конфігурація поки зберігається глобально в app_settings;
-// PACS та payment вже мають per-org джерела. Резолвер не повинен підміняти
-// tenant-specific PACS readiness даними першої організації.
+// Messaging configuration is still legacy-global in app_settings. The external
+// calendar URL is also legacy-global and belongs to the primary/public tenant,
+// so secondary tenants must not receive it until calendar storage is tenantized.
+// PACS та payment вже мають per-org джерела.
 
 import { getSettings } from "../settings";
 import { getOrgProfile } from "../org-profile";
@@ -11,6 +12,8 @@ import { createMessagingProvider } from "./messaging";
 import { createCalendarProvider } from "./calendar";
 import { createPaymentProvider, type PaymentConfig } from "./payment";
 import type { PacsProvider, ResolvedProviders } from "./types";
+
+const PRIMARY_ORGANIZATION_ID = 1;
 
 // Дістає конфіг оплат із settings_json профілю організації (безпечно).
 function paymentConfig(settings: Record<string, unknown>): PaymentConfig {
@@ -25,6 +28,10 @@ function paymentConfig(settings: Record<string, unknown>): PaymentConfig {
 }
 
 export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise<ResolvedProviders> {
+  const calendarUrl = ctx.organizationId === PRIMARY_ORGANIZATION_ID
+    ? getSettings(db, ["external_ics_url"]).then((s) => s.external_ics_url || "").catch(() => "")
+    : Promise.resolve("");
+
   const [cfg, profile, pacsRow, icsUrl] = await Promise.all([
     getSettings(db, [
       "sms_gateway_url", "sms_gateway_auth",
@@ -34,7 +41,7 @@ export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise
     db.prepare(
       "SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE organization_id = ? LIMIT 1"
     ).bind(ctx.organizationId).first<{ enabled: number; viewer: string; dicomweb: string }>().catch(() => null),
-    getSettings(db, ["external_ics_url"]).then((s) => s.external_ics_url || "").catch(() => ""),
+    calendarUrl,
   ]);
 
   const messaging = createMessagingProvider({

--- a/tests/external-calendar-tenant-isolation.behavior.test.mjs
+++ b/tests/external-calendar-tenant-isolation.behavior.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+test("secondary tenant cannot resolve or read the primary tenant external calendar", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'calendar-two', 'Calendar Two', 1)").run();
+    await db.prepare(
+      `INSERT INTO app_settings (key, value) VALUES ('external_ics_url', 'https://calendar.example/private.ics')
+       ON CONFLICT(key) DO UPDATE SET value=excluded.value`
+    ).run();
+
+    const registrarCookie = await seedStaffSession(db, {
+      email:"calendar-reg2@example.com", role:"registrar", organizationId:2,
+    });
+    const feed = await callWorker(
+      jsonRequest("/api/staff/external-calendar", undefined, { method:"GET", headers:{ cookie:registrarCookie } }),
+      db,
+    );
+    assert.equal(feed.status, 200);
+    assert.deepEqual(await feed.json(), { configured:false, events:[] });
+
+    const adminCookie = await seedStaffSession(db, {
+      email:"calendar-admin2@example.com", role:"admin", organizationId:2,
+    });
+    const status = await callWorker(
+      jsonRequest("/api/staff/providers", undefined, { method:"GET", headers:{ cookie:adminCookie } }),
+      db,
+    );
+    assert.equal(status.status, 200);
+    const body = await status.json();
+    assert.equal(body.organization.id, 2);
+    assert.equal(body.providers.calendar.name, "none");
+    assert.equal(body.providers.calendar.configured, false);
+  });
+});
+
+test("primary tenant provider diagnostics still see the configured external calendar", async () => {
+  await withD1(async (db) => {
+    await db.prepare(
+      `INSERT INTO app_settings (key, value) VALUES ('external_ics_url', 'https://calendar.example/private.ics')
+       ON CONFLICT(key) DO UPDATE SET value=excluded.value`
+    ).run();
+    const cookie = await seedStaffSession(db, { email:"calendar-admin1@example.com", role:"admin" });
+    const response = await callWorker(
+      jsonRequest("/api/staff/providers", undefined, { method:"GET", headers:{ cookie } }),
+      db,
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.providers.calendar.name, "ics");
+    assert.equal(body.providers.calendar.configured, true);
+  });
+});
+
+test("provider resolver fails closed for legacy-global calendar URL outside org 1", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(new URL("../lib/providers/index.ts", import.meta.url), "utf8");
+  assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/);
+  assert.match(source, /ctx\.organizationId === PRIMARY_ORGANIZATION_ID/);
+  assert.match(source, /getSettings\(db, \["external_ics_url"\]\)/);
+  assert.match(source, /: Promise\.resolve\(""\)/);
+});


### PR DESCRIPTION
## Summary
- fail closed in the provider resolver for the legacy-global `external_ics_url` outside org 1
- prevent secondary tenants from receiving org1 calendar summaries through `/api/staff/external-calendar` or provider diagnostics
- preserve configured calendar behavior for the primary/public organization
- add end-to-end tenant isolation coverage without external network calls

## Security impact
Closes a cross-tenant read where staff in another organization could resolve the primary tenant's global ICS feed. Parsed ICS output includes event `SUMMARY`, so calendar titles could contain patient or appointment context.

## Deployment
No production deploy in this PR.