### PR TITLE
Add staff UI for protocol corrections

### DIFF
--- a/app/staff/protocols/corrections/page.module.css
+++ b/app/staff/protocols/corrections/page.module.css
@@ -1,0 +1,57 @@
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(250px, 340px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.queue,
+.content {
+  min-width: 0;
+}
+
+.queue {
+  position: sticky;
+  top: 82px;
+  max-height: calc(100vh - 112px);
+  overflow: auto;
+  border: 1px solid var(--line, #d9e0e8);
+  border-radius: 14px;
+  background: var(--surface, #fff);
+}
+
+.tools {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  padding: 14px;
+  border-bottom: 1px solid var(--line, #d9e0e8);
+  background: inherit;
+}
+
+.tools input { grid-column: 1 / -1; width: 100%; }
+.list { display: grid; gap: 7px; padding: 10px; }
+.item,
+.activeItem { display: grid; gap: 3px; text-align: left; padding: 11px 12px; border: 1px solid var(--line, #d9e0e8); border-radius: 10px; background: transparent; }
+.activeItem { outline: 2px solid currentColor; outline-offset: 1px; }
+.item span,
+.activeItem span { font-size: .86rem; }
+.item small,
+.activeItem small { opacity: .68; }
+
+.content { display: grid; gap: 16px; }
+.selectedHead { display: flex; justify-content: space-between; align-items: flex-start; gap: 18px; padding: 18px 20px; border: 1px solid var(--line, #d9e0e8); border-radius: 14px; background: var(--surface, #fff); }
+.selectedHead h2 { margin: 3px 0 5px; }
+.selectedHead p { margin: 0; }
+.selectedHead a { white-space: nowrap; font-weight: 700; }
+.eyebrow { font-size: .75rem; font-weight: 800; text-transform: uppercase; letter-spacing: .06em; opacity: .65; }
+.placeholder { padding: 40px 24px; text-align: center; border: 1px dashed var(--line, #d9e0e8); border-radius: 14px; }
+.muted { opacity: .65; padding: 8px; }
+
+@media (max-width: 980px) {
+  .workspace { grid-template-columns: 1fr; }
+  .queue { position: static; max-height: 340px; }
+}

--- a/app/staff/protocols/corrections/page.tsx
+++ b/app/staff/protocols/corrections/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+import ProtocolAddendaPanel from "../protocol-addenda-panel";
+import styles from "./page.module.css";
+
+type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer";
+type StaffInfo = { email:string; displayName:string; role:StaffRole };
+type QueueItem = {
+  id:number;
+  code:string;
+  name:string;
+  service:string;
+  serviceTitle:string;
+  desiredDate:string;
+  desiredTime:string;
+  protocolNumber:string;
+  protocolStatus:string;
+  protocolIssuedAt:string;
+  documentStatus:string;
+  documentVersion:number;
+};
+
+const roleLabels:Record<StaffRole,string> = {
+  admin:"Адміністратор",
+  registrar:"Реєстратор",
+  radiologist:"Лікар-рентгенолог",
+  radiographer:"Рентгенолаборант",
+};
+
+function formatDateTime(value:string) {
+  if (!value) return "—";
+  const parsed = new Date(value.includes("T") ? value : value.replace(" ", "T") + "Z");
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString("uk-UA");
+}
+
+export default function ProtocolCorrectionsPage() {
+  const [queue,setQueue] = useState<QueueItem[]>([]);
+  const [staff,setStaff] = useState<StaffInfo | null>(null);
+  const [selectedId,setSelectedId] = useState<number | null>(null);
+  const [query,setQuery] = useState("");
+  const [error,setError] = useState("");
+  const [loading,setLoading] = useState(true);
+
+  useEffect(()=>{
+    const controller = new AbortController();
+    async function load() {
+      try {
+        const response = await fetch("/api/staff/protocols", { cache:"no-store", signal:controller.signal });
+        const data = await response.json() as { queue?:QueueItem[]; staff?:StaffInfo; error?:string };
+        if (!response.ok) {
+          setError(data.error || "Немає доступу");
+          return;
+        }
+        setQueue(data.queue || []);
+        setStaff(data.staff || null);
+      } catch (cause) {
+        if (!(cause instanceof DOMException && cause.name === "AbortError")) setError("Не вдалося завантажити видані протоколи");
+      } finally {
+        setLoading(false);
+      }
+    }
+    void load();
+    return ()=>controller.abort();
+  },[]);
+
+  const issued = useMemo(()=>queue
+    .filter((item)=>item.documentStatus === "issued" || item.protocolStatus === "issued")
+    .filter((item)=>!query.trim() || `${item.code} ${item.name} ${item.serviceTitle} ${item.service}`.toLowerCase().includes(query.trim().toLowerCase())),
+  [queue,query]);
+
+  useEffect(()=>{
+    if (selectedId !== null || issued.length === 0) return;
+    const requested = Number(new URLSearchParams(window.location.search).get("open"));
+    const initial = issued.find((item)=>item.id === requested) || issued[0];
+    setSelectedId(initial.id);
+  },[issued,selectedId]);
+
+  const selected = issued.find((item)=>item.id === selectedId) || null;
+  const canManage = staff?.role === "admin" || staff?.role === "radiologist";
+
+  return <StaffWorkspaceShell
+    active="protocols"
+    title="Виправлення до виданих протоколів"
+    description="Окремі підписані доповнення без зміни оригінального медичного документа."
+    staffName={staff?.displayName || staff?.email}
+    staffRole={staff ? roleLabels[staff.role] : undefined}
+  >
+    {error ? <section className="accessDenied"><b>Захищений розділ</b><p>{error}</p></section>
+      : !loading && staff && !canManage ? <section className="accessDenied">
+        <b>Недостатньо прав</b>
+        <p>Створювати та редагувати виправлення можуть лише лікар-рентгенолог або адміністратор. Підписувати — лише лікар-рентгенолог.</p>
+      </section>
+      : <div className={styles.workspace}>
+        <aside className={styles.queue} aria-label="Видані протоколи">
+          <div className={styles.tools}>
+            <b>Видані протоколи</b>
+            <span>{issued.length}</span>
+            <input type="search" value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Код, ПІБ, дослідження"/>
+          </div>
+          <div className={styles.list}>
+            {loading ? <p className={styles.muted}>Завантаження…</p>
+              : issued.length === 0 ? <p className={styles.muted}>Виданих протоколів не знайдено.</p>
+                : issued.map((item)=><button type="button" key={item.id}
+                  className={item.id === selectedId ? styles.activeItem : styles.item}
+                  onClick={()=>setSelectedId(item.id)}>
+                  <b>{item.serviceTitle || item.service}</b>
+                  <span>{item.code} · {item.name}</span>
+                  <small>Протокол {item.protocolNumber || "—"} · v{item.documentVersion || 1}</small>
+                  <small>Видано: {formatDateTime(item.protocolIssuedAt)}</small>
+                </button>)}
+          </div>
+        </aside>
+
+        <main className={styles.content}>
+          {!selected ? <section className={styles.placeholder}>
+            <b>Оберіть виданий протокол</b>
+            <p>Виправлення створюється як окремий документ і не переписує первинний протокол.</p>
+          </section> : <>
+            <header className={styles.selectedHead}>
+              <div>
+                <p className={styles.eyebrow}>Виданий протокол</p>
+                <h2>{selected.serviceTitle || selected.service}</h2>
+                <p>{selected.code} · {selected.name}</p>
+              </div>
+              <a href={`/staff/protocols?open=${selected.id}`}>Відкрити оригінал</a>
+            </header>
+            <ProtocolAddendaPanel bookingId={selected.id} staffRole={staff?.role || ""}/>
+          </>}
+        </main>
+      </div>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/protocols/corrections/page.tsx
+++ b/app/staff/protocols/corrections/page.tsx
@@ -70,14 +70,8 @@ export default function ProtocolCorrectionsPage() {
     .filter((item)=>!query.trim() || `${item.code} ${item.name} ${item.serviceTitle} ${item.service}`.toLowerCase().includes(query.trim().toLowerCase())),
   [queue,query]);
 
-  useEffect(()=>{
-    if (selectedId !== null || issued.length === 0) return;
-    const requested = Number(new URLSearchParams(window.location.search).get("open"));
-    const initial = issued.find((item)=>item.id === requested) || issued[0];
-    setSelectedId(initial.id);
-  },[issued,selectedId]);
-
-  const selected = issued.find((item)=>item.id === selectedId) || null;
+  const selected = issued.find((item)=>item.id === selectedId) || issued[0] || null;
+  const effectiveSelectedId = selected?.id ?? null;
   const canManage = staff?.role === "admin" || staff?.role === "radiologist";
 
   return <StaffWorkspaceShell
@@ -103,7 +97,7 @@ export default function ProtocolCorrectionsPage() {
             {loading ? <p className={styles.muted}>Завантаження…</p>
               : issued.length === 0 ? <p className={styles.muted}>Виданих протоколів не знайдено.</p>
                 : issued.map((item)=><button type="button" key={item.id}
-                  className={item.id === selectedId ? styles.activeItem : styles.item}
+                  className={item.id === effectiveSelectedId ? styles.activeItem : styles.item}
                   onClick={()=>setSelectedId(item.id)}>
                   <b>{item.serviceTitle || item.service}</b>
                   <span>{item.code} · {item.name}</span>

--- a/app/staff/protocols/layout.tsx
+++ b/app/staff/protocols/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+import ProtocolWorkspaceSubnav from "./protocol-workspace-subnav";
+
+export default function ProtocolsLayout({ children }:{ children:ReactNode }) {
+  return <>
+    {children}
+    <ProtocolWorkspaceSubnav />
+  </>;
+}

--- a/app/staff/protocols/protocol-addenda-panel.module.css
+++ b/app/staff/protocols/protocol-addenda-panel.module.css
@@ -1,0 +1,71 @@
+.panel {
+  margin-top: 24px;
+  border: 1px solid var(--line, #d9e0e8);
+  border-radius: 16px;
+  padding: 20px;
+  background: var(--surface, #fff);
+}
+
+.head {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.head h3 { margin: 2px 0 6px; font-size: 1.2rem; }
+.head p { margin: 0; max-width: 760px; }
+.eyebrow { font-size: .76rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; opacity: .65; }
+.base { white-space: nowrap; font-size: .82rem; font-weight: 700; padding: 7px 10px; border: 1px solid currentColor; border-radius: 999px; opacity: .75; }
+
+.createBox {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px dashed var(--line, #d9e0e8);
+  border-radius: 12px;
+  margin-bottom: 16px;
+}
+
+.createBox label,
+.editor label { display: grid; gap: 6px; font-weight: 600; }
+.createBox input,
+.createBox textarea,
+.editor input,
+.editor textarea { width: 100%; }
+.createBox textarea,
+.editor textarea { min-height: 120px; resize: vertical; }
+
+.workspace { display: grid; grid-template-columns: minmax(190px, .34fr) minmax(0, 1fr); gap: 16px; }
+.list { display: grid; gap: 8px; align-content: start; }
+.item,
+.activeItem { display: grid; gap: 3px; text-align: left; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--line, #d9e0e8); background: transparent; }
+.activeItem { outline: 2px solid currentColor; outline-offset: 1px; }
+.item small,
+.activeItem small { opacity: .65; }
+
+.editor { display: grid; gap: 12px; min-width: 0; }
+.meta { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; font-size: .82rem; }
+.status { font-weight: 800; padding: 5px 8px; border: 1px solid currentColor; border-radius: 999px; }
+.signed { margin: 0; font-size: .84rem; font-weight: 600; }
+.actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.primary { font-weight: 800; }
+
+.history { border-top: 1px solid var(--line, #d9e0e8); padding-top: 10px; }
+.history summary { cursor: pointer; font-weight: 700; }
+.history ol { display: grid; gap: 8px; padding-left: 22px; }
+.history li { display: grid; gap: 2px; }
+.history li span,
+.history li small { opacity: .7; }
+
+.error,
+.success { padding: 10px 12px; border-radius: 10px; border: 1px solid currentColor; }
+.error { font-weight: 700; }
+.success { font-weight: 600; }
+.muted { opacity: .65; }
+
+@media (max-width: 860px) {
+  .head { display: grid; }
+  .workspace { grid-template-columns: 1fr; }
+}

--- a/app/staff/protocols/protocol-addenda-panel.tsx
+++ b/app/staff/protocols/protocol-addenda-panel.tsx
@@ -109,12 +109,15 @@ export default function ProtocolAddendaPanel({ bookingId, staffRole }:{ bookingI
   }
 
   useEffect(()=>{
-    setSelectedId("");
-    setReason("");
-    setCorrectionText("");
-    setNewReason("");
-    setNewText("");
-    const timer = window.setTimeout(()=>{ void load(); },0);
+    const timer = window.setTimeout(()=>{
+      setSelectedId("");
+      setReason("");
+      setCorrectionText("");
+      setNewReason("");
+      setNewText("");
+      setSuccess("");
+      void load();
+    },0);
     return ()=>window.clearTimeout(timer);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[bookingId]);
@@ -221,7 +224,7 @@ export default function ProtocolAddendaPanel({ bookingId, staffRole }:{ bookingI
 
         {selected && <div className={styles.editor}>
           <div className={styles.meta}>
-            <span className={`${styles.status} ${styles[selected.status]}`}>{statusLabels[selected.status]}</span>
+            <span className={styles.status}>{statusLabels[selected.status]}</span>
             <span>Версія {selected.version}</span>
             <span>База v{selected.baseProtocolVersion}</span>
             <span>Автор: {selected.authorEmail}</span>

--- a/app/staff/protocols/protocol-addenda-panel.tsx
+++ b/app/staff/protocols/protocol-addenda-panel.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import styles from "./protocol-addenda-panel.module.css";
+
+type StaffRole = "admin" | "registrar" | "radiologist" | "radiographer" | "";
+type AddendumStatus = "draft" | "ready" | "signed" | "issued";
+
+type Addendum = {
+  id:string;
+  bookingId:number;
+  baseProtocolVersion:number;
+  reason:string;
+  correctionText:string;
+  status:AddendumStatus;
+  version:number;
+  authorEmail:string;
+  updatedBy:string;
+  updatedAt:string;
+  signedBy:string;
+  signedAt:string;
+  signedVersion:number;
+  createdAt:string;
+};
+
+type Revision = {
+  id:number;
+  addendumId:string;
+  baseProtocolVersion:number;
+  version:number;
+  reason:string;
+  correctionText:string;
+  status:"draft" | "ready" | "signed";
+  savedBy:string;
+  createdAt:string;
+};
+
+type ApiPayload = {
+  baseProtocol?:{ version?:number; number?:string; status?:string } | null;
+  addenda?:Addendum[];
+  revisions?:Revision[];
+  error?:string;
+};
+
+const statusLabels:Record<AddendumStatus,string> = {
+  draft:"Чернетка",
+  ready:"До підпису",
+  signed:"Підписано",
+  issued:"Видано пацієнту",
+};
+
+function formatDateTime(value:string) {
+  if (!value) return "—";
+  const parsed = new Date(value.includes("T") ? value : value.replace(" ", "T") + "Z");
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString("uk-UA");
+}
+
+export default function ProtocolAddendaPanel({ bookingId, staffRole }:{ bookingId:number; staffRole:StaffRole }) {
+  const [addenda,setAddenda] = useState<Addendum[]>([]);
+  const [revisions,setRevisions] = useState<Revision[]>([]);
+  const [baseVersion,setBaseVersion] = useState<number>(0);
+  const [selectedId,setSelectedId] = useState("");
+  const [reason,setReason] = useState("");
+  const [correctionText,setCorrectionText] = useState("");
+  const [newReason,setNewReason] = useState("");
+  const [newText,setNewText] = useState("");
+  const [loading,setLoading] = useState(true);
+  const [busy,setBusy] = useState(false);
+  const [error,setError] = useState("");
+  const [success,setSuccess] = useState("");
+
+  const selected = useMemo(
+    () => addenda.find((item)=>item.id === selectedId) || null,
+    [addenda,selectedId],
+  );
+  const selectedRevisions = useMemo(
+    () => revisions.filter((revision)=>revision.addendumId === selectedId),
+    [revisions,selectedId],
+  );
+
+  function applySelection(item:Addendum | null) {
+    setSelectedId(item?.id || "");
+    setReason(item?.reason || "");
+    setCorrectionText(item?.correctionText || "");
+  }
+
+  async function load(preferredId?:string) {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch(`/api/staff/protocols/addenda?bookingId=${bookingId}`, { cache:"no-store" });
+      const data = await response.json() as ApiPayload;
+      if (!response.ok) {
+        setError(data.error || "Не вдалося завантажити виправлення");
+        return;
+      }
+      const next = data.addenda || [];
+      setAddenda(next);
+      setRevisions(data.revisions || []);
+      setBaseVersion(Number(data.baseProtocol?.version || 0));
+      const keep = preferredId || selectedId;
+      const chosen = next.find((item)=>item.id === keep) || next.at(-1) || null;
+      applySelection(chosen);
+    } catch {
+      setError("Помилка мережі під час завантаження виправлень");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(()=>{
+    setSelectedId("");
+    setReason("");
+    setCorrectionText("");
+    setNewReason("");
+    setNewText("");
+    const timer = window.setTimeout(()=>{ void load(); },0);
+    return ()=>window.clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[bookingId]);
+
+  async function createAddendum() {
+    setError(""); setSuccess("");
+    if (!newReason.trim() || !newText.trim()) {
+      setError("Вкажіть причину і текст виправлення.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const response = await fetch("/api/staff/protocols/addenda", {
+        method:"POST",
+        headers:{ "content-type":"application/json" },
+        body:JSON.stringify({ bookingId, reason:newReason, correctionText:newText }),
+      });
+      const data = await response.json() as { addendum?:Addendum; error?:string };
+      if (!response.ok || !data.addendum) {
+        setError(data.error || "Не вдалося створити виправлення");
+        return;
+      }
+      setNewReason(""); setNewText("");
+      setSuccess("Чернетку виправлення створено. Оригінальний виданий протокол не змінено.");
+      await load(data.addendum.id);
+    } catch {
+      setError("Помилка мережі під час створення виправлення");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function transition(status:AddendumStatus) {
+    if (!selected) return;
+    setError(""); setSuccess(""); setBusy(true);
+    try {
+      const response = await fetch("/api/staff/protocols/addenda", {
+        method:"PUT",
+        headers:{ "content-type":"application/json" },
+        body:JSON.stringify({
+          id:selected.id,
+          baseVersion:selected.version,
+          reason,
+          correctionText,
+          status,
+        }),
+      });
+      const data = await response.json() as { addendum?:Addendum; error?:string };
+      if (!response.ok || !data.addendum) {
+        setError(data.error || "Не вдалося змінити виправлення");
+        if (response.status === 409) await load(selected.id);
+        return;
+      }
+      setSuccess(
+        status === "issued" ? "Виправлення видано пацієнту."
+          : status === "signed" ? "Виправлення підписано лікарем-рентгенологом і заблоковано від редагування."
+            : status === "ready" ? "Виправлення готове до підпису."
+              : "Чернетку виправлення збережено.",
+      );
+      await load(data.addendum.id);
+    } catch {
+      setError("Помилка мережі під час збереження виправлення");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const locked = selected?.status === "signed" || selected?.status === "issued";
+  const canSign = staffRole === "radiologist" && selected?.status === "ready";
+  const canIssue = (staffRole === "radiologist" || staffRole === "admin") && selected?.status === "signed";
+
+  return <section className={styles.panel} aria-labelledby="protocol-addenda-title">
+    <header className={styles.head}>
+      <div>
+        <p className={styles.eyebrow}>Окремий медичний документ</p>
+        <h3 id="protocol-addenda-title">Виправлення / доповнення</h3>
+        <p>Виданий протокол залишається незмінним. Кожне виправлення має власні версії, підпис і окрему видачу пацієнту.</p>
+      </div>
+      <span className={styles.base}>Базовий протокол v{baseVersion || "—"}</span>
+    </header>
+
+    {error && <p className={styles.error} role="alert">{error}</p>}
+    {success && <p className={styles.success} role="status">{success}</p>}
+    {loading ? <p className={styles.muted}>Завантаження виправлень…</p> : <>
+      <div className={styles.createBox}>
+        <b>Створити нове виправлення</b>
+        <label><span>Причина</span><input value={newReason} maxLength={500} disabled={busy}
+          onChange={(event)=>setNewReason(event.target.value)} placeholder="Наприклад, уточнення сторони або формулювання"/></label>
+        <label><span>Текст виправлення / доповнення</span><textarea value={newText} maxLength={12000} disabled={busy}
+          onChange={(event)=>setNewText(event.target.value)} placeholder="Що саме слід читати замість/на додаток до виданого протоколу"/></label>
+        <button type="button" onClick={()=>void createAddendum()} disabled={busy}>Створити чернетку</button>
+      </div>
+
+      {addenda.length === 0 ? <p className={styles.muted}>До цього протоколу ще немає виправлень.</p> : <div className={styles.workspace}>
+        <nav className={styles.list} aria-label="Список виправлень">
+          {addenda.map((item,index)=><button type="button" key={item.id}
+            className={item.id === selectedId ? styles.activeItem : styles.item}
+            onClick={()=>applySelection(item)}>
+            <span>Виправлення №{index + 1}</span>
+            <b>{statusLabels[item.status]}</b>
+            <small>v{item.version} · {formatDateTime(item.updatedAt)}</small>
+          </button>)}
+        </nav>
+
+        {selected && <div className={styles.editor}>
+          <div className={styles.meta}>
+            <span className={`${styles.status} ${styles[selected.status]}`}>{statusLabels[selected.status]}</span>
+            <span>Версія {selected.version}</span>
+            <span>База v{selected.baseProtocolVersion}</span>
+            <span>Автор: {selected.authorEmail}</span>
+          </div>
+          {selected.signedBy && <p className={styles.signed}>Підпис: {selected.signedBy} · {formatDateTime(selected.signedAt)} · підписана v{selected.signedVersion}</p>}
+          <label><span>Причина</span><input value={reason} maxLength={500} readOnly={locked || busy}
+            onChange={(event)=>setReason(event.target.value)}/></label>
+          <label><span>Текст виправлення / доповнення</span><textarea value={correctionText} maxLength={12000} readOnly={locked || busy}
+            onChange={(event)=>setCorrectionText(event.target.value)}/></label>
+
+          <div className={styles.actions}>
+            {selected.status === "draft" && <>
+              <button type="button" disabled={busy} onClick={()=>void transition("draft")}>Зберегти чернетку</button>
+              <button type="button" disabled={busy} onClick={()=>void transition("ready")}>Готове до підпису</button>
+            </>}
+            {selected.status === "ready" && <button type="button" disabled={busy} onClick={()=>void transition("ready")}>Зберегти зміни</button>}
+            {canSign && <button type="button" className={styles.primary} disabled={busy} onClick={()=>void transition("signed")}>Підписати виправлення</button>}
+            {selected.status === "ready" && staffRole === "admin" && <span className={styles.muted}>Підпис доступний лише лікарю-рентгенологу.</span>}
+            {canIssue && <button type="button" className={styles.primary} disabled={busy} onClick={()=>void transition("issued")}>Видати пацієнту</button>}
+          </div>
+
+          <details className={styles.history}>
+            <summary>Історія версій ({selectedRevisions.length})</summary>
+            {selectedRevisions.length === 0 ? <p className={styles.muted}>Історія відсутня.</p> : <ol>
+              {selectedRevisions.map((revision)=><li key={revision.id}>
+                <b>v{revision.version} · {statusLabels[revision.status]}</b>
+                <span>{formatDateTime(revision.createdAt)} · {revision.savedBy}</span>
+                <small>{revision.reason}</small>
+              </li>)}
+            </ol>}
+          </details>
+        </div>}
+      </div>}
+    </>}
+  </section>;
+}

--- a/app/staff/protocols/protocol-workspace-subnav.module.css
+++ b/app/staff/protocols/protocol-workspace-subnav.module.css
@@ -1,0 +1,26 @@
+.nav {
+  position: fixed;
+  right: 22px;
+  bottom: 22px;
+  z-index: 80;
+  display: flex;
+  gap: 4px;
+  padding: 5px;
+  border: 1px solid var(--line, #d9e0e8);
+  border-radius: 999px;
+  background: var(--surface, #fff);
+  box-shadow: 0 8px 28px rgb(15 23 42 / 14%);
+}
+
+.nav a {
+  padding: 8px 12px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: .84rem;
+  font-weight: 700;
+}
+
+.nav a:not(.active) { opacity: .7; }
+.active { outline: 1px solid currentColor; }
+
+@media print { .nav { display: none; } }

--- a/app/staff/protocols/protocol-workspace-subnav.tsx
+++ b/app/staff/protocols/protocol-workspace-subnav.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import styles from "./protocol-workspace-subnav.module.css";
+
+export default function ProtocolWorkspaceSubnav() {
+  const pathname = usePathname();
+  const corrections = pathname.startsWith("/staff/protocols/corrections");
+  return <nav className={styles.nav} aria-label="Розділи протоколів">
+    <Link className={!corrections ? styles.active : ""} href="/staff/protocols">Протоколи</Link>
+    <Link className={corrections ? styles.active : ""} href="/staff/protocols/corrections">Виправлення</Link>
+  </nav>;
+}

--- a/tests/protocol-addendum-ui.behavior.test.mjs
+++ b/tests/protocol-addendum-ui.behavior.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+async function source(path) {
+  return readFile(new URL(`../${path}`, import.meta.url), "utf8");
+}
+
+test("protocol workspace exposes a dedicated corrections screen without replacing the original editor", async () => {
+  const [layout, subnav, page] = await Promise.all([
+    source("app/staff/protocols/layout.tsx"),
+    source("app/staff/protocols/protocol-workspace-subnav.tsx"),
+    source("app/staff/protocols/corrections/page.tsx"),
+  ]);
+
+  assert.match(layout, /ProtocolWorkspaceSubnav/);
+  assert.match(subnav, /\/staff\/protocols\/corrections/);
+  assert.match(subnav, /href="\/staff\/protocols"/);
+  assert.match(page, /documentStatus === "issued" \|\| item\.protocolStatus === "issued"/);
+  assert.match(page, /<ProtocolAddendaPanel bookingId=\{selected\.id\}/);
+  assert.match(page, /\/staff\/protocols\?open=\$\{selected\.id\}/);
+  assert.doesNotMatch(page, /protocols[^\n]*UPDATE|UPDATE protocols/i);
+});
+
+test("addendum panel preserves role separation and exact lifecycle actions", async () => {
+  const panel = await source("app/staff/protocols/protocol-addenda-panel.tsx");
+
+  assert.match(panel, /fetch\(`\/api\/staff\/protocols\/addenda\?bookingId=\$\{bookingId\}`/);
+  assert.match(panel, /method:"POST"/);
+  assert.match(panel, /method:"PUT"/);
+  assert.match(panel, /staffRole === "radiologist" && selected\?\.status === "ready"/);
+  assert.match(panel, /\(staffRole === "radiologist" \|\| staffRole === "admin"\) && selected\?\.status === "signed"/);
+  assert.match(panel, /transition\("draft"\)/);
+  assert.match(panel, /transition\("ready"\)/);
+  assert.match(panel, /transition\("signed"\)/);
+  assert.match(panel, /transition\("issued"\)/);
+  assert.match(panel, /Історія версій/);
+  assert.match(panel, /Оригінальний виданий протокол не змінено/);
+});


### PR DESCRIPTION
## Summary
- add a dedicated staff corrections workspace under Protocols
- list only issued base protocols as correction targets
- add create/edit/ready/sign/issue controls for immutable protocol addenda
- preserve radiologist-only clinical signing in the UI while the server remains authoritative
- show addendum signature metadata and database-derived revision history
- provide a direct link back to the immutable original protocol
- add compact Protocols / Corrections navigation without rewriting the existing protocol editor
- add focused UI behavior/source guards

## Safety
- UI never edits the issued base protocol
- patient delivery remains server-controlled and only follows signed addenda
- admin cannot sign; radiologist-only sign control mirrors backend authorization
- corrections screen only selects already issued protocols

## Validation
- CI #925: green (install, audit, lint, typecheck, build, tests, production release gate)
- CodeQL #840: green

No production deploy.