### PR TITLE
Add immutable protocol correction addenda

### DIFF
--- a/app/api/my-protocol/route.ts
+++ b/app/api/my-protocol/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
   const booking = await db.prepare(
     `SELECT id, name, service, protocol_status AS protocolStatus, protocol_issued_at AS issuedAt
      FROM bookings
-     WHERE ${whereClause} LIMIT 1`
+     WHERE ${whereClause} LIMIT 1`,
   ).bind(...bindings).first<{
     id: number; name: string; service: string; protocolStatus: string; issuedAt: string;
   }>();
@@ -47,11 +47,36 @@ export async function POST(request: Request) {
 
   const proto = await db.prepare(
     `SELECT number, method, findings, conclusion, recommendations
-     FROM protocols WHERE organization_id = ? AND booking_id = ? AND status = 'issued' LIMIT 1`
+     FROM protocols WHERE organization_id = ? AND booking_id = ? AND status = 'issued' LIMIT 1`,
   ).bind(session.organizationId, booking.id).first<{
     number: string; method: string; findings: string; conclusion: string; recommendations: string;
   }>();
   if (!proto) return Response.json({ error: "Протокол ще не готовий" }, { status: 409 });
+
+  const addenda = await db.prepare(
+    `SELECT id,
+            base_protocol_version AS baseProtocolVersion,
+            reason,
+            correction_text AS correctionText,
+            version,
+            signed_by AS signedBy,
+            signed_at AS signedAt,
+            created_at AS createdAt,
+            updated_at AS updatedAt
+     FROM protocol_addenda
+     WHERE organization_id = ? AND booking_id = ? AND status = 'issued'
+     ORDER BY created_at ASC, id ASC`,
+  ).bind(session.organizationId, booking.id).all<{
+    id: string;
+    baseProtocolVersion: number;
+    reason: string;
+    correctionText: string;
+    version: number;
+    signedBy: string;
+    signedAt: string;
+    createdAt: string;
+    updatedAt: string;
+  }>();
 
   await audit(db, {
     organizationId: session.organizationId,
@@ -59,7 +84,11 @@ export async function POST(request: Request) {
     action: "patient_protocol_viewed",
     resource: "protocol",
     targetId: booking.id,
-    details: { channel: "patient_cabinet", identityKind:session.patientId ? "patient_id" : session.identityKind },
+    details: {
+      channel: "patient_cabinet",
+      identityKind: session.patientId ? "patient_id" : session.identityKind,
+      issuedAddenda: addenda.results.length,
+    },
   });
 
   return Response.json({
@@ -72,6 +101,7 @@ export async function POST(request: Request) {
       findings: proto.findings,
       conclusion: proto.conclusion,
       recommendations: proto.recommendations,
+      addenda: addenda.results,
     },
   }, { headers: { "cache-control": "no-store" } });
 }

--- a/app/api/staff/protocols/addenda/route.ts
+++ b/app/api/staff/protocols/addenda/route.ts
@@ -5,23 +5,31 @@ import { requireOrgContext } from "../../../../../lib/tenant";
 
 const ADDENDUM_ID_RE = /^[0-9a-f]{32}$/;
 const STATUSES = new Set(["draft", "ready", "signed", "issued"]);
+const REASON_MAX = 500;
+const CORRECTION_MAX = 12000;
 
 type AddendumRow = {
   id:string; bookingId:number; baseProtocolVersion:number; reason:string; correctionText:string;
   status:string; version:number; authorEmail:string; updatedBy:string; updatedAt:string;
   signedBy:string; signedAt:string; signedVersion:number; createdAt:string;
 };
+type AddendumRevisionRow = {
+  id:number; addendumId:string; baseProtocolVersion:number; version:number;
+  reason:string; correctionText:string; status:string; savedBy:string; createdAt:string;
+};
 
-function cleanText(value:unknown, max:number):string {
-  return String(value ?? "").replace(/\r\n?/g, "\n").trim().slice(0, max);
+function normalizedText(value:unknown):string {
+  return String(value ?? "").replace(/\r\n?/g, "\n").trim();
 }
 
 function parseDocument(body:Record<string, unknown>) {
-  const reason = cleanText(body.reason, 500);
-  const correctionText = cleanText(body.correctionText, 12000);
+  const reason = normalizedText(body.reason);
+  const correctionText = normalizedText(body.correctionText);
   const status = String(body.status || "draft");
   if (!reason) return { ok:false as const, error:"Вкажіть причину виправлення або доповнення" };
+  if (reason.length > REASON_MAX) return { ok:false as const, error:`Причина виправлення не може перевищувати ${REASON_MAX} символів` };
   if (!correctionText) return { ok:false as const, error:"Вкажіть текст виправлення або доповнення" };
+  if (correctionText.length > CORRECTION_MAX) return { ok:false as const, error:`Текст виправлення не може перевищувати ${CORRECTION_MAX} символів` };
   if (!STATUSES.has(status)) return { ok:false as const, error:"Некоректний статус виправлення" };
   return { ok:true as const, reason, correctionText, status };
 }
@@ -52,7 +60,7 @@ export async function GET(request:Request) {
     return Response.json({ error:"Заявку не знайдено або її не призначено вам" }, { status:404 });
   }
 
-  const [base, rows] = await Promise.all([
+  const [base, rows, revisions] = await Promise.all([
     db.prepare(
       `SELECT version, number, status FROM protocols
        WHERE organization_id = ? AND booking_id = ? LIMIT 1`,
@@ -61,12 +69,24 @@ export async function GET(request:Request) {
       `SELECT ${SELECT_COLUMNS} FROM protocol_addenda
        WHERE organization_id = ? AND booking_id = ? ORDER BY created_at, id`,
     ).bind(ctx.organizationId, bookingId).all<AddendumRow>(),
+    db.prepare(
+      `SELECT id, addendum_id AS addendumId, base_protocol_version AS baseProtocolVersion,
+              version, reason, correction_text AS correctionText, status,
+              saved_by AS savedBy, created_at AS createdAt
+       FROM protocol_addendum_revisions
+       WHERE organization_id = ? AND booking_id = ?
+       ORDER BY addendum_id, version`,
+    ).bind(ctx.organizationId, bookingId).all<AddendumRevisionRow>(),
   ]);
   await audit(db, {
     organizationId:ctx.organizationId, actorEmail:member.email,
     action:"protocol_addenda_viewed", resource:"protocol_addendum", targetId:bookingId,
   });
-  return Response.json({ baseProtocol:base || null, addenda:rows.results || [] }, { headers:{ "cache-control":"no-store" } });
+  return Response.json({
+    baseProtocol:base || null,
+    addenda:rows.results || [],
+    revisions:revisions.results || [],
+  }, { headers:{ "cache-control":"no-store" } });
 }
 
 export async function POST(request:Request) {

--- a/app/api/staff/protocols/addenda/route.ts
+++ b/app/api/staff/protocols/addenda/route.ts
@@ -93,7 +93,7 @@ export async function POST(request:Request) {
 
   const id = crypto.randomUUID().replace(/-/g, "").toLowerCase();
   try {
-    await db.batch([
+    const results = await db.batch([
       db.prepare(
         `INSERT INTO protocol_addenda
           (id, organization_id, booking_id, base_protocol_version, reason, correction_text,
@@ -101,16 +101,11 @@ export async function POST(request:Request) {
          VALUES (?, ?, ?, ?, ?, ?, 'draft', 1, ?, ?)`,
       ).bind(id, ctx.organizationId, bookingId, base.version, parsed.reason, parsed.correctionText, member.email, member.email),
       db.prepare(
-        `INSERT INTO protocol_addendum_revisions
-          (addendum_id, organization_id, booking_id, base_protocol_version, version,
-           reason, correction_text, status, saved_by)
-         VALUES (?, ?, ?, ?, 1, ?, ?, 'draft', ?)`,
-      ).bind(id, ctx.organizationId, bookingId, base.version, parsed.reason, parsed.correctionText, member.email),
-      db.prepare(
         `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
          VALUES (?, ?, 'protocol_addendum_created', ?, ?)`,
       ).bind(ctx.organizationId, bookingId, `addendum ${id} · base v${base.version}`, member.email),
     ]);
+    if (!results[0]?.meta.changes) throw new Error("addendum insert did not change a row");
   } catch {
     return Response.json({ error:"Не вдалося створити виправлення. Оновіть сторінку." }, { status:409 });
   }
@@ -187,20 +182,12 @@ export async function PUT(request:Request) {
       ).bind(parsed.reason, parsed.correctionText, parsed.status, nextVersion, member.email,
         signedBy, signedAt, signedVersion, id, ctx.organizationId, existing.version, existing.status),
       db.prepare(
-        `INSERT INTO protocol_addendum_revisions
-          (addendum_id, organization_id, booking_id, base_protocol_version, version,
-           reason, correction_text, status, saved_by)
-         SELECT id, organization_id, booking_id, base_protocol_version, version,
-           reason, correction_text, status, ? FROM protocol_addenda
-         WHERE id = ? AND organization_id = ? AND version = ?`,
-      ).bind(member.email, id, ctx.organizationId, nextVersion),
-      db.prepare(
         `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
          SELECT organization_id, booking_id, 'protocol_addendum_saved', ?, ?
          FROM protocol_addenda WHERE id = ? AND organization_id = ? AND version = ?`,
       ).bind(`${parsed.status} · addendum ${id} · v${nextVersion}`, member.email, id, ctx.organizationId, nextVersion),
     ]);
-    if (!results[0]?.meta.changes || !results[1]?.meta.changes) {
+    if (!results[0]?.meta.changes) {
       return Response.json({ error:"Конфлікт версій виправлення. Оновіть сторінку." }, { status:409 });
     }
   } catch {

--- a/app/api/staff/protocols/addenda/route.ts
+++ b/app/api/staff/protocols/addenda/route.ts
@@ -1,0 +1,216 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import { canAccessBooking, canManageProtocols, canSignProtocols } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+const ADDENDUM_ID_RE = /^[0-9a-f]{32}$/;
+const STATUSES = new Set(["draft", "ready", "signed", "issued"]);
+
+type AddendumRow = {
+  id:string; bookingId:number; baseProtocolVersion:number; reason:string; correctionText:string;
+  status:string; version:number; authorEmail:string; updatedBy:string; updatedAt:string;
+  signedBy:string; signedAt:string; signedVersion:number; createdAt:string;
+};
+
+function cleanText(value:unknown, max:number):string {
+  return String(value ?? "").replace(/\r\n?/g, "\n").trim().slice(0, max);
+}
+
+function parseDocument(body:Record<string, unknown>) {
+  const reason = cleanText(body.reason, 500);
+  const correctionText = cleanText(body.correctionText, 12000);
+  const status = String(body.status || "draft");
+  if (!reason) return { ok:false as const, error:"Вкажіть причину виправлення або доповнення" };
+  if (!correctionText) return { ok:false as const, error:"Вкажіть текст виправлення або доповнення" };
+  if (!STATUSES.has(status)) return { ok:false as const, error:"Некоректний статус виправлення" };
+  return { ok:true as const, reason, correctionText, status };
+}
+
+const SELECT_COLUMNS = `id, booking_id AS bookingId, base_protocol_version AS baseProtocolVersion,
+  reason, correction_text AS correctionText, status, version,
+  author_email AS authorEmail, updated_by AS updatedBy, updated_at AS updatedAt,
+  signed_by AS signedBy, signed_at AS signedAt, signed_version AS signedVersion,
+  created_at AS createdAt`;
+
+async function loadAddendum(db:D1Database, organizationId:number, id:string) {
+  return db.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM protocol_addenda WHERE organization_id = ? AND id = ? LIMIT 1`,
+  ).bind(organizationId, id).first<AddendumRow>();
+}
+
+export async function GET(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+  const member = ctx.member;
+  if (!canManageProtocols(member.role)) return Response.json({ error:"Виправлення доступні лише лікарю або адміністратору" }, { status:403 });
+
+  const bookingId = Number(new URL(request.url).searchParams.get("bookingId"));
+  if (!Number.isInteger(bookingId) || bookingId <= 0) return Response.json({ error:"Некоректна заявка" }, { status:400 });
+  if (!await canAccessBooking(db, member, bookingId, ctx.organizationId)) {
+    return Response.json({ error:"Заявку не знайдено або її не призначено вам" }, { status:404 });
+  }
+
+  const [base, rows] = await Promise.all([
+    db.prepare(
+      `SELECT version, number, status FROM protocols
+       WHERE organization_id = ? AND booking_id = ? LIMIT 1`,
+    ).bind(ctx.organizationId, bookingId).first<Record<string, unknown>>(),
+    db.prepare(
+      `SELECT ${SELECT_COLUMNS} FROM protocol_addenda
+       WHERE organization_id = ? AND booking_id = ? ORDER BY created_at, id`,
+    ).bind(ctx.organizationId, bookingId).all<AddendumRow>(),
+  ]);
+  await audit(db, {
+    organizationId:ctx.organizationId, actorEmail:member.email,
+    action:"protocol_addenda_viewed", resource:"protocol_addendum", targetId:bookingId,
+  });
+  return Response.json({ baseProtocol:base || null, addenda:rows.results || [] }, { headers:{ "cache-control":"no-store" } });
+}
+
+export async function POST(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+  const member = ctx.member;
+  if (!canManageProtocols(member.role)) return Response.json({ error:"Виправлення може створити лише лікар або адміністратор" }, { status:403 });
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const bookingId = Number(body.bookingId);
+  if (!Number.isInteger(bookingId) || bookingId <= 0) return Response.json({ error:"Некоректна заявка" }, { status:400 });
+  if (!await canAccessBooking(db, member, bookingId, ctx.organizationId)) {
+    return Response.json({ error:"Заявку не знайдено або її не призначено вам" }, { status:404 });
+  }
+  const parsed = parseDocument({ ...body, status:"draft" });
+  if (!parsed.ok) return Response.json({ error:parsed.error }, { status:400 });
+
+  const base = await db.prepare(
+    `SELECT version FROM protocols WHERE organization_id = ? AND booking_id = ? AND status = 'issued' LIMIT 1`,
+  ).bind(ctx.organizationId, bookingId).first<{ version:number }>();
+  if (!base) return Response.json({ error:"Виправлення можна створити лише до вже виданого протоколу" }, { status:409 });
+
+  const id = crypto.randomUUID().replace(/-/g, "").toLowerCase();
+  try {
+    await db.batch([
+      db.prepare(
+        `INSERT INTO protocol_addenda
+          (id, organization_id, booking_id, base_protocol_version, reason, correction_text,
+           status, version, author_email, updated_by)
+         VALUES (?, ?, ?, ?, ?, ?, 'draft', 1, ?, ?)`,
+      ).bind(id, ctx.organizationId, bookingId, base.version, parsed.reason, parsed.correctionText, member.email, member.email),
+      db.prepare(
+        `INSERT INTO protocol_addendum_revisions
+          (addendum_id, organization_id, booking_id, base_protocol_version, version,
+           reason, correction_text, status, saved_by)
+         VALUES (?, ?, ?, ?, 1, ?, ?, 'draft', ?)`,
+      ).bind(id, ctx.organizationId, bookingId, base.version, parsed.reason, parsed.correctionText, member.email),
+      db.prepare(
+        `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+         VALUES (?, ?, 'protocol_addendum_created', ?, ?)`,
+      ).bind(ctx.organizationId, bookingId, `addendum ${id} · base v${base.version}`, member.email),
+    ]);
+  } catch {
+    return Response.json({ error:"Не вдалося створити виправлення. Оновіть сторінку." }, { status:409 });
+  }
+  await audit(db, {
+    organizationId:ctx.organizationId, actorEmail:member.email,
+    action:"protocol_addendum_created", resource:"protocol_addendum", targetId:id,
+    details:{ bookingId, baseProtocolVersion:base.version },
+  });
+  return Response.json({ ok:true, addendum:await loadAddendum(db, ctx.organizationId, id) }, { status:201 });
+}
+
+export async function PUT(request:Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
+  const member = ctx.member;
+  if (!canManageProtocols(member.role)) return Response.json({ error:"Виправлення може змінювати лише лікар або адміністратор" }, { status:403 });
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const id = String(body.id || "").trim().toLowerCase();
+  if (!ADDENDUM_ID_RE.test(id)) return Response.json({ error:"Некоректне виправлення" }, { status:400 });
+  const existing = await loadAddendum(db, ctx.organizationId, id);
+  if (!existing) return Response.json({ error:"Виправлення не знайдено" }, { status:404 });
+  if (!await canAccessBooking(db, member, existing.bookingId, ctx.organizationId)) {
+    return Response.json({ error:"Виправлення не знайдено або дослідження не призначено вам" }, { status:404 });
+  }
+  const baseVersion = Number(body.baseVersion);
+  if (!Number.isInteger(baseVersion) || baseVersion !== Number(existing.version)) {
+    return Response.json({ error:"Виправлення вже змінено в іншому вікні. Оновіть сторінку." }, { status:409 });
+  }
+  const parsed = parseDocument(body);
+  if (!parsed.ok) return Response.json({ error:parsed.error }, { status:400 });
+  if (existing.status === "issued") return Response.json({ error:"Видане виправлення незмінне" }, { status:409 });
+
+  if (parsed.status === "issued") {
+    if (existing.status !== "signed") return Response.json({ error:"Перед видачею виправлення має бути підписане лікарем-рентгенологом" }, { status:409 });
+    if (parsed.reason !== existing.reason || parsed.correctionText !== existing.correctionText) {
+      return Response.json({ error:"Підписане виправлення незмінне. Оновіть сторінку." }, { status:409 });
+    }
+    const result = await db.prepare(
+      `UPDATE protocol_addenda SET status = 'issued', updated_by = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE id = ? AND organization_id = ? AND status = 'signed' AND version = ?`,
+    ).bind(member.email, id, ctx.organizationId, existing.version).run().catch(() => null);
+    if (!result?.meta.changes) return Response.json({ error:"Статус виправлення змінився. Оновіть сторінку." }, { status:409 });
+    await audit(db, {
+      organizationId:ctx.organizationId, actorEmail:member.email,
+      action:"protocol_addendum_issued", resource:"protocol_addendum", targetId:id,
+      details:{ bookingId:existing.bookingId, version:existing.version, baseProtocolVersion:existing.baseProtocolVersion },
+    });
+    return Response.json({ ok:true, addendum:await loadAddendum(db, ctx.organizationId, id) });
+  }
+
+  if (existing.status === "signed") return Response.json({ error:"Підписане виправлення незмінне. Доступна лише видача пацієнту." }, { status:409 });
+  const allowed:Record<string, string[]> = { draft:["draft", "ready"], ready:["ready", "signed"] };
+  if (!(allowed[existing.status] || []).includes(parsed.status)) return Response.json({ error:"Недопустимий перехід статусу виправлення" }, { status:409 });
+  if (parsed.status === "signed" && !canSignProtocols(member.role)) {
+    return Response.json({ error:"Підписати виправлення може лише лікар-рентгенолог" }, { status:403 });
+  }
+
+  const nextVersion = existing.version + 1;
+  const signedAtRow = parsed.status === "signed"
+    ? await db.prepare("SELECT CURRENT_TIMESTAMP AS now").first<{ now:string }>()
+    : null;
+  const signedBy = parsed.status === "signed" ? member.email : "";
+  const signedAt = signedAtRow?.now || "";
+  const signedVersion = parsed.status === "signed" ? nextVersion : 0;
+  try {
+    const results = await db.batch([
+      db.prepare(
+        `UPDATE protocol_addenda SET reason = ?, correction_text = ?, status = ?, version = ?,
+           updated_by = ?, updated_at = CURRENT_TIMESTAMP, signed_by = ?, signed_at = ?, signed_version = ?
+         WHERE id = ? AND organization_id = ? AND version = ? AND status = ?`,
+      ).bind(parsed.reason, parsed.correctionText, parsed.status, nextVersion, member.email,
+        signedBy, signedAt, signedVersion, id, ctx.organizationId, existing.version, existing.status),
+      db.prepare(
+        `INSERT INTO protocol_addendum_revisions
+          (addendum_id, organization_id, booking_id, base_protocol_version, version,
+           reason, correction_text, status, saved_by)
+         SELECT id, organization_id, booking_id, base_protocol_version, version,
+           reason, correction_text, status, ? FROM protocol_addenda
+         WHERE id = ? AND organization_id = ? AND version = ?`,
+      ).bind(member.email, id, ctx.organizationId, nextVersion),
+      db.prepare(
+        `INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+         SELECT organization_id, booking_id, 'protocol_addendum_saved', ?, ?
+         FROM protocol_addenda WHERE id = ? AND organization_id = ? AND version = ?`,
+      ).bind(`${parsed.status} · addendum ${id} · v${nextVersion}`, member.email, id, ctx.organizationId, nextVersion),
+    ]);
+    if (!results[0]?.meta.changes || !results[1]?.meta.changes) {
+      return Response.json({ error:"Конфлікт версій виправлення. Оновіть сторінку." }, { status:409 });
+    }
+  } catch {
+    return Response.json({ error:"Конфлікт версій або стану виправлення. Оновіть сторінку." }, { status:409 });
+  }
+  await audit(db, {
+    organizationId:ctx.organizationId, actorEmail:member.email,
+    action:parsed.status === "signed" ? "protocol_addendum_signed" : "protocol_addendum_saved",
+    resource:"protocol_addendum", targetId:id,
+    details:{ bookingId:existing.bookingId, version:nextVersion, status:parsed.status, baseProtocolVersion:existing.baseProtocolVersion },
+  });
+  return Response.json({ ok:true, addendum:await loadAddendum(db, ctx.organizationId, id) });
+}

--- a/drizzle/0056_protocol_addendum_lifecycle.sql
+++ b/drizzle/0056_protocol_addendum_lifecycle.sql
@@ -1,0 +1,188 @@
+-- Corrections to an already issued radiology report are separate medical
+-- documents. The original protocol and its revision history remain immutable.
+-- An addendum is permanently anchored to the exact issued base protocol version,
+-- has its own append-only revision trail and requires a radiologist signature
+-- before it may be delivered to the patient.
+
+CREATE TABLE `protocol_addenda` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `base_protocol_version` integer NOT NULL,
+  `reason` text NOT NULL DEFAULT '',
+  `correction_text` text NOT NULL DEFAULT '',
+  `status` text NOT NULL DEFAULT 'draft',
+  `version` integer NOT NULL DEFAULT 1,
+  `author_email` text NOT NULL,
+  `updated_by` text NOT NULL,
+  `signed_by` text NOT NULL DEFAULT '',
+  `signed_at` text NOT NULL DEFAULT '',
+  `signed_version` integer NOT NULL DEFAULT 0,
+  `created_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (`status` IN ('draft','ready','signed','issued')),
+  CHECK (`base_protocol_version` > 0),
+  CHECK (`version` > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `protocol_addenda_org_booking_idx`
+ON `protocol_addenda` (`organization_id`, `booking_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX `protocol_addenda_status_idx`
+ON `protocol_addenda` (`organization_id`, `status`, `updated_at`);
+--> statement-breakpoint
+
+CREATE TABLE `protocol_addendum_revisions` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `addendum_id` integer NOT NULL,
+  `organization_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `base_protocol_version` integer NOT NULL,
+  `version` integer NOT NULL,
+  `reason` text NOT NULL DEFAULT '',
+  `correction_text` text NOT NULL DEFAULT '',
+  `status` text NOT NULL DEFAULT 'draft',
+  `saved_by` text NOT NULL,
+  `created_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (`addendum_id`, `version`),
+  CHECK (`status` IN ('draft','ready','signed')),
+  CHECK (`base_protocol_version` > 0),
+  CHECK (`version` > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `protocol_addendum_revisions_scope_idx`
+ON `protocol_addendum_revisions` (`organization_id`, `booking_id`, `addendum_id`, `version`);
+--> statement-breakpoint
+
+-- An addendum may only belong to the same tenant/booking as an already issued
+-- base report and must remain anchored to that exact immutable base version.
+CREATE TRIGGER `protocol_addenda_base_guard_insert`
+BEFORE INSERT ON `protocol_addenda`
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1 FROM protocols p
+  WHERE p.organization_id = NEW.organization_id
+    AND p.booking_id = NEW.booking_id
+    AND p.status = 'issued'
+    AND p.version = NEW.base_protocol_version
+)
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum base must be issued');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_scope_immutable`
+BEFORE UPDATE OF `organization_id`, `booking_id`, `base_protocol_version` ON `protocol_addenda`
+FOR EACH ROW
+WHEN NEW.organization_id IS NOT OLD.organization_id
+  OR NEW.booking_id IS NOT OLD.booking_id
+  OR NEW.base_protocol_version IS NOT OLD.base_protocol_version
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum scope is immutable');
+END;
+--> statement-breakpoint
+
+-- Signature metadata and lifecycle state must always agree.
+CREATE TRIGGER `protocol_addenda_signature_guard_insert`
+BEFORE INSERT ON `protocol_addenda`
+FOR EACH ROW
+WHEN (
+    NEW.status IN ('signed','issued') AND
+      (NEW.signed_by = '' OR NEW.signed_at = '' OR NEW.signed_version != NEW.version)
+  ) OR (
+    NEW.status NOT IN ('signed','issued') AND
+      (NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0)
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum signature state mismatch');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_signature_guard_update`
+BEFORE UPDATE ON `protocol_addenda`
+FOR EACH ROW
+WHEN (
+    NEW.status IN ('signed','issued') AND
+      (NEW.signed_by = '' OR NEW.signed_at = '' OR NEW.signed_version != NEW.version)
+  ) OR (
+    NEW.status NOT IN ('signed','issued') AND
+      (NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0)
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum signature state mismatch');
+END;
+--> statement-breakpoint
+
+-- Once signed, the clinical correction, version, author and signature cannot be
+-- rewritten. Delivery is the only permitted transition: signed -> issued.
+CREATE TRIGGER `protocol_addenda_signed_content_immutable`
+BEFORE UPDATE ON `protocol_addenda`
+FOR EACH ROW
+WHEN OLD.status IN ('signed','issued') AND (
+     NEW.reason IS NOT OLD.reason
+  OR NEW.correction_text IS NOT OLD.correction_text
+  OR NEW.version IS NOT OLD.version
+  OR NEW.author_email IS NOT OLD.author_email
+  OR NEW.signed_by IS NOT OLD.signed_by
+  OR NEW.signed_at IS NOT OLD.signed_at
+  OR NEW.signed_version IS NOT OLD.signed_version
+)
+BEGIN
+  SELECT RAISE(ABORT, 'signed protocol addendum content is immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_signed_status_guard`
+BEFORE UPDATE OF `status` ON `protocol_addenda`
+FOR EACH ROW
+WHEN (OLD.status = 'signed' AND NEW.status NOT IN ('signed','issued'))
+   OR (OLD.status = 'issued' AND NEW.status != 'issued')
+BEGIN
+  SELECT RAISE(ABORT, 'signed protocol addendum status is immutable');
+END;
+--> statement-breakpoint
+
+-- Revision rows are permanent medical evidence. No application or maintenance
+-- query may rewrite or delete a saved snapshot.
+CREATE TRIGGER `protocol_addendum_revisions_scope_guard_insert`
+BEFORE INSERT ON `protocol_addendum_revisions`
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1 FROM protocol_addenda a
+  WHERE a.id = NEW.addendum_id
+    AND a.organization_id = NEW.organization_id
+    AND a.booking_id = NEW.booking_id
+    AND a.base_protocol_version = NEW.base_protocol_version
+)
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum revision scope mismatch');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addendum_revisions_append_only_update`
+BEFORE UPDATE ON `protocol_addendum_revisions`
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum revisions are append-only');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addendum_revisions_append_only_delete`
+BEFORE DELETE ON `protocol_addendum_revisions`
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum revisions are append-only');
+END;
+--> statement-breakpoint
+
+-- Audit delivery from the physical state transition so concurrent/repeated
+-- requests can never fabricate duplicate delivery events.
+CREATE TRIGGER `protocol_addendum_issue_event`
+AFTER UPDATE OF `status` ON `protocol_addenda`
+FOR EACH ROW
+WHEN OLD.status = 'signed' AND NEW.status = 'issued'
+BEGIN
+  INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
+  VALUES (
+    NEW.organization_id,
+    NEW.booking_id,
+    'protocol_addendum_issued',
+    'addendum ' || NEW.id || ' · base v' || NEW.base_protocol_version || ' · v' || NEW.version,
+    NEW.updated_by
+  );
+END;

--- a/drizzle/0056_protocol_addendum_lifecycle.sql
+++ b/drizzle/0056_protocol_addendum_lifecycle.sql
@@ -20,7 +20,11 @@ CREATE TABLE `protocol_addenda` (
   `signed_version` integer NOT NULL DEFAULT 0,
   `created_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  CHECK (`length`(`id`) = 32),
+  CHECK (`length`(`id`) = 32 AND `id` NOT GLOB '*[^0-9a-f]*'),
+  CHECK (`length`(`trim`(`reason`)) BETWEEN 1 AND 500),
+  CHECK (`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000),
+  CHECK (`length`(`trim`(`author_email`)) > 0),
+  CHECK (`length`(`trim`(`updated_by`)) > 0),
   CHECK (`status` IN ('draft','ready','signed','issued')),
   CHECK (`base_protocol_version` > 0),
   CHECK (`version` > 0)
@@ -44,6 +48,10 @@ CREATE TABLE `protocol_addendum_revisions` (
   `saved_by` text NOT NULL,
   `created_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE (`addendum_id`, `version`),
+  CHECK (`length`(`addendum_id`) = 32 AND `addendum_id` NOT GLOB '*[^0-9a-f]*'),
+  CHECK (`length`(`trim`(`reason`)) BETWEEN 1 AND 500),
+  CHECK (`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000),
+  CHECK (`length`(`trim`(`saved_by`)) > 0),
   CHECK (`status` IN ('draft','ready','signed')),
   CHECK (`base_protocol_version` > 0),
   CHECK (`version` > 0)

--- a/drizzle/0056_protocol_addendum_lifecycle.sql
+++ b/drizzle/0056_protocol_addendum_lifecycle.sql
@@ -64,6 +64,15 @@ BEGIN
   SELECT RAISE(ABORT, 'protocol addendum base must be issued');
 END;
 --> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_initial_state_guard`
+BEFORE INSERT ON `protocol_addenda`
+FOR EACH ROW
+WHEN NEW.status != 'draft' OR NEW.version != 1
+  OR NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum must start as draft v1');
+END;
+--> statement-breakpoint
 CREATE TRIGGER `protocol_addenda_scope_immutable`
 BEFORE UPDATE OF `organization_id`, `booking_id`, `base_protocol_version` ON `protocol_addenda`
 FOR EACH ROW
@@ -73,6 +82,18 @@ WHEN NEW.organization_id IS NOT OLD.organization_id
 BEGIN
   SELECT RAISE(ABORT, 'protocol addendum scope is immutable');
 END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_identity_immutable`
+BEFORE UPDATE OF `id`, `author_email`, `created_at` ON `protocol_addenda`
+FOR EACH ROW
+WHEN NEW.id IS NOT OLD.id OR NEW.author_email IS NOT OLD.author_email OR NEW.created_at IS NOT OLD.created_at
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum identity is immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_delete_guard`
+BEFORE DELETE ON `protocol_addenda` FOR EACH ROW
+BEGIN SELECT RAISE(ABORT, 'protocol addenda are immutable records'); END;
 --> statement-breakpoint
 
 CREATE TRIGGER `protocol_addenda_signature_guard_insert`
@@ -94,6 +115,30 @@ BEGIN
 END;
 --> statement-breakpoint
 
+CREATE TRIGGER `protocol_addenda_status_transition_guard`
+BEFORE UPDATE OF `status` ON `protocol_addenda`
+FOR EACH ROW
+WHEN (OLD.status = 'draft' AND NEW.status NOT IN ('draft','ready'))
+   OR (OLD.status = 'ready' AND NEW.status NOT IN ('ready','signed'))
+   OR (OLD.status = 'signed' AND NEW.status NOT IN ('signed','issued'))
+   OR (OLD.status = 'issued' AND NEW.status != 'issued')
+BEGIN
+  SELECT RAISE(ABORT, 'invalid protocol addendum status transition');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addenda_edit_version_guard`
+BEFORE UPDATE ON `protocol_addenda`
+FOR EACH ROW
+WHEN OLD.status IN ('draft','ready')
+  AND (
+       NEW.reason IS NOT OLD.reason OR NEW.correction_text IS NOT OLD.correction_text
+    OR NEW.status IS NOT OLD.status OR NEW.version IS NOT OLD.version
+  )
+  AND NEW.version != OLD.version + 1
+BEGIN
+  SELECT RAISE(ABORT, 'protocol addendum edits require next version');
+END;
+--> statement-breakpoint
 CREATE TRIGGER `protocol_addenda_signed_content_immutable`
 BEFORE UPDATE ON `protocol_addenda`
 FOR EACH ROW
@@ -107,26 +152,19 @@ BEGIN
   SELECT RAISE(ABORT, 'signed protocol addendum content is immutable');
 END;
 --> statement-breakpoint
-CREATE TRIGGER `protocol_addenda_signed_status_guard`
-BEFORE UPDATE OF `status` ON `protocol_addenda`
-FOR EACH ROW
-WHEN (OLD.status = 'signed' AND NEW.status NOT IN ('signed','issued'))
-   OR (OLD.status = 'issued' AND NEW.status != 'issued')
-BEGIN
-  SELECT RAISE(ABORT, 'signed protocol addendum status is immutable');
-END;
---> statement-breakpoint
 
-CREATE TRIGGER `protocol_addendum_revisions_scope_guard_insert`
+CREATE TRIGGER `protocol_addendum_revisions_snapshot_guard_insert`
 BEFORE INSERT ON `protocol_addendum_revisions`
 FOR EACH ROW
 WHEN NOT EXISTS (
   SELECT 1 FROM protocol_addenda a
   WHERE a.id = NEW.addendum_id AND a.organization_id = NEW.organization_id
     AND a.booking_id = NEW.booking_id AND a.base_protocol_version = NEW.base_protocol_version
+    AND a.version = NEW.version AND a.reason = NEW.reason
+    AND a.correction_text = NEW.correction_text AND a.status = NEW.status
 )
 BEGIN
-  SELECT RAISE(ABORT, 'protocol addendum revision scope mismatch');
+  SELECT RAISE(ABORT, 'protocol addendum revision must match current document');
 END;
 --> statement-breakpoint
 CREATE TRIGGER `protocol_addendum_revisions_append_only_update`
@@ -136,6 +174,33 @@ BEGIN SELECT RAISE(ABORT, 'protocol addendum revisions are append-only'); END;
 CREATE TRIGGER `protocol_addendum_revisions_append_only_delete`
 BEFORE DELETE ON `protocol_addendum_revisions` FOR EACH ROW
 BEGIN SELECT RAISE(ABORT, 'protocol addendum revisions are append-only'); END;
+--> statement-breakpoint
+
+-- Revision history is database-derived, not best-effort application logging.
+CREATE TRIGGER `protocol_addendum_revision_v1`
+AFTER INSERT ON `protocol_addenda`
+FOR EACH ROW
+BEGIN
+  INSERT INTO protocol_addendum_revisions
+    (addendum_id, organization_id, booking_id, base_protocol_version, version,
+     reason, correction_text, status, saved_by)
+  VALUES
+    (NEW.id, NEW.organization_id, NEW.booking_id, NEW.base_protocol_version, NEW.version,
+     NEW.reason, NEW.correction_text, NEW.status, NEW.updated_by);
+END;
+--> statement-breakpoint
+CREATE TRIGGER `protocol_addendum_revision_next`
+AFTER UPDATE ON `protocol_addenda`
+FOR EACH ROW
+WHEN NEW.version = OLD.version + 1 AND NEW.status IN ('draft','ready','signed')
+BEGIN
+  INSERT INTO protocol_addendum_revisions
+    (addendum_id, organization_id, booking_id, base_protocol_version, version,
+     reason, correction_text, status, saved_by)
+  VALUES
+    (NEW.id, NEW.organization_id, NEW.booking_id, NEW.base_protocol_version, NEW.version,
+     NEW.reason, NEW.correction_text, NEW.status, NEW.updated_by);
+END;
 --> statement-breakpoint
 
 CREATE TRIGGER `protocol_addendum_issue_event`

--- a/drizzle/0056_protocol_addendum_lifecycle.sql
+++ b/drizzle/0056_protocol_addendum_lifecycle.sql
@@ -5,7 +5,7 @@
 -- before it may be delivered to the patient.
 
 CREATE TABLE `protocol_addenda` (
-  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `id` text PRIMARY KEY NOT NULL,
   `organization_id` integer NOT NULL,
   `booking_id` integer NOT NULL,
   `base_protocol_version` integer NOT NULL,
@@ -20,21 +20,20 @@ CREATE TABLE `protocol_addenda` (
   `signed_version` integer NOT NULL DEFAULT 0,
   `created_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (`length`(`id`) = 32),
   CHECK (`status` IN ('draft','ready','signed','issued')),
   CHECK (`base_protocol_version` > 0),
   CHECK (`version` > 0)
 );
 --> statement-breakpoint
-CREATE INDEX `protocol_addenda_org_booking_idx`
-ON `protocol_addenda` (`organization_id`, `booking_id`, `created_at`);
+CREATE INDEX `protocol_addenda_org_booking_idx` ON `protocol_addenda` (`organization_id`, `booking_id`, `created_at`);
 --> statement-breakpoint
-CREATE INDEX `protocol_addenda_status_idx`
-ON `protocol_addenda` (`organization_id`, `status`, `updated_at`);
+CREATE INDEX `protocol_addenda_status_idx` ON `protocol_addenda` (`organization_id`, `status`, `updated_at`);
 --> statement-breakpoint
 
 CREATE TABLE `protocol_addendum_revisions` (
   `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-  `addendum_id` integer NOT NULL,
+  `addendum_id` text NOT NULL,
   `organization_id` integer NOT NULL,
   `booking_id` integer NOT NULL,
   `base_protocol_version` integer NOT NULL,
@@ -50,21 +49,16 @@ CREATE TABLE `protocol_addendum_revisions` (
   CHECK (`version` > 0)
 );
 --> statement-breakpoint
-CREATE INDEX `protocol_addendum_revisions_scope_idx`
-ON `protocol_addendum_revisions` (`organization_id`, `booking_id`, `addendum_id`, `version`);
+CREATE INDEX `protocol_addendum_revisions_scope_idx` ON `protocol_addendum_revisions` (`organization_id`, `booking_id`, `addendum_id`, `version`);
 --> statement-breakpoint
 
--- An addendum may only belong to the same tenant/booking as an already issued
--- base report and must remain anchored to that exact immutable base version.
 CREATE TRIGGER `protocol_addenda_base_guard_insert`
 BEFORE INSERT ON `protocol_addenda`
 FOR EACH ROW
 WHEN NOT EXISTS (
   SELECT 1 FROM protocols p
-  WHERE p.organization_id = NEW.organization_id
-    AND p.booking_id = NEW.booking_id
-    AND p.status = 'issued'
-    AND p.version = NEW.base_protocol_version
+  WHERE p.organization_id = NEW.organization_id AND p.booking_id = NEW.booking_id
+    AND p.status = 'issued' AND p.version = NEW.base_protocol_version
 )
 BEGIN
   SELECT RAISE(ABORT, 'protocol addendum base must be issued');
@@ -81,17 +75,11 @@ BEGIN
 END;
 --> statement-breakpoint
 
--- Signature metadata and lifecycle state must always agree.
 CREATE TRIGGER `protocol_addenda_signature_guard_insert`
 BEFORE INSERT ON `protocol_addenda`
 FOR EACH ROW
-WHEN (
-    NEW.status IN ('signed','issued') AND
-      (NEW.signed_by = '' OR NEW.signed_at = '' OR NEW.signed_version != NEW.version)
-  ) OR (
-    NEW.status NOT IN ('signed','issued') AND
-      (NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0)
-  )
+WHEN (NEW.status IN ('signed','issued') AND (NEW.signed_by = '' OR NEW.signed_at = '' OR NEW.signed_version != NEW.version))
+   OR (NEW.status NOT IN ('signed','issued') AND (NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0))
 BEGIN
   SELECT RAISE(ABORT, 'protocol addendum signature state mismatch');
 END;
@@ -99,30 +87,20 @@ END;
 CREATE TRIGGER `protocol_addenda_signature_guard_update`
 BEFORE UPDATE ON `protocol_addenda`
 FOR EACH ROW
-WHEN (
-    NEW.status IN ('signed','issued') AND
-      (NEW.signed_by = '' OR NEW.signed_at = '' OR NEW.signed_version != NEW.version)
-  ) OR (
-    NEW.status NOT IN ('signed','issued') AND
-      (NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0)
-  )
+WHEN (NEW.status IN ('signed','issued') AND (NEW.signed_by = '' OR NEW.signed_at = '' OR NEW.signed_version != NEW.version))
+   OR (NEW.status NOT IN ('signed','issued') AND (NEW.signed_by != '' OR NEW.signed_at != '' OR NEW.signed_version != 0))
 BEGIN
   SELECT RAISE(ABORT, 'protocol addendum signature state mismatch');
 END;
 --> statement-breakpoint
 
--- Once signed, the clinical correction, version, author and signature cannot be
--- rewritten. Delivery is the only permitted transition: signed -> issued.
 CREATE TRIGGER `protocol_addenda_signed_content_immutable`
 BEFORE UPDATE ON `protocol_addenda`
 FOR EACH ROW
 WHEN OLD.status IN ('signed','issued') AND (
-     NEW.reason IS NOT OLD.reason
-  OR NEW.correction_text IS NOT OLD.correction_text
-  OR NEW.version IS NOT OLD.version
-  OR NEW.author_email IS NOT OLD.author_email
-  OR NEW.signed_by IS NOT OLD.signed_by
-  OR NEW.signed_at IS NOT OLD.signed_at
+     NEW.reason IS NOT OLD.reason OR NEW.correction_text IS NOT OLD.correction_text
+  OR NEW.version IS NOT OLD.version OR NEW.author_email IS NOT OLD.author_email
+  OR NEW.signed_by IS NOT OLD.signed_by OR NEW.signed_at IS NOT OLD.signed_at
   OR NEW.signed_version IS NOT OLD.signed_version
 )
 BEGIN
@@ -139,50 +117,33 @@ BEGIN
 END;
 --> statement-breakpoint
 
--- Revision rows are permanent medical evidence. No application or maintenance
--- query may rewrite or delete a saved snapshot.
 CREATE TRIGGER `protocol_addendum_revisions_scope_guard_insert`
 BEFORE INSERT ON `protocol_addendum_revisions`
 FOR EACH ROW
 WHEN NOT EXISTS (
   SELECT 1 FROM protocol_addenda a
-  WHERE a.id = NEW.addendum_id
-    AND a.organization_id = NEW.organization_id
-    AND a.booking_id = NEW.booking_id
-    AND a.base_protocol_version = NEW.base_protocol_version
+  WHERE a.id = NEW.addendum_id AND a.organization_id = NEW.organization_id
+    AND a.booking_id = NEW.booking_id AND a.base_protocol_version = NEW.base_protocol_version
 )
 BEGIN
   SELECT RAISE(ABORT, 'protocol addendum revision scope mismatch');
 END;
 --> statement-breakpoint
 CREATE TRIGGER `protocol_addendum_revisions_append_only_update`
-BEFORE UPDATE ON `protocol_addendum_revisions`
-FOR EACH ROW
-BEGIN
-  SELECT RAISE(ABORT, 'protocol addendum revisions are append-only');
-END;
+BEFORE UPDATE ON `protocol_addendum_revisions` FOR EACH ROW
+BEGIN SELECT RAISE(ABORT, 'protocol addendum revisions are append-only'); END;
 --> statement-breakpoint
 CREATE TRIGGER `protocol_addendum_revisions_append_only_delete`
-BEFORE DELETE ON `protocol_addendum_revisions`
-FOR EACH ROW
-BEGIN
-  SELECT RAISE(ABORT, 'protocol addendum revisions are append-only');
-END;
+BEFORE DELETE ON `protocol_addendum_revisions` FOR EACH ROW
+BEGIN SELECT RAISE(ABORT, 'protocol addendum revisions are append-only'); END;
 --> statement-breakpoint
 
--- Audit delivery from the physical state transition so concurrent/repeated
--- requests can never fabricate duplicate delivery events.
 CREATE TRIGGER `protocol_addendum_issue_event`
 AFTER UPDATE OF `status` ON `protocol_addenda`
-FOR EACH ROW
-WHEN OLD.status = 'signed' AND NEW.status = 'issued'
+FOR EACH ROW WHEN OLD.status = 'signed' AND NEW.status = 'issued'
 BEGIN
   INSERT INTO booking_events (organization_id, booking_id, action, details, actor)
-  VALUES (
-    NEW.organization_id,
-    NEW.booking_id,
-    'protocol_addendum_issued',
+  VALUES (NEW.organization_id, NEW.booking_id, 'protocol_addendum_issued',
     'addendum ' || NEW.id || ' · base v' || NEW.base_protocol_version || ' · v' || NEW.version,
-    NEW.updated_by
-  );
+    NEW.updated_by);
 END;

--- a/tests/protocol-addendum-lifecycle.behavior.test.mjs
+++ b/tests/protocol-addendum-lifecycle.behavior.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedPatientSession, withD1 } from "./helpers/d1.mjs";
+
+const PHONE = "380971112233";
+const CODE = "RD-ADD001";
+const ADDENDUM = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const ADDENDUM_HIDDEN = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function seedBooking(raw, { code = CODE, protocolStatus = "issued" } = {}) {
+  const result = raw.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, phone_normalized, date_of_birth,
+       service, desired_date, desired_time, status, protocol_status, protocol_issued_at)
+     VALUES (1, ?, 'Пацієнт Addendum', ?, ?, '1980-01-02',
+       'КТ ОГК', '2026-09-20', '10:00', 'completed', ?,
+       CASE WHEN ? = 'issued' THEN CURRENT_TIMESTAMP ELSE '' END)`,
+  ).run(code, `+${PHONE}`, PHONE, protocolStatus, protocolStatus);
+  return Number(result.lastInsertRowid);
+}
+
+function seedProtocol(raw, bookingId, status = "issued") {
+  if (status === "issued") {
+    raw.prepare(
+      `INSERT INTO protocols
+        (organization_id, booking_id, number, status, version, author_email, updated_by,
+         findings, conclusion, signed_by, signed_at, signed_version)
+       VALUES (1, ?, 'P-ADD-1', 'issued', 1, 'radiologist@example.com', 'radiologist@example.com',
+         'Основний опис', 'Основний висновок', 'radiologist@example.com', CURRENT_TIMESTAMP, 1)`,
+    ).run(bookingId);
+  } else {
+    raw.prepare(
+      `INSERT INTO protocols
+        (organization_id, booking_id, number, status, version, author_email, updated_by,
+         findings, conclusion)
+       VALUES (1, ?, 'P-DRAFT-1', 'draft', 1, 'radiologist@example.com', 'radiologist@example.com',
+         'Чернетка', 'Чернетка')`,
+    ).run(bookingId);
+  }
+}
+
+function insertDraftAddendum(raw, bookingId, id = ADDENDUM, text = "Початкове виправлення") {
+  raw.prepare(
+    `INSERT INTO protocol_addenda
+      (id, organization_id, booking_id, base_protocol_version, reason, correction_text,
+       status, version, author_email, updated_by)
+     VALUES (?, 1, ?, 1, 'Уточнення формулювання', ?, 'draft', 1,
+       'radiologist@example.com', 'radiologist@example.com')`,
+  ).run(id, bookingId, text);
+}
+
+test("D1 enforces addendum base, lifecycle, immutable identity and append-only revision history", async () => {
+  await withD1(async (_db, raw) => {
+    const draftBooking = seedBooking(raw, { code: "RD-ADD-DRAFT", protocolStatus: "draft" });
+    seedProtocol(raw, draftBooking, "draft");
+
+    assert.throws(() => {
+      raw.prepare(
+        `INSERT INTO protocol_addenda
+          (id, organization_id, booking_id, base_protocol_version, reason, correction_text,
+           status, version, author_email, updated_by)
+         VALUES ('cccccccccccccccccccccccccccccccc', 1, ?, 1, 'Причина', 'Текст',
+           'draft', 1, 'radiologist@example.com', 'radiologist@example.com')`,
+      ).run(draftBooking);
+    }, /base must be issued/);
+
+    const bookingId = seedBooking(raw);
+    seedProtocol(raw, bookingId);
+
+    assert.throws(() => {
+      raw.prepare(
+        `INSERT INTO protocol_addenda
+          (id, organization_id, booking_id, base_protocol_version, reason, correction_text,
+           status, version, author_email, updated_by, signed_by, signed_at, signed_version)
+         VALUES ('dddddddddddddddddddddddddddddddd', 1, ?, 1, 'Причина', 'Текст',
+           'issued', 1, 'radiologist@example.com', 'radiologist@example.com',
+           'radiologist@example.com', CURRENT_TIMESTAMP, 1)`,
+      ).run(bookingId);
+    }, /must start as draft v1/);
+
+    insertDraftAddendum(raw, bookingId);
+
+    let revisions = raw.prepare(
+      `SELECT version, status, correction_text AS correctionText
+       FROM protocol_addendum_revisions WHERE addendum_id = ? ORDER BY version`,
+    ).all(ADDENDUM);
+    assert.deepEqual(revisions, [{ version: 1, status: "draft", correctionText: "Початкове виправлення" }]);
+
+    assert.throws(() => {
+      raw.prepare(`UPDATE protocol_addendum_revisions SET correction_text = 'tamper' WHERE addendum_id = ?`).run(ADDENDUM);
+    }, /append-only/);
+    assert.throws(() => {
+      raw.prepare(`DELETE FROM protocol_addendum_revisions WHERE addendum_id = ?`).run(ADDENDUM);
+    }, /append-only/);
+    assert.throws(() => {
+      raw.prepare(`DELETE FROM protocol_addenda WHERE id = ?`).run(ADDENDUM);
+    }, /immutable records/);
+
+    assert.throws(() => {
+      raw.prepare(
+        `UPDATE protocol_addenda
+         SET correction_text = 'Без нової версії', updated_by = 'radiologist@example.com'
+         WHERE id = ?`,
+      ).run(ADDENDUM);
+    }, /require next version/);
+
+    assert.throws(() => {
+      raw.prepare(
+        `UPDATE protocol_addenda
+         SET status = 'signed', version = 2, signed_by = 'radiologist@example.com',
+             signed_at = CURRENT_TIMESTAMP, signed_version = 2, updated_by = 'radiologist@example.com'
+         WHERE id = ?`,
+      ).run(ADDENDUM);
+    }, /invalid protocol addendum status transition/);
+
+    raw.prepare(
+      `UPDATE protocol_addenda
+       SET correction_text = 'Уточнений текст', status = 'ready', version = 2,
+           updated_by = 'radiologist@example.com', updated_at = CURRENT_TIMESTAMP
+       WHERE id = ?`,
+    ).run(ADDENDUM);
+
+    raw.prepare(
+      `UPDATE protocol_addenda
+       SET status = 'signed', version = 3, updated_by = 'radiologist@example.com',
+           signed_by = 'radiologist@example.com', signed_at = CURRENT_TIMESTAMP, signed_version = 3,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = ?`,
+    ).run(ADDENDUM);
+
+    revisions = raw.prepare(
+      `SELECT version, status, correction_text AS correctionText
+       FROM protocol_addendum_revisions WHERE addendum_id = ? ORDER BY version`,
+    ).all(ADDENDUM);
+    assert.deepEqual(revisions, [
+      { version: 1, status: "draft", correctionText: "Початкове виправлення" },
+      { version: 2, status: "ready", correctionText: "Уточнений текст" },
+      { version: 3, status: "signed", correctionText: "Уточнений текст" },
+    ]);
+
+    assert.throws(() => {
+      raw.prepare(`UPDATE protocol_addenda SET correction_text = 'tamper' WHERE id = ?`).run(ADDENDUM);
+    }, /signed protocol addendum content is immutable/);
+    assert.throws(() => {
+      raw.prepare(`UPDATE protocol_addenda SET id = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' WHERE id = ?`).run(ADDENDUM);
+    }, /identity is immutable/);
+    assert.throws(() => {
+      raw.prepare(`UPDATE protocol_addenda SET organization_id = 2 WHERE id = ?`).run(ADDENDUM);
+    }, /scope is immutable/);
+
+    raw.prepare(
+      `UPDATE protocol_addenda
+       SET status = 'issued', updated_by = 'registrar@example.com', updated_at = CURRENT_TIMESTAMP
+       WHERE id = ?`,
+    ).run(ADDENDUM);
+
+    let issueEvents = raw.prepare(
+      `SELECT action, actor FROM booking_events
+       WHERE booking_id = ? AND action = 'protocol_addendum_issued'`,
+    ).all(bookingId);
+    assert.deepEqual(issueEvents, [{ action: "protocol_addendum_issued", actor: "registrar@example.com" }]);
+
+    raw.prepare(
+      `UPDATE protocol_addenda SET status = 'issued', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).run(ADDENDUM);
+    issueEvents = raw.prepare(
+      `SELECT action FROM booking_events
+       WHERE booking_id = ? AND action = 'protocol_addendum_issued'`,
+    ).all(bookingId);
+    assert.equal(issueEvents.length, 1);
+  });
+});
+
+test("patient protocol returns issued addenda only", async () => {
+  await withD1(async (db, raw) => {
+    const bookingId = seedBooking(raw);
+    seedProtocol(raw, bookingId);
+
+    insertDraftAddendum(raw, bookingId, ADDENDUM, "Видимий текст після видачі");
+    raw.prepare(
+      `UPDATE protocol_addenda SET status = 'ready', version = 2,
+         updated_by = 'radiologist@example.com', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).run(ADDENDUM);
+    raw.prepare(
+      `UPDATE protocol_addenda SET status = 'signed', version = 3,
+         updated_by = 'radiologist@example.com', signed_by = 'radiologist@example.com',
+         signed_at = CURRENT_TIMESTAMP, signed_version = 3, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).run(ADDENDUM);
+    raw.prepare(
+      `UPDATE protocol_addenda SET status = 'issued', updated_by = 'registrar@example.com',
+         updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).run(ADDENDUM);
+
+    insertDraftAddendum(raw, bookingId, ADDENDUM_HIDDEN, "Секретна чернетка");
+    raw.prepare(
+      `UPDATE protocol_addenda SET status = 'ready', version = 2,
+         updated_by = 'radiologist@example.com', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).run(ADDENDUM_HIDDEN);
+    raw.prepare(
+      `UPDATE protocol_addenda SET status = 'signed', version = 3,
+         updated_by = 'radiologist@example.com', signed_by = 'radiologist@example.com',
+         signed_at = CURRENT_TIMESTAMP, signed_version = 3, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    ).run(ADDENDUM_HIDDEN);
+
+    const cookie = await seedPatientSession(db, PHONE, 1, { kind: "booking", value: CODE });
+    const response = await callWorker(
+      jsonRequest("/api/my-protocol", { code: CODE }, { method: "POST", headers: { cookie } }),
+      db,
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.protocol.conclusion, "Основний висновок");
+    assert.equal(body.protocol.addenda.length, 1);
+    assert.equal(body.protocol.addenda[0].id, ADDENDUM);
+    assert.equal(body.protocol.addenda[0].correctionText, "Видимий текст після видачі");
+    assert.equal(body.protocol.addenda[0].version, 3);
+    assert.doesNotMatch(JSON.stringify(body), /Секретна чернетка|bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/);
+  });
+});

--- a/tests/protocol-addendum-lifecycle.behavior.test.mjs
+++ b/tests/protocol-addendum-lifecycle.behavior.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { callWorker, jsonRequest, seedPatientSession, withD1 } from "./helpers/d1.mjs";
+import { callWorker, jsonRequest, seedPatientSession, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
 const PHONE = "380971112233";
 const CODE = "RD-260920-1";
@@ -11,15 +11,16 @@ function plainRows(rows) {
   return rows.map((row) => ({ ...row }));
 }
 
-function seedBooking(raw, { code = CODE, protocolStatus = "issued" } = {}) {
+function seedBooking(raw, { code = CODE, protocolStatus = "issued", assignedRadiologistEmail = "" } = {}) {
   const result = raw.prepare(
     `INSERT INTO bookings
       (organization_id, code, name, phone, phone_normalized, date_of_birth,
-       service, desired_date, desired_time, status, protocol_status, protocol_issued_at)
+       service, desired_date, desired_time, status, protocol_status, protocol_issued_at,
+       assigned_radiologist_email)
      VALUES (1, ?, 'Пацієнт Addendum', ?, ?, '1980-01-02',
        'КТ ОГК', '2026-09-20', '10:00', 'completed', ?,
-       CASE WHEN ? = 'issued' THEN CURRENT_TIMESTAMP ELSE '' END)`,
-  ).run(code, `+${PHONE}`, PHONE, protocolStatus, protocolStatus);
+       CASE WHEN ? = 'issued' THEN CURRENT_TIMESTAMP ELSE '' END, ?)`,
+  ).run(code, `+${PHONE}`, PHONE, protocolStatus, protocolStatus, assignedRadiologistEmail);
   return Number(result.lastInsertRowid);
 }
 
@@ -172,6 +173,132 @@ test("D1 enforces addendum base, lifecycle, immutable identity and append-only r
        WHERE booking_id = ? AND action = 'protocol_addendum_issued'`,
     ).all(bookingId);
     assert.equal(issueEvents.length, 1);
+  });
+});
+
+test("staff API preserves signer separation and rejects stale addendum versions", async () => {
+  await withD1(async (db, raw) => {
+    const doctorEmail = "addendum-doctor@example.com";
+    const adminCookie = await seedStaffSession(db, { email:"addendum-admin@example.com", role:"admin" });
+    const doctorCookie = await seedStaffSession(db, { email:doctorEmail, role:"radiologist" });
+    const bookingId = seedBooking(raw, {
+      code:"RD-260920-3",
+      assignedRadiologistEmail:doctorEmail,
+    });
+    seedProtocol(raw, bookingId);
+
+    const createResponse = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        bookingId,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+      }, { method:"POST", headers:{ cookie:adminCookie } }),
+      db,
+    );
+    assert.equal(createResponse.status, 201);
+    const created = await createResponse.json();
+    const id = created.addendum.id;
+    assert.equal(created.addendum.status, "draft");
+    assert.equal(created.addendum.version, 1);
+
+    const readyResponse = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        id, baseVersion:1,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+        status:"ready",
+      }, { method:"PUT", headers:{ cookie:adminCookie } }),
+      db,
+    );
+    assert.equal(readyResponse.status, 200);
+    const ready = await readyResponse.json();
+    assert.equal(ready.addendum.version, 2);
+    assert.equal(ready.addendum.status, "ready");
+
+    const adminSignResponse = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        id, baseVersion:2,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+        status:"signed",
+      }, { method:"PUT", headers:{ cookie:adminCookie } }),
+      db,
+    );
+    assert.equal(adminSignResponse.status, 403);
+
+    const staleSignResponse = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        id, baseVersion:1,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+        status:"signed",
+      }, { method:"PUT", headers:{ cookie:doctorCookie } }),
+      db,
+    );
+    assert.equal(staleSignResponse.status, 409);
+
+    let revisions = await db.prepare(
+      `SELECT version, status FROM protocol_addendum_revisions
+       WHERE organization_id=1 AND addendum_id=? ORDER BY version`,
+    ).bind(id).all();
+    assert.deepEqual(revisions.results.map((row) => [row.version, row.status]), [
+      [1, "draft"], [2, "ready"],
+    ]);
+
+    const signResponse = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        id, baseVersion:2,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+        status:"signed",
+      }, { method:"PUT", headers:{ cookie:doctorCookie } }),
+      db,
+    );
+    assert.equal(signResponse.status, 200);
+    const signed = await signResponse.json();
+    assert.equal(signed.addendum.status, "signed");
+    assert.equal(signed.addendum.version, 3);
+    assert.equal(signed.addendum.signedBy, doctorEmail);
+    assert.ok(signed.addendum.signedAt);
+
+    const issueResponse = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        id, baseVersion:3,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+        status:"issued",
+      }, { method:"PUT", headers:{ cookie:adminCookie } }),
+      db,
+    );
+    assert.equal(issueResponse.status, 200);
+    const issued = await issueResponse.json();
+    assert.equal(issued.addendum.status, "issued");
+    assert.equal(issued.addendum.version, 3, "issuance must not create a clinical revision");
+    assert.equal(issued.addendum.signedBy, doctorEmail);
+
+    const repeatedIssue = await callWorker(
+      jsonRequest("/api/staff/protocols/addenda", {
+        id, baseVersion:3,
+        reason:"Уточнення сторони у висновку",
+        correctionText:"У висновку слід читати: зміни зліва.",
+        status:"issued",
+      }, { method:"PUT", headers:{ cookie:adminCookie } }),
+      db,
+    );
+    assert.equal(repeatedIssue.status, 409);
+
+    revisions = await db.prepare(
+      `SELECT version, status FROM protocol_addendum_revisions
+       WHERE organization_id=1 AND addendum_id=? ORDER BY version`,
+    ).bind(id).all();
+    assert.deepEqual(revisions.results.map((row) => [row.version, row.status]), [
+      [1, "draft"], [2, "ready"], [3, "signed"],
+    ]);
+    const eventCount = await db.prepare(
+      `SELECT COUNT(*) AS count FROM booking_events
+       WHERE organization_id=1 AND booking_id=? AND action='protocol_addendum_issued'`,
+    ).bind(bookingId).first();
+    assert.equal(Number(eventCount.count), 1);
   });
 });
 

--- a/tests/protocol-addendum-lifecycle.behavior.test.mjs
+++ b/tests/protocol-addendum-lifecycle.behavior.test.mjs
@@ -3,9 +3,13 @@ import test from "node:test";
 import { callWorker, jsonRequest, seedPatientSession, withD1 } from "./helpers/d1.mjs";
 
 const PHONE = "380971112233";
-const CODE = "RD-ADD001";
+const CODE = "RD-260920-1";
 const ADDENDUM = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const ADDENDUM_HIDDEN = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function plainRows(rows) {
+  return rows.map((row) => ({ ...row }));
+}
 
 function seedBooking(raw, { code = CODE, protocolStatus = "issued" } = {}) {
   const result = raw.prepare(
@@ -51,7 +55,7 @@ function insertDraftAddendum(raw, bookingId, id = ADDENDUM, text = "Початк
 
 test("D1 enforces addendum base, lifecycle, immutable identity and append-only revision history", async () => {
   await withD1(async (_db, raw) => {
-    const draftBooking = seedBooking(raw, { code: "RD-ADD-DRAFT", protocolStatus: "draft" });
+    const draftBooking = seedBooking(raw, { code: "RD-260920-2", protocolStatus: "draft" });
     seedProtocol(raw, draftBooking, "draft");
 
     assert.throws(() => {
@@ -84,7 +88,7 @@ test("D1 enforces addendum base, lifecycle, immutable identity and append-only r
       `SELECT version, status, correction_text AS correctionText
        FROM protocol_addendum_revisions WHERE addendum_id = ? ORDER BY version`,
     ).all(ADDENDUM);
-    assert.deepEqual(revisions, [{ version: 1, status: "draft", correctionText: "Початкове виправлення" }]);
+    assert.deepEqual(plainRows(revisions), [{ version: 1, status: "draft", correctionText: "Початкове виправлення" }]);
 
     assert.throws(() => {
       raw.prepare(`UPDATE protocol_addendum_revisions SET correction_text = 'tamper' WHERE addendum_id = ?`).run(ADDENDUM);
@@ -132,7 +136,7 @@ test("D1 enforces addendum base, lifecycle, immutable identity and append-only r
       `SELECT version, status, correction_text AS correctionText
        FROM protocol_addendum_revisions WHERE addendum_id = ? ORDER BY version`,
     ).all(ADDENDUM);
-    assert.deepEqual(revisions, [
+    assert.deepEqual(plainRows(revisions), [
       { version: 1, status: "draft", correctionText: "Початкове виправлення" },
       { version: 2, status: "ready", correctionText: "Уточнений текст" },
       { version: 3, status: "signed", correctionText: "Уточнений текст" },
@@ -158,7 +162,7 @@ test("D1 enforces addendum base, lifecycle, immutable identity and append-only r
       `SELECT action, actor FROM booking_events
        WHERE booking_id = ? AND action = 'protocol_addendum_issued'`,
     ).all(bookingId);
-    assert.deepEqual(issueEvents, [{ action: "protocol_addendum_issued", actor: "registrar@example.com" }]);
+    assert.deepEqual(plainRows(issueEvents), [{ action: "protocol_addendum_issued", actor: "registrar@example.com" }]);
 
     raw.prepare(
       `UPDATE protocol_addenda SET status = 'issued', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,


### PR DESCRIPTION
## Summary
- keep the original issued radiology protocol immutable
- add separate correction/addendum documents anchored to the exact issued base protocol version
- enforce lifecycle and append-only revision history at the D1 layer
- require radiologist-only clinical signing while allowing administrative issuance after signature
- derive issuance audit from the real signed → issued transition
- return addendum revision history to authorized staff
- expose only issued addenda in the patient protocol endpoint
- reject oversized clinical correction text instead of silently truncating it
- add focused D1, staff-role, stale-version and patient-delivery behavioral coverage

## Safety invariants
- addenda can only start as draft v1 against an issued base protocol
- identifiers, tenant/booking scope, base version, author and creation provenance are immutable
- addenda and revisions cannot be deleted or rewritten
- draft/ready edits must advance exactly one version
- status transitions cannot skip required states
- signed/issued clinical content and signature metadata cannot change
- revision rows are database-derived exact snapshots
- admin cannot become the clinical signer
- stale writers fail closed without appending a revision
- patient cabinet never exposes draft/ready/signed-but-not-issued corrections

## Validation
- CI #921: green (install, audit, lint, typecheck, build, tests, production release gate)
- CodeQL #836: green

Staff UI integration is intentionally kept for a follow-up PR so this change remains focused on clinical data integrity and API behavior.

No production deploy in this PR.