### PR TITLE
Anchor patient Telegram delivery to immutable identity

### DIFF
--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -1,8 +1,9 @@
 // Видає пацієнту (за активною сесією кабінету) deep-link для під'єднання
 // Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до tenant,
 // телефону та доведеної ідентичності пацієнта. Exact sessions additionally
-// carry immutable patient_id; fully legacy DOB sessions are reduced to their
-// one concrete booking before a persistent Telegram identity is created.
+// carry immutable patient_id. Any DOB proof is canonicalized to a concrete
+// booking code before persistence so relatives with the same phone and DOB do
+// not collide in the legacy identity-key primary key.
 // Telegram bot config is still legacy-global and belongs to org 1, so secondary
 // tenants must not receive a deep-link until bot configuration is tenantized.
 
@@ -48,23 +49,29 @@ export async function POST(request: Request) {
     kind: session.identityKind,
     value: session.identityValue,
   };
-  if (!session.patientId && session.identityKind === "dob") {
+  if (session.identityKind === "dob") {
+    const exactClause = session.patientId ? "AND patient_id = ?" : "";
+    const bindings = session.patientId
+      ? [session.organizationId, session.phoneNormalized, session.identityValue, session.patientId]
+      : [session.organizationId, session.phoneNormalized, session.identityValue];
     const rows = await db.prepare(
       `SELECT code FROM bookings
-       WHERE organization_id = ? AND phone_normalized = ? AND date_of_birth = ?
-       ORDER BY id LIMIT 2`,
-    ).bind(
-      session.organizationId,
-      session.phoneNormalized,
-      session.identityValue,
-    ).all<{ code:string }>();
-    if (rows.results.length !== 1 || !rows.results[0]?.code) {
+       WHERE organization_id = ? AND phone_normalized = ? AND date_of_birth = ? ${exactClause}
+       ORDER BY id DESC LIMIT 2`,
+    ).bind(...bindings).all<{ code:string }>();
+
+    // A legacy DOB session is permitted only while it maps to one booking.
+    // An exact patient_id session may have many bookings; any one explicitly
+    // linked booking is sufficient as a unique proof-key because patient_id is
+    // the persisted delivery authority.
+    const chosen = session.patientId ? rows.results[0] : rows.results.length === 1 ? rows.results[0] : null;
+    if (!chosen?.code) {
       return Response.json(
         { error: "Не вдалося однозначно визначити заявку. Увійдіть за кодом конкретної заявки." },
         { status: 409, headers: { "cache-control": "no-store" } },
       );
     }
-    telegramIdentity = { kind:"booking", value:rows.results[0].code };
+    telegramIdentity = { kind:"booking", value:chosen.code };
   }
 
   const token = await createTelegramLinkToken(

--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -1,12 +1,15 @@
 // Видає пацієнту (за активною сесією кабінету) deep-link для під'єднання
 // Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до tenant,
-// телефону та доведеної ідентичності пацієнта.
+// телефону та доведеної ідентичності пацієнта. Exact sessions additionally
+// carry immutable patient_id; fully legacy DOB sessions are reduced to their
+// one concrete booking before a persistent Telegram identity is created.
 // Telegram bot config is still legacy-global and belongs to org 1, so secondary
 // tenants must not receive a deep-link until bot configuration is tenantized.
 
 import {
   patientSessionScopeIsUnambiguous,
   requirePatientSession,
+  type PatientIdentityScope,
 } from "../../../lib/patient-auth";
 import { createTelegramLinkToken } from "../../../lib/telegram-link";
 import { telegramBotUsername } from "../../../lib/telegram";
@@ -40,11 +43,36 @@ export async function POST(request: Request) {
   if (!username) {
     return Response.json({ error: "Telegram-канал ще не налаштований відділенням", botConfigured: false }, { status: 503 });
   }
+
+  let telegramIdentity: PatientIdentityScope = {
+    kind: session.identityKind,
+    value: session.identityValue,
+  };
+  if (!session.patientId && session.identityKind === "dob") {
+    const rows = await db.prepare(
+      `SELECT code FROM bookings
+       WHERE organization_id = ? AND phone_normalized = ? AND date_of_birth = ?
+       ORDER BY id LIMIT 2`,
+    ).bind(
+      session.organizationId,
+      session.phoneNormalized,
+      session.identityValue,
+    ).all<{ code:string }>();
+    if (rows.results.length !== 1 || !rows.results[0]?.code) {
+      return Response.json(
+        { error: "Не вдалося однозначно визначити заявку. Увійдіть за кодом конкретної заявки." },
+        { status: 409, headers: { "cache-control": "no-store" } },
+      );
+    }
+    telegramIdentity = { kind:"booking", value:rows.results[0].code };
+  }
+
   const token = await createTelegramLinkToken(
     db,
     session.phoneNormalized,
     session.organizationId,
-    { kind:session.identityKind, value:session.identityValue },
+    telegramIdentity,
+    session.patientId || "",
   );
   const url = `https://t.me/${username}?start=${token}`;
   return Response.json({ url }, { headers: { "cache-control":"no-store" } });

--- a/db/patient-auth-schema.ts
+++ b/db/patient-auth-schema.ts
@@ -51,6 +51,7 @@ export const telegramLinkTokensScoped = sqliteTable("telegram_link_tokens", {
   phoneNormalized: text("phone_normalized").notNull(),
   identityKind: text("identity_kind").notNull().default(""),
   identityValue: text("identity_value").notNull().default(""),
+  patientId: text("patient_id").notNull().default(""),
   createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
   expiresAt: text("expires_at").notNull(),
 }, table => [
@@ -58,6 +59,7 @@ export const telegramLinkTokensScoped = sqliteTable("telegram_link_tokens", {
   index("telegram_link_tokens_identity_scope_idx").on(
     table.organizationId, table.phoneNormalized, table.identityKind, table.identityValue, table.expiresAt,
   ),
+  index("telegram_link_tokens_patient_idx").on(table.organizationId, table.patientId, table.expiresAt),
 ]);
 
 export const patientTelegramIdentities = sqliteTable("patient_telegram_identities", {
@@ -65,9 +67,11 @@ export const patientTelegramIdentities = sqliteTable("patient_telegram_identitie
   phoneNormalized: text("phone_normalized").notNull(),
   identityKind: text("identity_kind").notNull(),
   identityValue: text("identity_value").notNull(),
+  patientId: text("patient_id").notNull().default(""),
   telegramChatId: text("telegram_chat_id").notNull().default(""),
   updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
 }, table => [
   primaryKey({ columns:[table.organizationId, table.phoneNormalized, table.identityKind, table.identityValue] }),
   index("patient_telegram_chat_idx").on(table.telegramChatId).where(sql`telegram_chat_id != ''`),
+  index("patient_telegram_patient_idx").on(table.organizationId, table.patientId, table.updatedAt),
 ]);

--- a/drizzle/0057_telegram_patient_identity.sql
+++ b/drizzle/0057_telegram_patient_identity.sql
@@ -1,7 +1,7 @@
 -- Telegram delivery contains patient-specific appointment information, so an
 -- exact booking -> patient link must never fall back to phone + DOB ownership.
 -- Carry immutable patient_id through short-lived link tokens and persisted
--- Telegram identities. Existing links predate this proof and are cleared rather
+-- Telegram identities. Existing links predate this proof and are removed rather
 -- than guessed; patients can reconnect from a freshly verified cabinet session.
 
 ALTER TABLE `telegram_link_tokens` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
@@ -17,12 +17,11 @@ ON `patient_telegram_identities` (`organization_id`, `patient_id`, `updated_at`)
 --> statement-breakpoint
 
 -- Old tokens/links cannot prove immutable ownership. Fail closed instead of
--- attributing a family-phone/DOB identity to a person retroactively.
+-- attributing a family-phone/DOB identity to a person retroactively. Remove the
+-- identity rows too so a fresh exact link does not collide with legacy scope.
 DELETE FROM `telegram_link_tokens`;
 --> statement-breakpoint
-UPDATE `patient_telegram_identities`
-SET `telegram_chat_id` = '', `updated_at` = CURRENT_TIMESTAMP
-WHERE `telegram_chat_id` != '';
+DELETE FROM `patient_telegram_identities`;
 --> statement-breakpoint
 
 CREATE TRIGGER IF NOT EXISTS `telegram_link_patient_link_insert`

--- a/drizzle/0057_telegram_patient_identity.sql
+++ b/drizzle/0057_telegram_patient_identity.sql
@@ -1,0 +1,81 @@
+-- Telegram delivery contains patient-specific appointment information, so an
+-- exact booking -> patient link must never fall back to phone + DOB ownership.
+-- Carry immutable patient_id through short-lived link tokens and persisted
+-- Telegram identities. Existing links predate this proof and are cleared rather
+-- than guessed; patients can reconnect from a freshly verified cabinet session.
+
+ALTER TABLE `telegram_link_tokens` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+ALTER TABLE `patient_telegram_identities` ADD COLUMN `patient_id` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `telegram_link_tokens_patient_idx`
+ON `telegram_link_tokens` (`organization_id`, `patient_id`, `expires_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_telegram_patient_idx`
+ON `patient_telegram_identities` (`organization_id`, `patient_id`, `updated_at`);
+--> statement-breakpoint
+
+-- Old tokens/links cannot prove immutable ownership. Fail closed instead of
+-- attributing a family-phone/DOB identity to a person retroactively.
+DELETE FROM `telegram_link_tokens`;
+--> statement-breakpoint
+UPDATE `patient_telegram_identities`
+SET `telegram_chat_id` = '', `updated_at` = CURRENT_TIMESTAMP
+WHERE `telegram_chat_id` != '';
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `telegram_link_patient_link_insert`
+BEFORE INSERT ON `telegram_link_tokens`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.organization_id = NEW.organization_id
+      AND b.patient_id = NEW.patient_id
+      AND b.phone_normalized = NEW.phone_normalized
+      AND (
+        (NEW.identity_kind = 'dob' AND b.date_of_birth = NEW.identity_value)
+        OR (NEW.identity_kind = 'booking' AND b.code = NEW.identity_value)
+      )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Telegram patient link invalid');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `telegram_identity_patient_link_insert`
+BEFORE INSERT ON `patient_telegram_identities`
+FOR EACH ROW
+WHEN NEW.patient_id != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.organization_id = NEW.organization_id
+      AND b.patient_id = NEW.patient_id
+      AND b.phone_normalized = NEW.phone_normalized
+      AND (
+        (NEW.identity_kind = 'dob' AND b.date_of_birth = NEW.identity_value)
+        OR (NEW.identity_kind = 'booking' AND b.code = NEW.identity_value)
+      )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'patient Telegram patient link invalid');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `telegram_link_patient_id_immutable`
+BEFORE UPDATE OF `patient_id` ON `telegram_link_tokens`
+FOR EACH ROW
+WHEN NEW.patient_id != OLD.patient_id
+BEGIN
+  SELECT RAISE(ABORT, 'Telegram patient id is immutable');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `telegram_identity_patient_id_immutable`
+BEFORE UPDATE OF `patient_id` ON `patient_telegram_identities`
+FOR EACH ROW
+WHEN NEW.patient_id != OLD.patient_id
+BEGIN
+  SELECT RAISE(ABORT, 'patient Telegram patient id is immutable');
+END;

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -148,10 +148,13 @@ async function patientMessagingProfile(
            AND ti.phone_normalized = b.phone_normalized
            AND ti.telegram_chat_id != ''
            AND (
-             (ti.identity_kind = 'booking' AND ti.identity_value = b.code)
-             OR (ti.identity_kind = 'dob' AND b.date_of_birth != '' AND ti.identity_value = b.date_of_birth)
+             (b.patient_id != '' AND ti.patient_id = b.patient_id)
+             OR (
+               b.patient_id = '' AND ti.patient_id = ''
+               AND ti.identity_kind = 'booking' AND ti.identity_value = b.code
+             )
            )
-         ORDER BY CASE ti.identity_kind WHEN 'booking' THEN 0 ELSE 1 END
+         ORDER BY ti.updated_at DESC
          LIMIT 1
        ), '') AS tg
      FROM bookings b

--- a/lib/telegram-link.ts
+++ b/lib/telegram-link.ts
@@ -1,7 +1,7 @@
 // Прив'язка Telegram пацієнта: короткоживучі токени для deep-link «Старт»
 // і обробник вхідних оновлень від бота (webhook). Пацієнт натискає «Старт»
 // у боті один раз — ми зіставляємо токен із tenant + телефоном + доведеною
-// ідентичністю (DOB або конкретна заявка) і зберігаємо identity-scoped chat_id.
+// ідентичністю та, коли вона відома, immutable patient_id.
 
 import { hashToken, newSessionToken } from "./auth";
 import type { PatientIdentityScope } from "./patient-auth";
@@ -15,19 +15,21 @@ export async function createTelegramLinkToken(
   phoneNormalized: string,
   organizationId: number,
   identity: PatientIdentityScope,
+  patientId = "",
 ): Promise<string> {
   const rawToken = newSessionToken();
   const tokenHash = await hashToken(rawToken);
   await db.prepare(
     `INSERT INTO telegram_link_tokens
-      (token_hash, organization_id, phone_normalized, identity_kind, identity_value, expires_at)
-     VALUES (?, ?, ?, ?, ?, datetime('now', ?))`
+      (token_hash, organization_id, phone_normalized, identity_kind, identity_value, patient_id, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?))`
   ).bind(
     tokenHash,
     organizationId,
     phoneNormalized,
     identity.kind,
     identity.value,
+    patientId,
     `+${TELEGRAM_LINK_TTL_SECONDS} seconds`,
   ).run();
   await db.prepare("DELETE FROM telegram_link_tokens WHERE expires_at <= CURRENT_TIMESTAMP").run();
@@ -37,13 +39,13 @@ export async function createTelegramLinkToken(
 export async function consumeTelegramLinkToken(
   db: D1Database,
   rawToken: string,
-): Promise<{ organizationId: number; phone: string; identity: PatientIdentityScope } | null> {
+): Promise<{ organizationId: number; phone: string; identity: PatientIdentityScope; patientId: string } | null> {
   const token = String(rawToken || "").trim();
   if (!/^[a-f0-9]{64}$/.test(token)) return null;
   const tokenHash = await hashToken(token);
   const row = await db.prepare(
     `SELECT organization_id AS organizationId, phone_normalized AS phone,
-       identity_kind AS identityKind, identity_value AS identityValue
+       identity_kind AS identityKind, identity_value AS identityValue, patient_id AS patientId
      FROM telegram_link_tokens
      WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP
        AND identity_kind IN ('dob','booking') AND identity_value != ''
@@ -53,12 +55,14 @@ export async function consumeTelegramLinkToken(
     phone: string;
     identityKind: "dob" | "booking";
     identityValue: string;
+    patientId: string;
   }>().catch(() => null);
   await db.prepare("DELETE FROM telegram_link_tokens WHERE token_hash = ?").bind(tokenHash).run();
   return row ? {
     organizationId: row.organizationId,
     phone: row.phone,
     identity: { kind:row.identityKind, value:row.identityValue },
+    patientId: row.patientId || "",
   } : null;
 }
 
@@ -68,14 +72,17 @@ export async function linkPatientTelegram(
   phoneNormalized: string,
   identity: PatientIdentityScope,
   chatId: string,
+  patientId = "",
 ): Promise<void> {
   await db.prepare(
     `INSERT INTO patient_telegram_identities
-      (organization_id, phone_normalized, identity_kind, identity_value, telegram_chat_id, updated_at)
-     VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+      (organization_id, phone_normalized, identity_kind, identity_value, patient_id, telegram_chat_id, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
      ON CONFLICT(organization_id, phone_normalized, identity_kind, identity_value) DO UPDATE SET
-       telegram_chat_id = excluded.telegram_chat_id, updated_at = CURRENT_TIMESTAMP`
-  ).bind(organizationId, phoneNormalized, identity.kind, identity.value, chatId).run();
+       telegram_chat_id = excluded.telegram_chat_id,
+       patient_id = excluded.patient_id,
+       updated_at = CURRENT_TIMESTAMP`
+  ).bind(organizationId, phoneNormalized, identity.kind, identity.value, patientId, chatId).run();
 }
 
 // /stop is bot-wide consent revocation for this chat. If the same human linked
@@ -115,6 +122,13 @@ export async function handleTelegramUpdate(db: D1Database, update: TelegramUpdat
   if (!target || target.organizationId !== PRIMARY_ORGANIZATION_ID) {
     return { chatId, reply: STALE_LINK_REPLY };
   }
-  await linkPatientTelegram(db, target.organizationId, target.phone, target.identity, chatId);
+  await linkPatientTelegram(
+    db,
+    target.organizationId,
+    target.phone,
+    target.identity,
+    chatId,
+    target.patientId,
+  );
   return { chatId, reply: "✅ Готово! Сповіщення про ваші дослідження надходитимуть у цей чат." };
 }

--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -137,7 +137,13 @@ export async function seedStaffSession(db, {
   return `rid_session=${rawToken}`;
 }
 
-export async function seedPatientSession(db, phoneNormalized, organizationId = 1, identity = null) {
+export async function seedPatientSession(
+  db,
+  phoneNormalized,
+  organizationId = 1,
+  identity = null,
+  patientId = "",
+) {
   let scope = identity;
   if (!scope) {
     const booking = await db.prepare(
@@ -155,9 +161,9 @@ export async function seedPatientSession(db, phoneNormalized, organizationId = 1
   const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
   await db.prepare(
     `INSERT INTO patient_sessions
-      (token_hash, phone_normalized, organization_id, identity_kind, identity_value, expires_at)
-     VALUES (?, ?, ?, ?, ?, datetime('now', '+30 minutes'))`
-  ).bind(tokenHash, phoneNormalized, organizationId, scope.kind, scope.value).run();
+      (token_hash, phone_normalized, organization_id, identity_kind, identity_value, patient_id, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now', '+30 minutes'))`
+  ).bind(tokenHash, phoneNormalized, organizationId, scope.kind, scope.value, patientId).run();
   return `rid_patient=${rawToken}`;
 }
 

--- a/tests/telegram-patient-id-access.behavior.test.mjs
+++ b/tests/telegram-patient-id-access.behavior.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedPatientSession, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const PHONE = "380501234567";
+const DOB = "1985-04-12";
+const PATIENT_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PATIENT_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const CODE_A = "RD-260930-1";
+const CODE_B = "RD-260930-2";
+
+async function setSetting(db, key, value) {
+  await db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).bind(key, value).run();
+}
+
+async function seedExactPatient(db, { patientId, code, name, time }) {
+  await db.prepare(
+    `INSERT INTO patient_profiles
+      (patient_id, organization_id, phone_normalized, display_name, birth_date, updated_by)
+     VALUES (?, 1, ?, ?, ?, 'test@example.com')`,
+  ).bind(patientId, PHONE, name, DOB).run();
+  const result = await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, patient_id, code, name, phone, phone_normalized, date_of_birth,
+       service, desired_date, desired_time, status)
+     VALUES (1, ?, ?, ?, ?, ?, ?, 'КТ', '2026-09-30', ?, 'confirmed')`,
+  ).bind(patientId, code, name, `+${PHONE}`, PHONE, DOB, time).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function linkTelegramFromCabinet(db, { patientId, code, chatId }) {
+  const cookie = await seedPatientSession(db, PHONE, 1, { kind:"dob", value:DOB }, patientId);
+  const linkResponse = await callWorker(
+    jsonRequest("/api/my-telegram-link", undefined, { method:"POST", headers:{ cookie } }),
+    db,
+  );
+  assert.equal(linkResponse.status, 200);
+  const linkBody = await linkResponse.json();
+  const url = new URL(linkBody.url);
+  const rawToken = url.searchParams.get("start");
+  assert.match(rawToken || "", /^[a-f0-9]{64}$/);
+
+  const tokenRow = await db.prepare(
+    `SELECT identity_kind AS identityKind, identity_value AS identityValue, patient_id AS patientId
+     FROM telegram_link_tokens WHERE patient_id = ? LIMIT 1`,
+  ).bind(patientId).first();
+  assert.deepEqual(
+    { ...tokenRow },
+    { identityKind:"booking", identityValue:code, patientId },
+    "DOB proof must be canonicalized to a unique booking while retaining immutable patient_id",
+  );
+
+  const webhook = await callWorker(
+    jsonRequest(
+      "/api/telegram/webhook",
+      { message:{ chat:{ id:chatId }, text:`/start ${rawToken}` } },
+      { headers:{ "x-telegram-bot-api-secret-token":"patient-identity-secret" } },
+    ),
+    db,
+  );
+  assert.equal(webhook.status, 200);
+}
+
+test("same phone + same DOB exact patients retain separate Telegram identities and delivery", async () => {
+  await withD1(async (db) => {
+    await setSetting(db, "telegram_bot_token", "test-bot-token");
+    await setSetting(db, "telegram_bot_username", "radiology_test_bot");
+    await setSetting(db, "telegram_webhook_secret", "patient-identity-secret");
+
+    const bookingA = await seedExactPatient(db, {
+      patientId:PATIENT_A, code:CODE_A, name:"Пацієнт А", time:"10:00",
+    });
+    const bookingB = await seedExactPatient(db, {
+      patientId:PATIENT_B, code:CODE_B, name:"Пацієнт Б", time:"11:00",
+    });
+
+    await linkTelegramFromCabinet(db, { patientId:PATIENT_A, code:CODE_A, chatId:111001 });
+    await linkTelegramFromCabinet(db, { patientId:PATIENT_B, code:CODE_B, chatId:222002 });
+
+    const identities = await db.prepare(
+      `SELECT patient_id AS patientId, identity_kind AS identityKind,
+              identity_value AS identityValue, telegram_chat_id AS chatId
+       FROM patient_telegram_identities
+       WHERE organization_id = 1 AND phone_normalized = ?
+       ORDER BY patient_id`,
+    ).bind(PHONE).all();
+    assert.deepEqual(identities.results.map((row)=>({ ...row })), [
+      { patientId:PATIENT_A, identityKind:"booking", identityValue:CODE_A, chatId:"111001" },
+      { patientId:PATIENT_B, identityKind:"booking", identityValue:CODE_B, chatId:"222002" },
+    ]);
+
+    await assert.rejects(
+      db.prepare(
+        `INSERT INTO patient_telegram_identities
+          (organization_id, phone_normalized, identity_kind, identity_value, patient_id, telegram_chat_id)
+         VALUES (1, ?, 'booking', ?, ?, 'wrong-chat')`,
+      ).bind(PHONE, CODE_B, PATIENT_A).run(),
+      /patient link invalid/i,
+      "D1 must reject a patient_id paired with another patient's booking proof",
+    );
+
+    const staffCookie = await seedStaffSession(db, { email:"telegram-admin@example.com", role:"admin" });
+    const sent = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const target = String(input);
+      if (target.includes("api.telegram.org") && target.endsWith("/sendMessage")) {
+        sent.push(JSON.parse(String(init?.body || "{}")));
+        return new Response(JSON.stringify({ ok:true, result:{} }), {
+          status:200,
+          headers:{ "content-type":"application/json" },
+        });
+      }
+      return originalFetch(input, init);
+    };
+    try {
+      const notifyA = await callWorker(
+        jsonRequest(
+          "/api/staff/notify",
+          { bookingId:bookingA, message:"Повідомлення лише для А" },
+          { method:"POST", headers:{ cookie:staffCookie } },
+        ),
+        db,
+      );
+      assert.equal(notifyA.status, 200);
+      const notifyB = await callWorker(
+        jsonRequest(
+          "/api/staff/notify",
+          { bookingId:bookingB, message:"Повідомлення лише для Б" },
+          { method:"POST", headers:{ cookie:staffCookie } },
+        ),
+        db,
+      );
+      assert.equal(notifyB.status, 200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.deepEqual(sent.map((item)=>String(item.chat_id)), ["111001", "222002"]);
+    assert.match(sent[0].text, /лише для А/);
+    assert.match(sent[1].text, /лише для Б/);
+  });
+});

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -4,10 +4,11 @@ import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-test("migrations add patient Telegram fields, tenant tokens and identity scope", async () => {
+test("migrations add patient Telegram fields, tenant tokens and immutable patient identity", async () => {
   const base = await read("drizzle/0025_patient_telegram.sql");
   const composite = await read("drizzle/0035_patient_composite_identity.sql");
   const identity = await read("drizzle/0046_patient_session_identity_scope.sql");
+  const immutable = await read("drizzle/0057_telegram_patient_identity.sql");
   assert.match(base, /ALTER TABLE `patient_profiles` ADD COLUMN `telegram_chat_id`/);
   assert.match(base, /CREATE TABLE IF NOT EXISTS `telegram_link_tokens`/);
   assert.match(base, /`token_hash` text PRIMARY KEY/);
@@ -16,28 +17,39 @@ test("migrations add patient Telegram fields, tenant tokens and identity scope",
   assert.match(identity, /ALTER TABLE telegram_link_tokens ADD COLUMN identity_kind/);
   assert.match(identity, /CREATE TABLE IF NOT EXISTS patient_telegram_identities/);
   assert.match(identity, /PRIMARY KEY \(organization_id, phone_normalized, identity_kind, identity_value\)/);
+  assert.match(immutable, /ALTER TABLE `telegram_link_tokens` ADD COLUMN `patient_id`/);
+  assert.match(immutable, /ALTER TABLE `patient_telegram_identities` ADD COLUMN `patient_id`/);
+  assert.match(immutable, /DELETE FROM `telegram_link_tokens`/);
+  assert.match(immutable, /DELETE FROM `patient_telegram_identities`/);
+  assert.match(immutable, /patient Telegram patient id is immutable/);
 });
 
-test("link lib: single-use hashed tenant + identity tokens + /start webhook handler", async () => {
+test("link lib: single-use hashed tenant + identity + patient tokens + /start webhook handler", async () => {
   const lib = await read("lib/telegram-link.ts");
   assert.match(lib, /export async function createTelegramLinkToken/);
-  assert.match(lib, /organization_id, phone_normalized, identity_kind, identity_value/);
+  assert.match(lib, /organization_id, phone_normalized, identity_kind, identity_value, patient_id/);
   assert.match(lib, /export async function consumeTelegramLinkToken/);
+  assert.match(lib, /patient_id AS patientId/);
   assert.match(lib, /export async function linkPatientTelegram/);
   assert.match(lib, /patient_telegram_identities/);
   assert.match(lib, /export async function handleTelegramUpdate/);
+  assert.match(lib, /target\.patientId/);
   assert.match(lib, /hashToken\(/);
   assert.match(lib, /DELETE FROM telegram_link_tokens WHERE token_hash = \?/);
   assert.match(lib, /ON CONFLICT\(organization_id, phone_normalized, identity_kind, identity_value\) DO UPDATE SET/);
   assert.match(lib, /\/stop\\b/);
 });
 
-test("patient link endpoint binds a deep link to the verified identity-scoped session", async () => {
+test("patient link endpoint binds Telegram to patient_id and canonicalizes DOB proof to a booking", async () => {
   const route = await read("app/api/my-telegram-link/route.ts");
   assert.match(route, /requirePatientSession\(/);
-  assert.match(route, /session\.identityKind/);
-  assert.match(route, /session\.identityValue/);
+  assert.match(route, /patientSessionScopeIsUnambiguous/);
+  assert.match(route, /session\.patientId/);
+  assert.match(route, /session\.identityKind === "dob"/);
+  assert.match(route, /AND patient_id = \?/);
+  assert.match(route, /telegramIdentity = \{ kind:"booking", value:chosen\.code \}/);
   assert.match(route, /createTelegramLinkToken\(/);
+  assert.match(route, /session\.patientId \|\| ""/);
   assert.match(route, /https:\/\/t\.me\/\$\{username\}\?start=\$\{token\}/);
   assert.match(route, /isRateLimited\(/);
 });
@@ -69,12 +81,14 @@ test("telegram lib can message an arbitrary chat and register a webhook", async 
   assert.match(lib, /secret_token: secret/);
 });
 
-test("notify selects Telegram chat by the concrete booking identity", async () => {
+test("notify selects exact Telegram chat by patient_id and legacy chat by booking code only", async () => {
   const notify = await read("lib/notify.ts");
   assert.match(notify, /import \{ sendTelegramTo \} from ".\/telegram"/);
   assert.match(notify, /FROM patient_telegram_identities ti/);
+  assert.match(notify, /b\.patient_id != '' AND ti\.patient_id = b\.patient_id/);
+  assert.match(notify, /b\.patient_id = '' AND ti\.patient_id = ''/);
   assert.match(notify, /ti\.identity_kind = 'booking' AND ti\.identity_value = b\.code/);
-  assert.match(notify, /ti\.identity_kind = 'dob'.*ti\.identity_value = b\.date_of_birth/s);
+  assert.doesNotMatch(notify, /ti\.identity_kind = 'dob'.*ti\.identity_value = b\.date_of_birth/s);
   const pushes = notify.match(/channel: "telegram"/g) || [];
   assert.ok(pushes.length >= 2, "очікуємо Telegram-канал у reminder і message");
   assert.match(notify, /sendTelegramTo\(db, telegramChatId, body\)/);


### PR DESCRIPTION
## Finding
An exact booking with immutable `patient_id` could still resolve a persisted Telegram chat by legacy phone + booking/DOB identity. With a shared family phone and matching DOB, a historical DOB-scoped Telegram identity could therefore be selected for the wrong exact patient.

## Fix
- migration 0057 adds `patient_id` to Telegram link tokens and persisted Telegram identities
- unverifiable pre-migration Telegram tokens/identities are removed rather than guessed
- any DOB-based cabinet proof is canonicalized to a concrete booking code before Telegram persistence
- exact sessions retain immutable `patient_id` through token consumption and webhook binding
- exact notifications resolve Telegram only by matching `patient_id`
- fully legacy notifications resolve Telegram only by exact booking code, never persistent DOB fallback
- D1 rejects patient_id ↔ foreign booking proof combinations and makes Telegram patient_id immutable
- Drizzle patient-auth schema updated
- end-to-end behavior test covers two different exact patients with the same phone + same DOB and verifies delivery reaches only their respective chats

## Validation
- CI #927: green (install, audit, lint, typecheck, build, full tests, production release gate)
- CodeQL #842: green

No production deploy.