### PR TITLE
Scope patient-linked tasks to booking access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,22 +44,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Focused booking-task access diagnostic
-        shell: bash
-        run: |
-          set +e
-          output="$(node --experimental-strip-types --test tests/staff-tasks-medical-scope.behavior.test.mjs 2>&1)"
-          status=$?
-          printf '%s\n' "$output"
-          if [ "$status" -ne 0 ]; then
-            tail_output="$(printf '%s' "$output" | tail -c 6000)"
-            tail_output="${tail_output//'%'/'%25'}"
-            tail_output="${tail_output//$'\r'/'%0D'}"
-            tail_output="${tail_output//$'\n'/'%0A'}"
-            echo "::error title=Focused booking-task access test::${tail_output}"
-            exit "$status"
-          fi
-
       - name: Tests
         run: node --experimental-strip-types --test tests/*.test.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,20 @@ jobs:
         run: npm run build
 
       - name: Focused booking-task access diagnostic
-        run: node --experimental-strip-types --test tests/staff-tasks-medical-scope.behavior.test.mjs
+        shell: bash
+        run: |
+          set +e
+          output="$(node --experimental-strip-types --test tests/staff-tasks-medical-scope.behavior.test.mjs 2>&1)"
+          status=$?
+          printf '%s\n' "$output"
+          if [ "$status" -ne 0 ]; then
+            tail_output="$(printf '%s' "$output" | tail -c 6000)"
+            tail_output="${tail_output//'%'/'%25'}"
+            tail_output="${tail_output//$'\r'/'%0D'}"
+            tail_output="${tail_output//$'\n'/'%0A'}"
+            echo "::error title=Focused booking-task access test::${tail_output}"
+            exit "$status"
+          fi
 
       - name: Tests
         run: node --experimental-strip-types --test tests/*.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Focused booking-task access diagnostic
+        run: node --experimental-strip-types --test tests/staff-tasks-medical-scope.behavior.test.mjs
+
       - name: Tests
         run: node --experimental-strip-types --test tests/*.test.mjs
 

--- a/app/api/staff/tasks/route.ts
+++ b/app/api/staff/tasks/route.ts
@@ -1,5 +1,6 @@
 import { audit } from "../../../../lib/audit";
 import { dbBinding } from "../../../../lib/db";
+import { canAccessBooking, type AccessRole } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
 
 type TaskRow = {
@@ -22,25 +23,45 @@ type TaskRow = {
   sourceEntityId:string;
 };
 
+type ActiveMember = { email:string; role:AccessRole };
+
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const PRIORITIES = new Set(["low","normal","high"]);
 
-async function activeMember(db:D1Database, organizationId:number, email:string) {
-  if (!email) return true;
-  const row = await db.prepare(
-    `SELECT 1 AS ok FROM memberships m
+async function activeMember(db:D1Database, organizationId:number, email:string):Promise<ActiveMember|null> {
+  if (!email) return null;
+  return db.prepare(
+    `SELECT m.member_email AS email, m.role AS role FROM memberships m
      JOIN staff_members s ON s.email = m.member_email
      WHERE m.organization_id = ? AND m.member_email = ? AND m.active = 1 AND s.active = 1
      LIMIT 1`
-  ).bind(organizationId,email).first<{ok:number}>();
-  return !!row?.ok;
+  ).bind(organizationId,email).first<ActiveMember>();
 }
 
-async function bookingBelongsToOrg(db:D1Database, organizationId:number, bookingId:number|null) {
-  if (!bookingId) return true;
-  const row = await db.prepare("SELECT 1 AS ok FROM bookings WHERE organization_id = ? AND id = ? LIMIT 1")
-    .bind(organizationId,bookingId).first<{ok:number}>();
-  return !!row?.ok;
+function addBookingVisibility(
+  where:string[],
+  binds:(string|number)[],
+  member:{email:string;role:AccessRole},
+) {
+  if (member.role === "admin" || member.role === "registrar") return;
+  const column = member.role === "radiologist"
+    ? "assigned_radiologist_email"
+    : member.role === "radiographer"
+      ? "assigned_radiographer_email"
+      : "";
+  if (!column) {
+    where.push("t.booking_id IS NULL");
+    return;
+  }
+  where.push(`(
+    t.booking_id IS NULL OR EXISTS (
+      SELECT 1 FROM bookings b
+      WHERE b.organization_id = t.organization_id
+        AND b.id = t.booking_id
+        AND b.${column} = ?
+    )
+  )`);
+  binds.push(member.email);
 }
 
 export async function GET(request:Request) {
@@ -52,24 +73,25 @@ export async function GET(request:Request) {
   const url = new URL(request.url);
   const status = url.searchParams.get("status");
   const mine = url.searchParams.get("mine") === "1";
-  const where = ["organization_id = ?"];
+  const where = ["t.organization_id = ?"];
   const binds:(string|number)[] = [ctx.organizationId];
-  if (status === "open" || status === "done") { where.push("status = ?"); binds.push(status); }
-  if (mine) { where.push("assigned_email = ?"); binds.push(ctx.member.email); }
+  if (status === "open" || status === "done") { where.push("t.status = ?"); binds.push(status); }
+  if (mine) { where.push("t.assigned_email = ?"); binds.push(ctx.member.email); }
+  addBookingVisibility(where,binds,ctx.member);
 
   const rows = await db.prepare(
-    `SELECT id, title, details, status, priority,
-            due_date AS dueDate, booking_id AS bookingId,
-            assigned_email AS assignedEmail, created_by AS createdBy,
-            completed_by AS completedBy, completed_at AS completedAt,
-            created_at AS createdAt, updated_at AS updatedAt,
-            source, automation_key AS automationKey,
-            source_entity_type AS sourceEntityType, source_entity_id AS sourceEntityId
-     FROM staff_tasks
+    `SELECT t.id, t.title, t.details, t.status, t.priority,
+            t.due_date AS dueDate, t.booking_id AS bookingId,
+            t.assigned_email AS assignedEmail, t.created_by AS createdBy,
+            t.completed_by AS completedBy, t.completed_at AS completedAt,
+            t.created_at AS createdAt, t.updated_at AS updatedAt,
+            t.source, t.automation_key AS automationKey,
+            t.source_entity_type AS sourceEntityType, t.source_entity_id AS sourceEntityId
+     FROM staff_tasks t
      WHERE ${where.join(" AND ")}
-     ORDER BY CASE status WHEN 'open' THEN 0 ELSE 1 END,
-              CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
-              CASE WHEN due_date = '' THEN 1 ELSE 0 END, due_date, id DESC
+     ORDER BY CASE t.status WHEN 'open' THEN 0 ELSE 1 END,
+              CASE t.priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+              CASE WHEN t.due_date = '' THEN 1 ELSE 0 END, t.due_date, t.id DESC
      LIMIT 500`
   ).bind(...binds).all<TaskRow>();
 
@@ -101,8 +123,17 @@ export async function POST(request:Request) {
 
   if (!title) return Response.json({ error:"Вкажіть назву завдання" }, { status:400 });
   if (dueDate && !DATE_RE.test(dueDate)) return Response.json({ error:"Некоректна дата виконання" }, { status:400 });
-  if (!(await activeMember(db,ctx.organizationId,assignedEmail))) return Response.json({ error:"Виконавець не належить до цієї організації" }, { status:400 });
-  if (!(await bookingBelongsToOrg(db,ctx.organizationId,bookingId))) return Response.json({ error:"Дослідження не належить до цієї організації" }, { status:400 });
+  const assignee = assignedEmail ? await activeMember(db,ctx.organizationId,assignedEmail) : null;
+  if (assignedEmail && !assignee) return Response.json({ error:"Виконавець не належить до цієї організації" }, { status:400 });
+
+  if (bookingId) {
+    if (!(await canAccessBooking(db,ctx.member,bookingId,ctx.organizationId))) {
+      return Response.json({ error:"Дослідження не знайдено або воно вам не призначене" }, { status:404 });
+    }
+    if (assignee && !(await canAccessBooking(db,assignee,bookingId,ctx.organizationId))) {
+      return Response.json({ error:"Виконавець не має доступу до цього дослідження" }, { status:400 });
+    }
+  }
 
   const result = await db.prepare(
     `INSERT INTO staff_tasks
@@ -125,10 +156,14 @@ export async function PATCH(request:Request) {
   if (!Number.isInteger(id) || id < 1) return Response.json({ error:"Некоректне завдання" }, { status:400 });
 
   const existing = await db.prepare(
-    `SELECT id, status, assigned_email AS assignedEmail, created_by AS createdBy, source
+    `SELECT id, status, booking_id AS bookingId, assigned_email AS assignedEmail, created_by AS createdBy, source
      FROM staff_tasks WHERE organization_id = ? AND id = ? LIMIT 1`
-  ).bind(ctx.organizationId,id).first<{id:number;status:string;assignedEmail:string;createdBy:string;source:string}>();
+  ).bind(ctx.organizationId,id).first<{id:number;status:string;bookingId:number|null;assignedEmail:string;createdBy:string;source:string}>();
   if (!existing) return Response.json({ error:"Завдання не знайдено" }, { status:404 });
+  if (existing.bookingId && !(await canAccessBooking(db,ctx.member,existing.bookingId,ctx.organizationId))) {
+    return Response.json({ error:"Завдання не знайдено" }, { status:404 });
+  }
+
   const canEdit = ctx.member.role === "admin" || existing.assignedEmail === ctx.member.email || existing.createdBy === ctx.member.email;
   if (!canEdit) return Response.json({ error:"Немає прав змінювати це завдання" }, { status:403 });
   if (existing.source === "automation" && existing.status === "done" && body.status === "open") {
@@ -141,7 +176,13 @@ export async function PATCH(request:Request) {
   const dueDate = body.dueDate === undefined ? null : String(body.dueDate || "").trim();
   if (body.priority !== undefined && !priority) return Response.json({ error:"Некоректний пріоритет" }, { status:400 });
   if (dueDate !== null && dueDate && !DATE_RE.test(dueDate)) return Response.json({ error:"Некоректна дата" }, { status:400 });
-  if (!(await activeMember(db,ctx.organizationId,assignedEmail))) return Response.json({ error:"Виконавець не належить до цієї організації" }, { status:400 });
+
+  const assignee = assignedEmail ? await activeMember(db,ctx.organizationId,assignedEmail) : null;
+  if (assignedEmail && !assignee) return Response.json({ error:"Виконавець не належить до цієї організації" }, { status:400 });
+  if (existing.bookingId && body.assignedEmail !== undefined && assignee
+    && !(await canAccessBooking(db,assignee,existing.bookingId,ctx.organizationId))) {
+    return Response.json({ error:"Виконавець не має доступу до цього дослідження" }, { status:400 });
+  }
 
   await db.prepare(
     `UPDATE staff_tasks SET

--- a/drizzle/0058_staff_task_booking_integrity.sql
+++ b/drizzle/0058_staff_task_booking_integrity.sql
@@ -1,0 +1,29 @@
+-- A patient-linked staff task must belong to the same tenant as its booking.
+-- Operational tasks with booking_id IS NULL remain department-wide.
+
+CREATE TRIGGER IF NOT EXISTS `staff_tasks_booking_tenant_insert`
+BEFORE INSERT ON `staff_tasks`
+FOR EACH ROW
+WHEN NEW.booking_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.id = NEW.booking_id
+      AND b.organization_id = NEW.organization_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'staff task booking tenant mismatch');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `staff_tasks_booking_tenant_update`
+BEFORE UPDATE OF `organization_id`, `booking_id` ON `staff_tasks`
+FOR EACH ROW
+WHEN NEW.booking_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.id = NEW.booking_id
+      AND b.organization_id = NEW.organization_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'staff task booking tenant mismatch');
+END;

--- a/tests/staff-tasks-medical-scope.behavior.test.mjs
+++ b/tests/staff-tasks-medical-scope.behavior.test.mjs
@@ -105,3 +105,36 @@ test("booking-linked tasks follow current booking access while department tasks 
       "new booking assignee receives patient-linked task visibility");
   });
 });
+
+test("D1 rejects cross-tenant booking references on staff tasks", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'task-org-two', 'Task Org Two', 1)").run();
+    const foreignBooking = await db.prepare(
+      `INSERT INTO bookings
+        (organization_id, code, name, phone, phone_normalized, service, service_code,
+         equipment_id, desired_date, desired_time)
+       VALUES (2, 'TASK-ORG2-001', 'Foreign Patient', '+380509999999', '380509999999',
+         'КТ', '408', 'ct', '2026-08-21', '15:00')`
+    ).run();
+    const foreignBookingId = Number(foreignBooking.meta.last_row_id);
+
+    await assert.rejects(
+      db.prepare(
+        `INSERT INTO staff_tasks
+          (organization_id, title, details, booking_id, created_by)
+         VALUES (1, 'Cross tenant', 'SECRET', ?, 'admin@example.com')`
+      ).bind(foreignBookingId).run(),
+      /staff task booking tenant mismatch/i,
+    );
+
+    const localTask = await db.prepare(
+      `INSERT INTO staff_tasks (organization_id, title, details, created_by)
+       VALUES (1, 'Department task', '', 'admin@example.com')`
+    ).run();
+    await assert.rejects(
+      db.prepare("UPDATE staff_tasks SET booking_id = ? WHERE organization_id = 1 AND id = ?")
+        .bind(foreignBookingId, Number(localTask.meta.last_row_id)).run(),
+      /staff task booking tenant mismatch/i,
+    );
+  });
+});

--- a/tests/staff-tasks-medical-scope.behavior.test.mjs
+++ b/tests/staff-tasks-medical-scope.behavior.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addBooking(db, { code, doctor = "", radiographer = "" }) {
+  const result = await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, phone_normalized, service, service_code,
+       equipment_id, desired_date, desired_time, assigned_radiologist_email, assigned_radiographer_email)
+     VALUES (1, ?, ?, '+380501112233', '380501112233', 'КТ', '408', 'ct',
+       '2026-08-20', '10:00', ?, ?)`
+  ).bind(code, `Patient ${code}`, doctor, radiographer).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function createTask(db, cookie, body) {
+  return callWorker(jsonRequest("/api/staff/tasks", body, { headers:{ cookie } }), db);
+}
+
+async function listTasks(db, cookie) {
+  const response = await callWorker(new Request("http://localhost/api/staff/tasks", { headers:{ cookie } }), db);
+  assert.equal(response.status, 200);
+  return response.json();
+}
+
+test("booking-linked tasks follow current booking access while department tasks remain shared", async () => {
+  await withD1(async (db) => {
+    const admin = await seedStaffSession(db, { email:"task-admin@example.com", role:"admin" });
+    const doctorA = await seedStaffSession(db, { email:"task-a@example.com", role:"radiologist" });
+    const doctorB = await seedStaffSession(db, { email:"task-b@example.com", role:"radiologist" });
+    const techA = await seedStaffSession(db, { email:"task-tech@example.com", role:"radiographer" });
+
+    const bookingA = await addBooking(db, { code:"TASK-A-001", doctor:"task-a@example.com", radiographer:"task-tech@example.com" });
+    const bookingB = await addBooking(db, { code:"TASK-B-001", doctor:"task-b@example.com" });
+
+    const general = await createTask(db, admin, { title:"Перевірити запас контрасту" });
+    assert.equal(general.status, 201);
+    const generalId = (await general.json()).id;
+
+    const linkedB = await createTask(db, admin, {
+      title:"Уточнити клінічний висновок пацієнта B",
+      details:"PATIENT-B-SECRET",
+      bookingId:bookingB,
+      assignedEmail:"task-b@example.com",
+    });
+    assert.equal(linkedB.status, 201);
+    const linkedBId = (await linkedB.json()).id;
+
+    const aList = await listTasks(db, doctorA);
+    assert.equal(aList.tasks.some((task) => task.id === generalId), true, "department task remains shared");
+    assert.equal(aList.tasks.some((task) => task.id === linkedBId), false, "foreign patient task must be hidden");
+    assert.doesNotMatch(JSON.stringify(aList), /PATIENT-B-SECRET/);
+
+    const bList = await listTasks(db, doctorB);
+    assert.equal(bList.tasks.some((task) => task.id === generalId), true);
+    assert.equal(bList.tasks.some((task) => task.id === linkedBId), true);
+
+    const techList = await listTasks(db, techA);
+    assert.equal(techList.tasks.some((task) => task.id === linkedBId), false);
+
+    const foreignCreate = await createTask(db, doctorA, {
+      title:"Спроба прив'язати чуже дослідження",
+      bookingId:bookingB,
+      assignedEmail:"task-a@example.com",
+    });
+    assert.equal(foreignCreate.status, 404);
+
+    const badAssignee = await createTask(db, admin, {
+      title:"Неправильний виконавець",
+      bookingId:bookingA,
+      assignedEmail:"task-b@example.com",
+    });
+    assert.equal(badAssignee.status, 400);
+    assert.match(JSON.stringify(await badAssignee.json()), /не має доступу/i);
+
+    const linkedA = await createTask(db, admin, {
+      title:"Завдання пацієнта A",
+      details:"PATIENT-A-SECRET",
+      bookingId:bookingA,
+      assignedEmail:"task-a@example.com",
+    });
+    assert.equal(linkedA.status, 201);
+    const linkedAId = (await linkedA.json()).id;
+
+    const techAList = await listTasks(db, techA);
+    assert.equal(techAList.tasks.some((task) => task.id === linkedAId), true,
+      "assigned radiographer may see a booking-linked task for the same study");
+
+    await db.prepare(
+      "UPDATE bookings SET assigned_radiologist_email = 'task-b@example.com' WHERE organization_id = 1 AND id = ?"
+    ).bind(bookingA).run();
+
+    const aAfterReassign = await listTasks(db, doctorA);
+    assert.equal(aAfterReassign.tasks.some((task) => task.id === linkedAId), false,
+      "revoked booking access must revoke task visibility too");
+    assert.doesNotMatch(JSON.stringify(aAfterReassign), /PATIENT-A-SECRET/);
+
+    const stalePatch = await callWorker(jsonRequest("/api/staff/tasks", { id:linkedAId, status:"done" }, {
+      method:"PATCH", headers:{ cookie:doctorA },
+    }), db);
+    assert.equal(stalePatch.status, 404, "former creator/assignee cannot mutate after booking access is revoked");
+
+    const bAfterReassign = await listTasks(db, doctorB);
+    assert.equal(bAfterReassign.tasks.some((task) => task.id === linkedAId), true,
+      "new booking assignee receives patient-linked task visibility");
+  });
+});

--- a/tests/staff-tasks-medical-scope.behavior.test.mjs
+++ b/tests/staff-tasks-medical-scope.behavior.test.mjs
@@ -2,14 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
-async function addBooking(db, { code, doctor = "", radiographer = "" }) {
+async function addBooking(db, { code, doctor = "", radiographer = "", time = "10:00" }) {
   const result = await db.prepare(
     `INSERT INTO bookings
       (organization_id, code, name, phone, phone_normalized, service, service_code,
        equipment_id, desired_date, desired_time, assigned_radiologist_email, assigned_radiographer_email)
      VALUES (1, ?, ?, '+380501112233', '380501112233', 'КТ', '408', 'ct',
-       '2026-08-20', '10:00', ?, ?)`
-  ).bind(code, `Patient ${code}`, doctor, radiographer).run();
+       '2026-08-20', ?, ?, ?)`
+  ).bind(code, `Patient ${code}`, time, doctor, radiographer).run();
   return Number(result.meta.last_row_id);
 }
 
@@ -30,8 +30,8 @@ test("booking-linked tasks follow current booking access while department tasks 
     const doctorB = await seedStaffSession(db, { email:"task-b@example.com", role:"radiologist" });
     const techA = await seedStaffSession(db, { email:"task-tech@example.com", role:"radiographer" });
 
-    const bookingA = await addBooking(db, { code:"TASK-A-001", doctor:"task-a@example.com", radiographer:"task-tech@example.com" });
-    const bookingB = await addBooking(db, { code:"TASK-B-001", doctor:"task-b@example.com" });
+    const bookingA = await addBooking(db, { code:"TASK-A-001", doctor:"task-a@example.com", radiographer:"task-tech@example.com", time:"10:00" });
+    const bookingB = await addBooking(db, { code:"TASK-B-001", doctor:"task-b@example.com", time:"13:00" });
 
     const general = await createTask(db, admin, { title:"Перевірити запас контрасту" });
     assert.equal(general.status, 201);


### PR DESCRIPTION
## Finding
Department tasks are intentionally shared, but tasks linked to a booking (`booking_id`) were also returned tenant-wide to every operational staff role. A radiologist/radiographer could therefore see task title/details for another clinician's patient, create a task against a foreign booking by ID, or retain mutation rights through old creator/assignee status after booking assignment changed.

## Fix
- keep unlinked operational tasks department-wide
- filter booking-linked task GET results by current booking access
- require the creator to have `canAccessBooking` before linking a task to a study
- reject a linked-task assignee who does not have access to that booking
- re-check current booking access before PATCH, so reassignment revokes old task access too
- return 404 for inaccessible patient-linked tasks to avoid confirming their existence
- migration 0058 enforces same-tenant `staff_tasks.booking_id` integrity at D1 level

## Regression coverage
- shared operational task remains visible to clinicians
- foreign patient task title/details do not leak
- clinician cannot create a task against another clinician's booking
- admin cannot assign a patient-linked task to a staff member without booking access
- radiologist and radiographer assigned to the same study can see its linked task
- after booking reassignment, former clinician loses both task visibility and mutation access
- D1 rejects insert/update of a task that references another tenant's booking

## Validation
- CI #940: green (install, audit, lint, typecheck, build, full tests, production release gate)
- CodeQL #855: green

No production deploy.