### PR TITLE
Isolate shared staff identities across tenants

### DIFF
--- a/app/api/staff/members/route.ts
+++ b/app/api/staff/members/route.ts
@@ -8,6 +8,17 @@ import { dbBinding } from "../../../../lib/db";
 
 const roles = new Set<StaffRole>(["admin", "registrar", "radiologist", "radiographer"]);
 
+type StaffIdentity = {
+  email:string;
+  phone:string | null;
+  lastName:string | null;
+  firstName:string | null;
+  patronymic:string | null;
+  contactEmail:string | null;
+  militaryRank:string | null;
+  positionTitle:string | null;
+};
+
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
@@ -57,11 +68,18 @@ export async function POST(request: Request) {
     return Response.json({ error: "Не можна забрати власний адміністративний доступ" }, { status: 409 });
   }
 
-  const [identity, existing] = await Promise.all([
-    db.prepare("SELECT email FROM staff_members WHERE email = ? LIMIT 1").bind(email).first(),
+  const [identity, existing, otherMembership] = await Promise.all([
+    db.prepare(
+      `SELECT email, phone, last_name AS lastName, first_name AS firstName, patronymic,
+         contact_email AS contactEmail, military_rank AS militaryRank, position_title AS positionTitle
+       FROM staff_members WHERE email = ? LIMIT 1`
+    ).bind(email).first<StaffIdentity>(),
     db.prepare(
       "SELECT role, active FROM memberships WHERE organization_id = ? AND member_email = ? LIMIT 1"
     ).bind(ctx.organizationId, email).first<{ role:string; active:number }>(),
+    db.prepare(
+      "SELECT 1 AS ok FROM memberships WHERE member_email = ? AND organization_id <> ? LIMIT 1"
+    ).bind(email, ctx.organizationId).first<{ ok:number }>(),
   ]);
   if (!identity && !password) {
     return Response.json({ error: "Для нового працівника потрібно задати PIN-код" }, { status: 400 });
@@ -71,34 +89,54 @@ export async function POST(request: Request) {
     if (problem) return Response.json({ error: problem }, { status: 400 });
   }
 
-  const statements = [
-    db.prepare(
-      `INSERT INTO staff_members (email, phone, display_name, last_name, first_name, patronymic,
-         contact_email, military_rank, position_title, role, active)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
-       ON CONFLICT(email) DO UPDATE SET
-         phone=excluded.phone, display_name=excluded.display_name, last_name=excluded.last_name,
-         first_name=excluded.first_name, patronymic=excluded.patronymic,
-         contact_email=excluded.contact_email, military_rank=excluded.military_rank,
-         position_title=excluded.position_title`
-    ).bind(email, phone, displayName, lastName, firstName, patronymic, contactEmail, militaryRank, positionTitle, role),
+  const sharedIdentity = Boolean(identity && otherMembership);
+  if (sharedIdentity && identity) {
+    const sameProfile =
+      String(identity.phone || "") === phone &&
+      String(identity.lastName || "") === lastName &&
+      String(identity.firstName || "") === firstName &&
+      String(identity.patronymic || "") === patronymic &&
+      String(identity.contactEmail || "").toLowerCase() === contactEmail &&
+      String(identity.militaryRank || "") === militaryRank &&
+      String(identity.positionTitle || "") === positionTitle;
+    if (password || !sameProfile) {
+      return Response.json(
+        { error: "Цей обліковий запис використовується іншою організацією. Тут можна змінити лише роль та активність; PIN і профіль залишаються спільними" },
+        { status: 409 },
+      );
+    }
+  }
+
+  const statements = [];
+  if (!sharedIdentity) {
+    statements.push(
+      db.prepare(
+        `INSERT INTO staff_members (email, phone, display_name, last_name, first_name, patronymic,
+           contact_email, military_rank, position_title, role, active)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+         ON CONFLICT(email) DO UPDATE SET
+           phone=excluded.phone, display_name=excluded.display_name, last_name=excluded.last_name,
+           first_name=excluded.first_name, patronymic=excluded.patronymic,
+           contact_email=excluded.contact_email, military_rank=excluded.military_rank,
+           position_title=excluded.position_title`
+      ).bind(email, phone, displayName, lastName, firstName, patronymic, contactEmail, militaryRank, positionTitle, role),
+    );
+  }
+  statements.push(
     db.prepare(
       `INSERT INTO memberships (organization_id, member_email, role, active)
        VALUES (?, ?, ?, ?)
        ON CONFLICT(organization_id, member_email) DO UPDATE SET
          role=excluded.role, active=excluded.active`
     ).bind(ctx.organizationId, email, role, active),
-  ];
+  );
 
   if (password) {
     statements.push(
       db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")
         .bind(await hashPassword(password), email),
+      db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(email),
     );
-  }
-  const accessChanged = !existing || existing.role !== role || Number(existing.active) !== active;
-  if (password || accessChanged) {
-    statements.push(db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(email));
   }
   await db.batch(statements);
 
@@ -108,7 +146,7 @@ export async function POST(request: Request) {
     action: existing ? "member_role" : "member_add",
     resource: "staff",
     targetId: phone,
-    details: { role, active: Boolean(active), passwordChanged: Boolean(password) },
+    details: { role, active: Boolean(active), passwordChanged: Boolean(password), sharedIdentity },
   });
   return Response.json({ ok:true, needsPassword:false }, { status:201 });
 }

--- a/tests/staff-member-identity-isolation.behavior.test.mjs
+++ b/tests/staff-member-identity-isolation.behavior.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'staff-two', 'Staff Two', 1)",
+  ).run();
+}
+
+const sharedProfile = {
+  lastName: "Спільний",
+  firstName: "Працівник",
+  patronymic: "Іванович",
+  contactEmail: "shared@example.com",
+  militaryRank: "капітан",
+  positionTitle: "лікар-рентгенолог",
+};
+
+async function seedSharedIdentity(db, phone = "380502225577") {
+  const email = `${phone}@phone.local`;
+  await seedStaffSession(db, {
+    email,
+    role: "radiologist",
+    displayName: `${sharedProfile.lastName} ${sharedProfile.firstName} ${sharedProfile.patronymic}`,
+    organizationId: 1,
+  });
+  await db.prepare(
+    `UPDATE staff_members SET
+       phone = ?, display_name = ?, last_name = ?, first_name = ?, patronymic = ?,
+       contact_email = ?, military_rank = ?, position_title = ?, password_hash = ?
+     WHERE email = ?`,
+  ).bind(
+    phone,
+    `${sharedProfile.lastName} ${sharedProfile.firstName} ${sharedProfile.patronymic}`,
+    sharedProfile.lastName,
+    sharedProfile.firstName,
+    sharedProfile.patronymic,
+    sharedProfile.contactEmail,
+    sharedProfile.militaryRank,
+    sharedProfile.positionTitle,
+    "original-shared-hash",
+    email,
+  ).run();
+  return { email, phone };
+}
+
+async function org2AdminCookie(db) {
+  return seedStaffSession(db, {
+    email: "org2-admin@example.com",
+    role: "admin",
+    organizationId: 2,
+  });
+}
+
+function memberBody(phone, overrides = {}) {
+  return {
+    phone: `+${phone}`,
+    ...sharedProfile,
+    role: "registrar",
+    active: true,
+    ...overrides,
+  };
+}
+
+test("secondary tenant cannot overwrite another tenant staff identity, PIN, or sessions", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const victim = await seedSharedIdentity(db);
+    const adminCookie = await org2AdminCookie(db);
+
+    const response = await callWorker(jsonRequest(
+      "/api/staff/members",
+      memberBody(victim.phone, {
+        lastName: "Захоплений",
+        positionTitle: "чужа посада",
+        password: "654321",
+      }),
+      { headers: { cookie: adminCookie } },
+    ), db);
+    assert.equal(response.status, 409);
+
+    const identity = await db.prepare(
+      `SELECT last_name AS lastName, position_title AS positionTitle, password_hash AS passwordHash
+       FROM staff_members WHERE email = ?`,
+    ).bind(victim.email).first();
+    assert.equal(identity.lastName, sharedProfile.lastName);
+    assert.equal(identity.positionTitle, sharedProfile.positionTitle);
+    assert.equal(identity.passwordHash, "original-shared-hash");
+
+    const sessionCount = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(victim.email).first();
+    assert.equal(sessionCount.n, 1);
+
+    const foreignMembership = await db.prepare(
+      "SELECT role, active FROM memberships WHERE organization_id = 2 AND member_email = ?",
+    ).bind(victim.email).first();
+    assert.equal(foreignMembership, null);
+
+    const ownerMembership = await db.prepare(
+      "SELECT role, active FROM memberships WHERE organization_id = 1 AND member_email = ?",
+    ).bind(victim.email).first();
+    assert.equal(ownerMembership.role, "radiologist");
+    assert.equal(ownerMembership.active, 1);
+  });
+});
+
+test("shared identity may attach and change only its local membership without global logout", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const victim = await seedSharedIdentity(db, "380502225588");
+    const adminCookie = await org2AdminCookie(db);
+
+    const attach = await callWorker(jsonRequest(
+      "/api/staff/members",
+      memberBody(victim.phone),
+      { headers: { cookie: adminCookie } },
+    ), db);
+    assert.equal(attach.status, 201);
+
+    const changeLocalAccess = await callWorker(jsonRequest(
+      "/api/staff/members",
+      memberBody(victim.phone, { role: "radiographer", active: false }),
+      { headers: { cookie: adminCookie } },
+    ), db);
+    assert.equal(changeLocalAccess.status, 201);
+
+    const org1 = await db.prepare(
+      "SELECT role, active FROM memberships WHERE organization_id = 1 AND member_email = ?",
+    ).bind(victim.email).first();
+    const org2 = await db.prepare(
+      "SELECT role, active FROM memberships WHERE organization_id = 2 AND member_email = ?",
+    ).bind(victim.email).first();
+    assert.equal(org1.role, "radiologist");
+    assert.equal(org1.active, 1);
+    assert.equal(org2.role, "radiographer");
+    assert.equal(org2.active, 0);
+
+    const identity = await db.prepare(
+      `SELECT last_name AS lastName, position_title AS positionTitle, password_hash AS passwordHash
+       FROM staff_members WHERE email = ?`,
+    ).bind(victim.email).first();
+    assert.equal(identity.lastName, sharedProfile.lastName);
+    assert.equal(identity.positionTitle, sharedProfile.positionTitle);
+    assert.equal(identity.passwordHash, "original-shared-hash");
+
+    const sessionCount = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(victim.email).first();
+    assert.equal(sessionCount.n, 1);
+  });
+});
+
+test("single-tenant identity can still update its profile and reset PIN", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380502225599";
+    const email = `${phone}@phone.local`;
+    await seedStaffSession(db, { email, role: "radiographer", organizationId: 2 });
+    await db.prepare(
+      `UPDATE staff_members SET phone = ?, last_name = 'Старий', first_name = 'Профіль',
+       display_name = 'Старий Профіль', position_title = 'лаборант', password_hash = 'old-hash'
+       WHERE email = ?`,
+    ).bind(phone, email).run();
+    const adminCookie = await org2AdminCookie(db);
+
+    const response = await callWorker(jsonRequest(
+      "/api/staff/members",
+      {
+        phone: `+${phone}`,
+        lastName: "Новий",
+        firstName: "Профіль",
+        patronymic: "",
+        contactEmail: "",
+        militaryRank: "",
+        positionTitle: "старший лаборант",
+        role: "radiographer",
+        active: true,
+        password: "123456",
+      },
+      { headers: { cookie: adminCookie } },
+    ), db);
+    assert.equal(response.status, 201);
+
+    const identity = await db.prepare(
+      `SELECT last_name AS lastName, position_title AS positionTitle, password_hash AS passwordHash
+       FROM staff_members WHERE email = ?`,
+    ).bind(email).first();
+    assert.equal(identity.lastName, "Новий");
+    assert.equal(identity.positionTitle, "старший лаборант");
+    assert.notEqual(identity.passwordHash, "old-hash");
+    assert.match(identity.passwordHash, /^pbkdf2\$sha256\$/);
+
+    const sessionCount = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(sessionCount.n, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent an organization admin from overwriting a staff identity that is also used by another organization
- reject cross-tenant changes to the shared global PIN/profile with 409 before any mutation
- allow safe membership-only attach/update when the submitted shared profile matches the existing global identity
- stop globally revoking staff sessions for local membership role/active changes; membership authorization is already checked live by `requireOrgContext`
- preserve profile/PIN reset behavior for identities that belong only to the current tenant

## Security regression
Behavioral D1 tests prove:
- org2 cannot overwrite an org1 staff profile/PIN or terminate the org1 session
- a shared identity can be attached to org2 and have only org2 membership changed, leaving org1 membership/global identity/session intact
- a single-tenant identity can still update profile and reset its PIN, revoking its session

No schema, UI, workflow, or production-deploy changes.