### PR TITLE
Anchor patient portal sessions to immutable patient ids

### DIFF
--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -22,6 +22,12 @@ export async function POST(request: Request) {
   const identityClause = session.identityKind === "dob"
     ? "b.date_of_birth = ?"
     : "b.code = ?";
+  const whereClause = session.patientId
+    ? "b.organization_id = ? AND b.patient_id = ?"
+    : `b.organization_id = ? AND b.phone_normalized = ? AND ${identityClause}`;
+  const bindings = session.patientId
+    ? [session.organizationId, session.patientId]
+    : [session.organizationId, session.phoneNormalized, session.identityValue];
   const rows = await db.prepare(
     `SELECT b.code, b.name AS patientName, b.service, b.service_code AS serviceCode,
        b.desired_date AS desiredDate, b.desired_time AS desiredTime,
@@ -43,10 +49,10 @@ export async function POST(request: Request) {
          WHERE pt.organization_id = b.organization_id AND pt.booking_id = b.id
          ORDER BY pt.id DESC LIMIT 1), '') AS paymentReference
      FROM bookings b LEFT JOIN organizations o ON o.id = b.organization_id
-     WHERE b.organization_id = ? AND b.phone_normalized = ? AND ${identityClause}
+     WHERE ${whereClause}
      ORDER BY b.created_at DESC, b.id DESC
      LIMIT 50`
-  ).bind(session.organizationId, session.phoneNormalized, session.identityValue).all();
+  ).bind(...bindings).all();
 
   const bookings = (rows.results || []).map((row) => ({
     ...row,

--- a/app/api/my-protocol/route.ts
+++ b/app/api/my-protocol/route.ts
@@ -17,11 +17,17 @@ export async function POST(request: Request) {
   if (!code) return Response.json({ error: "Некоректний код заявки" }, { status: 400 });
 
   const identityClause = session.identityKind === "dob" ? "date_of_birth = ?" : "code = ?";
+  const whereClause = session.patientId
+    ? "organization_id = ? AND code = ? AND patient_id = ?"
+    : `organization_id = ? AND code = ? AND phone_normalized = ? AND ${identityClause}`;
+  const bindings = session.patientId
+    ? [session.organizationId, code, session.patientId]
+    : [session.organizationId, code, session.phoneNormalized, session.identityValue];
   const booking = await db.prepare(
     `SELECT id, name, service, protocol_status AS protocolStatus, protocol_issued_at AS issuedAt
      FROM bookings
-     WHERE organization_id = ? AND code = ? AND phone_normalized = ? AND ${identityClause} LIMIT 1`
-  ).bind(session.organizationId, code, session.phoneNormalized, session.identityValue).first<{
+     WHERE ${whereClause} LIMIT 1`
+  ).bind(...bindings).first<{
     id: number; name: string; service: string; protocolStatus: string; issuedAt: string;
   }>();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
@@ -43,7 +49,7 @@ export async function POST(request: Request) {
     action: "patient_protocol_viewed",
     resource: "protocol",
     targetId: booking.id,
-    details: { channel: "patient_cabinet", identityKind:session.identityKind },
+    details: { channel: "patient_cabinet", identityKind:session.patientId ? "patient_id" : session.identityKind },
   });
 
   return Response.json({

--- a/app/api/patient-otp/route.ts
+++ b/app/api/patient-otp/route.ts
@@ -42,50 +42,59 @@ function opaqueChallengeResponse() {
   );
 }
 
-export async function provePatientIdentity(
+async function provePatientIdentity(
   db: D1Database,
   phoneNormalized: string,
   body: { dob?: unknown; bookingCode?: unknown },
 ): Promise<ProvenPatientIdentity | null> {
   const dob = normalizeDob(body.dob);
   if (dob) {
-    const owner = await db.prepare(
-      `SELECT organization_id AS organizationId
-       FROM bookings
-       WHERE phone_normalized = ? AND date_of_birth = ?
-       ORDER BY created_at DESC, id DESC LIMIT 1`,
-    ).bind(phoneNormalized, dob).first<{ organizationId: number }>();
-    if (!owner) return null;
-
-    const matches = await db.prepare(
-      `SELECT b.patient_id AS patientId,
-         COALESCE(p.phone_normalized, '') AS profilePhone
+    const summary = await db.prepare(
+      `SELECT COUNT(*) AS total,
+         SUM(CASE WHEN b.patient_id != '' THEN 1 ELSE 0 END) AS linkedCount,
+         COUNT(DISTINCT CASE WHEN b.patient_id != '' THEN b.patient_id END) AS patientCount,
+         MAX(CASE WHEN b.patient_id != '' THEN b.patient_id ELSE '' END) AS patientId,
+         SUM(CASE
+           WHEN b.patient_id != '' AND COALESCE(p.phone_normalized, '') = ? THEN 1
+           ELSE 0
+         END) AS currentPhoneCount
        FROM bookings b
        LEFT JOIN patient_profiles p
          ON p.organization_id = b.organization_id AND p.patient_id = b.patient_id
-       WHERE b.organization_id = ? AND b.phone_normalized = ? AND b.date_of_birth = ?
-       ORDER BY b.created_at DESC, b.id DESC
-       LIMIT 100`,
-    ).bind(owner.organizationId, phoneNormalized, dob).all();
-    const candidates = (matches.results || []) as unknown as { patientId:string; profilePhone:string }[];
-    const linked = candidates.filter((row) => !!row.patientId);
+       WHERE b.organization_id = ? AND b.phone_normalized = ? AND b.date_of_birth = ?`,
+    ).bind(
+      phoneNormalized,
+      PRIMARY_ORGANIZATION_ID,
+      phoneNormalized,
+      dob,
+    ).first<{
+      total:number;
+      linkedCount:number;
+      patientCount:number;
+      patientId:string;
+      currentPhoneCount:number;
+    }>();
 
-    // Historical unlinked data keeps the existing portal scope. Once any row
-    // is explicitly linked, DOB may upgrade to immutable patient_id only when
-    // every matching booking resolves to the same exact patient and that
-    // patient's current contact phone is the number being possession-verified.
-    if (!linked.length) {
-      return { organizationId: owner.organizationId, identity: { kind:"dob", value:dob }, patientId:"" };
+    const total = Number(summary?.total || 0);
+    if (!total) return null;
+    const linkedCount = Number(summary?.linkedCount || 0);
+    if (!linkedCount) {
+      return {
+        organizationId: PRIMARY_ORGANIZATION_ID,
+        identity: { kind:"dob", value:dob },
+        patientId:"",
+      };
     }
-    const ids = new Set(linked.map((row) => row.patientId));
-    const exact = linked.length === candidates.length
-      && ids.size === 1
-      && linked.every((row) => row.profilePhone === phoneNormalized);
+
+    const exact = linkedCount === total
+      && Number(summary?.patientCount || 0) === 1
+      && Number(summary?.currentPhoneCount || 0) === linkedCount
+      && !!summary?.patientId;
     if (!exact) return null;
     return {
-      organizationId: owner.organizationId,
+      organizationId: PRIMARY_ORGANIZATION_ID,
       identity: { kind:"dob", value:dob },
-      patientId: linked[0].patientId,
+      patientId: summary.patientId,
     };
   }
 
@@ -97,8 +106,8 @@ export async function provePatientIdentity(
        FROM bookings b
        LEFT JOIN patient_profiles p
          ON p.organization_id = b.organization_id AND p.patient_id = b.patient_id
-       WHERE b.phone_normalized = ? AND b.code = ? LIMIT 1`,
-    ).bind(phoneNormalized, bookingCode).first<{
+       WHERE b.organization_id = ? AND b.phone_normalized = ? AND b.code = ? LIMIT 1`,
+    ).bind(PRIMARY_ORGANIZATION_ID, phoneNormalized, bookingCode).first<{
       organizationId:number; patientId:string; profilePhone:string;
     }>();
     if (!row) return null;

--- a/app/api/patient-otp/route.ts
+++ b/app/api/patient-otp/route.ts
@@ -23,6 +23,7 @@ const PRIMARY_ORGANIZATION_ID = 1;
 type ProvenPatientIdentity = {
   organizationId: number;
   identity: PatientIdentityScope;
+  patientId: string;
 };
 
 function maskedPhone(phoneNormalized: string): string {
@@ -41,29 +42,74 @@ function opaqueChallengeResponse() {
   );
 }
 
-async function provePatientIdentity(
+export async function provePatientIdentity(
   db: D1Database,
   phoneNormalized: string,
   body: { dob?: unknown; bookingCode?: unknown },
 ): Promise<ProvenPatientIdentity | null> {
   const dob = normalizeDob(body.dob);
   if (dob) {
-    const row = await db.prepare(
+    const owner = await db.prepare(
       `SELECT organization_id AS organizationId
        FROM bookings
        WHERE phone_normalized = ? AND date_of_birth = ?
        ORDER BY created_at DESC, id DESC LIMIT 1`,
     ).bind(phoneNormalized, dob).first<{ organizationId: number }>();
-    return row ? { organizationId: row.organizationId, identity: { kind:"dob", value:dob } } : null;
+    if (!owner) return null;
+
+    const matches = await db.prepare(
+      `SELECT b.patient_id AS patientId,
+         COALESCE(p.phone_normalized, '') AS profilePhone
+       FROM bookings b
+       LEFT JOIN patient_profiles p
+         ON p.organization_id = b.organization_id AND p.patient_id = b.patient_id
+       WHERE b.organization_id = ? AND b.phone_normalized = ? AND b.date_of_birth = ?
+       ORDER BY b.created_at DESC, b.id DESC
+       LIMIT 100`,
+    ).bind(owner.organizationId, phoneNormalized, dob).all();
+    const candidates = (matches.results || []) as unknown as { patientId:string; profilePhone:string }[];
+    const linked = candidates.filter((row) => !!row.patientId);
+
+    // Historical unlinked data keeps the existing portal scope. Once any row
+    // is explicitly linked, DOB may upgrade to immutable patient_id only when
+    // every matching booking resolves to the same exact patient and that
+    // patient's current contact phone is the number being possession-verified.
+    if (!linked.length) {
+      return { organizationId: owner.organizationId, identity: { kind:"dob", value:dob }, patientId:"" };
+    }
+    const ids = new Set(linked.map((row) => row.patientId));
+    const exact = linked.length === candidates.length
+      && ids.size === 1
+      && linked.every((row) => row.profilePhone === phoneNormalized);
+    if (!exact) return null;
+    return {
+      organizationId: owner.organizationId,
+      identity: { kind:"dob", value:dob },
+      patientId: linked[0].patientId,
+    };
   }
 
   const bookingCode = normalizeBookingCode(body.bookingCode);
   if (bookingCode) {
     const row = await db.prepare(
-      `SELECT organization_id AS organizationId
-       FROM bookings WHERE phone_normalized = ? AND code = ? LIMIT 1`,
-    ).bind(phoneNormalized, bookingCode).first<{ organizationId: number }>();
-    return row ? { organizationId: row.organizationId, identity: { kind:"booking", value:bookingCode } } : null;
+      `SELECT b.organization_id AS organizationId, b.patient_id AS patientId,
+         COALESCE(p.phone_normalized, '') AS profilePhone
+       FROM bookings b
+       LEFT JOIN patient_profiles p
+         ON p.organization_id = b.organization_id AND p.patient_id = b.patient_id
+       WHERE b.phone_normalized = ? AND b.code = ? LIMIT 1`,
+    ).bind(phoneNormalized, bookingCode).first<{
+      organizationId:number; patientId:string; profilePhone:string;
+    }>();
+    if (!row) return null;
+    return {
+      organizationId: row.organizationId,
+      identity: { kind:"booking", value:bookingCode },
+      // A historical booking can still be opened through its exact code even
+      // if the patient's current profile phone has changed, but it must not
+      // expand into the whole immutable patient record via that old number.
+      patientId: row.patientId && row.profilePhone === phoneNormalized ? row.patientId : "",
+    };
   }
   return null;
 }
@@ -133,6 +179,7 @@ export async function POST(request: Request) {
     proof.organizationId,
     proof.identity,
     PURPOSE,
+    proof.patientId,
   );
   const text = `RadiologyOS: код підтвердження ${challenge.code}. Код діє 5 хвилин. Нікому його не повідомляйте.`;
   try {
@@ -225,6 +272,7 @@ export async function PATCH(request: Request) {
     phoneNormalized,
     verified.organizationId,
     verified.identity,
+    verified.patientId || "",
   );
   await audit(db, {
     organizationId: verified.organizationId,

--- a/db/patient-auth-schema.ts
+++ b/db/patient-auth-schema.ts
@@ -2,15 +2,17 @@ import { sql } from "drizzle-orm";
 import { index, integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // Drizzle representation of possession-based patient authentication added by
-// migration 0028 and identity-scoped by migration 0046. The legacy core schema
-// keeps the original patientSessions export for compatibility; this scoped
-// model is the authoritative patient-auth shape.
+// migration 0028, identity-scoped by migration 0046, and optionally anchored
+// to immutable patient_id by migration 0053. The legacy core schema keeps the
+// original patientSessions export for compatibility; this scoped model is the
+// authoritative patient-auth shape.
 export const patientSessionsScoped = sqliteTable("patient_sessions", {
   tokenHash: text("token_hash").primaryKey(),
   phoneNormalized: text("phone_normalized").notNull(),
   organizationId: integer("organization_id").notNull().default(1),
   identityKind: text("identity_kind").notNull().default(""),
   identityValue: text("identity_value").notNull().default(""),
+  patientId: text("patient_id").notNull().default(""),
   createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
   expiresAt: text("expires_at").notNull(),
 }, table => [
@@ -18,6 +20,7 @@ export const patientSessionsScoped = sqliteTable("patient_sessions", {
   index("patient_sessions_identity_scope_idx").on(
     table.organizationId, table.phoneNormalized, table.identityKind, table.identityValue, table.expiresAt,
   ),
+  index("patient_sessions_patient_idx").on(table.organizationId, table.patientId, table.expiresAt),
 ]);
 
 export const patientOtpChallenges = sqliteTable("patient_otp_challenges", {
@@ -26,6 +29,7 @@ export const patientOtpChallenges = sqliteTable("patient_otp_challenges", {
   phoneNormalized: text("phone_normalized").notNull(),
   identityKind: text("identity_kind").notNull().default(""),
   identityValue: text("identity_value").notNull().default(""),
+  patientId: text("patient_id").notNull().default(""),
   purpose: text("purpose").notNull().default("cabinet_login"),
   codeHash: text("code_hash").notNull(),
   attempts: integer("attempts").notNull().default(0),
@@ -38,6 +42,7 @@ export const patientOtpChallenges = sqliteTable("patient_otp_challenges", {
   index("patient_otp_identity_scope_idx").on(
     table.organizationId, table.phoneNormalized, table.identityKind, table.identityValue, table.createdAt,
   ),
+  index("patient_otp_patient_idx").on(table.organizationId, table.patientId, table.createdAt),
 ]);
 
 export const telegramLinkTokensScoped = sqliteTable("telegram_link_tokens", {

--- a/drizzle/0053_patient_session_patient_id.sql
+++ b/drizzle/0053_patient_session_patient_id.sql
@@ -1,0 +1,73 @@
+-- Bind possession-verified patient auth to the immutable patient identity when
+-- an exact booking -> patient link is already known.
+--
+-- Legacy sessions/challenges remain valid with patient_id=''. This keeps the
+-- current phone + DOB / booking-code portal compatible for historical unlinked
+-- bookings, while exact linked identities can no longer expand by phone/DOB.
+
+ALTER TABLE `patient_otp_challenges` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+ALTER TABLE `patient_sessions` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_otp_patient_idx`
+ON `patient_otp_challenges` (`organization_id`, `patient_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_sessions_patient_idx`
+ON `patient_sessions` (`organization_id`, `patient_id`, `expires_at`);
+--> statement-breakpoint
+
+-- A non-empty immutable patient id may only be attached when the exact auth
+-- scope is backed by a booking explicitly linked to that same patient.
+CREATE TRIGGER IF NOT EXISTS `patient_otp_patient_link_insert`
+BEFORE INSERT ON `patient_otp_challenges`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.organization_id = NEW.organization_id
+      AND b.patient_id = NEW.patient_id
+      AND b.phone_normalized = NEW.phone_normalized
+      AND (
+        (NEW.identity_kind = 'dob' AND b.date_of_birth = NEW.identity_value)
+        OR (NEW.identity_kind = 'booking' AND b.code = NEW.identity_value)
+      )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'patient OTP patient link invalid');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_session_patient_link_insert`
+BEFORE INSERT ON `patient_sessions`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.organization_id = NEW.organization_id
+      AND b.patient_id = NEW.patient_id
+      AND b.phone_normalized = NEW.phone_normalized
+      AND (
+        (NEW.identity_kind = 'dob' AND b.date_of_birth = NEW.identity_value)
+        OR (NEW.identity_kind = 'booking' AND b.code = NEW.identity_value)
+      )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'patient session patient link invalid');
+END;
+--> statement-breakpoint
+
+-- Auth identity cannot be retargeted after issuance, even by direct SQL.
+CREATE TRIGGER IF NOT EXISTS `patient_otp_patient_id_immutable`
+BEFORE UPDATE OF `patient_id` ON `patient_otp_challenges`
+FOR EACH ROW
+WHEN NEW.patient_id != OLD.patient_id
+BEGIN
+  SELECT RAISE(ABORT, 'patient OTP patient id is immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_session_patient_id_immutable`
+BEFORE UPDATE OF `patient_id` ON `patient_sessions`
+FOR EACH ROW
+WHEN NEW.patient_id != OLD.patient_id
+BEGIN
+  SELECT RAISE(ABORT, 'patient session patient id is immutable');
+END;

--- a/lib/patient-auth.ts
+++ b/lib/patient-auth.ts
@@ -43,6 +43,7 @@ export async function createPatientOtpChallenge(
   organizationId: number,
   identity: PatientIdentityScope,
   purpose = "cabinet_login",
+  patientId = "",
 ): Promise<{ challengeId: string; code: string; expiresIn: number }> {
   const challengeId = newSessionToken();
   const code = newOtpCode();
@@ -61,14 +62,15 @@ export async function createPatientOtpChallenge(
     db.prepare(
       `INSERT INTO patient_otp_challenges
        (id, organization_id, phone_normalized, identity_kind, identity_value,
-        purpose, code_hash, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now', ?))`,
+        patient_id, purpose, code_hash, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', ?))`,
     ).bind(
       challengeId,
       organizationId,
       phoneNormalized,
       identity.kind,
       identity.value,
+      patientId,
       purpose.slice(0, 40),
       codeHash,
       `+${PATIENT_OTP_TTL_SECONDS} seconds`,
@@ -91,14 +93,15 @@ export async function verifyPatientOtpChallenge(
     code: string;
     purpose?: string;
   },
-): Promise<{ organizationId: number; identity: PatientIdentityScope } | null> {
+): Promise<{ organizationId: number; identity: PatientIdentityScope; patientId?: string } | null> {
   const code = normalizeOtp(input.code);
   if (!/^[a-f0-9]{64}$/i.test(input.challengeId) || !input.phoneNormalized || !code) return null;
   const purpose = (input.purpose || "cabinet_login").slice(0, 40);
 
   const row = await db.prepare(
     `SELECT organization_id AS organizationId, identity_kind AS identityKind,
-       identity_value AS identityValue, code_hash AS codeHash, attempts
+       identity_value AS identityValue, patient_id AS patientId,
+       code_hash AS codeHash, attempts
      FROM patient_otp_challenges
      WHERE id = ? AND phone_normalized = ? AND purpose = ?
        AND identity_kind IN ('dob','booking') AND identity_value != ''
@@ -114,6 +117,7 @@ export async function verifyPatientOtpChallenge(
     organizationId: number;
     identityKind: "dob" | "booking";
     identityValue: string;
+    patientId: string;
     codeHash: string;
     attempts: number;
   }>();
@@ -142,10 +146,12 @@ export async function verifyPatientOtpChallenge(
     purpose,
     PATIENT_OTP_MAX_ATTEMPTS,
   ).run();
-  return consumed.meta.changes ? {
+  if (!consumed.meta.changes) return null;
+  return {
     organizationId: row.organizationId,
     identity: { kind: row.identityKind, value: row.identityValue },
-  } : null;
+    ...(row.patientId ? { patientId: row.patientId } : {}),
+  };
 }
 
 export async function createPatientSession(
@@ -153,19 +159,21 @@ export async function createPatientSession(
   phoneNormalized: string,
   organizationId: number,
   identity: PatientIdentityScope,
+  patientId = "",
 ): Promise<string> {
   const rawToken = newSessionToken();
   const tokenHash = await hashToken(rawToken);
   await db.prepare(
     `INSERT INTO patient_sessions
-      (token_hash, phone_normalized, organization_id, identity_kind, identity_value, expires_at)
-     VALUES (?, ?, ?, ?, ?, datetime('now', ?))`,
+      (token_hash, phone_normalized, organization_id, identity_kind, identity_value, patient_id, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?))`,
   ).bind(
     tokenHash,
     phoneNormalized,
     organizationId,
     identity.kind,
     identity.value,
+    patientId,
     `+${PATIENT_SESSION_TTL_SECONDS} seconds`,
   ).run();
   await db.prepare("DELETE FROM patient_sessions WHERE expires_at <= CURRENT_TIMESTAMP").run();
@@ -178,7 +186,8 @@ export async function requirePatientSession(request: Request, db: D1Database) {
   const tokenHash = await hashToken(rawToken);
   return db.prepare(
     `SELECT phone_normalized AS phoneNormalized, organization_id AS organizationId,
-       identity_kind AS identityKind, identity_value AS identityValue
+       identity_kind AS identityKind, identity_value AS identityValue,
+       patient_id AS patientId
      FROM patient_sessions
      WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP
        AND identity_kind IN ('dob','booking') AND identity_value != ''
@@ -188,6 +197,7 @@ export async function requirePatientSession(request: Request, db: D1Database) {
     organizationId: number;
     identityKind: "dob" | "booking";
     identityValue: string;
+    patientId: string;
   }>();
 }
 

--- a/tests/patient-session-patient-id.behavior.test.mjs
+++ b/tests/patient-session-patient-id.behavior.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHash } from "node:crypto";
+import { callWorker, jsonRequest, withD1 } from "./helpers/d1.mjs";
+import {
+  createPatientOtpChallenge,
+  createPatientSession,
+  requirePatientSession,
+  verifyPatientOtpChallenge,
+} from "../lib/patient-auth.ts";
+import { provePatientIdentity } from "../app/api/patient-otp/route.ts";
+
+const PHONE = "380971112233";
+const OTHER_PHONE = "380975556677";
+const DOB = "1990-05-05";
+const PID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_PID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const IDENTITY = { kind:"dob", value:DOB };
+
+async function seedProfile(db, patientId = PID, phone = PHONE) {
+  await db.prepare(
+    `INSERT INTO patient_profiles
+      (patient_id, organization_id, phone_normalized, display_name, birth_date, birth_year, updated_by)
+     VALUES (?, 1, ?, 'Exact Patient', ?, 1990, 'test')`
+  ).bind(patientId, phone, DOB).run();
+}
+
+async function seedBooking(db, {
+  code,
+  phone = PHONE,
+  dob = DOB,
+  patientId = "",
+  time = "10:00",
+} = {}) {
+  await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, phone_normalized, patient_id, date_of_birth,
+       service, service_code, desired_date, desired_time, status, patient_category)
+     VALUES (1, ?, 'Portal Patient', ?, ?, ?, ?, 'КТ', 'CT-01',
+       '2026-09-01', ?, 'confirmed', 'civilian')`
+  ).bind(code, `+${phone}`, phone, patientId, dob, time).run();
+}
+
+function requestWithCookie(path, cookie, body) {
+  return jsonRequest(path, body, { headers:{ cookie } });
+}
+
+test("DOB proof upgrades to patient_id only when every matching booking resolves to one exact current profile", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db);
+    await seedBooking(db, { code:"RD-EXACT001", patientId:PID, time:"10:00" });
+    await seedBooking(db, { code:"RD-EXACT002", patientId:PID, time:"10:30" });
+
+    const exact = await provePatientIdentity(db, PHONE, { dob:DOB });
+    assert.deepEqual(exact, {
+      organizationId:1,
+      identity:IDENTITY,
+      patientId:PID,
+    });
+
+    await seedBooking(db, { code:"RD-LEGACY01", patientId:"", time:"11:00" });
+    assert.equal(
+      await provePatientIdentity(db, PHONE, { dob:DOB }),
+      null,
+      "mixed linked/unlinked DOB scope must fail closed instead of guessing identity",
+    );
+  });
+});
+
+test("fully legacy DOB proof remains compatible without inventing a patient link", async () => {
+  await withD1(async (db) => {
+    await seedBooking(db, { code:"RD-LEGACY02" });
+    assert.deepEqual(await provePatientIdentity(db, PHONE, { dob:DOB }), {
+      organizationId:1,
+      identity:IDENTITY,
+      patientId:"",
+    });
+  });
+});
+
+test("OTP challenge and session carry an immutable exact patient id", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db);
+    await seedBooking(db, { code:"RD-EXACT003", patientId:PID });
+
+    const challenge = await createPatientOtpChallenge(db, PHONE, 1, IDENTITY, "cabinet_login", PID);
+    const stored = await db.prepare(
+      "SELECT patient_id AS patientId FROM patient_otp_challenges WHERE id = ?"
+    ).bind(challenge.challengeId).first();
+    assert.equal(stored.patientId, PID);
+
+    const verified = await verifyPatientOtpChallenge(db, {
+      challengeId:challenge.challengeId,
+      phoneNormalized:PHONE,
+      code:challenge.code,
+    });
+    assert.deepEqual(verified, { organizationId:1, identity:IDENTITY, patientId:PID });
+
+    const raw = await createPatientSession(db, PHONE, 1, IDENTITY, PID);
+    const session = await requirePatientSession(new Request("https://radiologyos.tech/api/my-bookings", {
+      headers:{ cookie:`rid_patient=${raw}` },
+    }), db);
+    assert.equal(session.patientId, PID);
+
+    await assert.rejects(
+      db.prepare("UPDATE patient_sessions SET patient_id = ? WHERE patient_id = ?").bind(OTHER_PID, PID).run(),
+      /immutable/i,
+    );
+  });
+});
+
+test("exact patient session returns every explicitly linked booking and excludes same-phone legacy rows", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db);
+    await seedBooking(db, { code:"RD-EXACT004", patientId:PID, time:"10:00" });
+    await seedBooking(db, { code:"RD-EXACT005", patientId:PID, phone:OTHER_PHONE, dob:"1988-01-01", time:"10:30" });
+    await seedBooking(db, { code:"RD-LEGACY03", patientId:"", time:"11:00" });
+
+    const exactRaw = await createPatientSession(db, PHONE, 1, IDENTITY, PID);
+    const exact = await callWorker(
+      requestWithCookie("/api/my-bookings", `rid_patient=${exactRaw}`),
+      db,
+    );
+    assert.equal(exact.status, 200);
+    const exactBody = await exact.json();
+    assert.deepEqual(
+      exactBody.bookings.map((b) => b.code).sort(),
+      ["RD-EXACT004", "RD-EXACT005"],
+    );
+
+    const legacyRaw = await createPatientSession(db, PHONE, 1, IDENTITY);
+    const legacy = await callWorker(
+      requestWithCookie("/api/my-bookings", `rid_patient=${legacyRaw}`),
+      db,
+    );
+    assert.equal(legacy.status, 200);
+    const legacyBody = await legacy.json();
+    assert.deepEqual(
+      legacyBody.bookings.map((b) => b.code).sort(),
+      ["RD-EXACT004", "RD-LEGACY03"],
+      "patient_id='' keeps the pre-existing phone+DOB portal behavior",
+    );
+  });
+});
+
+test("D1 rejects an exact patient id that is not backed by the authenticated booking scope", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db);
+    await seedProfile(db, OTHER_PID, OTHER_PHONE);
+    await seedBooking(db, { code:"RD-EXACT006", patientId:PID });
+
+    const raw = "c".repeat(64);
+    const tokenHash = createHash("sha256").update(raw, "utf8").digest("hex");
+    await assert.rejects(
+      db.prepare(
+        `INSERT INTO patient_sessions
+          (token_hash, phone_normalized, organization_id, identity_kind, identity_value, patient_id, expires_at)
+         VALUES (?, ?, 1, 'dob', ?, ?, datetime('now', '+30 minutes'))`
+      ).bind(tokenHash, PHONE, DOB, OTHER_PID).run(),
+      /patient link invalid/i,
+    );
+  });
+});

--- a/tests/patient-session-patient-id.behavior.test.mjs
+++ b/tests/patient-session-patient-id.behavior.test.mjs
@@ -8,7 +8,6 @@ import {
   requirePatientSession,
   verifyPatientOtpChallenge,
 } from "../lib/patient-auth.ts";
-import { provePatientIdentity } from "../app/api/patient-otp/route.ts";
 
 const PHONE = "380971112233";
 const OTHER_PHONE = "380975556677";
@@ -41,6 +40,40 @@ async function seedBooking(db, {
   ).bind(code, `+${phone}`, phone, patientId, dob, time).run();
 }
 
+async function setSmsGateway(db) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES ('sms_gateway_url', 'https://gateway.example/sms')
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  ).run();
+}
+
+async function requestOtp(db, phone = PHONE, dob = DOB) {
+  const previousFetch = globalThis.fetch;
+  const previousHosts = globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
+  globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = "gateway.example";
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : String(input?.url || input);
+    if (url.startsWith("https://gateway.example/")) {
+      return new Response("ok", { status:200 });
+    }
+    return previousFetch(input, init);
+  };
+  try {
+    return await callWorker(
+      jsonRequest(
+        "/api/patient-otp",
+        { phone:`+${phone}`, dob },
+        { ip:"203.0.113.81" },
+      ),
+      db,
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousHosts === undefined) delete globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
+    else globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = previousHosts;
+  }
+}
+
 function requestWithCookie(path, cookie, body) {
   return jsonRequest(path, body, { headers:{ cookie } });
 }
@@ -50,19 +83,33 @@ test("DOB proof upgrades to patient_id only when every matching booking resolves
     await seedProfile(db);
     await seedBooking(db, { code:"RD-EXACT001", patientId:PID, time:"10:00" });
     await seedBooking(db, { code:"RD-EXACT002", patientId:PID, time:"10:30" });
+    await setSmsGateway(db);
 
-    const exact = await provePatientIdentity(db, PHONE, { dob:DOB });
-    assert.deepEqual(exact, {
-      organizationId:1,
-      identity:IDENTITY,
-      patientId:PID,
-    });
+    const exactResponse = await requestOtp(db);
+    assert.equal(exactResponse.status, 202);
+    const exact = await db.prepare(
+      `SELECT patient_id AS patientId
+       FROM patient_otp_challenges
+       WHERE organization_id = 1 AND phone_normalized = ?
+         AND identity_kind = 'dob' AND identity_value = ?
+       ORDER BY created_at DESC, id DESC LIMIT 1`
+    ).bind(PHONE, DOB).first();
+    assert.equal(exact.patientId, PID);
 
+    const before = await db.prepare(
+      "SELECT COUNT(*) AS n FROM patient_otp_challenges WHERE organization_id = 1 AND phone_normalized = ?"
+    ).bind(PHONE).first("n");
     await seedBooking(db, { code:"RD-LEGACY01", patientId:"", time:"11:00" });
+
+    const mixedResponse = await requestOtp(db);
+    assert.equal(mixedResponse.status, 202);
+    const after = await db.prepare(
+      "SELECT COUNT(*) AS n FROM patient_otp_challenges WHERE organization_id = 1 AND phone_normalized = ?"
+    ).bind(PHONE).first("n");
     assert.equal(
-      await provePatientIdentity(db, PHONE, { dob:DOB }),
-      null,
-      "mixed linked/unlinked DOB scope must fail closed instead of guessing identity",
+      after,
+      before,
+      "mixed linked/unlinked DOB scope must fail closed instead of issuing a real challenge",
     );
   });
 });
@@ -70,11 +117,18 @@ test("DOB proof upgrades to patient_id only when every matching booking resolves
 test("fully legacy DOB proof remains compatible without inventing a patient link", async () => {
   await withD1(async (db) => {
     await seedBooking(db, { code:"RD-LEGACY02" });
-    assert.deepEqual(await provePatientIdentity(db, PHONE, { dob:DOB }), {
-      organizationId:1,
-      identity:IDENTITY,
-      patientId:"",
-    });
+    await setSmsGateway(db);
+
+    const response = await requestOtp(db);
+    assert.equal(response.status, 202);
+    const patientId = await db.prepare(
+      `SELECT patient_id AS patientId
+       FROM patient_otp_challenges
+       WHERE organization_id = 1 AND phone_normalized = ?
+         AND identity_kind = 'dob' AND identity_value = ?
+       ORDER BY created_at DESC, id DESC LIMIT 1`
+    ).bind(PHONE, DOB).first("patientId");
+    assert.equal(patientId, "");
   });
 });
 

--- a/tests/patient-session-patient-id.behavior.test.mjs
+++ b/tests/patient-session-patient-id.behavior.test.mjs
@@ -48,30 +48,14 @@ async function setSmsGateway(db) {
 }
 
 async function requestOtp(db, phone = PHONE, dob = DOB) {
-  const previousFetch = globalThis.fetch;
-  const previousHosts = globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
-  globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = "gateway.example";
-  globalThis.fetch = async (input, init) => {
-    const url = typeof input === "string" ? input : String(input?.url || input);
-    if (url.startsWith("https://gateway.example/")) {
-      return new Response("ok", { status:200 });
-    }
-    return previousFetch(input, init);
-  };
-  try {
-    return await callWorker(
-      jsonRequest(
-        "/api/patient-otp",
-        { phone:`+${phone}`, dob },
-        { ip:"203.0.113.81" },
-      ),
-      db,
-    );
-  } finally {
-    globalThis.fetch = previousFetch;
-    if (previousHosts === undefined) delete globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__;
-    else globalThis.__RADIOLOGY_OUTBOUND_ALLOWED_HOSTS__ = previousHosts;
-  }
+  return callWorker(
+    jsonRequest(
+      "/api/patient-otp",
+      { phone:`+${phone}`, dob },
+      { ip:"203.0.113.81" },
+    ),
+    db,
+  );
 }
 
 function requestWithCookie(path, cookie, body) {
@@ -85,16 +69,21 @@ test("DOB proof upgrades to patient_id only when every matching booking resolves
     await seedBooking(db, { code:"RD-EXACT002", patientId:PID, time:"10:30" });
     await setSmsGateway(db);
 
+    // The test gateway is intentionally not allowlisted in the Worker VM. A
+    // proven identity still creates the challenge first; failed delivery then
+    // consumes it and returns 503. That lets this test verify identity proof
+    // without weakening the real outbound policy or mocking across VM realms.
     const exactResponse = await requestOtp(db);
-    assert.equal(exactResponse.status, 202);
+    assert.equal(exactResponse.status, 503);
     const exact = await db.prepare(
-      `SELECT patient_id AS patientId
+      `SELECT patient_id AS patientId, consumed_at AS consumedAt
        FROM patient_otp_challenges
        WHERE organization_id = 1 AND phone_normalized = ?
          AND identity_kind = 'dob' AND identity_value = ?
        ORDER BY created_at DESC, id DESC LIMIT 1`
     ).bind(PHONE, DOB).first();
     assert.equal(exact.patientId, PID);
+    assert.ok(exact.consumedAt, "undelivered exact challenge must be unusable");
 
     const before = await db.prepare(
       "SELECT COUNT(*) AS n FROM patient_otp_challenges WHERE organization_id = 1 AND phone_normalized = ?"
@@ -120,15 +109,16 @@ test("fully legacy DOB proof remains compatible without inventing a patient link
     await setSmsGateway(db);
 
     const response = await requestOtp(db);
-    assert.equal(response.status, 202);
-    const patientId = await db.prepare(
-      `SELECT patient_id AS patientId
+    assert.equal(response.status, 503);
+    const challenge = await db.prepare(
+      `SELECT patient_id AS patientId, consumed_at AS consumedAt
        FROM patient_otp_challenges
        WHERE organization_id = 1 AND phone_normalized = ?
          AND identity_kind = 'dob' AND identity_value = ?
        ORDER BY created_at DESC, id DESC LIMIT 1`
-    ).bind(PHONE, DOB).first("patientId");
-    assert.equal(patientId, "");
+    ).bind(PHONE, DOB).first();
+    assert.equal(challenge.patientId, "");
+    assert.ok(challenge.consumedAt, "undelivered legacy challenge must be unusable");
   });
 });
 

--- a/tests/protocol-medical-access.test.mjs
+++ b/tests/protocol-medical-access.test.mjs
@@ -67,7 +67,8 @@ test("protocol access, signing and delivery are security audited with tenant att
 
 test("patient can only read an issued tenant protocol and the access is audited without PII actor data", async () => {
   const route = await read("app/api/my-protocol/route.ts");
-  assert.match(route, /WHERE organization_id = \? AND code = \? AND phone_normalized = \?/);
+  assert.match(route, /session\.patientId[\s\S]*organization_id = \? AND code = \? AND patient_id = \?/);
+  assert.match(route, /organization_id = \? AND code = \? AND phone_normalized = \? AND \$\{identityClause\}/);
   assert.match(route, /WHERE organization_id = \? AND booking_id = \? AND status = 'issued'/);
   assert.match(route, /actorEmail: "patient_session"/);
   assert.match(route, /action: "patient_protocol_viewed"/);

--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -26,7 +26,7 @@ test("worker delegates generated and public static assets to the Cloudflare ASSE
   assert.match(worker, /env\.ASSETS\.fetch\(request\)/);
 });
 
-test("patient data requires a short-lived OTP-backed tenant + identity-scoped server session", async () => {
+test("patient data requires a short-lived OTP-backed tenant + immutable-or-legacy identity-scoped server session", async () => {
   const auth = await read("lib/patient-auth.ts");
   const otp = await read("app/api/patient-otp/route.ts");
   const bookings = await read("app/api/my-bookings/route.ts");
@@ -35,16 +35,19 @@ test("patient data requires a short-lived OTP-backed tenant + identity-scoped se
   assert.match(auth, /PATIENT_OTP_TTL_SECONDS = 5 \* 60/);
   assert.match(auth, /HttpOnly; Secure; SameSite=Strict/);
   assert.match(auth, /identity_kind AS identityKind, identity_value AS identityValue/);
-  assert.match(otp, /createPatientSession\([\s\S]*verified\.organizationId,[\s\S]*verified\.identity/);
+  assert.match(auth, /patient_id AS patientId/);
+  assert.match(otp, /createPatientSession\([\s\S]*verified\.organizationId,[\s\S]*verified\.identity,[\s\S]*verified\.patientId/);
   assert.match(bookings, /requirePatientSession\(/);
   assert.doesNotMatch(bookings, /createPatientSession\(/);
   assert.match(bookings, /session\.identityKind === "dob"/);
   assert.match(bookings, /session\.identityValue/);
-  assert.match(bookings, /WHERE b\.organization_id = \? AND b\.phone_normalized = \? AND \$\{identityClause\}/);
+  assert.match(bookings, /session\.patientId[\s\S]*b\.organization_id = \? AND b\.patient_id = \?/);
+  assert.match(bookings, /b\.organization_id = \? AND b\.phone_normalized = \? AND \$\{identityClause\}/);
   assert.match(protocol, /requirePatientSession\(/);
   assert.match(protocol, /session\.identityKind === "dob"/);
   assert.match(protocol, /session\.identityValue/);
-  assert.match(protocol, /WHERE organization_id = \? AND code = \? AND phone_normalized = \? AND \$\{identityClause\}/);
+  assert.match(protocol, /session\.patientId[\s\S]*organization_id = \? AND code = \? AND patient_id = \?/);
+  assert.match(protocol, /organization_id = \? AND code = \? AND phone_normalized = \? AND \$\{identityClause\}/);
   assert.doesNotMatch(protocol, /substr\(phone_normalized, -4\)/);
 });
 

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -47,22 +47,25 @@ test("patient cabinet lists verified-session bookings and reads protocols from D
   assert.doesNotMatch(cabinet, /radiologyos_applications_v1/);
 });
 
-test("my-bookings lists only the verified phone inside the verified tenant", async () => {
+test("my-bookings prefers immutable patient_id and preserves the verified legacy fallback", async () => {
   const route = await read("app/api/my-bookings/route.ts");
   assert.match(route, /requirePatientSession\(/);
   assert.doesNotMatch(route, /normalizeUkrainianPhone\(/);
   assert.doesNotMatch(route, /createPatientSession\(/);
-  assert.match(route, /WHERE b\.organization_id = \? AND b\.phone_normalized = \?/);
-  assert.match(route, /session\.organizationId, session\.phoneNormalized/);
+  assert.match(route, /session\.patientId[\s\S]*b\.organization_id = \? AND b\.patient_id = \?/);
+  assert.match(route, /b\.organization_id = \? AND b\.phone_normalized = \? AND \$\{identityClause\}/);
+  assert.match(route, /\[session\.organizationId, session\.patientId\]/);
+  assert.match(route, /\[session\.organizationId, session\.phoneNormalized, session\.identityValue\]/);
   assert.match(route, /protocol_status = 'issued'/);
   assert.match(route, /isRateLimited\(/);
 });
 
-test("my-protocol only returns an issued protocol behind the same tenant-scoped patient session", async () => {
+test("my-protocol returns issued protocol through immutable patient_id or the exact verified legacy scope", async () => {
   const route = await read("app/api/my-protocol/route.ts");
   assert.match(route, /normalizeBookingCode\(/);
   assert.match(route, /requirePatientSession\(/);
-  assert.match(route, /WHERE organization_id = \? AND code = \? AND phone_normalized = \?/);
+  assert.match(route, /session\.patientId[\s\S]*organization_id = \? AND code = \? AND patient_id = \?/);
+  assert.match(route, /organization_id = \? AND code = \? AND phone_normalized = \? AND \$\{identityClause\}/);
   assert.match(route, /protocolStatus !== "issued"/);
   assert.match(route, /FROM protocols WHERE organization_id = \? AND booking_id = \?/);
 });


### PR DESCRIPTION
## Summary
- add optional immutable `patient_id` to patient OTP challenges and patient sessions
- carry an exact patient id from OTP proof into the authenticated portal session when the booking identity is already explicitly linked
- exact patient sessions read bookings/protocols by tenant + `patient_id`, not by phone/DOB snapshots
- preserve the existing phone + DOB / booking-code portal behavior for historical unlinked records
- keep booking-code compatibility when a historical booking phone differs from the current patient profile phone, but do not expand that old phone into the whole patient record
- fail closed for DOB scopes that mix linked/unlinked or multiple exact identities instead of guessing
- enforce the patient-session/challenge link and patient-id immutability directly in D1
- sync the scoped Drizzle auth schema

## Safety boundary
No historical booking is backfilled or inferred into a patient profile. `patient_id` is attached to auth only when the exact OTP identity scope is backed by an already linked booking. Existing sessions/challenges receive `patient_id=''` and keep legacy semantics.

## Regression coverage
- exact DOB proof upgrades only when all matching bookings resolve to one current exact patient
- mixed linked/unlinked DOB proof fails closed
- fully legacy DOB proof remains compatible
- OTP challenge -> verification -> session preserves `patient_id`
- direct D1 retargeting of a session patient id is rejected
- exact cabinet session includes linked bookings across historical phone/DOB snapshots and excludes same-phone unlinked rows
- legacy portal session behavior remains unchanged
- direct D1 session link to the wrong patient id is rejected

No production deploy.