### PR TITLE
Scope AI prior-study context to patient DOB

### DIFF
--- a/app/api/staff/ai/protocol-draft/route.ts
+++ b/app/api/staff/ai/protocol-draft/route.ts
@@ -30,12 +30,18 @@ export async function POST(request: Request) {
 
   let priorStudies = 0;
   const booking = await db.prepare(
-    "SELECT phone_normalized AS phone FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1"
-  ).bind(bookingId, ctx.organizationId).first<{ phone: string }>();
-  if (booking?.phone) {
+    `SELECT phone_normalized AS phone, date_of_birth AS dob
+     FROM bookings WHERE id = ? AND organization_id = ? LIMIT 1`
+  ).bind(bookingId, ctx.organizationId).first<{ phone: string; dob: string }>();
+  // A phone number can be shared by family members. Only use prior studies as
+  // AI context when the tenant-local booking identity also matches DOB. If DOB
+  // is absent, fail closed instead of treating the phone as a patient id.
+  if (booking?.phone && booking.dob) {
     const prior = await db.prepare(
-      "SELECT COUNT(*) AS count FROM bookings WHERE phone_normalized = ? AND performed_at != '' AND id != ? AND organization_id = ?"
-    ).bind(booking.phone, bookingId, ctx.organizationId).first<{ count: number }>();
+      `SELECT COUNT(*) AS count FROM bookings
+       WHERE phone_normalized = ? AND date_of_birth = ?
+         AND performed_at != '' AND id != ? AND organization_id = ?`
+    ).bind(booking.phone, booking.dob, bookingId, ctx.organizationId).first<{ count: number }>();
     priorStudies = Number(prior?.count || 0);
   }
 

--- a/tests/ai-prior-study-identity.behavior.test.mjs
+++ b/tests/ai-prior-study-identity.behavior.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, jsonRequest, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+
+async function addBooking(db, {
+  id,
+  organizationId = 1,
+  code,
+  phone = "+380971110100",
+  phoneNormalized = "380971110100",
+  dob = "1990-01-01",
+  time,
+  performedAt = "",
+  radiologist = "",
+}) {
+  await db.prepare(
+    `INSERT INTO bookings (
+      id, organization_id, code, name, phone, phone_normalized, service, service_code,
+      equipment_id, duration_minutes, desired_date, desired_time, status, date_of_birth,
+      patient_category, performed_at, assigned_radiologist_email
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+  ).bind(
+    id, organizationId, code, `Patient ${code}`, phone, phoneNormalized, "КТ", "CT-01",
+    "ct", 30, "2026-09-04", time, performedAt ? "completed" : "confirmed", dob,
+    "civilian", performedAt, radiologist,
+  ).run();
+}
+
+function draftRequest(db, cookie, bookingId) {
+  return callWorker(jsonRequest("/api/staff/ai/protocol-draft", {
+    bookingId,
+    templateKey:"ct_chest",
+    method:"",
+    sections:{},
+    findings:"",
+    conclusion:"",
+    recommendations:"",
+    number:"",
+  }, { method:"POST", headers:{ cookie } }), db);
+}
+
+test("AI prior-study context uses tenant + phone + DOB, not a shared phone alone", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2,'ai-other','AI Other',1)").run();
+    const email = "ai-rad@likarnya.test";
+
+    await addBooking(db, { id:941, code:"RD-AI941", time:"09:00", radiologist:email });
+    await addBooking(db, { id:942, code:"RD-AI942", time:"10:00", performedAt:"2026-08-01T10:00:00" });
+    await addBooking(db, { id:943, code:"RD-AI943", dob:"2000-02-02", time:"11:00", performedAt:"2026-08-02T10:00:00" });
+    await addBooking(db, { id:944, organizationId:2, code:"RD-AI944", time:"12:00", performedAt:"2026-08-03T10:00:00" });
+
+    const cookie = await seedStaffSession(db, { email, role:"radiologist", organizationId:1 });
+    const response = await draftRequest(db, cookie, 941);
+    assert.equal(response.status, 200);
+    const data = await response.json();
+    assert.equal(data.draft.engine, "heuristic");
+    assert.match(data.draft.recommendations, /попередніми дослідженнями пацієнта \(1\)/i);
+    assert.doesNotMatch(data.draft.recommendations, /\(2\)|\(3\)/);
+  });
+});
+
+test("AI prior-study context fails closed when DOB is absent", async () => {
+  await withD1(async (db) => {
+    const email = "ai-rad-nodob@likarnya.test";
+    const phone = "+380971110200";
+    const phoneNormalized = "380971110200";
+    await addBooking(db, { id:951, code:"RD-AI951", phone, phoneNormalized, dob:"", time:"13:00", radiologist:email });
+    await addBooking(db, { id:952, code:"RD-AI952", phone, phoneNormalized, dob:"", time:"14:00", performedAt:"2026-08-04T10:00:00" });
+
+    const cookie = await seedStaffSession(db, { email, role:"radiologist", organizationId:1 });
+    const response = await draftRequest(db, cookie, 951);
+    assert.equal(response.status, 200);
+    const data = await response.json();
+    assert.doesNotMatch(data.draft.recommendations, /попередніми дослідженнями/i);
+  });
+});


### PR DESCRIPTION
## Summary
- stop treating a phone number alone as patient identity when building AI draft context
- count prior studies only within the same tenant when both normalized phone and DOB match
- fail closed to zero prior studies when the current booking has no DOB
- keep the AI engine fully offline/deterministic

## Security / clinical correctness property
A shared family phone no longer causes another person's performed studies to influence the radiologist's AI draft recommendation. Cross-tenant studies are excluded as before.

## Regression coverage
Real D1 tests cover:
- same phone + same DOB counted
- same phone + different DOB excluded
- same phone + same DOB in another tenant excluded
- missing DOB disables prior-study context

No schema, UI, external-AI, or production-deploy changes.