### PR TITLE
Restore manual-only production deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to Cloudflare
 
-# Manual trigger remains the normal deployment path. The temporary push trigger
-# below runs only for an explicitly approved main merge whose commit message
-# contains [deploy-approved]; it will be removed immediately after this rollout.
+# Manual trigger only — run it from the Actions tab after the two repository
+# secrets (CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID) are set. The build runs
+# on GitHub's Linux runner, so nothing needs to be built locally.
 on:
   workflow_dispatch:
     inputs:
@@ -14,9 +14,6 @@ on:
         options:
           - CANCEL
           - DEPLOY
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -28,7 +25,7 @@ concurrency:
 jobs:
   deploy:
     name: Build and deploy
-    if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.confirmation == 'DEPLOY') || (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[deploy-approved]')) }}
+    if: ${{ inputs.confirmation == 'DEPLOY' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     environment: production


### PR DESCRIPTION
Production deploy run #135 succeeded. This cleanup PR removes the temporary `[deploy-approved]` push trigger and restores `.github/workflows/deploy.yml` byte-for-byte to the prior manual-only workflow.

No application code, D1 migration, runtime configuration, or production data changes are included.