### PR TITLE
Make staff self-profile membership-role authoritative

### DIFF
--- a/app/api/staff/profile/route.ts
+++ b/app/api/staff/profile/route.ts
@@ -1,4 +1,4 @@
-import { requireOrgContext } from "../../../../lib/tenant";
+import { requireSelfServiceOrgContext } from "../../../../lib/tenant";
 import { hashPassword, verifyPassword } from "../../../../lib/auth";
 import { passwordProblem } from "../../../../lib/staff-accounts";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
@@ -12,26 +12,25 @@ function clean(value: unknown, max = 120) {
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
+  const ctx = await requireSelfServiceOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Потрібно увійти" }, { status: 401 });
   const staff = ctx.member;
 
   const profile = await db.prepare(
     `SELECT email, phone, display_name AS displayName, last_name AS lastName,
        first_name AS firstName, patronymic, contact_email AS contactEmail,
-       military_rank AS militaryRank, position_title AS positionTitle,
-       role, active
+       military_rank AS militaryRank, position_title AS positionTitle, active
      FROM staff_members WHERE email = ? AND active = 1 LIMIT 1`
-  ).bind(staff.email).first();
+  ).bind(staff.email).first<Record<string, unknown>>();
 
   if (!profile) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
-  return Response.json({ profile });
+  return Response.json({ profile: { ...profile, role: ctx.role } });
 }
 
 export async function PATCH(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
+  const ctx = await requireSelfServiceOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Потрібно увійти" }, { status: 401 });
   const staff = ctx.member;
 

--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -27,6 +27,14 @@ const MEDICAL_OPERATIONAL_ROLES = new Set<StaffRole>([
 ]);
 const SYSTEM_ADMIN_ROLES = new Set<SystemRole>(["admin", "organization_admin"]);
 const MANAGEMENT_ROLES = new Set<ManagementRole>(["admin", "department_head"]);
+const SELF_SERVICE_ROLES = new Set<AccessRole>([
+  "admin",
+  "organization_admin",
+  "department_head",
+  "registrar",
+  "radiologist",
+  "radiographer",
+]);
 
 export interface OrgMember<R extends AccessRole = StaffRole> {
   email: string;
@@ -116,4 +124,11 @@ export function requireSystemOrgContext(request: Request, db: D1Database): Promi
 // state but is kept outside both medical/operational and system-admin contexts.
 export function requireManagementOrgContext(request: Request, db: D1Database): Promise<OrgContext<ManagementRole> | null> {
   return resolveOrgContext(request, db, MANAGEMENT_ROLES);
+}
+
+// Neutral self-service identity context. It is intentionally capability-free:
+// it exists only for a user to read/update their own account profile and does
+// not grant access to medical, management, or system-admin resources.
+export function requireSelfServiceOrgContext(request: Request, db: D1Database): Promise<OrgContext<AccessRole> | null> {
+  return resolveOrgContext(request, db, SELF_SERVICE_ROLES);
 }

--- a/tests/staff-profile-membership-context.behavior.test.mjs
+++ b/tests/staff-profile-membership-context.behavior.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function setMembershipRole(db, email, role, organizationId = 1) {
+  await db.prepare(
+    "UPDATE memberships SET role = ?, active = 1 WHERE organization_id = ? AND member_email = ?"
+  ).bind(role, organizationId, email).run();
+}
+
+async function getProfile(db, cookie) {
+  return callWorker(
+    jsonRequest("/api/staff/profile", undefined, { method:"GET", headers:{ cookie } }),
+    db,
+  );
+}
+
+test("self-profile returns the active tenant membership role, not the legacy global identity role", async () => {
+  await withD1(async (db) => {
+    const cases = [
+      { email:"profile-system@example.com", role:"organization_admin" },
+      { email:"profile-head@example.com", role:"department_head" },
+      { email:"profile-rad@example.com", role:"radiologist" },
+    ];
+
+    for (const item of cases) {
+      const cookie = await seedStaffSession(db, { email:item.email, role:"admin", displayName:"Profile User" });
+      await setMembershipRole(db, item.email, item.role);
+
+      const response = await getProfile(db, cookie);
+      assert.equal(response.status, 200, `${item.role} must be able to read their own profile`);
+      const body = await response.json();
+      assert.equal(body.profile.email, item.email);
+      assert.equal(body.profile.role, item.role);
+
+      const identity = await db.prepare("SELECT role FROM staff_members WHERE email = ?").bind(item.email).first();
+      assert.equal(identity.role, "admin", "test keeps legacy global identity role different from membership role");
+    }
+  });
+});
+
+test("system and management roles can update only their own shared profile through the neutral context", async () => {
+  await withD1(async (db) => {
+    const email = "profile-update@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"admin", displayName:"Before" });
+    await setMembershipRole(db, email, "organization_admin");
+
+    const response = await callWorker(
+      jsonRequest("/api/staff/profile", {
+        lastName:"Системний",
+        firstName:"Адміністратор",
+        patronymic:"Тестович",
+        phone:"+380501234567",
+        contactEmail:"self@example.com",
+        militaryRank:"",
+        positionTitle:"Системний адміністратор",
+      }, { method:"PATCH", headers:{ cookie } }),
+      db,
+    );
+    assert.equal(response.status, 200);
+
+    const stored = await db.prepare(
+      `SELECT display_name AS displayName, phone, contact_email AS contactEmail,
+        position_title AS positionTitle, role
+       FROM staff_members WHERE email = ?`
+    ).bind(email).first();
+    assert.equal(stored.displayName, "Системний Адміністратор Тестович");
+    assert.equal(stored.phone, "380501234567");
+    assert.equal(stored.contactEmail, "self@example.com");
+    assert.equal(stored.positionTitle, "Системний адміністратор");
+    assert.equal(stored.role, "admin", "self-service must never rewrite the legacy global authorization role");
+
+    const after = await getProfile(db, cookie);
+    assert.equal(after.status, 200);
+    const body = await after.json();
+    assert.equal(body.profile.role, "organization_admin");
+
+    const audit = await db.prepare(
+      `SELECT organization_id AS organizationId, action, details_json AS detailsJson
+       FROM security_audit_log WHERE actor_email = ? AND action='profile_update'
+       ORDER BY id DESC LIMIT 1`
+    ).bind(email).first();
+    assert.equal(audit.organizationId, 1);
+    assert.equal(audit.action, "profile_update");
+    assert.doesNotMatch(String(audit.detailsJson), /Системний|self@example|380501234567/);
+  });
+});
+
+test("profile route uses the neutral membership context and never trusts staff_members.role for the response", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const route = await readFile(new URL("../app/api/staff/profile/route.ts", import.meta.url), "utf8");
+  const tenant = await readFile(new URL("../lib/tenant.ts", import.meta.url), "utf8");
+
+  assert.match(route, /requireSelfServiceOrgContext\(request, db\)/);
+  assert.match(route, /profile: \{ \.\.\.profile, role: ctx\.role \}/);
+  assert.doesNotMatch(route, /position_title AS positionTitle,[\s\S]*role, active/);
+  assert.match(tenant, /SELF_SERVICE_ROLES/);
+  assert.match(tenant, /requireSelfServiceOrgContext/);
+  assert.match(tenant, /resolveOrgContext\(request, db, SELF_SERVICE_ROLES\)/);
+});


### PR DESCRIPTION
## Summary
- add a capability-neutral tenant context for self-service account operations
- allow activated runtime roles (`admin`, `organization_admin`, `department_head`, `registrar`, `radiologist`, `radiographer`) to read/update their own profile
- return `memberships.role` from `/api/staff/profile` instead of legacy `staff_members.role`
- keep profile edits self-only and keep the global legacy role untouched

## Why
After system/management role separation, `/api/staff/profile` still used the medical `requireOrgContext`, so `organization_admin` and `department_head` could not access their own profile. It also exposed the legacy global identity role, which could mislabel tenant authority in the UI.

The new self-service context grants no medical, management, or system-admin capability; it only resolves an active tenant membership for the signed-in identity.

## Regression coverage
- organization_admin and department_head can read their own profile
- profile role reflects tenant membership even when global identity role is different
- self-update preserves global legacy role
- audit remains tenant-scoped and contains no profile PII in details

No production deploy.