### PR TITLE
Fail closed for legacy-global messaging outside primary tenant

### DIFF
--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -1,6 +1,8 @@
 // Видає пацієнту (за активною сесією кабінету) deep-link для під'єднання
 // Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до tenant,
 // телефону та доведеної ідентичності пацієнта.
+// Telegram bot config is still legacy-global and belongs to org 1, so secondary
+// tenants must not receive a deep-link until bot configuration is tenantized.
 
 import { requirePatientSession } from "../../../lib/patient-auth";
 import { createTelegramLinkToken } from "../../../lib/telegram-link";
@@ -8,11 +10,19 @@ import { telegramBotUsername } from "../../../lib/telegram";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { dbBinding } from "../../../lib/db";
 
+const PRIMARY_ORGANIZATION_ID = 1;
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
   const session = await requirePatientSession(request, db);
   if (!session) return Response.json({ error: "Сесію не підтверджено" }, { status: 401 });
+  if (session.organizationId !== PRIMARY_ORGANIZATION_ID) {
+    return Response.json(
+      { error: "Telegram-канал ще не налаштований відділенням", botConfigured: false },
+      { status: 503, headers: { "cache-control": "no-store" } },
+    );
+  }
   if (await isRateLimited(db, request, "telegram-link", 6, 15)) {
     return Response.json({ error: "Забагато спроб. Спробуйте трохи пізніше." }, { status: 429 });
   }

--- a/app/api/patient-otp/route.ts
+++ b/app/api/patient-otp/route.ts
@@ -18,6 +18,7 @@ import { dbBinding } from "../../../lib/db";
 
 const PURPOSE = "cabinet_login";
 const PHONE_REQUEST_LIMIT = 5;
+const PRIMARY_ORGANIZATION_ID = 1;
 
 type ProvenPatientIdentity = {
   organizationId: number;
@@ -26,6 +27,18 @@ type ProvenPatientIdentity = {
 
 function maskedPhone(phoneNormalized: string): string {
   return phoneNormalized ? `***${phoneNormalized.slice(-4)}` : "";
+}
+
+function opaqueChallengeResponse() {
+  return Response.json(
+    {
+      ok: true,
+      challengeId: newSessionToken(),
+      expiresIn: 300,
+      message: "Якщо дані збігаються із записом, код підтвердження надіслано.",
+    },
+    { status: 202, headers: { "cache-control": "no-store" } },
+  );
 }
 
 async function provePatientIdentity(
@@ -59,6 +72,11 @@ async function provePatientIdentity(
 // deliver a possession challenge. Unknown identities receive the same neutral
 // response shape and never get a session/challenge row. The proof scope is
 // persisted with the challenge and later copied into the patient session.
+//
+// SMS gateway storage is still legacy-global and belongs to org 1. A valid
+// secondary-tenant identity therefore follows the SAME opaque fake-challenge
+// path as an unknown identity: no DB challenge and no SMS. This avoids turning
+// the temporary org1-only delivery boundary into a patient-enumeration oracle.
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
@@ -92,19 +110,12 @@ export async function POST(request: Request) {
   }
 
   const proof = await provePatientIdentity(db, phoneNormalized, body);
-  if (!proof) {
+  if (!proof || proof.organizationId !== PRIMARY_ORGANIZATION_ID) {
     // Burn similar local crypto work and return an opaque fake challenge id.
-    // No database row exists, so verification can never succeed.
+    // No database row exists, so verification can never succeed. Secondary
+    // tenant identities deliberately share this response to prevent enumeration.
     await hashPassword("000000");
-    return Response.json(
-      {
-        ok: true,
-        challengeId: newSessionToken(),
-        expiresIn: 300,
-        message: "Якщо дані збігаються із записом, код підтвердження надіслано.",
-      },
-      { status: 202, headers: { "cache-control": "no-store" } },
-    );
+    return opaqueChallengeResponse();
   }
 
   const recent = await db.prepare(

--- a/app/api/staff/chat/route.ts
+++ b/app/api/staff/chat/route.ts
@@ -1,6 +1,7 @@
 // Єдиний контакт-центр пацієнтів. Історія береться з patient_communications
-// незалежно від каналу; ручні відповіді поки відправляються через уже
-// налаштований WhatsApp-шлюз. Усі читання та записи tenant-scoped.
+// незалежно від каналу; ручні відповіді поки відправляються через legacy-global
+// WhatsApp-шлюз org 1. Усі читання та записи tenant-scoped; secondary tenants
+// можуть читати свою історію, але не використовувати глобальний шлюз для reply.
 
 import { canViewPatientRegistry } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
@@ -9,6 +10,7 @@ import { sendWhatsApp } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
 
+const PRIMARY_ORGANIZATION_ID = 1;
 const CHANNELS = new Set(["whatsapp", "telegram", "sms", "email"]);
 
 function channelFilter(request: Request): string {
@@ -76,7 +78,7 @@ export async function GET(request: Request) {
       name: patient?.name || "",
       messages: rows.results,
       issues: issues.results,
-      availableReplyChannels: ["whatsapp"],
+      availableReplyChannels: orgId === PRIMARY_ORGANIZATION_ID ? ["whatsapp"] : [],
       linkedTelegram: Number(patient?.telegramLinked || 0) === 1,
       staff: member,
     }, { headers: { "cache-control": "no-store" } });
@@ -142,6 +144,9 @@ export async function POST(request: Request) {
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const member = ctx.member;
   if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Відповідати може реєстратор або адміністратор" }, { status: 403 });
+  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID) {
+    return Response.json({ error: "Вихідний WhatsApp ще не налаштований для цієї організації" }, { status: 403 });
+  }
 
   const body = await request.json().catch(() => ({})) as { phone?: string; text?: string; channel?: string };
   const phone = normalizeUkrainianPhone(String(body.phone || ""));

--- a/app/api/staff/chat/route.ts
+++ b/app/api/staff/chat/route.ts
@@ -46,15 +46,18 @@ export async function GET(request: Request) {
            ORDER BY created_at ASC, id ASC LIMIT 400`
         ).bind(phone, orgId).all();
 
+    // Use ordinary positional placeholders here. Node's SQLite test runtime and
+    // D1 both accept them reliably; repeated numbered ?1/?2 parameters in this
+    // scalar-subquery shape trigger SQLITE_RANGE in node:sqlite.
     const patient = await db.prepare(
       `SELECT COALESCE(
-         (SELECT display_name FROM patient_profiles WHERE phone_normalized = ?1 AND organization_id = ?2),
-         (SELECT name FROM bookings WHERE phone_normalized = ?1 AND organization_id = ?2 ORDER BY id DESC LIMIT 1), '') AS name,
+         (SELECT display_name FROM patient_profiles WHERE phone_normalized = ? AND organization_id = ?),
+         (SELECT name FROM bookings WHERE phone_normalized = ? AND organization_id = ? ORDER BY id DESC LIMIT 1), '') AS name,
        CASE WHEN EXISTS (
          SELECT 1 FROM patient_telegram_identities ti
-         WHERE ti.phone_normalized = ?1 AND ti.organization_id = ?2 AND ti.telegram_chat_id != ''
+         WHERE ti.phone_normalized = ? AND ti.organization_id = ? AND ti.telegram_chat_id != ''
        ) THEN 1 ELSE 0 END AS telegramLinked`
-    ).bind(phone, orgId).first<{ name: string; telegramLinked: number }>();
+    ).bind(phone, orgId, phone, orgId, phone, orgId).first<{ name: string; telegramLinked: number }>();
 
     const issues = await db.prepare(
       `SELECT n.id, n.channel, n.kind, n.status, n.error, n.created_at AS createdAt, n.booking_id AS bookingId

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,12 +1,15 @@
 // Публічний вебхук green-api для вхідних WhatsApp-повідомлень. Захищений
-// секретним ?token=. Зберігає повідомлення в patient_communications, дедуплікує
-// за idMessage і за потреби відповідає бот-меню.
+// секретним ?token=. Глобальна green-api конфігурація належить org 1, тому
+// весь webhook data-path явно прив'язаний до основної організації: lookup
+// записів, inbound/outbound communications і bot replies.
 
 import { getSetting } from "../../../../lib/settings";
 import { isRateLimited } from "../../../../lib/rate-limit";
 import { parseSiteContent, SITE_CONTENT_KEY } from "../../../../lib/site-content";
 import { interpretBotCommand, menuText, parseIncomingWebhook, sendWhatsApp } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
+
+const PRIMARY_ORGANIZATION_ID = 1;
 
 function todayKyiv(): string {
   return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
@@ -41,9 +44,9 @@ async function botReply(db: D1Database, phone: string, text: string, origin: str
   if (action === "appointments") {
     const rows = await db.prepare(
       `SELECT service, desired_date AS d, desired_time AS t, status FROM bookings
-       WHERE phone_normalized = ? AND desired_date >= ? AND status NOT IN ('cancelled','completed')
+       WHERE organization_id = ? AND phone_normalized = ? AND desired_date >= ? AND status NOT IN ('cancelled','completed')
        ORDER BY desired_date, desired_time LIMIT 5`
-    ).bind(phone, todayKyiv()).all();
+    ).bind(PRIMARY_ORGANIZATION_ID, phone, todayKyiv()).all();
     const list = (rows.results || []) as Array<{ service: string; d: string; t: string }>;
     if (!list.length) return "У вас немає найближчих записів. Надішліть 2, щоб записатися.";
     return ["Ваші найближчі записи:", ...list.map((r) => `• ${r.d}${r.t ? ` ${r.t}` : ""} — ${r.service}`)].join("\n");
@@ -69,11 +72,17 @@ export async function POST(request: Request) {
   const msg = parseIncomingWebhook(body);
   if (!msg) return Response.json({ ok: true }); // не текстове/не вхідне — ігноруємо
 
-  // Дедуплікація повторних вебхуків за idMessage.
+  // Дедуплікація повторних вебхуків за idMessage всередині org 1.
   const inserted = await db.prepare(
-    `INSERT OR IGNORE INTO patient_communications (phone_normalized, channel, direction, summary, actor, external_id)
-     VALUES (?, 'whatsapp', 'inbound', ?, 'patient', ?)`
-  ).bind(msg.phoneNormalized, msg.text || "(без тексту)", msg.idMessage || `${msg.phoneNormalized}-${msg.text.slice(0, 40)}`).run();
+    `INSERT OR IGNORE INTO patient_communications
+      (organization_id, phone_normalized, channel, direction, summary, actor, external_id)
+     VALUES (?, ?, 'whatsapp', 'inbound', ?, 'patient', ?)`
+  ).bind(
+    PRIMARY_ORGANIZATION_ID,
+    msg.phoneNormalized,
+    msg.text || "(без тексту)",
+    msg.idMessage || `${msg.phoneNormalized}-${msg.text.slice(0, 40)}`,
+  ).run();
   if (!inserted.meta.changes) return Response.json({ ok: true }); // вже опрацьовано
 
   const reply = await botReply(db, msg.phoneNormalized, msg.text, url.origin);
@@ -81,9 +90,10 @@ export async function POST(request: Request) {
     const sent = await sendWhatsApp(db, msg.phoneNormalized, reply);
     if (sent.ok) {
       await db.prepare(
-        `INSERT INTO patient_communications (phone_normalized, channel, direction, summary, actor, external_id)
-         VALUES (?, 'whatsapp', 'outbound', ?, 'bot', ?)`
-      ).bind(msg.phoneNormalized, reply, sent.idMessage || "").run();
+        `INSERT INTO patient_communications
+          (organization_id, phone_normalized, channel, direction, summary, actor, external_id)
+         VALUES (?, ?, 'whatsapp', 'outbound', ?, 'bot', ?)`
+      ).bind(PRIMARY_ORGANIZATION_ID, msg.phoneNormalized, reply, sent.idMessage || "").run();
     }
   }
   return Response.json({ ok: true });

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -5,6 +5,9 @@
 // Кожна спроба фіксується в журналі `patient_notifications` (outbox) і, за
 // успіху, в історії комунікацій пацієнта. Ніколи не кидає виняток —
 // підтвердження / перенесення не має падати через недоступний шлюз.
+//
+// Messaging credentials are still legacy-global and belong to org 1. Until
+// they are tenantized, secondary-tenant bookings must never use those gateways.
 
 import { getSettings } from "./settings";
 import { createMessagingProvider } from "./providers/messaging";
@@ -33,14 +36,7 @@ export interface ReminderSummary {
 }
 
 const DEPARTMENT = "Відділення променевої діагностики, Чернігівський військовий госпіталь";
-
-export function reminderText(kind: ReminderKind, booking: ReminderBooking): string {
-  const when = `${booking.desiredDate}${booking.desiredTime ? ` о ${booking.desiredTime}` : ""}`;
-  const lead = kind === "confirmed"
-    ? `Ваш запис на «${booking.service}» підтверджено`
-    : `Ваш запис на «${booking.service}» перенесено`;
-  return `${lead}: ${when}. ${DEPARTMENT}. Якщо час не підходить — зателефонуйте у реєстратуру.`;
-}
+const PRIMARY_ORGANIZATION_ID = 1;
 
 function truthy(value: string): boolean {
   return ["1", "true", "on", "yes"].includes(value.trim().toLowerCase());
@@ -52,6 +48,15 @@ async function bookingOrganizationId(db: D1Database, bookingId: number): Promise
   ).bind(bookingId).first<{ organizationId: number }>().catch(() => null);
   const id = Number(row?.organizationId || 0);
   return Number.isInteger(id) && id > 0 ? id : 0;
+}
+
+async function globalMessagingSettings(
+  db: D1Database,
+  organizationId: number,
+  keys: string[],
+): Promise<Record<string, string>> {
+  if (organizationId !== PRIMARY_ORGANIZATION_ID) return {};
+  return getSettings(db, keys);
 }
 
 async function record(
@@ -124,7 +129,7 @@ export async function sendPatientReminder(
   if (!organizationId) return summary;
   const body = reminderText(kind, booking);
 
-  const cfg = await getSettings(db, [
+  const cfg = await globalMessagingSettings(db, organizationId, [
     "patient_reminders_enabled", "telegram_bot_token",
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
@@ -154,12 +159,14 @@ export async function sendPatientReminder(
       send: async () => { const r = await sendTelegramTo(db, telegramChatId, body); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
     });
   }
-  const wa = await whatsappConfig(db);
-  if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
-    channels.push({
-      channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
-      send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
-    });
+  if (organizationId === PRIMARY_ORGANIZATION_ID) {
+    const wa = await whatsappConfig(db);
+    if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
+      channels.push({
+        channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
+        send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
+      });
+    }
   }
   if (booking.phone) {
     channels.push({
@@ -215,7 +222,7 @@ export async function sendPatientMessage(
   const body = (text || "").trim();
   if (!body) return summary;
 
-  const cfg = await getSettings(db, [
+  const cfg = await globalMessagingSettings(db, organizationId, [
     "telegram_bot_token",
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
@@ -243,12 +250,14 @@ export async function sendPatientMessage(
       send: async () => { const r = await sendTelegramTo(db, telegramChatId, body); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
     });
   }
-  const wa = await whatsappConfig(db);
-  if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
-    channels.push({
-      channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
-      send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
-    });
+  if (organizationId === PRIMARY_ORGANIZATION_ID) {
+    const wa = await whatsappConfig(db);
+    if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
+      channels.push({
+        channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
+        send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
+      });
+    }
   }
   if (booking.phone) {
     channels.push({ channel: "sms", recipient: booking.phone, url: cfg.sms_gateway_url || "", send: () => messaging.sendSms(booking.phone, body) });

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -38,6 +38,14 @@ export interface ReminderSummary {
 const DEPARTMENT = "Відділення променевої діагностики, Чернігівський військовий госпіталь";
 const PRIMARY_ORGANIZATION_ID = 1;
 
+export function reminderText(kind: ReminderKind, booking: ReminderBooking): string {
+  const when = `${booking.desiredDate}${booking.desiredTime ? ` о ${booking.desiredTime}` : ""}`;
+  const lead = kind === "confirmed"
+    ? `Ваш запис на «${booking.service}» підтверджено`
+    : `Ваш запис на «${booking.service}» перенесено`;
+  return `${lead}: ${when}. ${DEPARTMENT}. Якщо час не підходить — зателефонуйте у реєстратуру.`;
+}
+
 function truthy(value: string): boolean {
   return ["1", "true", "on", "yes"].includes(value.trim().toLowerCase());
 }

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,8 +1,8 @@
 // Резолвер провайдерів — добирає реалізації інтеграцій у tenant-контексті.
 //
-// Messaging configuration is still legacy-global in app_settings. The external
-// calendar URL is also legacy-global and belongs to the primary/public tenant,
-// so secondary tenants must not receive it until calendar storage is tenantized.
+// Messaging configuration and the external calendar URL are still legacy-global
+// in app_settings and belong to the primary/public tenant. Secondary tenants
+// must not receive those credentials/capabilities until storage is tenantized.
 // PACS та payment вже мають per-org джерела.
 
 import { getSettings } from "../settings";
@@ -14,6 +14,10 @@ import { createPaymentProvider, type PaymentConfig } from "./payment";
 import type { PacsProvider, ResolvedProviders } from "./types";
 
 const PRIMARY_ORGANIZATION_ID = 1;
+const MESSAGING_SETTING_KEYS = [
+  "sms_gateway_url", "sms_gateway_auth",
+  "email_gateway_url", "email_gateway_auth", "email_gateway_from",
+];
 
 // Дістає конфіг оплат із settings_json профілю організації (безпечно).
 function paymentConfig(settings: Record<string, unknown>): PaymentConfig {
@@ -28,15 +32,16 @@ function paymentConfig(settings: Record<string, unknown>): PaymentConfig {
 }
 
 export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise<ResolvedProviders> {
-  const calendarUrl = ctx.organizationId === PRIMARY_ORGANIZATION_ID
+  const primaryTenant = ctx.organizationId === PRIMARY_ORGANIZATION_ID;
+  const messagingSettings = primaryTenant
+    ? getSettings(db, MESSAGING_SETTING_KEYS)
+    : Promise.resolve({} as Record<string, string>);
+  const calendarUrl = primaryTenant
     ? getSettings(db, ["external_ics_url"]).then((s) => s.external_ics_url || "").catch(() => "")
     : Promise.resolve("");
 
   const [cfg, profile, pacsRow, icsUrl] = await Promise.all([
-    getSettings(db, [
-      "sms_gateway_url", "sms_gateway_auth",
-      "email_gateway_url", "email_gateway_auth", "email_gateway_from",
-    ]),
+    messagingSettings,
     getOrgProfile(db, ctx),
     db.prepare(
       "SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE organization_id = ? LIMIT 1"

--- a/tests/global-messaging-primary-tenant.behavior.test.mjs
+++ b/tests/global-messaging-primary-tenant.behavior.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  callWorker,
+  jsonRequest,
+  seedPatientSession,
+  seedStaffSession,
+  withD1,
+} from "./helpers/d1.mjs";
+
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'messaging-two', 'Messaging Two', 1)"
+  ).run();
+}
+
+async function setGlobal(db, key, value) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  ).bind(key, value).run();
+}
+
+async function addBooking(db, {
+  id,
+  organizationId,
+  code,
+  phone = "380501112233",
+  email = "",
+  date = "2026-09-01",
+  time = "10:00",
+}) {
+  await db.prepare(
+    `INSERT INTO bookings
+      (id, organization_id, code, name, phone, phone_normalized, patient_email,
+       service, service_code, desired_date, desired_time, status, date_of_birth, patient_category)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'КТ', 'CT-01', ?, ?, 'confirmed', '1990-05-05', 'civilian')`
+  ).bind(id, organizationId, code, `Patient ${code}`, `+${phone}`, phone, email, date, time).run();
+}
+
+test("secondary tenant manual notify never uses primary global gateways", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    await addBooking(db, { id:201, organizationId:2, code:"MSG-ORG2" });
+    await setGlobal(db, "sms_gateway_url", "https://gateway.example/sms");
+    await setGlobal(db, "sms_gateway_auth", "org1-secret");
+    await setGlobal(db, "email_gateway_url", "https://gateway.example/email");
+    await setGlobal(db, "telegram_bot_token", "123456:abcdefghijklmnopqrstuvwxyzABCDE");
+    await setGlobal(db, "whatsapp_id_instance", "org1-instance");
+    await setGlobal(db, "whatsapp_api_token_instance", "org1-token");
+    await setGlobal(db, "whatsapp_enabled", "1");
+
+    const cookie = await seedStaffSession(db, {
+      email:"org2-registrar@example.com", role:"registrar", organizationId:2,
+    });
+    const response = await callWorker(
+      jsonRequest(
+        "/api/staff/notify",
+        { bookingId:201, message:"Повідомлення для пацієнта" },
+        { headers:{ cookie } },
+      ),
+      db,
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.summary.sent, 0);
+    assert.equal(body.summary.failed, 0);
+    assert.ok(body.summary.skipped >= 1);
+
+    const rows = await db.prepare(
+      `SELECT organization_id AS organizationId, channel, status
+       FROM patient_notifications WHERE booking_id = 201 ORDER BY id`
+    ).all();
+    assert.ok(rows.results.length >= 1);
+    assert.ok(rows.results.every((row) => row.organizationId === 2));
+    assert.ok(rows.results.every((row) => row.status === "skipped"));
+    assert.ok(rows.results.every((row) => row.channel !== "whatsapp"));
+  });
+});
+
+test("secondary tenant contact-center cannot reply through primary WhatsApp", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380502223344";
+    await addBooking(db, { id:202, organizationId:2, code:"CHAT-ORG2", phone });
+    await setGlobal(db, "whatsapp_id_instance", "org1-instance");
+    await setGlobal(db, "whatsapp_api_token_instance", "org1-token");
+    await setGlobal(db, "whatsapp_enabled", "1");
+
+    const cookie = await seedStaffSession(db, {
+      email:"org2-chat@example.com", role:"registrar", organizationId:2,
+    });
+    const thread = await callWorker(
+      jsonRequest(`/api/staff/chat?phone=${phone}`, undefined, { method:"GET", headers:{ cookie } }),
+      db,
+    );
+    assert.equal(thread.status, 200);
+    assert.deepEqual((await thread.json()).availableReplyChannels, []);
+
+    const reply = await callWorker(
+      jsonRequest(
+        "/api/staff/chat",
+        { phone:`+${phone}`, text:"Не використовуйте org1 gateway", channel:"whatsapp" },
+        { headers:{ cookie } },
+      ),
+      db,
+    );
+    assert.equal(reply.status, 403);
+    const outbound = await db.prepare(
+      `SELECT COUNT(*) AS n FROM patient_communications
+       WHERE organization_id = 2 AND phone_normalized = ? AND direction = 'outbound'`
+    ).bind(phone).first("n");
+    assert.equal(outbound, 0);
+  });
+});
+
+test("secondary tenant patient cannot receive a deep-link to the primary Telegram bot", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380503334455";
+    await addBooking(db, { id:203, organizationId:2, code:"TG-ORG2", phone });
+    await setGlobal(db, "telegram_bot_token", "123456:abcdefghijklmnopqrstuvwxyzABCDE");
+    const cookie = await seedPatientSession(db, phone, 2);
+
+    const response = await callWorker(
+      jsonRequest("/api/my-telegram-link", {}, { headers:{ cookie } }),
+      db,
+    );
+    assert.equal(response.status, 503);
+    const body = await response.json();
+    assert.equal(body.botConfigured, false);
+    const tokens = await db.prepare(
+      "SELECT COUNT(*) AS n FROM telegram_link_tokens WHERE organization_id = 2"
+    ).first("n");
+    assert.equal(tokens, 0);
+  });
+});
+
+test("provider diagnostics hide primary SMS/email capabilities from secondary tenant", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    await setGlobal(db, "sms_gateway_url", "https://gateway.example/sms");
+    await setGlobal(db, "email_gateway_url", "https://gateway.example/email");
+
+    const org2Cookie = await seedStaffSession(db, {
+      email:"org2-provider@example.com", role:"admin", organizationId:2,
+    });
+    const org2 = await callWorker(
+      jsonRequest("/api/staff/providers", undefined, { method:"GET", headers:{ cookie:org2Cookie } }),
+      db,
+    );
+    assert.equal(org2.status, 200);
+    const org2Body = await org2.json();
+    assert.equal(org2Body.providers.messaging.sms, false);
+    assert.equal(org2Body.providers.messaging.email, false);
+
+    const org1Cookie = await seedStaffSession(db, {
+      email:"org1-provider@example.com", role:"admin", organizationId:1,
+    });
+    const org1 = await callWorker(
+      jsonRequest("/api/staff/providers", undefined, { method:"GET", headers:{ cookie:org1Cookie } }),
+      db,
+    );
+    assert.equal(org1.status, 200);
+    const org1Body = await org1.json();
+    assert.equal(org1Body.providers.messaging.sms, true);
+    assert.equal(org1Body.providers.messaging.email, true);
+  });
+});
+
+test("global WhatsApp webhook writes and looks up only primary-tenant data", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380504445566";
+    await addBooking(db, { id:204, organizationId:1, code:"WA-ORG1", phone, time:"09:00" });
+    await addBooking(db, { id:205, organizationId:2, code:"WA-ORG2", phone, time:"11:00" });
+    await setGlobal(db, "whatsapp_webhook_token", "webhook-secret");
+
+    const response = await callWorker(
+      jsonRequest(
+        "/api/whatsapp/webhook",
+        {
+          typeWebhook:"incomingMessageReceived",
+          idMessage:"MSG-PRIMARY-SCOPE",
+          senderData:{ chatId:`${phone}@c.us`, senderName:"Patient" },
+          messageData:{ typeMessage:"textMessage", textMessageData:{ textMessage:"невідома команда" } },
+        },
+        { headers:{ "x-webhook-token":"webhook-secret" } },
+      ),
+      db,
+    );
+    assert.equal(response.status, 200);
+
+    const rows = await db.prepare(
+      `SELECT organization_id AS organizationId, external_id AS externalId
+       FROM patient_communications WHERE external_id = 'MSG-PRIMARY-SCOPE'`
+    ).all();
+    assert.equal(rows.results.length, 1);
+    assert.equal(rows.results[0].organizationId, 1);
+  });
+});
+
+test("WhatsApp webhook source scopes appointment lookup and communication inserts to org 1", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(new URL("../app/api/whatsapp/webhook/route.ts", import.meta.url), "utf8");
+  assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/);
+  assert.match(source, /WHERE organization_id = \? AND phone_normalized = \?/);
+  assert.match(source, /\.bind\(PRIMARY_ORGANIZATION_ID, phone, todayKyiv\(\)\)/);
+  assert.match(source, /\(organization_id, phone_normalized, channel, direction, summary, actor, external_id\)/);
+  assert.doesNotMatch(source, /INSERT OR IGNORE INTO patient_communications \(phone_normalized/);
+});

--- a/tests/patient-otp-primary-tenant.behavior.test.mjs
+++ b/tests/patient-otp-primary-tenant.behavior.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, withD1 } from "./helpers/d1.mjs";
+
+async function setGlobalSms(db) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES ('sms_gateway_url', 'https://gateway.example/sms')
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  ).run();
+}
+
+async function addOrg2Booking(db, phone) {
+  await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'otp-two', 'OTP Two', 1)").run();
+  await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, phone_normalized, service, service_code,
+       desired_date, desired_time, status, date_of_birth, patient_category)
+     VALUES (2, 'OTP-ORG2', 'Org2 Patient', ?, ?, 'КТ', 'CT-01',
+       '2026-09-01', '10:00', 'confirmed', '1990-05-05', 'civilian')`
+  ).bind(`+${phone}`, phone).run();
+}
+
+test("secondary tenant OTP request returns an opaque fake challenge and never creates a usable row", async () => {
+  await withD1(async (db) => {
+    const phone = "380505556677";
+    await addOrg2Booking(db, phone);
+    await setGlobalSms(db);
+
+    const response = await callWorker(
+      jsonRequest(
+        "/api/patient-otp",
+        { phone:`+${phone}`, dob:"1990-05-05" },
+        { ip:"203.0.113.21" },
+      ),
+      db,
+    );
+    assert.equal(response.status, 202);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.match(body.challengeId, /^[a-f0-9]{64}$/);
+    assert.equal(body.expiresIn, 300);
+    assert.match(body.message, /Якщо дані збігаються/);
+
+    const rows = await db.prepare(
+      "SELECT COUNT(*) AS n FROM patient_otp_challenges WHERE organization_id = 2 AND phone_normalized = ?"
+    ).bind(phone).first("n");
+    assert.equal(rows, 0);
+  });
+});
+
+test("secondary tenant and unknown identity use the same neutral OTP response shape", async () => {
+  await withD1(async (db) => {
+    const knownPhone = "380506667788";
+    await addOrg2Booking(db, knownPhone);
+    await setGlobalSms(db);
+
+    const known = await callWorker(
+      jsonRequest(
+        "/api/patient-otp",
+        { phone:`+${knownPhone}`, dob:"1990-05-05" },
+        { ip:"203.0.113.22" },
+      ),
+      db,
+    );
+    const unknown = await callWorker(
+      jsonRequest(
+        "/api/patient-otp",
+        { phone:"+380507778899", dob:"1990-05-05" },
+        { ip:"203.0.113.23" },
+      ),
+      db,
+    );
+    assert.equal(known.status, 202);
+    assert.equal(unknown.status, 202);
+    const knownBody = await known.json();
+    const unknownBody = await unknown.json();
+    assert.deepEqual(
+      { ok:knownBody.ok, expiresIn:knownBody.expiresIn, message:knownBody.message },
+      { ok:unknownBody.ok, expiresIn:unknownBody.expiresIn, message:unknownBody.message },
+    );
+    assert.match(knownBody.challengeId, /^[a-f0-9]{64}$/);
+    assert.match(unknownBody.challengeId, /^[a-f0-9]{64}$/);
+  });
+});
+
+test("OTP source checks primary tenant only after identity proof and shares opaque response with unknown identities", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(new URL("../app/api/patient-otp/route.ts", import.meta.url), "utf8");
+  assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/);
+  assert.match(source, /!proof \|\| proof\.organizationId !== PRIMARY_ORGANIZATION_ID/);
+  assert.match(source, /return opaqueChallengeResponse\(\)/);
+  assert.match(source, /createPatientOtpChallenge\([\s\S]*proof\.organizationId/);
+});


### PR DESCRIPTION
## Summary
- prevent secondary tenants from resolving org1 SMS/e-mail capabilities or using org1 messaging credentials
- make reminders/manual notify skip global SMS/e-mail/Telegram/WhatsApp outside org1
- disable contact-center WhatsApp replies and patient Telegram deep-links outside org1 until messaging config is tenantized
- keep patient OTP anti-enumeration while preventing valid org2 identities from using the global org1 SMS gateway: org2 follows the same opaque fake-challenge path as an unknown identity, with no DB challenge row
- explicitly scope the global WhatsApp webhook to org1 for appointment lookup and inbound/outbound communication rows
- add end-to-end regressions for secondary-tenant notify, contact-center, Telegram link, OTP, provider diagnostics, and WhatsApp webhook storage

## Security impact
Closes multiple cross-tenant side effects caused by legacy-global messaging configuration. A secondary tenant could otherwise send patient messages or OTPs through org1 gateways, receive a deep-link to the org1 Telegram bot, or have the global WhatsApp bot query bookings without an organization filter.

## Scope
This PR intentionally does not tenantize messaging storage. Until that architecture work is complete, global messaging remains available only to org1 and fails closed elsewhere.

## Deployment
No production deploy in this PR.