### PR TITLE
Fail closed on stale Drizzle generation metadata

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,34 @@
+# Database migrations
+
+## Current source of truth
+
+Production D1 schema changes are the committed SQL files in `drizzle/`, applied in filename order by Cloudflare Wrangler. The production deployment script runs:
+
+```sh
+wrangler d1 migrations apply radiologyos --remote
+```
+
+Do not generate or replace an already committed migration after it may have been applied to an environment.
+
+## Why `npm run db:generate` is guarded
+
+The repository has a historical Drizzle metadata gap: `drizzle/meta/_journal.json` and the available snapshots do not represent the full committed SQL migration history. `db/schema.ts` also does not yet model every table/column introduced by later manual migrations.
+
+Running `drizzle-kit generate` against that stale state can create duplicate or rollback-like SQL for objects that already exist in D1. `npm run db:generate` therefore runs `scripts/db-generate-guard.mjs` first and fails closed unless both conditions are true:
+
+1. the latest journal tag equals the latest committed SQL migration tag; and
+2. a snapshot for that latest migration number exists.
+
+This guard does not affect production deployment because deployment applies committed SQL migrations directly.
+
+## Re-enabling generated migrations
+
+Re-enable normal Drizzle generation only as a dedicated migration-maintenance change:
+
+1. reconstruct a canonical Drizzle schema that matches the fully migrated D1 shape;
+2. rebaseline `drizzle/meta` through the latest committed migration without changing production data;
+3. verify a fresh `drizzle-kit generate` proposes no duplicate/destructive migration for the current schema;
+4. keep the generation guard until CI proves the journal and latest snapshot are current;
+5. review the generated SQL before any future migration is merged or applied.
+
+Clinical and tenant-integrity triggers that are intentionally authored as raw SQL remain part of the committed migration history even when the table shape is represented in Drizzle.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:production-gate": "npm run build && node --experimental-strip-types --test tests/canonical-public-url.test.mjs tests/hosting-headers.test.mjs tests/deploy-config.test.mjs tests/outbound-security.test.mjs tests/reminders-tenant.behavior.test.mjs tests/site-booking.behavior.test.mjs tests/booking-capacity.test.mjs tests/staff-confirm-reschedule.behavior.test.mjs tests/staff-rbac.behavior.test.mjs tests/patient-otp.behavior.test.mjs tests/patient-cabinet-tenant.test.mjs tests/my-bookings.behavior.test.mjs tests/payment-api.behavior.test.mjs tests/payment-ledger.behavior.test.mjs tests/payment-settlement.behavior.test.mjs tests/study-state.test.mjs tests/protocol-builder.test.mjs tests/dashboard.test.mjs tests/security-hardening.test.mjs tests/tenant-hardening.test.mjs tests/migration-upgrade.test.mjs",
     "validate:artifact": "bash scripts/validate-artifact.sh",
     "lint": "bash scripts/sites-env.sh -- eslint . --ignore-pattern dist --ignore-pattern .next --ignore-pattern public",
-    "db:generate": "bash scripts/sites-env.sh -- drizzle-kit generate"
+    "db:generate": "node scripts/db-generate-guard.mjs"
   },
   "dependencies": {
     "drizzle-orm": "0.45.2",
@@ -34,7 +34,6 @@
     "drizzle-kit": "0.31.10",
     "eslint": "9.39.4",
     "eslint-config-next": "16.2.12",
-    "react-server-dom-webpack": "19.2.6",
     "tailwindcss": "4.2.1",
     "typescript": "5.9.3",
     "vinext": "0.0.50",

--- a/scripts/db-generate-guard.mjs
+++ b/scripts/db-generate-guard.mjs
@@ -1,0 +1,66 @@
+import { readdir, readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = new URL("../", import.meta.url);
+const drizzleDir = new URL("drizzle/", root);
+const metaDir = new URL("drizzle/meta/", root);
+
+function migrationTag(name) {
+  return name.replace(/\.sql$/i, "");
+}
+
+async function state() {
+  const files = (await readdir(fileURLToPath(drizzleDir)))
+    .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+    .sort();
+  if (!files.length) throw new Error("No SQL migrations found in drizzle/");
+
+  const latestMigration = migrationTag(files.at(-1));
+  const journal = JSON.parse(await readFile(new URL("_journal.json", metaDir), "utf8"));
+  const entries = Array.isArray(journal?.entries) ? journal.entries : [];
+  const latestJournal = entries.length ? String(entries.at(-1)?.tag || "") : "";
+  const snapshots = (await readdir(fileURLToPath(metaDir)))
+    .filter((name) => /^\d{4}_snapshot\.json$/.test(name))
+    .sort();
+  const expectedSnapshot = `${latestMigration.slice(0,4)}_snapshot.json`;
+
+  return {
+    latestMigration,
+    latestJournal,
+    expectedSnapshot,
+    hasLatestSnapshot:snapshots.includes(expectedSnapshot),
+  };
+}
+
+async function main() {
+  const current = await state();
+  if (current.latestJournal !== current.latestMigration || !current.hasLatestSnapshot) {
+    console.error("Drizzle schema generation is blocked: migration metadata is stale.");
+    console.error(`Latest SQL migration: ${current.latestMigration}`);
+    console.error(`Latest journal entry: ${current.latestJournal || "<none>"}`);
+    console.error(`Required current snapshot: drizzle/meta/${current.expectedSnapshot}`);
+    console.error("Do not run drizzle-kit generate until the full migration history has been rebaselined into Drizzle metadata.");
+    console.error("Production deployment is unaffected: it applies committed SQL migrations with wrangler d1 migrations apply.");
+    process.exit(1);
+  }
+
+  const child = spawn(process.platform === "win32" ? "npm.cmd" : "npm", ["exec", "drizzle-kit", "generate"], {
+    cwd:fileURLToPath(root),
+    stdio:"inherit",
+    shell:false,
+  });
+  child.on("error", (error) => {
+    console.error(`Unable to start drizzle-kit: ${error.message}`);
+    process.exit(1);
+  });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      console.error(`drizzle-kit terminated by ${signal}`);
+      process.exit(1);
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+await main();

--- a/tests/drizzle-generation-guard.test.mjs
+++ b/tests/drizzle-generation-guard.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = new URL("../", import.meta.url);
+const read = (path) => readFile(new URL(path, root), "utf8");
+
+test("db:generate fails closed while Drizzle metadata trails committed SQL migrations", async () => {
+  const pkg = JSON.parse(await read("package.json"));
+  assert.equal(pkg.scripts["db:generate"], "node scripts/db-generate-guard.mjs");
+
+  const migrationFiles = (await readdir(fileURLToPath(new URL("drizzle/", root))))
+    .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+    .sort();
+  const latestMigration = migrationFiles.at(-1).replace(/\.sql$/, "");
+  const journal = JSON.parse(await read("drizzle/meta/_journal.json"));
+  const latestJournal = String(journal.entries.at(-1)?.tag || "");
+  assert.notEqual(latestJournal, latestMigration,
+    "this guard test should be removed/changed after Drizzle metadata is fully rebaselined");
+
+  const result = spawnSync(process.execPath, ["scripts/db-generate-guard.mjs"], {
+    cwd:fileURLToPath(root),
+    encoding:"utf8",
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /migration metadata is stale/i);
+  assert.match(result.stderr, new RegExp(`Latest SQL migration: ${latestMigration}`));
+  assert.match(result.stderr, new RegExp(`Latest journal entry: ${latestJournal}`));
+  assert.match(result.stderr, /Do not run drizzle-kit generate until the full migration history has been rebaselined/i);
+});
+
+test("production deploy applies committed SQL migrations directly instead of generating schema", async () => {
+  const deploy = await read("scripts/deploy-cloudflare.sh");
+  assert.match(deploy, /wrangler d1 migrations apply radiologyos --remote/);
+  assert.doesNotMatch(deploy, /db:generate|drizzle-kit generate/);
+});


### PR DESCRIPTION
## Finding
`drizzle.config.ts` points `drizzle-kit generate` at `db/schema.ts`, but the Drizzle metadata is far behind the real committed SQL history: `_journal.json` stops at 0016 while production migrations now extend through 0058, and only the 0000 snapshot exists. The TypeScript schema also trails later manually-authored tables/columns. Running `npm run db:generate` in this state can therefore create duplicate or rollback-like SQL for objects that already exist in D1.

## Fix
- replace direct `drizzle-kit generate` with `scripts/db-generate-guard.mjs`
- guard compares the latest committed SQL migration tag with the latest journal tag
- guard also requires a snapshot matching the latest migration number
- only when metadata is current does it invoke `drizzle-kit generate`
- document committed SQL migrations as the current production source of truth and the controlled rebaseline procedure
- add regression coverage proving generation fails closed while metadata is stale and production deploy still applies committed SQL directly

## Runtime / deployment impact
- no D1 schema change
- no migration added
- no application runtime change
- production deployment remains `wrangler d1 migrations apply` and is unaffected

Draft until CI and CodeQL are green.

No production deploy.