### PR TITLE
Route staff patient messages through controlled notifier

### DIFF
--- a/app/staff/dashboard/page.tsx
+++ b/app/staff/dashboard/page.tsx
@@ -52,8 +52,6 @@ const needsPay = (b:CalBooking) => b.patientCategory === "civilian" && b.payment
 // Дослідження вже зроблено, але висновку ще немає — черга опису.
 const NEEDS_REPORT = new Set(["performed", "images_ready", "reporting"]);
 const needsReport = (b:CalBooking) => NEEDS_REPORT.has(b.status);
-// Посилання «написати у WhatsApp»: лишаємо тільки цифри номера.
-const waLink = (phone:string) => `https://wa.me/${(phone || "").replace(/[^\d]/g, "")}`;
 // Пацієнт як центр: імʼя веде в єдину картку пацієнта (CRM за номером).
 const patientHref = (phone:string) => `/staff/patients?phone=${(phone || "").replace(/[^\d]/g, "")}`;
 // Кольорова смужка за типом дослідження — розпізнавання за частку секунди.
@@ -331,7 +329,7 @@ export default function DashboardPage() {
                 <span className="dashNeedsCallWho"><b>{b.name || "Без імені"}</b><small>{b.service}{b.desiredDate ? ` · ${b.desiredDate} ${b.desiredTime || ""}` : ""}</small></span>
                 <span className="dashNeedsCallActions">
                   <a className="dashCardBtn" href={`tel:${b.phone}`} title={b.phone}>📞 {b.phone || "—"}</a>
-                  <a className="dashCardBtn wa" href={waLink(b.phone)} target="_blank" rel="noreferrer">WhatsApp</a>
+                  <button type="button" className="dashCardBtn wa" onClick={()=>setOpenId(b.id)}>Повідомити</button>
                   <button type="button" className="dashCardBtn ok" onClick={()=>setNeedsCall(cur => cur.filter(x => x.id !== b.id))}>✓ Подзвонив</button>
                 </span>
               </li>
@@ -361,12 +359,12 @@ export default function DashboardPage() {
       {/* Три рівні пріоритету: 1) робота зараз, 2) робота сьогодні, 3) аналітика. */}
       <p className="dashTier t1">Робота зараз</p>
 
-      {/* Дія передусім: нові заявки — картками, з телефоном, WhatsApp і підтвердженням. */}
+      {/* Дія передусім: нові заявки — картками, з телефоном, безпечним повідомленням і підтвердженням. */}
       <section className="dashPending" id="dash-pending">
         <div className="dashPendingHead">
           <h2>Нові заявки {pending.length ? <span className="dashPendingBadge">{pending.length}</span> : null}</h2>
           <small>{canManage
-            ? "Позначте кілька й підтвердьте разом, або по одній. Пацієнту йде WhatsApp."
+            ? "Позначте кілька й підтвердьте разом, або по одній. Сповіщення надсилається через захищений канал."
             : "Заявки, що очікують підтвердження реєстратури."}</small>
           {canManage && pending.length > 0 &&
             <div className="dashPendingTools">
@@ -399,7 +397,7 @@ export default function DashboardPage() {
                   <span className="dashCardWhen">{b.desiredDate} · {b.desiredTime || "—"}{doctorShort(b.assignedRadiologistEmail) ? ` · 👨‍⚕️ ${doctorShort(b.assignedRadiologistEmail)}` : ""}</span>
                   <div className="dashCardActions">
                     <a className="dashCardBtn" href={`tel:${b.phone}`} title={b.phone}>📞</a>
-                    <a className="dashCardBtn wa" href={waLink(b.phone)} target="_blank" rel="noreferrer">WhatsApp</a>
+                    <button type="button" className="dashCardBtn wa" onClick={()=>setOpenId(b.id)}>Повідомити</button>
                     {canManage
                       ? <button type="button" className="dashCardBtn ok" disabled={busyId===b.id} onClick={()=>void confirmBooking(b.id)}>
                           {busyId===b.id ? "…" : "✓ Підтвердити"}
@@ -486,7 +484,7 @@ export default function DashboardPage() {
                 <span className="dashUndWho"><b>{item.name || "—"}</b><small>{item.serviceTitle}{item.desiredDate ? ` · ${item.desiredDate} ${item.desiredTime || ""}` : ""}</small></span>
                 <span className="dashUndActions">
                   <a className="dashCardBtn" href={`tel:${item.phone || ""}`} title={item.phone}>📞 {item.phone || "—"}</a>
-                  <a className="dashCardBtn wa" href={waLink(item.phone || "")} target="_blank" rel="noreferrer">WhatsApp</a>
+                  <button type="button" className="dashCardBtn wa" onClick={()=>setOpenId(item.id)}>Повідомити</button>
                 </span>
               </li>
             ))}

--- a/app/staff/intake/page.tsx
+++ b/app/staff/intake/page.tsx
@@ -219,7 +219,6 @@ export default function IntakePage() {
               <div className="intakeHeadActions">
                 <a className="intakeCall" href={`tel:${selected.phone}`}>{selected.phone || "—"}</a>
                 {digits(selected.phone) && <a className="intakePatientLink" href={`/staff/patients?phone=${digits(selected.phone)}`}>Картка пацієнта →</a>}
-                <a className="intakeWa" href={`https://wa.me/${digits(selected.phone)}`} target="_blank" rel="noreferrer">WhatsApp</a>
                 {!readOnly && (selected.status==="new"||selected.status==="rescheduled") && <button className="intakeConfirm" disabled={busy} onClick={confirmBooking}>✓ Підтвердити</button>}
               </div>
             </div>

--- a/tests/staff-safe-patient-contact.test.mjs
+++ b/tests/staff-safe-patient-contact.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("staff booking surfaces never bypass patient contact controls with direct wa.me links", async () => {
+  const staffRoot = new URL("../app/staff/", import.meta.url);
+  const entries = await readdir(staffRoot, { recursive:true });
+  for (const entry of entries) {
+    if (!/\.(?:tsx?|jsx?)$/.test(entry)) continue;
+    const source = await readFile(new URL(entry, staffRoot), "utf8");
+    assert.doesNotMatch(source, /https:\/\/wa\.me\//, `direct WhatsApp link in app/staff/${entry}`);
+  }
+});
+
+test("dashboard patient message actions open the controlled booking drawer", async () => {
+  const dashboard = await read("app/staff/dashboard/page.tsx");
+  assert.doesNotMatch(dashboard, /const waLink/);
+  assert.doesNotMatch(dashboard, /href=\{waLink/);
+  const safeButtons = dashboard.match(/onClick=\{\(\)=>setOpenId\((?:b|item)\.id\)\}>Повідомити<\/button>/g) || [];
+  assert.equal(safeButtons.length, 3, "pending, needs-call and undelivered actions must use the safe drawer");
+
+  const drawer = await read("app/staff/booking-drawer.tsx");
+  assert.match(drawer, /fetch\("\/api\/staff\/notify"/);
+  assert.match(drawer, /bookingId: b\.id/);
+});
+
+test("intake has no direct patient messaging URL", async () => {
+  const intake = await read("app/staff/intake/page.tsx");
+  assert.doesNotMatch(intake, /wa\.me/);
+  assert.doesNotMatch(intake, /className="intakeWa"/);
+  assert.match(intake, /\/staff\/patients\?phone=/);
+});


### PR DESCRIPTION
## Finding
Staff booking surfaces still exposed direct `wa.me` links. Those links bypass the server-side patient messaging controls that enforce shared-phone ambiguity, stale exact-contact checks, do-not-contact preferences, tenant/assignment access, and the notification/audit trail.

## Fix
- remove direct WhatsApp navigation from Intake
- replace Dashboard direct WhatsApp actions in pending, needs-call, and undelivered lists with `BookingDrawer` message actions
- reuse the existing `/api/staff/notify` flow rather than duplicating messaging logic
- add a repo-level regression that forbids direct `wa.me` links anywhere under `app/staff`
- assert the dashboard safe actions open the controlled drawer and the drawer posts the exact booking id to `/api/staff/notify`

## Safety
- no patient identity is inferred from phone
- existing safe notification checks remain authoritative
- booking confirmation/reminder behavior is unchanged
- manual phone call links remain separate from app messaging

## Validation
- CI #932: green (install, audit, lint, typecheck, build, full tests, production release gate)
- CodeQL #847: green

No production deploy.