### PR TITLE
Redact contact and finance fields from clinician booking payloads

### DIFF
--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -15,6 +15,7 @@ import {
   canWriteNotes,
   type StaffRole,
 } from "../../../../lib/staff-auth";
+import { projectBookingForStaff, staffBookingCapabilities } from "../../../../lib/staff-booking-projection";
 import { requireOrgContext } from "../../../../lib/tenant";
 import { nextBookingCode } from "../../../../lib/booking-code";
 import { dbBinding } from "../../../../lib/db";
@@ -150,7 +151,8 @@ export async function GET(request: Request) {
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const member = ctx.member;
   const scope = bookingScope(member, ctx.organizationId);
-  const includeFinancialDetails = canManageFinance(member.role);
+  const capabilities = staffBookingCapabilities(member.role);
+  const includeFinancialDetails = capabilities.canManageFinance;
   const financeEventScope = includeFinancialDetails
     ? ""
     : " AND action NOT IN ('finance_updated','payment_confirmed','payment_refunded')";
@@ -202,17 +204,15 @@ export async function GET(request: Request) {
        ORDER BY created_at DESC LIMIT 1000`
     ).bind(ctx.organizationId, ...scope.values).all(),
   ]);
-  const bookings = (result.results as Array<Record<string, unknown>>).map((booking) => ({
-    ...booking,
-    // Existing bookings keep the price snapshot captured when they were created.
-    listedPrice: Number(booking.paymentAmount) || 0,
-  }));
+  const bookings = (result.results as Array<Record<string, unknown>>)
+    .map((booking) => projectBookingForStaff(booking, capabilities));
   return Response.json({
     bookings,
     events: events.results,
     notes: notes.results,
     staffOptions: staffOptions.results,
     notifications: notifications.results,
+    capabilities,
     staff: member,
   });
 }

--- a/app/staff/page.tsx
+++ b/app/staff/page.tsx
@@ -6,22 +6,27 @@ import StaffWorkspaceShell from "./workspace-shell";
 type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer";
 type StaffInfo = { email:string; displayName:string; role:StaffRole };
 type StaffOption = { email:string; displayName:string; role:StaffRole };
+type BookingCapabilities = {
+  canManageBookings:boolean;
+  canViewPatientContact:boolean;
+  canManageFinance:boolean;
+};
 type Booking = {
-  id:number; code:string; name:string; phone:string; patientEmail:string; service:string;
+  id:number; code:string; name:string; phone?:string; patientEmail?:string; service:string;
   serviceCode:string; equipmentId:string; durationMinutes:number;
   desiredDate:string; desiredTime:string; referral:string;
   patientCategory:string; referralType:string; referralNumber:string;
-  marketingSource:string; protocolNumber:string; protocolStatus:string; protocolUpdatedAt:string;
+  marketingSource?:string; protocolNumber:string; protocolStatus:string; protocolUpdatedAt:string;
   assignedRadiologistEmail:string; assignedRadiographerEmail:string;
   performedAt:string; anatomicalRegionsCount:number;
   protocolReadyAt:string; protocolIssuedAt:string;
-  paidAmount:number; externalReference:string;
-  paymentStatus:string; paymentAmount:number; paymentMethod:string;
-  nszuStatus:string; nszuReference:string; listedPrice:number;
+  paidAmount?:number; externalReference:string;
+  paymentStatus?:string; paymentAmount?:number; paymentMethod?:string;
+  nszuStatus?:string; nszuReference?:string; listedPrice?:number;
   comment:string; status:string; createdAt:string;
 };
 type BookingEvent = { id:number; bookingId:number; action:string; details:string; actor:string; createdAt:string };
-type PatientNotification = { id:number; bookingId:number; kind:string; channel:string; recipient:string; status:string; error:string; createdAt:string; sentAt:string };
+type PatientNotification = { id:number; bookingId:number; kind:string; channel:string; recipient?:string; status:string; error:string; createdAt:string; sentAt:string };
 type ReminderResult = { sent:number; skipped:number; failed:number } | null | undefined;
 type StaffNote = { bookingId:number; note:string; updatedBy:string; updatedAt:string };
 type Equipment = { id:string; name:string; slotMinutes:number; start:string; end:string };
@@ -31,6 +36,12 @@ type EquipmentBlock = {
 type StaffMember = {
   email:string; phone:string; displayName:string; lastName:string; firstName:string; patronymic:string;
   contactEmail:string; militaryRank:string; positionTitle:string; role:StaffRole; active:number; createdAt:string;
+};
+
+const NO_BOOKING_CAPABILITIES: BookingCapabilities = {
+  canManageBookings:false,
+  canViewPatientContact:false,
+  canManageFinance:false,
 };
 
 const labels: Record<string,string> = {
@@ -183,6 +194,7 @@ export default function StaffPage() {
   const [notes,setNotes] = useState<StaffNote[]>([]);
   const [notifications,setNotifications] = useState<PatientNotification[]>([]);
   const [staff,setStaff] = useState<StaffInfo | null>(null);
+  const [capabilities,setCapabilities] = useState<BookingCapabilities>(NO_BOOKING_CAPABILITIES);
   const [equipment,setEquipment] = useState<Equipment[]>([]);
   const [blocks,setBlocks] = useState<EquipmentBlock[]>([]);
   const [members,setMembers] = useState<StaffMember[]>([]);
@@ -207,7 +219,8 @@ export default function StaffPage() {
     ]);
     const data = await bookingsResponse.json() as {
       bookings?:Booking[]; events?:BookingEvent[]; notes?:StaffNote[]; staff?:StaffInfo;
-      staffOptions?:StaffOption[]; notifications?:PatientNotification[]; error?:string;
+      staffOptions?:StaffOption[]; notifications?:PatientNotification[];
+      capabilities?:BookingCapabilities; error?:string;
     };
     if (!bookingsResponse.ok) { setError(data.error || "Немає доступу"); return; }
     const equipmentData = await equipmentResponse.json() as {
@@ -219,6 +232,7 @@ export default function StaffPage() {
     setNotes(data.notes || []);
     setNotifications(data.notifications || []);
     setStaff(data.staff || null);
+    setCapabilities(data.capabilities || NO_BOOKING_CAPABILITIES);
     setStaffOptions(data.staffOptions || []);
     setEquipment(equipmentData.equipment || []);
     setBlocks(equipmentData.blocks || []);
@@ -395,10 +409,10 @@ export default function StaffPage() {
     .filter(item => equipmentFilter === "all" || item.equipmentId === equipmentFilter)
     .filter(item => !dayFilter || item.desiredDate === dayFilter)
     .filter(item => categoryFilter === "all" || item.patientCategory === categoryFilter)
-    .filter(item => paymentFilter === "all" || (paymentFilter === "paid" ? item.paymentStatus === "paid" : item.patientCategory === "civilian" && item.paymentStatus !== "paid"))
-    .filter(item => !query.trim() || `${item.name} ${item.phone} ${item.code} ${item.service} ${item.serviceCode}`.toLowerCase().includes(query.trim().toLowerCase()))
+    .filter(item => !capabilities.canManageFinance || paymentFilter === "all" || (paymentFilter === "paid" ? item.paymentStatus === "paid" : item.patientCategory === "civilian" && item.paymentStatus !== "paid"))
+    .filter(item => !query.trim() || `${item.name} ${capabilities.canViewPatientContact ? item.phone || "" : ""} ${item.code} ${item.service} ${item.serviceCode}`.toLowerCase().includes(query.trim().toLowerCase()))
     .sort((a,b)=>`${a.desiredDate} ${a.desiredTime}`.localeCompare(`${b.desiredDate} ${b.desiredTime}`)),
-  [items,equipmentFilter,categoryFilter,paymentFilter,dayFilter,query]);
+  [items,equipmentFilter,categoryFilter,paymentFilter,dayFilter,query,capabilities]);
   const statusCounts = useMemo(() => {
     const counts:Record<string,number> = { all:baseFiltered.length };
     for (const item of baseFiltered) counts[item.status] = (counts[item.status] || 0) + 1;
@@ -415,14 +429,15 @@ export default function StaffPage() {
     return [...map.entries()];
   }, [visible]);
   const today = todayInKyiv();
-  const canManage = staff?.role === "admin" || staff?.role === "registrar";
+  const canManage = capabilities.canManageBookings;
+  const canViewPatientContact = capabilities.canViewPatientContact;
   const canProtocol = staff?.role === "admin" || staff?.role === "radiologist";
-  const canFinance = staff?.role === "admin" || staff?.role === "registrar";
+  const canFinance = capabilities.canManageFinance;
 
   return <StaffWorkspaceShell
     active="overview"
     title="Записи"
-    description="Записи пацієнтів за статусами й днями. Керування кожним записом — протокол, оплата, виконання — у деталях запису."
+    description="Записи пацієнтів за статусами й днями. Деталі запису містять лише доступні вашій ролі операційні дані."
     staffName={staff?.displayName || staff?.email}
     staffRole={staff ? roleLabels[staff.role] : undefined}
   >
@@ -444,7 +459,7 @@ export default function StaffPage() {
         <article><span>На сьогодні</span><b>{items.filter(i=>i.desiredDate===today).length}</b></article>
         <article className="militaryStat"><span>Військові</span><b>{items.filter(i=>i.desiredDate===today&&i.patientCategory==="military").length}</b></article>
         <article className="civilianStat"><span>Цивільні</span><b>{items.filter(i=>i.desiredDate===today&&i.patientCategory==="civilian").length}</b></article>
-        <article className="attentionStat"><span>Оплату перевірити</span><b>{items.filter(i=>i.patientCategory==="civilian"&&i.paymentStatus!=="paid"&&i.status!=="cancelled"&&i.status!=="no_show").length}</b></article>
+        {canFinance && <article className="attentionStat"><span>Оплату перевірити</span><b>{items.filter(i=>i.patientCategory==="civilian"&&i.paymentStatus!=="paid"&&i.status!=="cancelled"&&i.status!=="no_show").length}</b></article>}
         <article><span>Прибули</span><b>{items.filter(i=>i.desiredDate===today&&i.status==="arrived").length}</b></article>
         <article><span>Неявка</span><b>{items.filter(i=>i.desiredDate===today&&i.status==="no_show").length}</b></article>
       </section>
@@ -462,8 +477,8 @@ export default function StaffPage() {
         <label>Дата <input type="date" value={dayFilter} onChange={e=>setDayFilter(e.target.value)}/></label>
         <label>Апарат <select value={equipmentFilter} onChange={e=>setEquipmentFilter(e.target.value)}><option value="all">Усе обладнання</option>{equipment.map(item=><option value={item.id} key={item.id}>{item.name}</option>)}</select></label>
         <label>Пацієнти <select value={categoryFilter} onChange={e=>setCategoryFilter(e.target.value)}><option value="all">Усі пацієнти</option><option value="military">Військовослужбовці</option><option value="civilian">Цивільні</option></select></label>
-        <label>Оплата <select value={paymentFilter} onChange={e=>setPaymentFilter(e.target.value)}><option value="all">Будь-який стан</option><option value="pending">Потрібно перевірити</option><option value="paid">Оплату перевірено</option></select></label>
-        <label>Пошук <input type="search" value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пацієнт, код, телефон…"/></label>
+        {canFinance && <label>Оплата <select value={paymentFilter} onChange={e=>setPaymentFilter(e.target.value)}><option value="all">Будь-який стан</option><option value="pending">Потрібно перевірити</option><option value="paid">Оплату перевірено</option></select></label>}
+        <label>Пошук <input type="search" value={query} onChange={e=>setQuery(e.target.value)} placeholder={canViewPatientContact ? "Пацієнт, код, телефон…" : "Пацієнт, код, дослідження…"}/></label>
         <div className="toolButtons"><button onClick={()=>{setDayFilter(today);setFilter("all")}}>Сьогодні</button><button onClick={()=>{setDayFilter("");setFilter("all");setEquipmentFilter("all");setCategoryFilter("all");setPaymentFilter("all");setQuery("");}}>Скинути</button><button onClick={()=>window.print()}>Друк</button><button onClick={()=>void load()}>Оновити</button></div>
       </div>
       <p className="scheduleCaption">{dayFilter?`Записи на ${dayFilter}`:"Усі дати"} · {visible.length} {pluralAppt(visible.length)}</p>
@@ -543,15 +558,15 @@ export default function StaffPage() {
         {visible.length === 0 ? <div className="apptEmpty"><span className="apptEmptyIcon" aria-hidden="true">🗓</span><b>Записів немає</b><p>На обрані фільтри записів не знайдено. Змініть дату, статус або пошук.</p></div> :
         groupedByDay.map(([groupDate, rows]) => <div className="apptDay" key={groupDate || "nodate"}>
         <div className="apptDayHead"><b>{formatApptDay(groupDate)}</b><span>{rows.length} {pluralAppt(rows.length)}</span></div>
-        {rows.map(item => <article id={`booking-${item.id}`} className={`bookingRow appointmentRow route-${item.patientCategory} ${item.paymentStatus==="paid"?"payment-ok":"payment-due"}`} key={item.id}>
+        {rows.map(item => <article id={`booking-${item.id}`} className={`bookingRow appointmentRow route-${item.patientCategory} ${canFinance ? item.paymentStatus==="paid"?"payment-ok":"payment-due" : ""}`} key={item.id}>
           <div className="bookingPrimary">
             <div className="bookingBadges"><span className={`patientRoute ${item.patientCategory}`}>{item.patientCategory==="military"?"Військовослужбовець":"Цивільний пацієнт"}</span><span className={`statusTag ${item.status}`}>{labels[item.status] || item.status}</span></div>
             <b>{item.name}</b>
             <strong className="appointmentMoment">{item.desiredTime}<small>{item.desiredDate}</small></strong>
             <small><span className="codeTag">{item.code}</span> · отримано {new Date(item.createdAt).toLocaleString("uk-UA")}</small>
           </div>
-          <div><small>Дослідження</small><b>{item.service}</b><span>Код {item.serviceCode} · {equipment.find(unit=>unit.id===item.equipmentId)?.name || item.equipmentId} · {item.durationMinutes} хв</span><span className={`paymentOverview ${item.patientCategory==="military"?"military":item.paymentStatus==="paid"?"paid":"pending"}`}>{item.patientCategory==="military"?"Безоплатно за направленням":item.paymentStatus==="paid"?`✓ Оплату перевірено · ${item.paidAmount || item.paymentAmount || item.listedPrice} грн`:`До перевірки · ${item.paymentAmount || item.listedPrice} грн`}</span></div>
-          <div><small>Контакт і маршрут</small><a href={`tel:${item.phone}`}>{item.phone}</a><a className="crmCardLink" href={`/staff/patients?phone=${encodeURIComponent(item.phone)}`}>Картка пацієнта →</a><span>{categoryLabels[item.patientCategory] || item.patientCategory}</span><span>{referralLabels[item.referralType] || item.referral}</span>{item.referralNumber&&<span>№ {item.referralNumber}</span>}{item.marketingSource&&<span>Джерело: {item.marketingSource}</span>}</div>
+          <div><small>Дослідження</small><b>{item.service}</b><span>Код {item.serviceCode} · {equipment.find(unit=>unit.id===item.equipmentId)?.name || item.equipmentId} · {item.durationMinutes} хв</span>{canFinance && <span className={`paymentOverview ${item.patientCategory==="military"?"military":item.paymentStatus==="paid"?"paid":"pending"}`}>{item.patientCategory==="military"?"Безоплатно за направленням":item.paymentStatus==="paid"?`✓ Оплату перевірено · ${item.paidAmount || item.paymentAmount || item.listedPrice || 0} грн`:`До перевірки · ${item.paymentAmount || item.listedPrice || 0} грн`}</span>}</div>
+          <div><small>{canViewPatientContact ? "Контакт і маршрут" : "Маршрут"}</small>{canViewPatientContact && item.phone && <><a href={`tel:${item.phone}`}>{item.phone}</a><a className="crmCardLink" href={`/staff/patients?phone=${encodeURIComponent(item.phone)}`}>Картка пацієнта →</a></>}<span>{categoryLabels[item.patientCategory] || item.patientCategory}</span><span>{referralLabels[item.referralType] || item.referral}</span>{item.referralNumber&&<span>№ {item.referralNumber}</span>}{canViewPatientContact&&item.marketingSource&&<span>Джерело: {item.marketingSource}</span>}</div>
           <div className="bookingAction"><small>Статус</small>
             {canManage?<select value={item.status} onChange={e=>void changeStatus(item.id,e.target.value)}>{Object.entries(labels).map(([v,l])=><option value={v} key={v}>{l}</option>)}</select>:<b>{labels[item.status] || item.status}</b>}
             {canManage && (item.status==="new"||item.status==="rescheduled") && <button type="button" className="confirmBooking" onClick={()=>void confirmBooking(item.id)}>✓ Підтвердити й у розклад</button>}
@@ -561,8 +576,8 @@ export default function StaffPage() {
             </div>}
             {canFinance && item.patientCategory==="civilian" && item.paymentStatus!=="paid" && <button type="button" className="paymentVerifyAction" onClick={()=>void saveOperations(item.id,{
               paymentStatus:"paid",
-              paymentAmount:item.paymentAmount || item.listedPrice,
-              paidAmount:item.paymentAmount || item.listedPrice,
+              paymentAmount:item.paymentAmount || item.listedPrice || 0,
+              paidAmount:item.paymentAmount || item.listedPrice || 0,
               paymentMethod:item.paymentMethod || "bank_transfer",
               nszuStatus:item.nszuStatus || "not_applicable",
               nszuReference:item.nszuReference || "",
@@ -570,7 +585,7 @@ export default function StaffPage() {
             {(() => { const last = notifications.find(note=>note.bookingId===item.id); return last ? <span className={`reminderTag ${last.status}`}>Нагадування: {notificationStatusLabels[last.status]||last.status} · {notificationChannelLabels[last.channel]||last.channel}{last.status==="failed"&&last.error?` — ${last.error}`:""}</span> : null; })()}
           </div>
           <details className="apptManage">
-            <summary>Керування записом · {item.performedAt ? "виконано" : "очікує виконання"} · протокол: {protocolLabels[item.protocolStatus] || item.protocolStatus} · оплата: {paymentLabels[item.paymentStatus] || item.paymentStatus}</summary>
+            <summary>Керування записом · {item.performedAt ? "виконано" : "очікує виконання"} · протокол: {protocolLabels[item.protocolStatus] || item.protocolStatus}{canFinance ? ` · оплата: ${paymentLabels[item.paymentStatus || ""] || item.paymentStatus || "—"}` : ""}</summary>
           {canManage && <RescheduleForm item={item} today={today} onSubmit={(newDate,newTime)=>reschedule(item.id,newDate,newTime)}/>}
           {item.comment && <p className="bookingComment">{item.comment}</p>}
           <form className="staffNoteForm" onSubmit={event=>{event.preventDefault();const data=new FormData(event.currentTarget);void saveNote(item.id,String(data.get("note")));}}>
@@ -646,9 +661,9 @@ export default function StaffPage() {
                   <div><dt>Видано</dt><dd>{item.protocolIssuedAt ? new Date(item.protocolIssuedAt).toLocaleString("uk-UA") : "—"}</dd></div>
                 </dl>}
               </section>
-              <section>
+              {canFinance && <section>
                 <h3>Оплата та НСЗУ</h3>
-                {canFinance ? <form onSubmit={event=>{
+                <form onSubmit={event=>{
                   event.preventDefault();
                   const data = new FormData(event.currentTarget);
                   void saveOperations(item.id,{
@@ -660,22 +675,17 @@ export default function StaffPage() {
                     nszuReference:String(data.get("nszuReference")),
                   },"Дані оплати та НСЗУ збережено.");
                 }}>
-                  <label><span>Статус оплати</span><select name="paymentStatus" defaultValue={item.paymentStatus}>{Object.entries(paymentLabels).map(([value,label])=><option value={value} key={value}>{label}</option>)}</select></label>
-                  <label><span>Сума до сплати, грн</span><input name="paymentAmount" type="number" min="0" max="100000" step="1" defaultValue={item.paymentAmount || item.listedPrice}/></label>
-                  <label><span>Фактично сплачено, грн</span><input name="paidAmount" type="number" min="0" max="100000" step="1" defaultValue={item.paidAmount}/></label>
-                  <label><span>Спосіб</span><select name="paymentMethod" defaultValue={item.paymentMethod}>{Object.entries(paymentMethodLabels).map(([value,label])=><option value={value} key={value}>{label}</option>)}</select></label>
-                  <label><span>Статус НСЗУ</span><select name="nszuStatus" defaultValue={item.nszuStatus}>{Object.entries(nszuLabels).map(([value,label])=><option value={value} key={value}>{label}</option>)}</select></label>
-                  <label><span>Номер підтвердження НСЗУ</span><input name="nszuReference" maxLength={80} defaultValue={item.nszuReference}/></label>
+                  <label><span>Статус оплати</span><select name="paymentStatus" defaultValue={item.paymentStatus || "not_set"}>{Object.entries(paymentLabels).map(([value,label])=><option value={value} key={value}>{label}</option>)}</select></label>
+                  <label><span>Сума до сплати, грн</span><input name="paymentAmount" type="number" min="0" max="100000" step="1" defaultValue={item.paymentAmount || item.listedPrice || 0}/></label>
+                  <label><span>Фактично сплачено, грн</span><input name="paidAmount" type="number" min="0" max="100000" step="1" defaultValue={item.paidAmount || 0}/></label>
+                  <label><span>Спосіб</span><select name="paymentMethod" defaultValue={item.paymentMethod || ""}>{Object.entries(paymentMethodLabels).map(([value,label])=><option value={value} key={value}>{label}</option>)}</select></label>
+                  <label><span>Статус НСЗУ</span><select name="nszuStatus" defaultValue={item.nszuStatus || "not_applicable"}>{Object.entries(nszuLabels).map(([value,label])=><option value={value} key={value}>{label}</option>)}</select></label>
+                  <label><span>Номер підтвердження НСЗУ</span><input name="nszuReference" maxLength={80} defaultValue={item.nszuReference || ""}/></label>
                   <button type="submit">Зберегти оплату / НСЗУ</button>
-                </form> : <dl className="operationReadOnly">
-                  <div><dt>Оплата</dt><dd>{paymentLabels[item.paymentStatus] || item.paymentStatus}</dd></div>
-                  <div><dt>До сплати</dt><dd>{item.paymentAmount || item.listedPrice} грн</dd></div>
-                  <div><dt>Сплачено</dt><dd>{item.paidAmount} грн</dd></div>
-                  <div><dt>НСЗУ</dt><dd>{nszuLabels[item.nszuStatus] || item.nszuStatus}</dd></div>
-                </dl>}
-              </section>
+                </form>
+              </section>}
             </div>
-            <p className="operationsNote">Це внутрішній облік. Фактичне списання коштів або перевірка в ЕСОЗ/НСЗУ відбуваються лише після підключення офіційного провайдера.</p>
+            {canFinance && <p className="operationsNote">Це внутрішній облік. Фактичне списання коштів або перевірка в ЕСОЗ/НСЗУ відбуваються лише після підключення офіційного провайдера.</p>}
           <details className="bookingHistory">
             <summary>Історія змін ({events.filter(event=>event.bookingId===item.id).length})</summary>
             {events.filter(event=>event.bookingId===item.id).length===0?<p>Змін ще не зафіксовано.</p>:

--- a/lib/staff-booking-projection.ts
+++ b/lib/staff-booking-projection.ts
@@ -1,0 +1,48 @@
+import { canManageBookings, canManageFinance, type AccessRole } from "./staff-auth";
+
+export type StaffBookingCapabilities = {
+  canManageBookings: boolean;
+  canViewPatientContact: boolean;
+  canManageFinance: boolean;
+};
+
+const CONTACT_FIELDS = ["phone", "patientEmail", "marketingSource"] as const;
+const FINANCE_FIELDS = [
+  "paymentStatus",
+  "paymentAmount",
+  "paymentMethod",
+  "nszuStatus",
+  "nszuReference",
+  "paidAmount",
+  "listedPrice",
+] as const;
+
+export function staffBookingCapabilities(role: AccessRole): StaffBookingCapabilities {
+  const bookingAdmin = canManageBookings(role);
+  return {
+    canManageBookings: bookingAdmin,
+    canViewPatientContact: bookingAdmin,
+    canManageFinance: canManageFinance(role),
+  };
+}
+
+export function projectBookingForStaff(
+  input: Record<string, unknown>,
+  capabilities: StaffBookingCapabilities,
+): Record<string, unknown> {
+  const booking: Record<string, unknown> = { ...input };
+
+  if (!capabilities.canViewPatientContact) {
+    for (const field of CONTACT_FIELDS) delete booking[field];
+  }
+
+  if (!capabilities.canManageFinance) {
+    for (const field of FINANCE_FIELDS) delete booking[field];
+  } else {
+    // Existing bookings keep the authoritative price snapshot captured when
+    // they were created. This derived convenience field is finance-only.
+    booking.listedPrice = Number(booking.paymentAmount) || 0;
+  }
+
+  return booking;
+}

--- a/tests/bookings-clinical-projection.behavior.test.mjs
+++ b/tests/bookings-clinical-projection.behavior.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function seedProjectedBooking(db, id, radiologist, radiographer) {
+  await db.prepare(
+    `INSERT INTO bookings (
+      id, organization_id, code, name, phone, phone_normalized, patient_email,
+      service, service_code, equipment_id, duration_minutes, desired_date, desired_time,
+      status, date_of_birth, patient_category, marketing_source,
+      assigned_radiologist_email, assigned_radiographer_email,
+      payment_status, payment_amount, paid_amount, payment_method, nszu_status, nszu_reference,
+      protocol_status, external_reference
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+  ).bind(
+    id, 1, `RD-PROJ${id}`, "Projection Patient", "+380971119999", "380971119999",
+    "private.patient@example.test", "КТ", "CT-01", "ct", 30, "2026-09-03", "12:00",
+    "confirmed", "1990-01-01", "civilian", "campaign-private",
+    radiologist, radiographer, "paid", 98765, 98765, "cash", "confirmed", "NSZU-PRIVATE-001",
+    "ready", "CLINICAL-REF-001",
+  ).run();
+
+  for (const [action, details] of [
+    ["status_changed", "confirmed"],
+    ["finance_updated", "paid 98765 cash"],
+  ]) {
+    await db.prepare(
+      `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+       VALUES (1, ?, ?, ?, 'finance@test')`,
+    ).bind(id, action, details).run();
+  }
+  await db.prepare(
+    `INSERT INTO patient_notifications
+      (organization_id, booking_id, kind, channel, recipient, body, status, error, sent_at)
+     VALUES (1, ?, 'custom', 'email', 'private.patient@example.test', 'Service message', 'sent', '', CURRENT_TIMESTAMP)`,
+  ).bind(id).run();
+}
+
+const getBookings = (db, cookie) => callWorker(
+  jsonRequest("/api/staff/bookings", undefined, { method:"GET", headers:{ cookie } }),
+  db,
+);
+
+const sensitiveFields = [
+  "phone", "patientEmail", "marketingSource", "paymentStatus", "paymentAmount",
+  "paymentMethod", "nszuStatus", "nszuReference", "paidAmount", "listedPrice",
+];
+
+for (const roleCase of [
+  { role:"radiologist", email:"projection-rad@example.test", assignment:"radiologist", id:931 },
+  { role:"radiographer", email:"projection-tech@example.test", assignment:"radiographer", id:932 },
+]) {
+  test(`${roleCase.role} booking DTO omits patient contact and finance fields`, async () => {
+    await withD1(async (db) => {
+      const radiologist = roleCase.assignment === "radiologist" ? roleCase.email : "other-rad@example.test";
+      const radiographer = roleCase.assignment === "radiographer" ? roleCase.email : "other-tech@example.test";
+      await seedProjectedBooking(db, roleCase.id, radiologist, radiographer);
+      const cookie = await seedStaffSession(db, { email:roleCase.email, role:roleCase.role });
+
+      const response = await getBookings(db, cookie);
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.deepEqual(body.capabilities, {
+        canManageBookings:false,
+        canViewPatientContact:false,
+        canManageFinance:false,
+      });
+      assert.equal(body.bookings.length, 1);
+      const booking = body.bookings[0];
+      for (const field of sensitiveFields) assert.equal(Object.hasOwn(booking, field), false, field);
+
+      assert.equal(booking.name, "Projection Patient");
+      assert.equal(booking.dateOfBirth, "1990-01-01");
+      assert.equal(booking.service, "КТ");
+      assert.equal(booking.protocolStatus, "ready");
+      assert.equal(booking.externalReference, "CLINICAL-REF-001");
+      assert.equal(booking.assignedRadiologistEmail, radiologist);
+      assert.equal(booking.assignedRadiographerEmail, radiographer);
+
+      const serialized = JSON.stringify(booking);
+      for (const privateValue of [
+        "+380971119999", "private.patient@example.test", "campaign-private",
+        "98765", "cash", "NSZU-PRIVATE-001",
+      ]) assert.equal(serialized.includes(privateValue), false, privateValue);
+
+      assert.deepEqual(body.events.map((event) => event.action), ["status_changed"]);
+      assert.equal(body.notifications.length, 1);
+      assert.equal(Object.hasOwn(body.notifications[0], "recipient"), false);
+    });
+  });
+}
+
+for (const role of ["registrar", "admin"]) {
+  test(`${role} keeps booking contact and finance fields`, async () => {
+    await withD1(async (db) => {
+      const id = role === "registrar" ? 933 : 934;
+      await seedProjectedBooking(db, id, "rad@example.test", "tech@example.test");
+      const cookie = await seedStaffSession(db, { email:`projection-${role}@example.test`, role });
+
+      const response = await getBookings(db, cookie);
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.deepEqual(body.capabilities, {
+        canManageBookings:true,
+        canViewPatientContact:true,
+        canManageFinance:true,
+      });
+      const booking = body.bookings.find((item) => item.id === id);
+      assert.equal(booking.phone, "+380971119999");
+      assert.equal(booking.patientEmail, "private.patient@example.test");
+      assert.equal(booking.marketingSource, "campaign-private");
+      assert.equal(booking.paymentStatus, "paid");
+      assert.equal(booking.paymentAmount, 98765);
+      assert.equal(booking.paidAmount, 98765);
+      assert.equal(booking.paymentMethod, "cash");
+      assert.equal(booking.nszuStatus, "confirmed");
+      assert.equal(booking.nszuReference, "NSZU-PRIVATE-001");
+      assert.equal(booking.listedPrice, 98765);
+      assert.equal(body.notifications[0].recipient, "private.patient@example.test");
+    });
+  });
+}
+
+test("staff overview gates contact and finance UI on server capabilities", async () => {
+  const page = await readFile(new URL("../app/staff/page.tsx", import.meta.url), "utf8");
+  const route = await readFile(new URL("../app/api/staff/bookings/route.ts", import.meta.url), "utf8");
+  const projection = await readFile(new URL("../lib/staff-booking-projection.ts", import.meta.url), "utf8");
+
+  assert.match(route, /staffBookingCapabilities\(member\.role\)/);
+  assert.match(route, /projectBookingForStaff\(booking, capabilities\)/);
+  assert.match(route, /capabilities,/);
+  assert.match(projection, /CONTACT_FIELDS/);
+  assert.match(projection, /FINANCE_FIELDS/);
+  assert.match(projection, /delete booking\[field\]/);
+
+  assert.match(page, /const canViewPatientContact = capabilities\.canViewPatientContact/);
+  assert.match(page, /const canFinance = capabilities\.canManageFinance/);
+  assert.match(page, /\{canFinance && <label>Оплата/);
+  assert.match(page, /\{canFinance && <span className=\{`paymentOverview/);
+  assert.match(page, /\{canViewPatientContact && item\.phone && <>/);
+  assert.match(page, /\{canFinance && <section>[\s\S]*<h3>Оплата та НСЗУ<\/h3>/);
+  assert.equal(/Оплата та НСЗУ<\/h3>[\s\S]*: <dl className="operationReadOnly">/.test(page), false);
+});

--- a/tests/bookings-clinical-projection.behavior.test.mjs
+++ b/tests/bookings-clinical-projection.behavior.test.mjs
@@ -18,7 +18,7 @@ async function seedProjectedBooking(db, id, radiologist, radiographer) {
     "private.patient@example.test", "КТ", "CT-01", "ct", 30, "2026-09-03", "12:00",
     "confirmed", "1990-01-01", "civilian", "campaign-private",
     radiologist, radiographer, "paid", 98765, 98765, "cash", "confirmed", "NSZU-PRIVATE-001",
-    "ready", "CLINICAL-REF-001",
+    "not_started", "CLINICAL-REF-001",
   ).run();
 
   for (const [action, details] of [
@@ -73,7 +73,7 @@ for (const roleCase of [
       assert.equal(booking.name, "Projection Patient");
       assert.equal(booking.dateOfBirth, "1990-01-01");
       assert.equal(booking.service, "КТ");
-      assert.equal(booking.protocolStatus, "ready");
+      assert.equal(booking.protocolStatus, "not_started");
       assert.equal(booking.externalReference, "CLINICAL-REF-001");
       assert.equal(booking.assignedRadiologistEmail, radiologist);
       assert.equal(booking.assignedRadiographerEmail, radiographer);

--- a/tests/effective-services.test.mjs
+++ b/tests/effective-services.test.mjs
@@ -75,10 +75,12 @@ test("staff booking UI consumes effective services rather than the static catalo
 
 test("staff booking mutations resolve effective services and preserve booking price snapshots", async () => {
   const route = await read("app/api/staff/bookings/route.ts");
+  const projection = await read("lib/staff-booking-projection.ts");
   assert.match(route, /effectiveServiceByCode\(db, serviceCode, ctx\.organizationId\)/);
   assert.match(route, /serviceAvailableTo\(service, category\)/);
   assert.match(route, /paymentStatus, service\.price/);
-  assert.match(route, /listedPrice: Number\(booking\.paymentAmount\) \|\| 0/);
+  assert.match(route, /projectBookingForStaff\(booking, capabilities\)/);
+  assert.match(projection, /booking\.listedPrice = Number\(booking\.paymentAmount\) \|\| 0/);
   assert.match(route, /effectiveServiceByCode\(db, e\.serviceCode\.trim\(\)\.slice\(0, 12\), ctx\.organizationId\)/);
   assert.match(route, /binds\.push\(svc\.price\)/);
   assert.doesNotMatch(route, /effectivePrice\(/);


### PR DESCRIPTION
## Summary
- add a capability-driven staff booking projection
- keep radiologist/radiographer booking access assignment-scoped while removing unnecessary patient contact, marketing, payment and NSZU fields from their JSON DTO
- preserve registrar/admin compatibility, including contact/finance fields and notification recipients
- return explicit booking capabilities from `/api/staff/bookings`
- update the shared `/staff` UI to gate contact and finance controls on server capabilities instead of rendering empty/false values

## Clinician projection
For radiologist/radiographer, booking JSON omits:
- `phone`, `patientEmail`, `marketingSource`
- `paymentStatus`, `paymentAmount`, `paymentMethod`, `paidAmount`, `listedPrice`
- `nszuStatus`, `nszuReference`

Clinical/operational fields remain available for assigned bookings, including patient name/DOB, service, equipment, protocol state, performer assignments, performed metadata and external clinical reference.

Finance booking events and notification recipients were already redacted; this PR preserves those controls.

## UI
When contact/finance capabilities are absent, the overview no longer renders:
- phone or CRM links
- marketing source
- payment stat/filter/badge/summary
- payment quick action
- finance/NSZU section

This avoids `tel:undefined`, fake `0 грн`, and misleading payment states after server redaction.

## Regression coverage
- radiologist and radiographer receive assigned clinical data but no sensitive DTO keys/values
- registrar and admin retain full booking/contact/finance workflow
- notification recipient remains absent for clinicians
- finance events remain absent for clinicians
- static assertions keep contact/finance UI behind server capability flags

No production deploy.