### PR TITLE
Add exact patient identity to CRM communications

### DIFF
--- a/app/api/staff/patients/route.ts
+++ b/app/api/staff/patients/route.ts
@@ -25,6 +25,9 @@ const PROFILE_COLUMNS = `patient_id AS patientId, phone_normalized AS phoneNorma
   tags, notes, do_not_contact AS doNotContact,
   updated_by AS updatedBy, updated_at AS updatedAt`;
 
+const COMMUNICATION_COLUMNS = `id, patient_id AS patientId, phone_normalized AS phoneNormalized,
+  channel, direction, summary, actor, created_at AS createdAt`;
+
 type PatientProfileRow = PatientProfile & { patientId:string };
 
 export async function GET(request: Request) {
@@ -50,11 +53,18 @@ export async function GET(request: Request) {
     ).bind(orgId, rawPatientId).first<PatientProfileRow>();
     if (!profileRow) return Response.json({ error: "Пацієнта не знайдено" }, { status: 404 });
 
-    const bookings = await db.prepare(
-      `SELECT ${BOOKING_COLUMNS} FROM bookings
-       WHERE organization_id = ? AND patient_id = ?
-       ORDER BY desired_date DESC, desired_time DESC`
-    ).bind(orgId, rawPatientId).all();
+    const [bookings, communications] = await Promise.all([
+      db.prepare(
+        `SELECT ${BOOKING_COLUMNS} FROM bookings
+         WHERE organization_id = ? AND patient_id = ?
+         ORDER BY desired_date DESC, desired_time DESC`
+      ).bind(orgId, rawPatientId).all(),
+      db.prepare(
+        `SELECT ${COMMUNICATION_COLUMNS} FROM patient_communications
+         WHERE organization_id = ? AND patient_id = ?
+         ORDER BY created_at DESC LIMIT 200`
+      ).bind(orgId, rawPatientId).all(),
+    ]);
     const rows = bookings.results as unknown as PatientBookingRow[];
     const summary = buildExactPatientSummary(rows, profileRow);
     await logSecurityEvent(db, {
@@ -70,9 +80,7 @@ export async function GET(request: Request) {
       phone: profileRow.phoneNormalized,
       profile: profileRow,
       bookings: bookings.results,
-      // Legacy communications are phone-scoped. Do not attach them to an exact
-      // identity until the communications table itself carries patient_id.
-      communications: [],
+      communications: communications.results,
       legacyCommunicationsExcluded: true,
       staff: member,
     }, { headers: { "cache-control": "no-store" } });
@@ -83,7 +91,7 @@ export async function GET(request: Request) {
     const [bookings, profileRow, communications] = await Promise.all([
       db.prepare(`SELECT ${BOOKING_COLUMNS} FROM bookings WHERE phone_normalized = ? AND organization_id = ? ORDER BY desired_date DESC, desired_time DESC`).bind(phone, orgId).all(),
       db.prepare(`SELECT ${PROFILE_COLUMNS} FROM patient_profiles WHERE phone_normalized = ? AND organization_id = ? LIMIT 1`).bind(phone, orgId).first<PatientProfileRow>(),
-      db.prepare(`SELECT id, channel, direction, summary, actor, created_at AS createdAt
+      db.prepare(`SELECT ${COMMUNICATION_COLUMNS}
          FROM patient_communications WHERE phone_normalized = ? AND organization_id = ? ORDER BY created_at DESC LIMIT 200`).bind(phone, orgId).all(),
     ]);
     const rows = bookings.results as unknown as PatientBookingRow[];
@@ -91,9 +99,6 @@ export async function GET(request: Request) {
     const profiles = new Map<string, PatientProfile>();
     if (profileRow) profiles.set(phone, profileRow);
     const [summary] = buildPatientSummaries(rows, profiles);
-    // Do not persist a phone number as the audit target. Existing CRM profiles
-    // have an immutable opaque id; booking-only legacy records use a booking id
-    // until an explicit patient linkage exists.
     const auditTarget = profileRow?.patientId || (rows[0]?.id ? `booking:${rows[0].id}` : "unlinked");
     await logSecurityEvent(db, { organizationId: orgId, actorEmail: member.email, action: "patient_record_viewed", resource: "patient", targetId: auditTarget });
     return Response.json({ patient: summary || null, phone, profile: profileRow || null, bookings: bookings.results, communications: communications.results, staff: member }, { headers: { "cache-control": "no-store" } });
@@ -147,8 +152,6 @@ export async function PUT(request: Request) {
     return Response.json({ ok: true, profile: saved });
   }
 
-  // Compatibility path for the current phone-keyed CRM UI/import workflow.
-  // It remains valid while patient_profiles still enforces tenant+phone unique.
   await db.prepare(
     `INSERT INTO patient_profiles
        (organization_id, phone_normalized, display_name, birth_year, birth_date, email, address, tags, notes, do_not_contact, updated_by, updated_at)
@@ -174,9 +177,35 @@ export async function POST(request: Request) {
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const member = ctx.member;
   if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Комунікації доступні лише реєстратору або адміністратору" }, { status: 403 });
-  const parsed = sanitizeCommunication(await request.json());
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const patientId = String(body.patientId || "").trim().toLowerCase();
+  let exactPhone = "";
+  if (patientId) {
+    if (!/^[0-9a-f]{32}$/.test(patientId)) {
+      return Response.json({ error: "Некоректний ідентифікатор пацієнта" }, { status: 400 });
+    }
+    const profile = await db.prepare(
+      `SELECT phone_normalized AS phoneNormalized FROM patient_profiles
+       WHERE organization_id = ? AND patient_id = ? LIMIT 1`
+    ).bind(ctx.organizationId, patientId).first<{ phoneNormalized:string }>();
+    if (!profile) return Response.json({ error: "Пацієнта не знайдено" }, { status: 404 });
+    exactPhone = profile.phoneNormalized;
+  }
+
+  const parsed = sanitizeCommunication({ ...body, ...(exactPhone ? { phoneNormalized: exactPhone, phone: exactPhone } : {}) });
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
   const { communication } = parsed;
-  const inserted = await db.prepare(`INSERT INTO patient_communications (organization_id, phone_normalized, channel, direction, summary, actor) VALUES (?, ?, ?, ?, ?, ?)`).bind(ctx.organizationId, communication.phoneNormalized, communication.channel, communication.direction, communication.summary, member.email).run();
-  return Response.json({ ok: true, communication: { id: inserted.meta.last_row_id, ...communication, actor: member.email } });
+  const inserted = await db.prepare(
+    `INSERT INTO patient_communications
+       (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).bind(
+    ctx.organizationId, patientId, communication.phoneNormalized,
+    communication.channel, communication.direction, communication.summary, member.email,
+  ).run();
+  return Response.json({
+    ok: true,
+    communication: { id: inserted.meta.last_row_id, patientId, ...communication, actor: member.email },
+  });
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -259,6 +259,7 @@ export const patientProfiles = sqliteTable("patient_profiles", {
 export const patientCommunications = sqliteTable("patient_communications", {
   organizationId: integer("organization_id").notNull().default(1),
   id: integer("id").primaryKey({ autoIncrement: true }),
+  patientId: text("patient_id").notNull().default(""),
   phoneNormalized: text("phone_normalized").notNull(),
   channel: text("channel").notNull().default("call"),
   direction: text("direction").notNull().default("outbound"),
@@ -268,6 +269,7 @@ export const patientCommunications = sqliteTable("patient_communications", {
   createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
 }, table => [
   index("patient_communications_phone_idx").on(table.phoneNormalized, table.createdAt),
+  index("patient_communications_org_patient_idx").on(table.organizationId, table.patientId, table.createdAt),
   uniqueIndex("patient_comm_external_idx").on(table.externalId).where(sql`external_id != ''`),
 ]);
 

--- a/drizzle/0052_patient_communication_identity.sql
+++ b/drizzle/0052_patient_communication_identity.sql
@@ -1,0 +1,35 @@
+-- Exact patient identity for CRM communications.
+--
+-- Existing chat/WhatsApp/call history is intentionally left unlinked. A phone
+-- number is contact data, not sufficient evidence that a communication belongs
+-- to one immutable patient when a family may share that number.
+ALTER TABLE `patient_communications` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_communications_org_patient_idx`
+ON `patient_communications` (`organization_id`, `patient_id`, `created_at`);
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_communications_patient_link_insert`
+BEFORE INSERT ON `patient_communications`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM patient_profiles p
+    WHERE p.organization_id = NEW.organization_id
+      AND p.patient_id = NEW.patient_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'patient communication link invalid');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_communications_patient_link_update`
+BEFORE UPDATE OF `organization_id`, `patient_id` ON `patient_communications`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM patient_profiles p
+    WHERE p.organization_id = NEW.organization_id
+      AND p.patient_id = NEW.patient_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'patient communication link invalid');
+END;

--- a/tests/patient-communication-identity.behavior.test.mjs
+++ b/tests/patient-communication-identity.behavior.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function patientPost(db, cookie, body) {
+  return callWorker(
+    jsonRequest("/api/staff/patients", body, { method: "POST", headers: { cookie } }),
+    db,
+  );
+}
+
+async function patientGet(db, cookie, patientId) {
+  return callWorker(
+    jsonRequest(`/api/staff/patients?patientId=${patientId}`, undefined, { method: "GET", headers: { cookie } }),
+    db,
+  );
+}
+
+test("exact patient communications are tenant-bound and never infer legacy phone history", async () => {
+  await withD1(async (db, raw) => {
+    await db.prepare(
+      `INSERT INTO organizations (id, slug, name, active)
+       VALUES (2, 'communication-test-org', 'Communication Test Org', 1)`
+    ).run();
+
+    const org1Cookie = await seedStaffSession(db, {
+      email: "comm-org1@example.com",
+      role: "registrar",
+      organizationId: 1,
+    });
+    const org2Cookie = await seedStaffSession(db, {
+      email: "comm-org2@example.com",
+      role: "registrar",
+      organizationId: 2,
+    });
+
+    await db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (1, '380501112233', 'Exact Contact', 'seed')`,
+    ).run();
+    await db.prepare(
+      `INSERT INTO patient_profiles
+        (organization_id, phone_normalized, display_name, updated_by)
+       VALUES (2, '380671234567', 'Other Tenant Contact', 'seed')`,
+    ).run();
+
+    const patientId = raw.prepare(
+      `SELECT patient_id AS patientId FROM patient_profiles
+       WHERE organization_id = 1 AND phone_normalized = '380501112233'`,
+    ).get().patientId;
+    const otherTenantPatientId = raw.prepare(
+      `SELECT patient_id AS patientId FROM patient_profiles
+       WHERE organization_id = 2 AND phone_normalized = '380671234567'`,
+    ).get().patientId;
+
+    // Existing messaging/contact-center rows remain deliberately unlinked.
+    await db.prepare(
+      `INSERT INTO patient_communications
+        (organization_id, phone_normalized, channel, direction, summary, actor)
+       VALUES (1, '380501112233', 'call', 'inbound', 'legacy phone-only history', 'legacy')`,
+    ).run();
+
+    const before = await patientGet(db, org1Cookie, patientId);
+    assert.equal(before.status, 200);
+    const beforeBody = await before.json();
+    assert.deepEqual(beforeBody.communications, [], "phone-only history must not be inferred into exact identity");
+
+    const exactWrite = await patientPost(db, org1Cookie, {
+      patientId,
+      phone: "+380 99 999 99 99",
+      channel: "call",
+      direction: "outbound",
+      summary: "exact identity note",
+    });
+    assert.equal(exactWrite.status, 200);
+    const exactWriteBody = await exactWrite.json();
+    assert.equal(exactWriteBody.communication.patientId, patientId);
+    assert.equal(exactWriteBody.communication.phoneNormalized, "380501112233", "server must use profile contact, not spoofed body phone");
+
+    const stored = raw.prepare(
+      `SELECT patient_id AS patientId, phone_normalized AS phoneNormalized, summary
+       FROM patient_communications WHERE summary = 'exact identity note'`,
+    ).get();
+    assert.equal(stored.patientId, patientId);
+    assert.equal(stored.phoneNormalized, "380501112233");
+
+    const exactRead = await patientGet(db, org1Cookie, patientId);
+    assert.equal(exactRead.status, 200);
+    const exactReadBody = await exactRead.json();
+    assert.equal(exactReadBody.communications.length, 1);
+    assert.equal(exactReadBody.communications[0].patientId, patientId);
+    assert.equal(exactReadBody.communications[0].summary, "exact identity note");
+    assert.equal(exactReadBody.legacyCommunicationsExcluded, true);
+
+    const legacyWrite = await patientPost(db, org1Cookie, {
+      phone: "+380 50 111 22 33",
+      channel: "call",
+      direction: "outbound",
+      summary: "new legacy phone-only note",
+    });
+    assert.equal(legacyWrite.status, 200);
+    const legacyStored = raw.prepare(
+      `SELECT patient_id AS patientId FROM patient_communications
+       WHERE summary = 'new legacy phone-only note'`,
+    ).get();
+    assert.equal(legacyStored.patientId, "");
+
+    const crossTenantApi = await patientPost(db, org1Cookie, {
+      patientId: otherTenantPatientId,
+      phone: "+380 50 111 22 33",
+      channel: "call",
+      direction: "outbound",
+      summary: "must not write",
+    });
+    assert.equal(crossTenantApi.status, 404);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM patient_communications WHERE summary = 'must not write'").get().n, 0);
+
+    assert.throws(
+      () => raw.prepare(
+        `INSERT INTO patient_communications
+          (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
+         VALUES (1, ?, '380671234567', 'call', 'outbound', 'direct cross tenant', 'seed')`,
+      ).run(otherTenantPatientId),
+      /patient communication link invalid/i,
+    );
+
+    const otherTenantOwn = await patientPost(db, org2Cookie, {
+      patientId: otherTenantPatientId,
+      phone: "+380 00 000 00 00",
+      channel: "call",
+      direction: "outbound",
+      summary: "other tenant own note",
+    });
+    assert.equal(otherTenantOwn.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit `patient_id` to `patient_communications`
- enforce same-tenant communication→patient links in D1
- keep all existing and messaging-generated phone-only communications unlinked
- exact patient cards now return only communications explicitly linked to that immutable patient id
- exact communication writes validate the tenant patient id and derive the contact phone from the stored profile, ignoring a spoofed body phone
- legacy phone-based CRM communication writes remain compatible and unlinked
- sync Drizzle schema

## Safety boundary
No phone-only communication is backfilled or inferred into an exact patient identity. WhatsApp/chat/notify writers are intentionally unchanged and continue with `patient_id=''` until they gain a trustworthy identity proof.

## Regression coverage
- phone-only legacy history does not appear in exact patient cards
- exact write stores patient id and server-derived profile phone
- spoofed request phone cannot override the exact profile contact
- legacy writes remain unlinked
- cross-tenant API link returns 404 and creates no row
- direct cross-tenant D1 link is rejected
- same-tenant exact write/read works

No production deploy.