### PR TITLE
Fail closed on cross-tenant payment routing

### DIFF
--- a/app/api/pay-link/route.ts
+++ b/app/api/pay-link/route.ts
@@ -1,5 +1,6 @@
-// Public GET exposes only the department's generic payment link. POST starts a
-// booking-bound manual payment for an OTP-authenticated patient.
+// Public GET exposes the primary department's generic payment link. POST starts a
+// booking-bound manual payment for an OTP-authenticated patient only while the
+// legacy payment destination remains primary-tenant scoped.
 
 import { getSetting } from "../../../lib/settings";
 import { dbBinding } from "../../../lib/db";
@@ -7,6 +8,7 @@ import { requirePatientSession } from "../../../lib/patient-auth";
 import { createPendingPayment, latestPaymentForBooking } from "../../../lib/payments";
 import { recordAnalyticsEvent } from "../../../lib/analytics";
 
+const PRIMARY_ORGANIZATION_ID = 1;
 const DEFAULT_PRIVAT24_PAY_LINK = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params=%7B%22token%22%3A%22cadc7a4d-d56c-4005-9cfe-04a96077f8c1%22%7D';
 
 async function configuredPayLink(db: D1Database | null | undefined) {
@@ -28,6 +30,12 @@ export async function POST(request: Request) {
 
   const session = await requirePatientSession(request, db);
   if (!session) return Response.json({ error: "Потрібне підтвердження номера телефону" }, { status: 401 });
+  if (session.organizationId !== PRIMARY_ORGANIZATION_ID) {
+    return Response.json(
+      { error: "Онлайн-оплата ще не налаштована для цієї організації" },
+      { status: 503, headers: { "cache-control": "no-store" } },
+    );
+  }
 
   const body = await request.json().catch(() => ({})) as Record<string, unknown>;
   const code = typeof body.code === "string" ? body.code.trim().toUpperCase().slice(0, 24) : "";

--- a/tests/payment-api.behavior.test.mjs
+++ b/tests/payment-api.behavior.test.mjs
@@ -14,6 +14,19 @@ async function seedBooking(db, { code, phone = "380501112233", amount = 1500, or
   return Number(result.meta.last_row_id);
 }
 
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'payment-two', 'Payment Two', 1)",
+  ).run();
+}
+
+async function setGlobal(db, key, value) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).bind(key, value).run();
+}
+
 test("patient payment start is session-scoped and server derives the amount", async () => {
   await withD1(async (db) => {
     await seedBooking(db, { code: "RD-PAY-001", amount: 1800, desiredTime: "10:00" });
@@ -34,6 +47,41 @@ test("patient payment start is session-scoped and server derives the amount", as
       headers: { cookie },
     }), db);
     assert.equal(foreign.status, 404);
+  });
+});
+
+test("secondary tenant payment start cannot use the primary global pay link or create a pending payment", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380502224466";
+    const code = "RD-PAY-ORG2";
+    const bookingId = await seedBooking(db, {
+      code,
+      phone,
+      amount: 2600,
+      organizationId: 2,
+      desiredTime: "11:00",
+    });
+    await setGlobal(db, "pay_link", "https://pay.example/org1-only");
+    const cookie = await seedPatientSession(db, phone, 2, { kind: "booking", value: code });
+
+    const response = await callWorker(jsonRequest("/api/pay-link", { code }, {
+      headers: { cookie },
+    }), db);
+    assert.equal(response.status, 503);
+    const body = await response.json();
+    assert.match(body.error, /не налаштована/i);
+    assert.equal(JSON.stringify(body).includes("pay.example/org1-only"), false);
+
+    const paymentCount = await db.prepare(
+      "SELECT COUNT(*) AS n FROM payment_transactions WHERE organization_id = 2 AND booking_id = ?",
+    ).bind(bookingId).first();
+    assert.equal(paymentCount.n, 0);
+
+    const analyticsCount = await db.prepare(
+      "SELECT COUNT(*) AS n FROM analytics_events WHERE organization_id = 2 AND event_name = 'payment_started'",
+    ).first();
+    assert.equal(analyticsCount.n, 0);
   });
 });
 


### PR DESCRIPTION
## Summary
- keep the legacy public payment link as the primary org storefront configuration
- reject authenticated patient payment starts outside organization 1 while `pay_link` remains legacy-global
- fail closed before booking/payment mutation, analytics, or exposure of the primary org payment destination
- add behavioral regression proving tenant 2 receives no org1 link and creates no pending payment or `payment_started` analytics

## Security rationale
`payment_transactions` were already tenant-scoped, but `/api/pay-link` POST returned the global org1 payment destination for a valid secondary-tenant patient after creating a pending manual payment. Until payment destinations are stored per organization, secondary tenants must not enter that flow.

No schema, UI, workflow, or production-deploy changes.