### PR TITLE
Fail closed on ambiguous legacy patient result scopes

### DIFF
--- a/app/api/my-bookings/route.ts
+++ b/app/api/my-bookings/route.ts
@@ -1,6 +1,7 @@
 import {
   clearedPatientSessionCookie,
   destroyPatientSession,
+  patientSessionScopeIsUnambiguous,
   requirePatientSession,
 } from "../../../lib/patient-auth";
 import { isRateLimited } from "../../../lib/rate-limit";
@@ -17,6 +18,12 @@ export async function POST(request: Request) {
   const session = await requirePatientSession(request, db);
   if (!session) {
     return Response.json({ error: "Сесію не підтверджено. Отримайте одноразовий код ще раз." }, { status: 401 });
+  }
+  if (!await patientSessionScopeIsUnambiguous(db, session)) {
+    return Response.json(
+      { error: "За цим номером і датою народження знайдено кілька записів. Увійдіть за кодом конкретної заявки." },
+      { status: 409, headers: { "cache-control": "no-store" } },
+    );
   }
 
   const identityClause = session.identityKind === "dob"

--- a/app/api/my-protocol/route.ts
+++ b/app/api/my-protocol/route.ts
@@ -1,5 +1,9 @@
 import { audit } from "../../../lib/audit";
-import { normalizeBookingCode, requirePatientSession } from "../../../lib/patient-auth";
+import {
+  normalizeBookingCode,
+  patientSessionScopeIsUnambiguous,
+  requirePatientSession,
+} from "../../../lib/patient-auth";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { dbBinding } from "../../../lib/db";
 
@@ -11,6 +15,12 @@ export async function POST(request: Request) {
   }
   const session = await requirePatientSession(request, db);
   if (!session) return Response.json({ error: "Сесію завершено. Увійдіть до кабінету повторно." }, { status: 401 });
+  if (!await patientSessionScopeIsUnambiguous(db, session)) {
+    return Response.json(
+      { error: "За цим номером і датою народження знайдено кілька записів. Увійдіть за кодом конкретної заявки." },
+      { status: 409, headers: { "cache-control": "no-store" } },
+    );
+  }
 
   const body = await request.json().catch(() => ({})) as { code?: string };
   const code = normalizeBookingCode(body.code);

--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -4,7 +4,10 @@
 // Telegram bot config is still legacy-global and belongs to org 1, so secondary
 // tenants must not receive a deep-link until bot configuration is tenantized.
 
-import { requirePatientSession } from "../../../lib/patient-auth";
+import {
+  patientSessionScopeIsUnambiguous,
+  requirePatientSession,
+} from "../../../lib/patient-auth";
 import { createTelegramLinkToken } from "../../../lib/telegram-link";
 import { telegramBotUsername } from "../../../lib/telegram";
 import { isRateLimited } from "../../../lib/rate-limit";
@@ -17,6 +20,12 @@ export async function POST(request: Request) {
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
   const session = await requirePatientSession(request, db);
   if (!session) return Response.json({ error: "Сесію не підтверджено" }, { status: 401 });
+  if (!await patientSessionScopeIsUnambiguous(db, session)) {
+    return Response.json(
+      { error: "За цим номером і датою народження знайдено кілька записів. Увійдіть за кодом конкретної заявки." },
+      { status: 409, headers: { "cache-control": "no-store" } },
+    );
+  }
   if (session.organizationId !== PRIMARY_ORGANIZATION_ID) {
     return Response.json(
       { error: "Telegram-канал ще не налаштований відділенням", botConfigured: false },
@@ -38,5 +47,5 @@ export async function POST(request: Request) {
     { kind:session.identityKind, value:session.identityValue },
   );
   const url = `https://t.me/${username}?start=${token}`;
-  return Response.json({ url }, { headers: { "cache-control": "no-store" } });
+  return Response.json({ url }, { headers: { "cache-control":"no-store" } });
 }

--- a/lib/patient-auth.ts
+++ b/lib/patient-auth.ts
@@ -16,6 +16,14 @@ export type PatientIdentityScope = {
   value: string;
 };
 
+export type PatientSession = {
+  phoneNormalized: string;
+  organizationId: number;
+  identityKind: "dob" | "booking";
+  identityValue: string;
+  patientId: string;
+};
+
 export function normalizeBookingCode(value: unknown): string {
   const code = String(value || "").trim().toUpperCase().slice(0, 24);
   // Новий формат RD-РРММДД-N (дата + добовий номер) та легасі RD-<hex16>.
@@ -180,7 +188,7 @@ export async function createPatientSession(
   return rawToken;
 }
 
-export async function requirePatientSession(request: Request, db: D1Database) {
+export async function requirePatientSession(request: Request, db: D1Database): Promise<PatientSession | null> {
   const rawToken = readCookie(request, PATIENT_SESSION_COOKIE);
   if (!rawToken) return null;
   const tokenHash = await hashToken(rawToken);
@@ -192,13 +200,26 @@ export async function requirePatientSession(request: Request, db: D1Database) {
      WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP
        AND identity_kind IN ('dob','booking') AND identity_value != ''
      LIMIT 1`,
-  ).bind(tokenHash).first<{
-    phoneNormalized: string;
-    organizationId: number;
-    identityKind: "dob" | "booking";
-    identityValue: string;
-    patientId: string;
-  }>();
+  ).bind(tokenHash).first<PatientSession>();
+}
+
+// Exact patient sessions and booking-code sessions are already identity-scoped.
+// A legacy DOB session has no immutable patient id, so more than one matching
+// booking is intrinsically ambiguous (shared family phone, twins, duplicate DOB,
+// or mixed historical records). Never infer that those rows belong to one person.
+export async function patientSessionScopeIsUnambiguous(
+  db: D1Database,
+  session: PatientSession,
+): Promise<boolean> {
+  if (session.patientId) return true;
+  if (session.identityKind === "booking") return true;
+  if (session.identityKind !== "dob") return false;
+
+  const row = await db.prepare(
+    `SELECT COUNT(*) AS n FROM bookings
+     WHERE organization_id = ? AND phone_normalized = ? AND date_of_birth = ?`,
+  ).bind(session.organizationId, session.phoneNormalized, session.identityValue).first<{ n:number }>();
+  return Number(row?.n || 0) === 1;
 }
 
 export async function destroyPatientSession(request: Request, db: D1Database): Promise<void> {

--- a/tests/patient-result-legacy-ambiguity.behavior.test.mjs
+++ b/tests/patient-result-legacy-ambiguity.behavior.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, withD1 } from "./helpers/d1.mjs";
+import { createPatientSession } from "../lib/patient-auth.ts";
+
+const PHONE = "380971234567";
+const DOB = "1991-02-03";
+const CODE_A = "RD-AMBIG001";
+const CODE_B = "RD-AMBIG002";
+
+async function seedLegacyBooking(db, code, name, time) {
+  const inserted = await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, phone_normalized, date_of_birth,
+       service, service_code, desired_date, desired_time, status, patient_category)
+     VALUES (1, ?, ?, ?, ?, ?, 'КТ', 'CT-01', '2026-09-10', ?, 'confirmed', 'civilian')`,
+  ).bind(code, name, `+${PHONE}`, PHONE, DOB, time).run();
+  return Number(inserted.meta.last_row_id);
+}
+
+async function seedIssuedProtocol(db, bookingId) {
+  await db.prepare(
+    `INSERT INTO protocols
+      (organization_id, booking_id, number, status, version, author_email, updated_by,
+       findings, conclusion, signed_by, signed_at, signed_version)
+     VALUES (1, ?, 'PROTO-A', 'issued', 1, 'doctor@example.com', 'doctor@example.com',
+       'Finding A', 'Result A', 'doctor@example.com', CURRENT_TIMESTAMP, 1)`,
+  ).bind(bookingId).run();
+}
+
+function request(path, cookie, body = undefined) {
+  return jsonRequest(path, body, { method:"POST", headers:{ cookie } });
+}
+
+test("ambiguous legacy DOB session cannot expand across patient results or messaging identity", async () => {
+  await withD1(async (db) => {
+    const bookingA = await seedLegacyBooking(db, CODE_A, "Legacy Alpha", "10:00");
+    await seedLegacyBooking(db, CODE_B, "Legacy Beta", "10:30");
+    await seedIssuedProtocol(db, bookingA);
+
+    const raw = await createPatientSession(db, PHONE, 1, { kind:"dob", value:DOB });
+    const cookie = `rid_patient=${raw}`;
+
+    const cabinet = await callWorker(request("/api/my-bookings", cookie), db);
+    assert.equal(cabinet.status, 409);
+    const cabinetText = await cabinet.text();
+    assert.doesNotMatch(cabinetText, /Legacy Alpha|Legacy Beta|Result A/);
+
+    const protocol = await callWorker(request("/api/my-protocol", cookie, { code:CODE_A }), db);
+    assert.equal(protocol.status, 409);
+    const protocolText = await protocol.text();
+    assert.doesNotMatch(protocolText, /Legacy Alpha|Legacy Beta|Result A/);
+
+    const telegram = await callWorker(request("/api/my-telegram-link", cookie), db);
+    assert.equal(telegram.status, 409);
+    assert.doesNotMatch(await telegram.text(), /t\.me\//);
+  });
+});
+
+test("exact legacy booking-code session remains compatible and exposes only that booking", async () => {
+  await withD1(async (db) => {
+    const bookingA = await seedLegacyBooking(db, CODE_A, "Legacy Alpha", "10:00");
+    await seedLegacyBooking(db, CODE_B, "Legacy Beta", "10:30");
+    await seedIssuedProtocol(db, bookingA);
+
+    const raw = await createPatientSession(db, PHONE, 1, { kind:"booking", value:CODE_A });
+    const cookie = `rid_patient=${raw}`;
+
+    const cabinet = await callWorker(request("/api/my-bookings", cookie), db);
+    assert.equal(cabinet.status, 200);
+    const cabinetBody = await cabinet.json();
+    assert.deepEqual(cabinetBody.bookings.map((row) => row.code), [CODE_A]);
+    assert.equal(cabinetBody.bookings[0].patientName, "Legacy Alpha");
+
+    const protocol = await callWorker(request("/api/my-protocol", cookie, { code:CODE_A }), db);
+    assert.equal(protocol.status, 200);
+    const protocolBody = await protocol.json();
+    assert.equal(protocolBody.protocol.patient, "Legacy Alpha");
+    assert.equal(protocolBody.protocol.conclusion, "Result A");
+    assert.doesNotMatch(JSON.stringify(protocolBody), /Legacy Beta/);
+  });
+});

--- a/tests/patient-session-patient-id.behavior.test.mjs
+++ b/tests/patient-session-patient-id.behavior.test.mjs
@@ -153,7 +153,7 @@ test("OTP challenge and session carry an immutable exact patient id", async () =
   });
 });
 
-test("exact patient session returns every explicitly linked booking and excludes same-phone legacy rows", async () => {
+test("exact patient session returns linked bookings while ambiguous legacy DOB scope fails closed", async () => {
   await withD1(async (db) => {
     await seedProfile(db);
     await seedBooking(db, { code:"RD-EXACT004", patientId:PID, time:"10:00" });
@@ -177,13 +177,8 @@ test("exact patient session returns every explicitly linked booking and excludes
       requestWithCookie("/api/my-bookings", `rid_patient=${legacyRaw}`),
       db,
     );
-    assert.equal(legacy.status, 200);
-    const legacyBody = await legacy.json();
-    assert.deepEqual(
-      legacyBody.bookings.map((b) => b.code).sort(),
-      ["RD-EXACT004", "RD-LEGACY03"],
-      "patient_id='' keeps the pre-existing phone+DOB portal behavior",
-    );
+    assert.equal(legacy.status, 409);
+    assert.doesNotMatch(await legacy.text(), /RD-EXACT004|RD-LEGACY03/);
   });
 });
 


### PR DESCRIPTION
## Scope
- treat legacy phone+DOB patient sessions as ambiguous when they match more than one booking
- block ambiguous legacy scope from patient cabinet listing and issued protocol delivery
- block ambiguous legacy scope from creating a Telegram patient identity link
- preserve exact immutable patient_id sessions and exact booking-code legacy compatibility
- add behavioral coverage proving ambiguous sessions expose no patient/result content

## Safety properties
- shared phone + same DOB never merges multiple legacy patient histories
- an existing/stale legacy DOB session cannot expand into multiple bookings
- issued protocol content remains available through immutable patient_id or exact booking-code scope
- no automatic patient merge/backfill
- production deploy is out of scope