### PR TITLE
Isolate legacy service configuration by tenant

### DIFF
--- a/app/api/staff/services/route.ts
+++ b/app/api/staff/services/route.ts
@@ -11,6 +11,8 @@ import {
 } from "../../../../lib/service-config";
 import { requireOrgContext } from "../../../../lib/tenant";
 
+const PRIMARY_ORGANIZATION_ID = 1;
+
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
@@ -18,7 +20,9 @@ export async function GET(request: Request) {
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
 
   const tenantStored = await getSetting(db, serviceConfigKey(ctx.organizationId));
-  const legacyStored = tenantStored ? "" : await getSetting(db, SERVICE_CONFIG_KEY);
+  const legacyStored = !tenantStored && ctx.organizationId === PRIMARY_ORGANIZATION_ID
+    ? await getSetting(db, SERVICE_CONFIG_KEY)
+    : "";
   const services = parseServiceConfig(tenantStored || legacyStored);
   const effective = await effectiveServices(db, ctx.organizationId);
   return Response.json(

--- a/lib/effective-services.ts
+++ b/lib/effective-services.ts
@@ -15,6 +15,8 @@ export type EffectiveService = ConfiguredService & {
   customPrice: boolean;
 };
 
+const PRIMARY_ORGANIZATION_ID = 1;
+
 /**
  * Canonical server-side service resolver.
  *
@@ -24,11 +26,11 @@ export type EffectiveService = ConfiguredService & {
  */
 export async function effectiveServices(
   db: D1Database,
-  organizationId = 1,
+  organizationId = PRIMARY_ORGANIZATION_ID,
 ): Promise<EffectiveService[]> {
   const [tenantConfig, legacyConfig, overrides] = await Promise.all([
     getSetting(db, serviceConfigKey(organizationId)),
-    getSetting(db, SERVICE_CONFIG_KEY),
+    organizationId === PRIMARY_ORGANIZATION_ID ? getSetting(db, SERVICE_CONFIG_KEY) : Promise.resolve(""),
     priceOverrides(db, organizationId),
   ]);
   const config = parseServiceConfig(tenantConfig || legacyConfig);
@@ -48,7 +50,7 @@ export async function effectiveServices(
 export async function effectiveServiceByCode(
   db: D1Database,
   code: string,
-  organizationId = 1,
+  organizationId = PRIMARY_ORGANIZATION_ID,
 ): Promise<EffectiveService | undefined> {
   const services = await effectiveServices(db, organizationId);
   return services.find((service) => service.code === code);

--- a/tests/service-config-tenant-isolation.behavior.test.mjs
+++ b/tests/service-config-tenant-isolation.behavior.test.mjs
@@ -4,7 +4,7 @@ import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.
 
 const LEGACY_KEY = "service_catalog_config_v1";
 const ORG2_KEY = `${LEGACY_KEY}:org:2`;
-const SERVICE_CODE = "ct-chest";
+const SERVICE_CODE = "408";
 
 async function addOrganizationTwo(db) {
   await db.prepare(

--- a/tests/service-config-tenant-isolation.behavior.test.mjs
+++ b/tests/service-config-tenant-isolation.behavior.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const LEGACY_KEY = "service_catalog_config_v1";
+const ORG2_KEY = `${LEGACY_KEY}:org:2`;
+const SERVICE_CODE = "ct-chest";
+
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'services-two', 'Services Two', 1)",
+  ).run();
+}
+
+async function setSetting(db, key, value) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).bind(key, value).run();
+}
+
+function serviceOverride(durationMinutes, active) {
+  return JSON.stringify([{ code: SERVICE_CODE, durationMinutes, active }]);
+}
+
+function byCode(rows, code = SERVICE_CODE) {
+  return rows.find((row) => row.code === code);
+}
+
+async function getServices(db, cookie) {
+  const response = await callWorker(
+    jsonRequest("/api/staff/services", undefined, { method: "GET", headers: { cookie } }),
+    db,
+  );
+  assert.equal(response.status, 200);
+  return response.json();
+}
+
+test("primary tenant keeps the legacy global service config fallback", async () => {
+  await withD1(async (db) => {
+    await setSetting(db, LEGACY_KEY, serviceOverride(355, false));
+    const cookie = await seedStaffSession(db, {
+      email: "org1-services@example.com",
+      role: "admin",
+      organizationId: 1,
+    });
+
+    const body = await getServices(db, cookie);
+    assert.equal(byCode(body.services).durationMinutes, 355);
+    assert.equal(byCode(body.services).active, false);
+    assert.equal(byCode(body.effectiveServices).durationMinutes, 355);
+    assert.equal(byCode(body.effectiveServices).active, false);
+  });
+});
+
+test("secondary tenant without its own config never inherits the primary legacy config", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    await setSetting(db, LEGACY_KEY, serviceOverride(355, false));
+    const cookie = await seedStaffSession(db, {
+      email: "org2-services@example.com",
+      role: "admin",
+      organizationId: 2,
+    });
+
+    const body = await getServices(db, cookie);
+    const raw = byCode(body.services);
+    const effective = byCode(body.effectiveServices);
+    assert.equal(raw.active, true);
+    assert.notEqual(raw.durationMinutes, 355);
+    assert.equal(effective.active, true);
+    assert.notEqual(effective.durationMinutes, 355);
+  });
+});
+
+test("secondary tenant uses its own service config instead of the primary legacy config", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    await setSetting(db, LEGACY_KEY, serviceOverride(355, false));
+    await setSetting(db, ORG2_KEY, serviceOverride(345, false));
+    const cookie = await seedStaffSession(db, {
+      email: "org2-own-services@example.com",
+      role: "admin",
+      organizationId: 2,
+    });
+
+    const body = await getServices(db, cookie);
+    assert.equal(byCode(body.services).durationMinutes, 345);
+    assert.equal(byCode(body.services).active, false);
+    assert.equal(byCode(body.effectiveServices).durationMinutes, 345);
+    assert.equal(byCode(body.effectiveServices).active, false);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve the legacy global service-config fallback only for organization 1
- make secondary tenants with no own config resolve clean catalog defaults instead of inheriting org1 service settings
- keep per-organization `service_catalog_config_v1:org:<id>` authoritative when present
- apply the same isolation in both `/api/staff/services` and the canonical `effectiveServices` runtime resolver

## Regression coverage
Behavioral D1 tests prove:
- org1 still receives the legacy global config for backward compatibility
- org2 without its own config does not inherit org1 changes in either raw services or `effectiveServices`
- org2 with its own config receives only that config

No schema, UI, workflow, or production-deploy changes.