### PR TITLE
Introduce immutable patient profile identifiers

### DIFF
--- a/app/api/staff/patients/route.ts
+++ b/app/api/staff/patients/route.ts
@@ -19,10 +19,12 @@ const BOOKING_COLUMNS = `id, code, name, phone_normalized AS phoneNormalized, se
   payment_amount AS paymentAmount, paid_amount AS paidAmount,
   performed_at AS performedAt, created_at AS createdAt`;
 
-const PROFILE_COLUMNS = `phone_normalized AS phoneNormalized, display_name AS displayName,
+const PROFILE_COLUMNS = `patient_id AS patientId, phone_normalized AS phoneNormalized, display_name AS displayName,
   birth_year AS birthYear, birth_date AS birthDate, email, address,
   tags, notes, do_not_contact AS doNotContact,
   updated_by AS updatedBy, updated_at AS updatedAt`;
+
+type PatientProfileRow = PatientProfile & { patientId:string };
 
 export async function GET(request: Request) {
   const db = dbBinding();
@@ -39,7 +41,7 @@ export async function GET(request: Request) {
   if (phone) {
     const [bookings, profileRow, communications] = await Promise.all([
       db.prepare(`SELECT ${BOOKING_COLUMNS} FROM bookings WHERE phone_normalized = ? AND organization_id = ? ORDER BY desired_date DESC, desired_time DESC`).bind(phone, orgId).all(),
-      db.prepare(`SELECT ${PROFILE_COLUMNS} FROM patient_profiles WHERE phone_normalized = ? AND organization_id = ? LIMIT 1`).bind(phone, orgId).first<PatientProfile>(),
+      db.prepare(`SELECT ${PROFILE_COLUMNS} FROM patient_profiles WHERE phone_normalized = ? AND organization_id = ? LIMIT 1`).bind(phone, orgId).first<PatientProfileRow>(),
       db.prepare(`SELECT id, channel, direction, summary, actor, created_at AS createdAt
          FROM patient_communications WHERE phone_normalized = ? AND organization_id = ? ORDER BY created_at DESC LIMIT 200`).bind(phone, orgId).all(),
     ]);
@@ -48,7 +50,11 @@ export async function GET(request: Request) {
     const profiles = new Map<string, PatientProfile>();
     if (profileRow) profiles.set(phone, profileRow);
     const [summary] = buildPatientSummaries(rows, profiles);
-    await logSecurityEvent(db, { organizationId: orgId, actorEmail: member.email, action: "patient_record_viewed", resource: "patient", targetId: phone });
+    // Do not persist a phone number as the audit target. Existing CRM profiles
+    // have an immutable opaque id; booking-only legacy records use a booking id
+    // until an explicit patient linkage exists in a later migration.
+    const auditTarget = profileRow?.patientId || (rows[0]?.id ? `booking:${rows[0].id}` : "unlinked");
+    await logSecurityEvent(db, { organizationId: orgId, actorEmail: member.email, action: "patient_record_viewed", resource: "patient", targetId: auditTarget });
     return Response.json({ patient: summary || null, phone, profile: profileRow || null, bookings: bookings.results, communications: communications.results, staff: member }, { headers: { "cache-control": "no-store" } });
   }
 
@@ -57,7 +63,7 @@ export async function GET(request: Request) {
     db.prepare(`SELECT ${PROFILE_COLUMNS} FROM patient_profiles WHERE organization_id = ? ORDER BY updated_at DESC LIMIT 5000`).bind(orgId).all(),
   ]);
   const profiles = new Map<string, PatientProfile>();
-  for (const row of profileRows.results as unknown as PatientProfile[]) profiles.set(row.phoneNormalized, row);
+  for (const row of profileRows.results as unknown as PatientProfileRow[]) profiles.set(row.phoneNormalized, row);
   const patients = buildPatientSummaries(bookings.results as unknown as PatientBookingRow[], profiles);
   await logSecurityEvent(db, { organizationId: orgId, actorEmail: member.email, action: "patient_registry_viewed", resource: "patient_registry", details: { rows: patients.length } });
   return Response.json({ patients, staff: member }, { headers: { "cache-control": "no-store" } });
@@ -84,7 +90,12 @@ export async function PUT(request: Request) {
        tags = excluded.tags, notes = excluded.notes, do_not_contact = excluded.do_not_contact,
        updated_by = excluded.updated_by, updated_at = CURRENT_TIMESTAMP`
   ).bind(ctx.organizationId, profile.phoneNormalized, profile.displayName, profile.birthYear, profile.birthDate, profile.email, profile.address, profile.tags, profile.notes, profile.doNotContact, member.email).run();
-  return Response.json({ ok: true, profile: { ...profile, updatedBy: member.email } });
+
+  const saved = await db.prepare(
+    `SELECT ${PROFILE_COLUMNS} FROM patient_profiles WHERE organization_id = ? AND phone_normalized = ? LIMIT 1`
+  ).bind(ctx.organizationId, profile.phoneNormalized).first<PatientProfileRow>();
+  if (!saved) return Response.json({ error: "Не вдалося зберегти картку пацієнта" }, { status: 500 });
+  return Response.json({ ok: true, profile: saved });
 }
 
 export async function POST(request: Request) {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -234,8 +234,9 @@ export const protocolRevisions = sqliteTable("protocol_revisions", {
 ]);
 
 export const patientProfiles = sqliteTable("patient_profiles", {
+  patientId: text("patient_id").primaryKey().default(sql`lower(hex(randomblob(16)))`),
   organizationId: integer("organization_id").notNull().default(1),
-  phoneNormalized: text("phone_normalized").primaryKey(),
+  phoneNormalized: text("phone_normalized").notNull(),
   displayName: text("display_name").notNull().default(""),
   birthYear: integer("birth_year").notNull().default(0),
   birthDate: text("birth_date").notNull().default(""),
@@ -244,9 +245,14 @@ export const patientProfiles = sqliteTable("patient_profiles", {
   tags: text("tags").notNull().default(""),
   notes: text("notes").notNull().default(""),
   doNotContact: integer("do_not_contact").notNull().default(0),
+  telegramChatId: text("telegram_chat_id").notNull().default(""),
   updatedBy: text("updated_by").notNull(),
   updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
-});
+}, table => [
+  uniqueIndex("patient_profiles_org_phone_idx").on(table.organizationId, table.phoneNormalized),
+  index("patient_profiles_phone_idx").on(table.phoneNormalized),
+  index("patient_profiles_org_updated_idx").on(table.organizationId, table.updatedAt),
+]);
 
 export const patientCommunications = sqliteTable("patient_communications", {
   organizationId: integer("organization_id").notNull().default(1),

--- a/drizzle/0050_patient_profile_id.sql
+++ b/drizzle/0050_patient_profile_id.sql
@@ -1,0 +1,54 @@
+-- Immutable patient identity foundation.
+--
+-- Historical CRM profiles were keyed by (organization_id, phone_normalized).
+-- Introduce an opaque patient_id as the real row identity while preserving the
+-- existing tenant+phone uniqueness contract for this compatibility phase.
+-- Bookings are intentionally NOT backfilled or linked here: a phone number is
+-- not sufficient evidence that historical studies belong to one person.
+
+CREATE TABLE `patient_profiles_v3` (
+  `patient_id` text PRIMARY KEY NOT NULL DEFAULT (lower(hex(randomblob(16)))),
+  `organization_id` integer NOT NULL DEFAULT 1,
+  `phone_normalized` text NOT NULL,
+  `display_name` text NOT NULL DEFAULT '',
+  `birth_year` integer NOT NULL DEFAULT 0,
+  `birth_date` text NOT NULL DEFAULT '',
+  `email` text NOT NULL DEFAULT '',
+  `address` text NOT NULL DEFAULT '',
+  `tags` text NOT NULL DEFAULT '',
+  `notes` text NOT NULL DEFAULT '',
+  `do_not_contact` integer NOT NULL DEFAULT 0,
+  `telegram_chat_id` text NOT NULL DEFAULT '',
+  `updated_by` text NOT NULL,
+  `updated_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (`organization_id`, `phone_normalized`)
+);
+--> statement-breakpoint
+INSERT INTO `patient_profiles_v3` (
+  `organization_id`, `phone_normalized`, `display_name`, `birth_year`, `birth_date`,
+  `email`, `address`, `tags`, `notes`, `do_not_contact`, `telegram_chat_id`,
+  `updated_by`, `updated_at`
+)
+SELECT
+  `organization_id`, `phone_normalized`, `display_name`, `birth_year`, `birth_date`,
+  `email`, `address`, `tags`, `notes`, `do_not_contact`, `telegram_chat_id`,
+  `updated_by`, `updated_at`
+FROM `patient_profiles`;
+--> statement-breakpoint
+DROP TABLE `patient_profiles`;
+--> statement-breakpoint
+ALTER TABLE `patient_profiles_v3` RENAME TO `patient_profiles`;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_profiles_phone_idx`
+ON `patient_profiles` (`phone_normalized`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_profiles_org_updated_idx`
+ON `patient_profiles` (`organization_id`, `updated_at`);
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_profiles_patient_id_immutable`
+BEFORE UPDATE OF `patient_id` ON `patient_profiles`
+FOR EACH ROW
+WHEN NEW.patient_id != OLD.patient_id
+BEGIN
+  SELECT RAISE(ABORT, 'patient id is immutable');
+END;

--- a/tests/patient-id-foundation.behavior.test.mjs
+++ b/tests/patient-id-foundation.behavior.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const DRIZZLE_DIR = new URL("../drizzle/", import.meta.url);
+
+function migrationNumber(file) {
+  return Number(file.slice(0, 4));
+}
+
+async function migrationFiles() {
+  return (await readdir(DRIZZLE_DIR))
+    .filter((file) => /^\d{4}_.+\.sql$/.test(file))
+    .sort();
+}
+
+async function apply(db, files) {
+  for (const file of files) {
+    const sql = await readFile(new URL(file, DRIZZLE_DIR), "utf8");
+    db.exec(sql);
+  }
+}
+
+test("0050 backfills opaque immutable patient ids without changing legacy profile data", async () => {
+  const files = await migrationFiles();
+  const before0050 = files.filter((file) => migrationNumber(file) < 50);
+  const migration0050 = files.find((file) => migrationNumber(file) === 50);
+  assert.ok(migration0050);
+
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec("PRAGMA foreign_keys = ON;");
+    await apply(db, before0050);
+    db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, birth_year, birth_date,
+         email, address, tags, notes, do_not_contact, telegram_chat_id, updated_by)
+       VALUES (1, '380501112233', 'Legacy Person', 1980, '1980-01-10',
+         'legacy@example.com', 'Address', 'vip', 'note', 1, 'legacy-chat', 'seed')`,
+    ).run();
+
+    await apply(db, [migration0050]);
+
+    const row = db.prepare(
+      `SELECT patient_id AS patientId, organization_id AS organizationId,
+        phone_normalized AS phone, display_name AS displayName, birth_date AS birthDate,
+        email, address, tags, notes, do_not_contact AS doNotContact,
+        telegram_chat_id AS telegramChatId, updated_by AS updatedBy
+       FROM patient_profiles WHERE organization_id = 1 AND phone_normalized = '380501112233'`,
+    ).get();
+    assert.match(String(row.patientId), /^[0-9a-f]{32}$/);
+    assert.deepEqual(
+      { ...row, patientId: undefined },
+      {
+        patientId: undefined,
+        organizationId: 1,
+        phone: "380501112233",
+        displayName: "Legacy Person",
+        birthDate: "1980-01-10",
+        email: "legacy@example.com",
+        address: "Address",
+        tags: "vip",
+        notes: "note",
+        doNotContact: 1,
+        telegramChatId: "legacy-chat",
+        updatedBy: "seed",
+      },
+    );
+
+    assert.throws(
+      () => db.prepare("UPDATE patient_profiles SET patient_id = 'changed' WHERE patient_id = ?").run(row.patientId),
+      /patient id is immutable/i,
+    );
+
+    db.prepare(
+      `INSERT INTO patient_profiles (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (2, '380501112233', 'Other tenant', 'seed')`,
+    ).run();
+    const otherId = db.prepare(
+      "SELECT patient_id AS patientId FROM patient_profiles WHERE organization_id = 2 AND phone_normalized = '380501112233'",
+    ).get().patientId;
+    assert.match(String(otherId), /^[0-9a-f]{32}$/);
+    assert.notEqual(otherId, row.patientId);
+
+    assert.throws(
+      () => db.prepare(
+        `INSERT INTO patient_profiles (organization_id, phone_normalized, display_name, updated_by)
+         VALUES (1, '380501112233', 'Duplicate', 'seed')`,
+      ).run(),
+      /UNIQUE constraint failed/i,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("patient registry returns a stable patient id and never audits the phone as target id", async () => {
+  await withD1(async (db, raw) => {
+    const cookie = await seedStaffSession(db, {
+      email: "registry@example.com",
+      role: "registrar",
+      displayName: "Registry User",
+    });
+
+    const create = await callWorker(
+      jsonRequest("/api/staff/patients", {
+        phone: "+380 50 111 22 33",
+        displayName: "Patient One",
+        birthDate: "1980-01-10",
+        email: "patient@example.com",
+      }, { method: "PUT", headers: { cookie } }),
+      db,
+    );
+    assert.equal(create.status, 200);
+    const created = await create.json();
+    assert.match(String(created.profile?.patientId || ""), /^[0-9a-f]{32}$/);
+    const patientId = created.profile.patientId;
+
+    const update = await callWorker(
+      jsonRequest("/api/staff/patients", {
+        phone: "+380 50 111 22 33",
+        displayName: "Patient One Updated",
+        birthDate: "1980-01-10",
+        email: "patient@example.com",
+      }, { method: "PUT", headers: { cookie } }),
+      db,
+    );
+    assert.equal(update.status, 200);
+    const updated = await update.json();
+    assert.equal(updated.profile.patientId, patientId, "profile updates must preserve immutable identity");
+
+    const get = await callWorker(
+      jsonRequest("/api/staff/patients?phone=380501112233", undefined, {
+        method: "GET",
+        headers: { cookie },
+      }),
+      db,
+    );
+    assert.equal(get.status, 200);
+    const card = await get.json();
+    assert.equal(card.profile.patientId, patientId);
+
+    const audit = raw.prepare(
+      `SELECT target_id AS targetId
+       FROM security_audit_log
+       WHERE action = 'patient_record_viewed'
+       ORDER BY id DESC LIMIT 1`,
+    ).get();
+    assert.equal(audit.targetId, patientId);
+    assert.notEqual(audit.targetId, "380501112233");
+
+    const booking = await db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized, date_of_birth,
+         service, service_code, equipment_id, desired_date, desired_time)
+       VALUES (1, 'RD-UNLINKED-PATIENT', 'Booking Only', '+380671234567', '380671234567',
+         '1990-02-02', 'КТ', '403', 'ct', '2026-09-10', '10:00')`,
+    ).run();
+    const bookingId = Number(booking.meta.last_row_id);
+
+    const bookingOnly = await callWorker(
+      jsonRequest("/api/staff/patients?phone=380671234567", undefined, {
+        method: "GET",
+        headers: { cookie },
+      }),
+      db,
+    );
+    assert.equal(bookingOnly.status, 200);
+    const bookingAudit = raw.prepare(
+      `SELECT target_id AS targetId
+       FROM security_audit_log
+       WHERE action = 'patient_record_viewed'
+       ORDER BY id DESC LIMIT 1`,
+    ).get();
+    assert.equal(bookingAudit.targetId, `booking:${bookingId}`);
+    assert.notEqual(bookingAudit.targetId, "380671234567");
+  });
+});


### PR DESCRIPTION
## Summary
- add opaque immutable `patient_id` as the primary identity of `patient_profiles`
- preserve the existing `(organization_id, phone_normalized)` uniqueness contract for this compatibility phase
- preserve all historical profile fields, including legacy `telegram_chat_id`, during migration
- expose `patientId` from the staff patient registry
- stop writing patient phone numbers into `security_audit_log.target_id`; use `patient_id` or a booking id for legacy booking-only records
- sync the Drizzle patient profile model with the actual database schema

## Safety / migration policy
This PR intentionally does **not** link historical bookings to patient profiles by phone. A phone number is not sufficient identity evidence. It also does not yet remove tenant+phone uniqueness; shared-phone support requires a coordinated `bookings.patient_id` + CRM UI migration in the next phase.

## Regression coverage
- migration 0050 preserves legacy profile data and generates opaque IDs
- patient IDs are physically immutable in D1
- same phone remains tenant-isolated
- current compatibility uniqueness remains enforced inside one tenant
- staff PUT preserves the same patient id across profile updates
- `patient_record_viewed` audit targets contain no phone number

No production deploy.