### PR TITLE
Add explicit tenant-safe booking patient links

### DIFF
--- a/app/api/staff/patients/link-booking/route.ts
+++ b/app/api/staff/patients/link-booking/route.ts
@@ -1,0 +1,67 @@
+import { logSecurityEvent } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import { canManageBookings } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!canManageBookings(ctx.member.role)) {
+    return Response.json({ error: "Прив’язувати заявки до картки пацієнта може реєстратор або адміністратор" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as { bookingId?: unknown; patientId?: unknown };
+  const bookingId = Number(body.bookingId);
+  const patientId = String(body.patientId || "").trim().toLowerCase();
+  if (!Number.isInteger(bookingId) || bookingId < 1 || !/^[0-9a-f]{32}$/.test(patientId)) {
+    return Response.json({ error: "Некоректні дані прив’язки" }, { status: 400 });
+  }
+
+  const [booking, patient] = await Promise.all([
+    db.prepare(
+      `SELECT id, patient_id AS patientId
+       FROM bookings WHERE organization_id = ? AND id = ? LIMIT 1`
+    ).bind(ctx.organizationId, bookingId).first<{ id:number; patientId:string }>(),
+    db.prepare(
+      `SELECT patient_id AS patientId
+       FROM patient_profiles WHERE organization_id = ? AND patient_id = ? LIMIT 1`
+    ).bind(ctx.organizationId, patientId).first<{ patientId:string }>(),
+  ]);
+
+  // Keep cross-tenant and nonexistent identifiers indistinguishable.
+  if (!booking || !patient) {
+    return Response.json({ error: "Заявку або картку пацієнта не знайдено" }, { status: 404 });
+  }
+  if (booking.patientId === patientId) {
+    return Response.json({ ok: true, bookingId, patientId, linked: true });
+  }
+  if (booking.patientId) {
+    return Response.json({ error: "Заявка вже прив’язана до іншої картки пацієнта" }, { status: 409 });
+  }
+
+  const updated = await db.prepare(
+    `UPDATE bookings SET patient_id = ?
+     WHERE organization_id = ? AND id = ? AND patient_id = ''`
+  ).bind(patientId, ctx.organizationId, bookingId).run();
+  if (!updated.meta.changes) {
+    return Response.json({ error: "Не вдалося виконати прив’язку" }, { status: 409 });
+  }
+
+  await db.prepare(
+    `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+     VALUES (?, ?, 'patient_linked', ?, ?)`
+  ).bind(ctx.organizationId, bookingId, `patient_id=${patientId}`, ctx.member.email).run();
+  await logSecurityEvent(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "booking_patient_linked",
+    resource: "booking",
+    targetId: String(bookingId),
+    details: { patientId },
+  });
+
+  return Response.json({ ok: true, bookingId, patientId, linked: true });
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -59,6 +59,7 @@ export const bookings = sqliteTable("bookings", {
   name: text("name").notNull(),
   phone: text("phone").notNull(),
   phoneNormalized: text("phone_normalized").notNull().default(""),
+  patientId: text("patient_id").notNull().default(""),
   patientEmail: text("patient_email").notNull().default(""),
   dateOfBirth: text("date_of_birth").notNull().default(""),
   service: text("service").notNull(),
@@ -102,6 +103,7 @@ export const bookings = sqliteTable("bookings", {
   index("bookings_performed_report_idx").on(table.performedAt, table.equipmentId),
   index("bookings_staff_report_idx").on(table.assignedRadiologistEmail, table.assignedRadiographerEmail),
   index("bookings_patient_idx").on(table.phoneNormalized, table.desiredDate),
+  index("bookings_org_patient_idx").on(table.organizationId, table.patientId, table.desiredDate),
 ]);
 
 export const bookingEvents = sqliteTable("booking_events", {

--- a/drizzle/0051_booking_patient_link.sql
+++ b/drizzle/0051_booking_patient_link.sql
@@ -44,3 +44,16 @@ WHEN NEW.organization_id != OLD.organization_id
 BEGIN
   SELECT RAISE(ABORT, 'patient organization is immutable');
 END;
+--> statement-breakpoint
+-- Do not allow a profile to disappear while clinical bookings still reference it.
+CREATE TRIGGER IF NOT EXISTS `patient_profiles_linked_delete_guard`
+BEFORE DELETE ON `patient_profiles`
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1 FROM bookings b
+  WHERE b.organization_id = OLD.organization_id
+    AND b.patient_id = OLD.patient_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'linked patient cannot be deleted');
+END;

--- a/drizzle/0051_booking_patient_link.sql
+++ b/drizzle/0051_booking_patient_link.sql
@@ -1,0 +1,46 @@
+-- Explicit patient linkage for bookings.
+--
+-- Historical rows intentionally remain unlinked. A phone number (even together
+-- with DOB) is not sufficient evidence to attach old studies to one immutable
+-- patient identity. New trusted workflows may set patient_id explicitly.
+ALTER TABLE `bookings` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bookings_org_patient_idx`
+ON `bookings` (`organization_id`, `patient_id`, `desired_date`)
+WHERE `patient_id` != '';
+--> statement-breakpoint
+-- A booking may only point at a patient profile owned by the same tenant.
+CREATE TRIGGER IF NOT EXISTS `bookings_patient_link_insert`
+BEFORE INSERT ON `bookings`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM patient_profiles p
+    WHERE p.organization_id = NEW.organization_id
+      AND p.patient_id = NEW.patient_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'booking patient link invalid');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `bookings_patient_link_update`
+BEFORE UPDATE OF `organization_id`, `patient_id` ON `bookings`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM patient_profiles p
+    WHERE p.organization_id = NEW.organization_id
+      AND p.patient_id = NEW.patient_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'booking patient link invalid');
+END;
+--> statement-breakpoint
+-- Tenant ownership of an identity cannot be moved underneath linked bookings.
+CREATE TRIGGER IF NOT EXISTS `patient_profiles_organization_immutable`
+BEFORE UPDATE OF `organization_id` ON `patient_profiles`
+FOR EACH ROW
+WHEN NEW.organization_id != OLD.organization_id
+BEGIN
+  SELECT RAISE(ABORT, 'patient organization is immutable');
+END;

--- a/drizzle/0051_booking_patient_link.sql
+++ b/drizzle/0051_booking_patient_link.sql
@@ -6,8 +6,7 @@
 ALTER TABLE `bookings` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS `bookings_org_patient_idx`
-ON `bookings` (`organization_id`, `patient_id`, `desired_date`)
-WHERE `patient_id` != '';
+ON `bookings` (`organization_id`, `patient_id`, `desired_date`);
 --> statement-breakpoint
 -- A booking may only point at a patient profile owned by the same tenant.
 CREATE TRIGGER IF NOT EXISTS `bookings_patient_link_insert`

--- a/tests/booking-patient-link.behavior.test.mjs
+++ b/tests/booking-patient-link.behavior.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const DRIZZLE_DIR = new URL("../drizzle/", import.meta.url);
+
+function migrationNumber(file) {
+  return Number(file.slice(0, 4));
+}
+
+async function migrationFiles() {
+  return (await readdir(DRIZZLE_DIR))
+    .filter((file) => /^\d{4}_.+\.sql$/.test(file))
+    .sort();
+}
+
+async function apply(db, files) {
+  for (const file of files) {
+    db.exec(await readFile(new URL(file, DRIZZLE_DIR), "utf8"));
+  }
+}
+
+test("0051 leaves historical bookings unlinked instead of guessing identity from phone", async () => {
+  const files = await migrationFiles();
+  const before0051 = files.filter((file) => migrationNumber(file) <= 50);
+  const migration0051 = files.find((file) => migrationNumber(file) === 51);
+  assert.ok(migration0051);
+
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec("PRAGMA foreign_keys = ON;");
+    await apply(db, before0051);
+
+    db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, birth_date, updated_by)
+       VALUES (1, '380501112233', 'Existing Profile', '1980-01-10', 'seed')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized, date_of_birth,
+         service, service_code, desired_date, desired_time)
+       VALUES (1, 'RD-PRELINK-01', 'Historical Booking', '+380501112233', '380501112233',
+         '1980-01-10', 'КТ', '403', '2026-09-10', '10:00')`,
+    ).run();
+
+    await apply(db, [migration0051]);
+
+    const booking = db.prepare(
+      "SELECT patient_id AS patientId FROM bookings WHERE code = 'RD-PRELINK-01'",
+    ).get();
+    assert.equal(booking.patientId, "", "phone/DOB similarity must not become identity evidence during migration");
+  } finally {
+    db.close();
+  }
+});
+
+test("D1 enforces same-tenant patient links and protects linked identities", async () => {
+  await withD1(async (db, raw) => {
+    db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (1, '380501112233', 'Tenant One', 'seed')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (2, '380501112233', 'Tenant Two', 'seed')`,
+    ).run();
+    const p1 = raw.prepare(
+      "SELECT patient_id AS patientId FROM patient_profiles WHERE organization_id = 1 AND phone_normalized = '380501112233'",
+    ).get().patientId;
+    const p2 = raw.prepare(
+      "SELECT patient_id AS patientId FROM patient_profiles WHERE organization_id = 2 AND phone_normalized = '380501112233'",
+    ).get().patientId;
+
+    const booking = db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized,
+         service, service_code, desired_date, desired_time)
+       VALUES (1, 'RD-LINK-D1', 'Booking One', '+380501112233', '380501112233',
+         'КТ', '403', '2026-09-11', '10:00')`,
+    );
+    await booking.run();
+    const bookingId = raw.prepare("SELECT id FROM bookings WHERE code = 'RD-LINK-D1'").get().id;
+
+    assert.throws(
+      () => raw.prepare("UPDATE bookings SET patient_id = ? WHERE id = ?").run(p2, bookingId),
+      /booking patient link invalid/i,
+    );
+    raw.prepare("UPDATE bookings SET patient_id = ? WHERE id = ?").run(p1, bookingId);
+    assert.equal(raw.prepare("SELECT patient_id AS patientId FROM bookings WHERE id = ?").get(bookingId).patientId, p1);
+
+    assert.throws(
+      () => raw.prepare("UPDATE patient_profiles SET organization_id = 2 WHERE patient_id = ?").run(p1),
+      /patient organization is immutable/i,
+    );
+    assert.throws(
+      () => raw.prepare("DELETE FROM patient_profiles WHERE patient_id = ?").run(p1),
+      /linked patient cannot be deleted/i,
+    );
+  });
+});
+
+test("registrar can explicitly link an unlinked tenant booking; clinicians and cross-tenant ids cannot", async () => {
+  await withD1(async (db, raw) => {
+    const registrarCookie = await seedStaffSession(db, {
+      email: "link-registrar@example.com",
+      role: "registrar",
+      displayName: "Registrar",
+      organizationId: 1,
+    });
+    const radiologistCookie = await seedStaffSession(db, {
+      email: "link-radiologist@example.com",
+      role: "radiologist",
+      displayName: "Radiologist",
+      organizationId: 1,
+    });
+
+    await db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (1, '380501112233', 'Exact Patient', 'seed')`,
+    ).run();
+    await db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (1, '380671234567', 'Other Patient', 'seed')`,
+    ).run();
+    await db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (2, '380931234567', 'Other Tenant Patient', 'seed')`,
+    ).run();
+    const patientId = raw.prepare(
+      "SELECT patient_id AS patientId FROM patient_profiles WHERE organization_id = 1 AND phone_normalized = '380501112233'",
+    ).get().patientId;
+    const otherPatientId = raw.prepare(
+      "SELECT patient_id AS patientId FROM patient_profiles WHERE organization_id = 1 AND phone_normalized = '380671234567'",
+    ).get().patientId;
+    const crossTenantPatientId = raw.prepare(
+      "SELECT patient_id AS patientId FROM patient_profiles WHERE organization_id = 2 AND phone_normalized = '380931234567'",
+    ).get().patientId;
+
+    await db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized,
+         service, service_code, desired_date, desired_time)
+       VALUES (1, 'RD-LINK-API', 'Booking Patient', '+380501112233', '380501112233',
+         'КТ', '403', '2026-09-12', '10:00')`,
+    ).run();
+    const bookingId = raw.prepare("SELECT id FROM bookings WHERE code = 'RD-LINK-API'").get().id;
+
+    const denied = await callWorker(
+      jsonRequest("/api/staff/patients/link-booking", { bookingId, patientId }, {
+        method: "POST",
+        headers: { cookie: radiologistCookie },
+      }),
+      db,
+    );
+    assert.equal(denied.status, 403);
+    assert.equal(raw.prepare("SELECT patient_id AS patientId FROM bookings WHERE id = ?").get(bookingId).patientId, "");
+
+    const crossTenant = await callWorker(
+      jsonRequest("/api/staff/patients/link-booking", { bookingId, patientId: crossTenantPatientId }, {
+        method: "POST",
+        headers: { cookie: registrarCookie },
+      }),
+      db,
+    );
+    assert.equal(crossTenant.status, 404);
+    assert.equal(raw.prepare("SELECT patient_id AS patientId FROM bookings WHERE id = ?").get(bookingId).patientId, "");
+
+    const linked = await callWorker(
+      jsonRequest("/api/staff/patients/link-booking", { bookingId, patientId }, {
+        method: "POST",
+        headers: { cookie: registrarCookie },
+      }),
+      db,
+    );
+    assert.equal(linked.status, 200);
+    const linkedBody = await linked.json();
+    assert.equal(linkedBody.patientId, patientId);
+    assert.equal(raw.prepare("SELECT patient_id AS patientId FROM bookings WHERE id = ?").get(bookingId).patientId, patientId);
+
+    const idempotent = await callWorker(
+      jsonRequest("/api/staff/patients/link-booking", { bookingId, patientId }, {
+        method: "POST",
+        headers: { cookie: registrarCookie },
+      }),
+      db,
+    );
+    assert.equal(idempotent.status, 200);
+
+    const reassign = await callWorker(
+      jsonRequest("/api/staff/patients/link-booking", { bookingId, patientId: otherPatientId }, {
+        method: "POST",
+        headers: { cookie: registrarCookie },
+      }),
+      db,
+    );
+    assert.equal(reassign.status, 409);
+    assert.equal(raw.prepare("SELECT patient_id AS patientId FROM bookings WHERE id = ?").get(bookingId).patientId, patientId);
+
+    const event = raw.prepare(
+      "SELECT action, details FROM booking_events WHERE booking_id = ? AND action = 'patient_linked' ORDER BY id DESC LIMIT 1",
+    ).get(bookingId);
+    assert.equal(event.action, "patient_linked");
+    assert.match(event.details, new RegExp(patientId));
+    assert.doesNotMatch(event.details, /380501112233/);
+
+    const audit = raw.prepare(
+      "SELECT target_id AS targetId, details_json AS detailsJson FROM security_audit_log WHERE action = 'booking_patient_linked' ORDER BY id DESC LIMIT 1",
+    ).get();
+    assert.equal(audit.targetId, String(bookingId));
+    assert.match(audit.detailsJson, new RegExp(patientId));
+    assert.doesNotMatch(audit.detailsJson, /380501112233/);
+  });
+});


### PR DESCRIPTION
## Summary
- add nullable-by-empty `bookings.patient_id` as an explicit link to immutable patient profiles
- leave all historical bookings unlinked; no phone or DOB backfill
- enforce same-tenant booking→patient links in D1
- make patient tenant ownership immutable and block deletion of identities referenced by bookings
- add a registrar/admin-only idempotent endpoint to link an unlinked booking to an exact patient id
- refuse silent reassignment of a booking already linked to another patient
- record append-only booking/security audit evidence without phone/PERSON name data
- sync Drizzle schema

## Safety boundary
Public anonymous booking routes are unchanged and continue to create unlinked bookings. This PR does not remove the existing tenant+phone uniqueness constraint from patient profiles; shared-phone UI/CRM cutover remains a later coordinated phase.

## Regression coverage
- migration 0051 does not infer historical identity from matching phone+DOB
- direct cross-tenant patient links are rejected by D1
- patient organization cannot be moved and linked profiles cannot be deleted
- registrar can explicitly link an exact same-tenant patient
- clinician cannot link
- cross-tenant patient id returns the same not-found boundary
- same link is idempotent; silent reassignment is rejected
- audit/event payloads contain internal patient id, not phone

No production deploy.