### PR TITLE
Redact patient phone from clinician global search

### DIFF
--- a/app/api/staff/search/route.ts
+++ b/app/api/staff/search/route.ts
@@ -35,6 +35,7 @@ export async function GET(request: Request) {
   if (q.length < 2) return Response.json({ results: [] }, { headers: { "cache-control": "no-store" } });
 
   const role = ctx.role as StaffRole;
+  const includeBookingPhone = role === "admin" || role === "registrar";
   const variants = nameVariants(q);
   const assignment = bookingAssignment("b", role, ctx.member.email);
   const bookingConds:string[] = [];
@@ -48,18 +49,18 @@ export async function GET(request: Request) {
   }
 
   const bookings = await db.prepare(
-    `SELECT b.id, b.code, b.name, b.phone, b.service, b.desired_date AS desiredDate,
+    `SELECT b.id, b.code, b.name${includeBookingPhone ? ", b.phone" : ""}, b.service, b.desired_date AS desiredDate,
             b.desired_time AS desiredTime, b.status
        FROM bookings b
       WHERE b.organization_id = ?${assignment.sql} AND (${bookingConds.join(" OR ")})
       ORDER BY b.created_at DESC, b.id DESC LIMIT 10`
   ).bind(...bookingBinds).all<{
-    id:number;code:string;name:string;phone:string;service:string;desiredDate:string;desiredTime:string;status:string;
+    id:number;code:string;name:string;phone?:string;service:string;desiredDate:string;desiredTime:string;status:string;
   }>();
 
   const results:Array<Record<string,unknown>> = (bookings.results || []).map((r) => ({
     type:"booking", key:`booking:${r.id}`, id:r.id, bookingId:r.id, code:r.code, name:r.name,
-    phone:r.phone, service:r.service, desiredDate:r.desiredDate, desiredTime:r.desiredTime,
+    ...(includeBookingPhone ? { phone:r.phone } : {}), service:r.service, desiredDate:r.desiredDate, desiredTime:r.desiredTime,
     statusLabel:stateLabel(String(r.status)),
     title:`${r.name || "Без імені"} · ${r.code}`,
     subtitle:`${r.service} · ${r.desiredDate}${r.desiredTime ? ` ${r.desiredTime}` : ""} · ${stateLabel(String(r.status))}`,

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -43,6 +43,7 @@ test("search matches booking by name, phone and RD code", async () => {
 
     const byPhone = await (await search(db, cookie, "0971112233")).json();
     assert.ok(bookingsOnly(byPhone).some((r) => r.code === "RD-AAAA1111"));
+    assert.equal(bookingsOnly(byPhone)[0].phone, "+380971112233");
     assert.ok(bookingsOnly(byPhone)[0].statusLabel);
   });
 });
@@ -79,6 +80,27 @@ test("clinician search is limited to bookings assigned to that membership", asyn
 
     const data = await (await search(db, cookie, "контрольний")).json();
     assert.deepEqual(bookingsOnly(data).map((r) => r.bookingId), [6]);
+  });
+});
+
+test("clinicians can find assigned bookings by phone without receiving the phone field", async () => {
+  await withD1(async (db) => {
+    await seed(db, { id: 8, code: "RD-RADPHONE", name: "Рентгенолог Пацієнт", phone: "+380971110008", phoneNorm: "380971110008", time: "11:00" });
+    await seed(db, { id: 9, code: "RD-TECHPHONE", name: "Лаборант Пацієнт", phone: "+380971110009", phoneNorm: "380971110009", time: "11:30" });
+
+    const cases = [
+      { role: "radiologist", email: "rad-phone@likarnya.test", bookingId: 8, field: "assigned_radiologist_email", query: "0971110008" },
+      { role: "radiographer", email: "tech-phone@likarnya.test", bookingId: 9, field: "assigned_radiographer_email", query: "0971110009" },
+    ];
+
+    for (const item of cases) {
+      const cookie = await seedStaffSession(db, { email: item.email, role: item.role });
+      await db.prepare(`UPDATE bookings SET ${item.field} = ? WHERE id = ?`).bind(item.email, item.bookingId).run();
+      const data = await (await search(db, cookie, item.query)).json();
+      const booking = bookingsOnly(data).find((r) => r.bookingId === item.bookingId);
+      assert.ok(booking);
+      assert.equal(Object.hasOwn(booking, "phone"), false);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- stop selecting booking phone from D1 for radiologist/radiographer global-search results
- keep server-side phone matching for assigned bookings
- preserve phone in admin/registrar results for existing operational workflow
- add behavioral coverage for radiologist and radiographer redaction plus registrar compatibility

## Security property
Clinical roles can use a phone query only as a locator for an already-assigned booking; the patient phone itself is not returned to them by `/api/staff/search`.

No schema, UI, or production-deploy changes.