### PR TITLE
Stop inferring intake patient history from phone

### DIFF
--- a/app/staff/intake/page.tsx
+++ b/app/staff/intake/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
-import BookingDrawer from "../booking-drawer";
-import { type CalBooking } from "../week-calendar";
 import { SERVICES, groupedServices } from "../../../lib/catalog";
 import { todayInKyiv } from "../../../lib/booking-rules";
 
@@ -59,9 +57,9 @@ export default function IntakePage() {
   const [form, setForm] = useState<Form>(emptyForm);
   const [times, setTimes] = useState<string[]>([]);
   const [filter, setFilter] = useState<"attention"|"all">("attention");
-  const [query, setQuery] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [toast, setToast] = useState("");
+  const [query,setQuery] = useState("");
+  const [busy,setBusy] = useState(false);
+  const [toast,setToast] = useState("");
 
   function flash(msg:string) { setToast(msg); window.setTimeout(()=>setToast(""), 2600); }
 
@@ -91,26 +89,9 @@ export default function IntakePage() {
 
   const selected = data?.bookings.find(b => b.id === selectedId) || null;
 
-  // Drawer у Дошці: швидкий контекст попередніх досліджень пацієнта.
-  const [drawerId,setDrawerId] = useState<number | null>(null);
-  const drawerBookings = useMemo<CalBooking[]>(() => (data?.bookings || []).map((b) => ({
-    id:b.id, code:b.code, name:b.name, phone:b.phone, service:b.service, serviceCode:b.serviceCode,
-    equipmentId:b.equipmentId, durationMinutes:b.durationMinutes, desiredDate:b.desiredDate,
-    desiredTime:b.desiredTime, status:b.status, patientCategory:b.patientCategory,
-    paymentStatus:b.paymentStatus, paymentAmount:b.paymentAmount,
-  })), [data]);
-  const drawerBooking = drawerBookings.find((b) => b.id === drawerId) || null;
-
-  // Попередні дослідження цього пацієнта — за номером телефону (без окремого
-  // бекенду: беремо з уже завантаженого списку заявок). Пацієнт як центр.
-  const history = useMemo(() => {
-    if (!selected) return [] as Booking[];
-    const ph = digits(selected.phone);
-    if (!ph) return [];
-    return (data?.bookings ?? [])
-      .filter(b => b.id !== selected.id && digits(b.phone) === ph)
-      .sort((a,b) => (b.desiredDate+b.desiredTime).localeCompare(a.desiredDate+a.desiredTime));
-  }, [data, selected]);
+  // Не виводимо «попередні дослідження» з телефонного збігу. Телефон є
+  // контактним реквізитом і може належати кільком людям. Історію відкриваємо
+  // через CRM, де shared-phone вимагає вибрати конкретний immutable patient_id.
 
   // Чи форма розходиться зі збереженою заявкою (лише поля корекції).
   function formMatchesSelected() {
@@ -264,17 +245,8 @@ export default function IntakePage() {
               {selected.comment && <div className="intakeCtxComment"><b>Коментар</b><p>{selected.comment}</p></div>}
 
               <div className="intakeHistory">
-                <div className="intakeHistoryHead"><b>Попередні дослідження</b>{digits(selected.phone) ? <a className="intakeHistoryAll" href={`/staff/patients?phone=${digits(selected.phone)}`}>уся картка →</a> : <span>{history.length}</span>}</div>
-                {history.length === 0
-                  ? <p className="intakeHistoryEmpty">Перше звернення цього пацієнта (за номером телефону).</p>
-                  : <ul>{history.slice(0,8).map(h => <li key={h.id}>
-                      <button type="button" onClick={()=>setDrawerId(h.id)}>
-                        <span className="ihDate">{h.desiredDate}</span>
-                        <span className="ihSvc">{h.service}{h.equipmentId?` · ${EQUIP_UK[h.equipmentId]||h.equipmentId}`:""}</span>
-                        <span className={`ihStatus st-${h.status}`}>{STATUS_LABELS[h.status]||h.status}</span>
-                      </button></li>)}
-                    {history.length>8 && <li className="ihMore">…і ще {history.length-8}</li>}
-                  </ul>}
+                <div className="intakeHistoryHead"><b>Попередні дослідження</b>{digits(selected.phone) ? <a className="intakeHistoryAll" href={`/staff/patients?phone=${digits(selected.phone)}`}>відкрити CRM →</a> : <span>—</span>}</div>
+                <p className="intakeHistoryEmpty">Історію не визначаємо за номером телефону. Відкрийте конкретну CRM-картку пацієнта.</p>
               </div>
             </div>
 
@@ -294,13 +266,6 @@ export default function IntakePage() {
 
   return <StaffWorkspaceShell active="intake" title="Дошка прийому" description="Заявки з сайту й ручні — перегляд, корекція та обробка в одному місці." staffName={data?.staff.displayName} staffRole={data?.staff.role}>
     {body}
-    {drawerBooking && <BookingDrawer
-      key={drawerBooking.id}
-      booking={drawerBooking}
-      all={drawerBookings}
-      onClose={()=>setDrawerId(null)}
-      onOpen={setDrawerId}
-    />}
   </StaffWorkspaceShell>;
 }
 

--- a/tests/intake-patient-history-identity.test.mjs
+++ b/tests/intake-patient-history-identity.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("intake never presents phone-matched bookings as one patient's clinical history", async () => {
+  const page = await read("app/staff/intake/page.tsx");
+
+  assert.doesNotMatch(page, /digits\(b\.phone\)\s*===\s*ph/);
+  assert.doesNotMatch(page, /Попередні дослідження цього пацієнта[^\n]*номер(?:ом)? телефону/i);
+  assert.doesNotMatch(page, /Перше звернення цього пацієнта \(за номером телефону\)/);
+  assert.match(page, /Історію не визначаємо за номером телефону/);
+  assert.match(page, /\/staff\/patients\?phone=/);
+});

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -52,20 +52,22 @@ test("intake board page is a two-pane queue + editable detail, wired into the sh
   assert.match(page, /guardUnsaved/); // попередження про незбережені зміни (D4)
   // Виправлено (аудит): помилки завантаження не кладуться в data (не білий екран).
   assert.match(page, /!Array\.isArray\(payload\.bookings\) \|\| !payload\.staff/);
-  // Notion-стиль: картка «живе» — контекст пацієнта, направлення, історія.
-  assert.match(page, /intakeCtx/); // блок контексту
-  assert.match(page, /Попередні дослідження/); // історія за телефоном
-  assert.match(page, /REFERRAL_UK/); // направлення людською мовою
-  assert.match(page, /intakeEdit/); // форма корекції — згорнута
-  assert.match(page, /digits\(b\.phone\) === ph/); // історія за номером телефону
-  // Пацієнт як центр: із Дошки — перехід у повну картку пацієнта (CRM).
+  // Notion-стиль: картка «живе» — контекст пацієнта та направлення.
+  assert.match(page, /intakeCtx/);
+  assert.match(page, /Попередні дослідження/);
+  assert.match(page, /REFERRAL_UK/);
+  assert.match(page, /intakeEdit/);
+  // Телефон — контакт, а не identity: intake не має права самостійно зливати
+  // записи в одну клінічну історію. Для цього користувач переходить у CRM,
+  // де shared-phone вимагає вибрати конкретну картку patient_id.
+  assert.doesNotMatch(page, /digits\(b\.phone\) === ph/);
+  assert.doesNotMatch(page, /Перше звернення цього пацієнта \(за номером телефону\)/);
+  assert.match(page, /Історію не визначаємо за номером телефону/);
   assert.match(page, /Картка пацієнта/);
   assert.match(page, /\/staff\/patients\?phone=/);
-  // Drawer у Дошці: клік по попередньому дослідженню відкриває спільну панель.
-  assert.match(page, /<BookingDrawer/);
-  assert.match(page, /setDrawerId\(h\.id\)/);
+  assert.doesNotMatch(page, /<BookingDrawer/);
   const css = await globalsCss();
-  assert.match(css, /\.intakeHistory\b/); // стилі історії
+  assert.match(css, /\.intakeHistory\b/); // стилі identity-safe handoff секції
   assert.match(css, /\.intakeFacts\b/);   // сітка фактів
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /href:"\/staff\/intake"/);


### PR DESCRIPTION
## Finding
The intake workspace still labeled bookings sharing the same phone number as “previous studies of this patient”. Phone is contact data, not identity, so a shared family phone could make another person’s studies appear as the selected patient’s clinical history.

## Fix
- remove phone-derived clinical history from the intake workspace
- hand off history review to the CRM route, where shared-phone ambiguity is already handled fail-closed and staff must choose a concrete patient card
- remove the now-unused booking drawer history path from intake
- update the stale intake test contract that previously required phone-based history
- add a regression test forbidding phone-based patient-history inference

## Safety
- no new identity heuristic is introduced
- legacy unlinked records are not guessed or merged
- existing booking create/edit/confirm/reschedule workflow remains unchanged

## Validation
- CI #930: green (install, audit, lint, typecheck, build, full tests, production release gate)
- CodeQL #845: green

No production deploy.