### PR TITLE
Post performed studies through BAS service-delivery acts

### DIFF
--- a/app/api/staff/service-delivery/print/route.ts
+++ b/app/api/staff/service-delivery/print/route.ts
@@ -1,0 +1,162 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import { getServiceDeliveryDocument } from "../../../../../lib/service-delivery";
+import { canManageFinance } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+const TEMPLATE_VERSION=1;
+const FORM_TYPE="service_act";
+
+type SnapshotRow={
+  id:number;documentId:number;formType:string;templateVersion:number;documentState:string;
+  payloadJson:string;generatedBy:string;generatedAt:string;storageKey:string;sha256:string;
+};
+
+function int(value:unknown) {
+  const n=Number(value);
+  return Number.isInteger(n)&&n>0?n:null;
+}
+
+async function sha256(value:string) {
+  const bytes=new TextEncoder().encode(value);
+  const digest=await crypto.subtle.digest("SHA-256",bytes);
+  return Array.from(new Uint8Array(digest),b=>b.toString(16).padStart(2,"0")).join("");
+}
+
+function publicSnapshot(row:SnapshotRow) {
+  const {payloadJson:_,...snapshot}=row;
+  void _;
+  return snapshot;
+}
+
+async function renderPayload(db:D1Database,organizationId:number,documentId:number) {
+  const serviceAct=await getServiceDeliveryDocument(db,organizationId,documentId);
+  if(!serviceAct) return null;
+  const organization=await db.prepare("SELECT name FROM organizations WHERE id=? LIMIT 1")
+    .bind(organizationId).first<{name:string}>();
+  return {
+    templateVersion:TEMPLATE_VERSION,
+    formType:FORM_TYPE,
+    organization:{name:organization?.name || "Організація"},
+    document:{
+      id:serviceAct.id,
+      number:serviceAct.number,
+      documentType:"service_delivery",
+      occurredAt:serviceAct.occurredAt,
+      state:serviceAct.state,
+      createdBy:serviceAct.createdBy,
+      postedBy:serviceAct.postedBy,
+      postedAt:serviceAct.postedAt,
+    },
+    booking:{
+      id:serviceAct.bookingId,
+      code:serviceAct.bookingCode,
+      patientName:serviceAct.patientName,
+      patientId:serviceAct.patientId,
+      patientCategory:serviceAct.patientCategory,
+    },
+    service:{
+      code:serviceAct.serviceCode,
+      name:serviceAct.serviceName,
+      chargeAmount:serviceAct.chargeAmount,
+      currency:serviceAct.currency,
+    },
+    execution:{
+      equipmentId:serviceAct.equipmentId,
+      durationMinutes:serviceAct.durationMinutes,
+      performedAt:serviceAct.performedAt,
+      anatomicalRegionsCount:serviceAct.anatomicalRegionsCount,
+      radiologistEmail:serviceAct.radiologistEmail,
+      radiographerEmail:serviceAct.radiographerEmail,
+    },
+  };
+}
+
+async function serviceActContext(request:Request) {
+  const db=dbBinding();
+  if(!db) return {response:Response.json({error:"База тимчасово недоступна"},{status:503})} as const;
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return {response:Response.json({error:"Доступ лише для персоналу"},{status:403})} as const;
+  if(!canManageFinance(ctx.member.role)) {
+    return {response:Response.json({error:"Друк актів доступний реєстратору або адміністратору"},{status:403})} as const;
+  }
+  return {db,ctx} as const;
+}
+
+export async function GET(request:Request) {
+  const auth=await serviceActContext(request);
+  if("response" in auth) return auth.response;
+  const {db,ctx}=auth;
+  const snapshotId=int(new URL(request.url).searchParams.get("snapshotId"));
+  if(!snapshotId) return Response.json({error:"Некоректна друкована форма"},{status:400});
+  const row=await db.prepare(
+    `SELECT s.id,s.document_id AS documentId,s.form_type AS formType,s.template_version AS templateVersion,
+            s.document_state AS documentState,s.payload_json AS payloadJson,s.generated_by AS generatedBy,
+            s.generated_at AS generatedAt,s.storage_key AS storageKey,s.sha256
+     FROM printed_form_snapshots s
+     JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+     JOIN service_delivery_details a ON a.document_id=d.id AND a.organization_id=d.organization_id
+     WHERE s.organization_id=? AND s.id=? AND s.form_type=? AND d.document_type='service_delivery' LIMIT 1`
+  ).bind(ctx.organizationId,snapshotId,FORM_TYPE).first<SnapshotRow>();
+  if(!row) return Response.json({error:"Друковану форму не знайдено"},{status:404});
+  return Response.json({snapshot:publicSnapshot(row),payload:JSON.parse(row.payloadJson)});
+}
+
+export async function POST(request:Request) {
+  const auth=await serviceActContext(request);
+  if("response" in auth) return auth.response;
+  const {db,ctx}=auth;
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const documentId=int(body.documentId);
+  if(!documentId) return Response.json({error:"Некоректний документ"},{status:400});
+
+  const serviceAct=await getServiceDeliveryDocument(db,ctx.organizationId,documentId);
+  if(!serviceAct) return Response.json({error:"Акт надання послуг не знайдено"},{status:404});
+  const documentState=serviceAct.state;
+
+  const existing=await db.prepare(
+    `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+            document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+            generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=? AND form_type=? AND template_version=? AND document_state=?
+     ORDER BY id ASC LIMIT 1`
+  ).bind(ctx.organizationId,documentId,FORM_TYPE,TEMPLATE_VERSION,documentState).first<SnapshotRow>();
+  if(existing) {
+    await audit(db,{
+      organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+      action:"printed_form_reprinted",resource:"business_document",targetId:documentId,
+      details:{formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,snapshotId:existing.id},
+    });
+    return Response.json({snapshot:publicSnapshot(existing),payload:JSON.parse(existing.payloadJson)});
+  }
+
+  const payload=await renderPayload(db,ctx.organizationId,documentId);
+  if(!payload) return Response.json({error:"Акт надання послуг не знайдено"},{status:404});
+  const payloadJson=JSON.stringify(payload);
+  const hash=await sha256(payloadJson);
+  await db.prepare(
+    `INSERT OR IGNORE INTO printed_form_snapshots
+      (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,sha256)
+     VALUES (?,?,?,?,?,?,?,?)`
+  ).bind(
+    ctx.organizationId,documentId,FORM_TYPE,TEMPLATE_VERSION,documentState,payloadJson,ctx.member.email,hash,
+  ).run();
+  const snapshot=await db.prepare(
+    `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+            document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+            generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=? AND form_type=? AND template_version=? AND document_state=? AND sha256=?
+     LIMIT 1`
+  ).bind(
+    ctx.organizationId,documentId,FORM_TYPE,TEMPLATE_VERSION,documentState,hash,
+  ).first<SnapshotRow>();
+  if(!snapshot) return Response.json({error:"Не вдалося зберегти друкований акт"},{status:500});
+  await audit(db,{
+    organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+    action:"printed_form_generated",resource:"business_document",targetId:documentId,
+    details:{formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,snapshotId:snapshot.id},
+  });
+  return Response.json({snapshot:publicSnapshot(snapshot),payload},{status:201});
+}

--- a/app/api/staff/service-delivery/route.ts
+++ b/app/api/staff/service-delivery/route.ts
@@ -1,0 +1,36 @@
+import { dbBinding } from "../../../../lib/db";
+import {
+  listEquipmentWorkload,
+  listRevenueMovements,
+  listServiceDeliveryDocuments,
+  listStaffOutput,
+  serviceDeliveryTotals,
+} from "../../../../lib/service-delivery";
+import { canManageFinance } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+export async function GET(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canManageFinance(ctx.member.role)) {
+    return Response.json({error:"Журнал наданих послуг доступний реєстратору або адміністратору"},{status:403});
+  }
+
+  const [totals,documents,revenueMovements,equipmentWorkload,staffOutput]=await Promise.all([
+    serviceDeliveryTotals(db,ctx.organizationId),
+    listServiceDeliveryDocuments(db,ctx.organizationId),
+    listRevenueMovements(db,ctx.organizationId),
+    listEquipmentWorkload(db,ctx.organizationId),
+    listStaffOutput(db,ctx.organizationId),
+  ]);
+
+  return Response.json({
+    totals,
+    documents,
+    revenueMovements,
+    equipmentWorkload,
+    staffOutput,
+  });
+}

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -102,6 +102,12 @@ export default function FinancePage() {
       <article><span>Документів</span><b>{data?.documents.length || 0}</b><small>оплата / повернення</small></article>
     </section>
 
+    <aside className="financeLegacyNotice">
+      <b>Надання послуг</b>
+      <span>Виконані дослідження проводяться окремими BAS-Актами з доходом, взаєморозрахунками, навантаженням обладнання та виробітком персоналу.</span>
+      <a href="/staff/service-delivery">Відкрити журнал наданих послуг →</a>
+    </aside>
+
     {!!data?.legacyTransactionCount && <aside className="financeLegacyNotice">
       <b>Legacy: {data.legacyTransactionCount}</b>
       <span>Історичні підтверджені транзакції, створені до BAS-реєстратора, не перетворюються на документи заднім числом і не входять у підсумки нового регістру.</span>

--- a/app/staff/service-delivery/page.tsx
+++ b/app/staff/service-delivery/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback,useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type Totals={
+  acts:number;civilianActs:number;militaryActs:number;revenue:number;
+  studies:number;minutes:number;regions:number;staffAssignments:number;unpostedPerformedCount:number;
+};
+type ServiceAct={
+  id:number;number:string;occurredAt:string;state:string;bookingId:number;bookingCode:string;
+  patientName:string;patientId:string;serviceCode:string;serviceName:string;patientCategory:string;
+  chargeAmount:number;currency:string;equipmentId:string;durationMinutes:number;performedAt:string;
+  anatomicalRegionsCount:number;radiologistEmail:string;radiographerEmail:string;
+};
+type RevenueMovement={
+  id:number;documentId:number;documentNumber:string;bookingId:number;bookingCode:string;patientName:string;
+  movementType:string;amountDelta:number;currency:string;serviceCode:string;actorEmail:string;occurredAt:string;
+};
+type EquipmentWorkload={
+  id:number;documentId:number;documentNumber:string;bookingId:number;bookingCode:string;equipmentId:string;
+  studyCount:number;durationMinutes:number;anatomicalRegionsCount:number;performedAt:string;
+};
+type StaffOutput={
+  id:number;documentId:number;documentNumber:string;bookingId:number;bookingCode:string;staffEmail:string;
+  staffRole:"radiologist"|"radiographer";studyCount:number;anatomicalRegionsCount:number;performedAt:string;
+};
+type Payload={
+  totals:Totals;documents:ServiceAct[];revenueMovements:RevenueMovement[];
+  equipmentWorkload:EquipmentWorkload[];staffOutput:StaffOutput[];error?:string;
+};
+type Tab="acts"|"revenue"|"equipment"|"staff";
+
+const CATEGORY_UK:Record<string,string>={civilian:"Цивільний",military:"Військовий"};
+const ROLE_UK:Record<string,string>={radiologist:"Лікар-рентгенолог",radiographer:"Рентгенолаборант"};
+function money(value:number,currency="UAH"){
+  return new Intl.NumberFormat("uk-UA",{style:"currency",currency,maximumFractionDigits:0}).format(Number(value||0));
+}
+function dateTime(value:string){
+  const date=new Date(value);
+  return Number.isNaN(date.getTime())?value:date.toLocaleString("uk-UA",{dateStyle:"medium",timeStyle:"short"});
+}
+
+export default function ServiceDeliveryPage(){
+  const [data,setData]=useState<Payload|null>(null);
+  const [error,setError]=useState("");
+  const [tab,setTab]=useState<Tab>("acts");
+  const [query,setQuery]=useState("");
+
+  const load=useCallback(async()=>{
+    try{
+      const response=await fetch("/api/staff/service-delivery",{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as Payload;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося завантажити журнал наданих послуг");
+      setData(payload);setError("");
+    }catch(e){setError(e instanceof Error?e.message:"Не вдалося завантажити журнал наданих послуг");}
+  },[]);
+
+  useEffect(()=>{
+    const timer=window.setTimeout(()=>{void load();},0);
+    return()=>window.clearTimeout(timer);
+  },[load]);
+
+  const q=query.trim().toLowerCase();
+  const acts=useMemo(()=>{
+    const rows=data?.documents||[];
+    if(!q)return rows;
+    return rows.filter(row=>`${row.number} ${row.bookingCode} ${row.patientName} ${row.serviceName} ${row.equipmentId}`.toLowerCase().includes(q));
+  },[data,q]);
+  const revenue=useMemo(()=>{
+    const rows=data?.revenueMovements||[];
+    if(!q)return rows;
+    return rows.filter(row=>`${row.documentNumber} ${row.bookingCode} ${row.patientName} ${row.serviceCode}`.toLowerCase().includes(q));
+  },[data,q]);
+  const equipment=useMemo(()=>{
+    const rows=data?.equipmentWorkload||[];
+    if(!q)return rows;
+    return rows.filter(row=>`${row.documentNumber} ${row.bookingCode} ${row.equipmentId}`.toLowerCase().includes(q));
+  },[data,q]);
+  const staff=useMemo(()=>{
+    const rows=data?.staffOutput||[];
+    if(!q)return rows;
+    return rows.filter(row=>`${row.documentNumber} ${row.bookingCode} ${row.staffEmail} ${row.staffRole}`.toLowerCase().includes(q));
+  },[data,q]);
+
+  function printAct(id:number){window.open(`/staff/service-delivery/print?id=${id}`,"_blank","noopener,noreferrer");}
+
+  return <StaffWorkspaceShell
+    active="finance"
+    title="Надані послуги"
+    description="BAS-журнал актів виконаних досліджень, доходу, навантаження обладнання та виробітку персоналу."
+  >
+    <section className="financeSummary" aria-label="Підсумок наданих послуг">
+      <article><span>Актів</span><b>{data?.totals.acts||0}</b><small>{data?`${data.totals.civilianActs} цив. · ${data.totals.militaryActs} військ.`:"—"}</small></article>
+      <article><span>Визнаний дохід</span><b>{money(data?.totals.revenue||0)}</b><small>тільки проведені цивільні послуги</small></article>
+      <article><span>Дослідження / зони</span><b>{data?`${data.totals.studies} / ${data.totals.regions}`:"0 / 0"}</b><small>{data?.totals.minutes||0} хв навантаження</small></article>
+      <article><span>Виробіток</span><b>{data?.totals.staffAssignments||0}</b><small>призначень виконавців</small></article>
+    </section>
+
+    {!!data?.totals.unpostedPerformedCount&&<aside className="financeLegacyNotice">
+      <b>Виконано без Акта: {data.totals.unpostedPerformedCount}</b>
+      <span>Це історичні або незавершені business-core факти. Система їх показує, але не створює Акти заднім числом автоматично.</span>
+    </aside>}
+
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div className="financeTabs" role="tablist" aria-label="Розділи журналу наданих послуг">
+          <button type="button" className={tab==="acts"?"active":""} onClick={()=>setTab("acts")}>Акти</button>
+          <button type="button" className={tab==="revenue"?"active":""} onClick={()=>setTab("revenue")}>Дохід</button>
+          <button type="button" className={tab==="equipment"?"active":""} onClick={()=>setTab("equipment")}>Обладнання</button>
+          <button type="button" className={tab==="staff"?"active":""} onClick={()=>setTab("staff")}>Виробіток</button>
+        </div>
+        <input value={query} onChange={event=>setQuery(event.target.value)} placeholder="Пошук: акт, RD, пацієнт, апарат…" aria-label="Пошук у журналі наданих послуг"/>
+        <button type="button" onClick={()=>void load()}>Оновити</button>
+      </header>
+
+      {error&&<p className="financeError">{error}</p>}
+      {!data&&!error&&<p className="financeLoading">Завантаження журналу наданих послуг…</p>}
+
+      {data&&tab==="acts"&&<div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Акт</th><th>Виконано</th><th>Заявка / пацієнт</th><th>Послуга</th><th>Категорія</th><th>Апарат / зони</th><th className="num">Сума</th><th/></tr></thead>
+        <tbody>{acts.map(row=><tr key={row.id}>
+          <td><b>{row.number}</b><small>Проведено</small></td>
+          <td>{dateTime(row.performedAt)}</td>
+          <td><b>{row.bookingCode}</b><small>{row.patientName}</small></td>
+          <td>{row.serviceName}<small>{row.serviceCode}</small></td>
+          <td>{CATEGORY_UK[row.patientCategory]||row.patientCategory}</td>
+          <td>{row.equipmentId}<small>{row.anatomicalRegionsCount} зон · {row.durationMinutes} хв</small></td>
+          <td className="num">{row.chargeAmount?money(row.chargeAmount,row.currency):"Безоплатно"}</td>
+          <td><button type="button" onClick={()=>printAct(row.id)}>Акт</button></td>
+        </tr>)}</tbody>
+      </table>{acts.length===0&&<p className="financeEmpty">Актів за цим відбором немає.</p>}</div>}
+
+      {data&&tab==="revenue"&&<div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Документ</th><th>Дата</th><th>Заявка / пацієнт</th><th>Послуга</th><th>Відповідальний</th><th className="num">Дохід</th></tr></thead>
+        <tbody>{revenue.map(row=><tr key={row.id}>
+          <td><b>{row.documentNumber}</b></td><td>{dateTime(row.occurredAt)}</td>
+          <td><b>{row.bookingCode}</b><small>{row.patientName}</small></td><td>{row.serviceCode}</td><td>{row.actorEmail}</td>
+          <td className="num positive">+{money(row.amountDelta,row.currency)}</td>
+        </tr>)}</tbody>
+      </table>{revenue.length===0&&<p className="financeEmpty">Рухів доходу за цим відбором немає.</p>}</div>}
+
+      {data&&tab==="equipment"&&<div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Документ</th><th>Виконано</th><th>Заявка</th><th>Обладнання</th><th className="num">Досліджень</th><th className="num">Зон</th><th className="num">Хвилин</th></tr></thead>
+        <tbody>{equipment.map(row=><tr key={row.id}>
+          <td><b>{row.documentNumber}</b></td><td>{dateTime(row.performedAt)}</td><td>{row.bookingCode}</td><td>{row.equipmentId}</td>
+          <td className="num">{row.studyCount}</td><td className="num">{row.anatomicalRegionsCount}</td><td className="num">{row.durationMinutes}</td>
+        </tr>)}</tbody>
+      </table>{equipment.length===0&&<p className="financeEmpty">Навантаження за цим відбором немає.</p>}</div>}
+
+      {data&&tab==="staff"&&<div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Документ</th><th>Виконано</th><th>Заявка</th><th>Працівник</th><th>Роль</th><th className="num">Досліджень</th><th className="num">Зон</th></tr></thead>
+        <tbody>{staff.map(row=><tr key={row.id}>
+          <td><b>{row.documentNumber}</b></td><td>{dateTime(row.performedAt)}</td><td>{row.bookingCode}</td><td>{row.staffEmail}</td>
+          <td>{ROLE_UK[row.staffRole]||row.staffRole}</td><td className="num">{row.studyCount}</td><td className="num">{row.anatomicalRegionsCount}</td>
+        </tr>)}</tbody>
+      </table>{staff.length===0&&<p className="financeEmpty">Виробітку за цим відбором немає.</p>}</div>}
+    </section>
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/service-delivery/print/page.tsx
+++ b/app/staff/service-delivery/print/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect,useState } from "react";
+
+type PrintPayload={
+  templateVersion:number;
+  formType:"service_act";
+  organization:{name:string};
+  document:{id:number;number:string;documentType:"service_delivery";occurredAt:string;state:string;createdBy:string;postedBy:string;postedAt:string};
+  booking:{id:number;code:string;patientName:string;patientId:string;patientCategory:string};
+  service:{code:string;name:string;chargeAmount:number;currency:string};
+  execution:{equipmentId:string;durationMinutes:number;performedAt:string;anatomicalRegionsCount:number;radiologistEmail:string;radiographerEmail:string};
+};
+type Snapshot={id:number;documentId:number;formType:string;templateVersion:number;documentState:string;generatedBy:string;generatedAt:string;storageKey:string;sha256:string};
+type ResponsePayload={snapshot:Snapshot;payload:PrintPayload;error?:string};
+
+function money(value:number,currency="UAH"){
+  return new Intl.NumberFormat("uk-UA",{style:"currency",currency,maximumFractionDigits:0}).format(Number(value||0));
+}
+function fmtDate(value:string){const d=new Date(value);return Number.isNaN(d.getTime())?value:d.toLocaleString("uk-UA",{dateStyle:"medium",timeStyle:"short"});}
+
+export default function ServiceDeliveryPrintPage(){
+  const [data,setData]=useState<ResponsePayload|null>(null);
+  const [error,setError]=useState("");
+  useEffect(()=>{
+    const controller=new AbortController();
+    const timer=window.setTimeout(()=>{
+      const id=Number(new URLSearchParams(window.location.search).get("id"));
+      if(!Number.isInteger(id)||id<1){setError("Некоректний Акт");return;}
+      void fetch("/api/staff/service-delivery/print",{
+        method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({documentId:id}),signal:controller.signal,
+      }).then(async response=>{
+        const payload=await response.json().catch(()=>({})) as ResponsePayload;
+        if(!response.ok)throw new Error(payload.error||"Не вдалося сформувати Акт");
+        setData(payload);
+      }).catch(e=>{if(e?.name!=="AbortError")setError(e instanceof Error?e.message:"Помилка друку");});
+    },0);
+    return()=>{window.clearTimeout(timer);controller.abort();};
+  },[]);
+
+  if(error)return <main className="financePrintPage"><div className="financePrintSheet"><h1>Не вдалося сформувати Акт</h1><p>{error}</p></div></main>;
+  if(!data)return <main className="financePrintPage"><div className="financePrintSheet"><p>Формування Акта…</p></div></main>;
+  const {payload,snapshot}=data;
+  const free=payload.service.chargeAmount===0;
+  return <main className="financePrintPage">
+    <div className="financePrintToolbar"><button onClick={()=>window.close()}>Закрити</button><button onClick={()=>window.print()}>Друкувати / PDF</button></div>
+    <article className="financePrintSheet">
+      <header><div><small>{payload.organization.name}</small><h1>Акт надання послуг</h1><p>Документ {payload.document.number}</p></div><strong>Проведено</strong></header>
+      <section className="financePrintMeta">
+        <div><span>Номер</span><b>{payload.document.number}</b></div><div><span>Дата виконання</span><b>{fmtDate(payload.execution.performedAt)}</b></div>
+        <div><span>Заявка</span><b>{payload.booking.code}</b></div><div><span>Пацієнт</span><b>{payload.booking.patientName}</b></div>
+        <div><span>Категорія</span><b>{payload.booking.patientCategory==="military"?"Військовий":"Цивільний"}</b></div><div><span>Апарат</span><b>{payload.execution.equipmentId}</b></div>
+      </section>
+      <section className="financePrintDetails">
+        <p><span>Надана послуга</span><b>{payload.service.name}</b></p>
+        <p><span>Код послуги</span><b>{payload.service.code}</b></p>
+        <p><span>Анатомічних зон</span><b>{payload.execution.anatomicalRegionsCount}</b></p>
+        <p><span>Тривалість</span><b>{payload.execution.durationMinutes} хв</b></p>
+        <p><span>Лікар-рентгенолог</span><b>{payload.execution.radiologistEmail||"—"}</b></p>
+        <p><span>Рентгенолаборант</span><b>{payload.execution.radiographerEmail||"—"}</b></p>
+      </section>
+      <section className="financePrintAmount"><span>{free?"Вартість для пацієнта":"Вартість послуги"}</span><b>{free?"Безоплатно":money(payload.service.chargeAmount,payload.service.currency)}</b></section>
+      <section className="financePrintFooter"><div><span>Провів документ</span><b>{payload.document.postedBy||payload.document.createdBy}</b></div><div><span>Підпис</span><i/></div></section>
+      <p className="financePrintVersion">Форма v{snapshot.templateVersion} · snapshot #{snapshot.id} · SHA-256 {snapshot.sha256.slice(0,12)}…</p>
+    </article>
+  </main>;
+}

--- a/docs/service-delivery-business-core.md
+++ b/docs/service-delivery-business-core.md
@@ -1,0 +1,98 @@
+# Service delivery in the RadiologyOS business core
+
+## Boundary
+
+The canonical product boundary remains:
+
+```text
+BAS Small Company = business core
+RadiologyOS = business core + medical modules
+Public site = storefront / booking intake
+```
+
+A performed radiology study is first a **medical execution fact**. It becomes a business fact only through the `service_delivery` registrar.
+
+```text
+medical: bookings.performed_at + booking_events.execution_recorded
+        ↓
+business: service_delivery Act (posted)
+        ↓
+registers: revenue / patient_settlements / equipment_load / staff_output
+        ↓
+report / printed service_act snapshot
+```
+
+DICOM/PACS identifiers, protocol lifecycle and result delivery do not post revenue and are not reused as business documents.
+
+## Canonical trigger
+
+`status='completed'` alone is not enough to recognize a delivered service. Legacy UI still allows broad status transitions for compatibility, therefore economic posting is anchored to the existing explicit execution operation:
+
+- `bookings.performed_at` is non-empty;
+- an `execution_recorded` booking event is written for the same organization and booking.
+
+The D1 posting trigger then creates one posted `service_delivery` document for that booking. A repeated execution event is idempotent and does not create a second Act.
+
+Historical rows with `performed_at` but no Act are not guessed or backfilled. The service-delivery journal exposes their count as `unpostedPerformedCount` so they can be reviewed explicitly.
+
+## Posting semantics
+
+### Civilian service
+
+A posted Act creates:
+
+- `revenue_movements`: positive recognized service revenue;
+- `patient_settlement_movements`: positive `charge` (the patient owes the organization);
+- `equipment_workload_movements`: one performed study plus duration and anatomical-region count;
+- `staff_output_movements`: one row for each assigned radiologist/radiographer present in the execution snapshot.
+
+If the patient paid before the study, payment previously created a negative patient-settlement movement. The Act's positive charge then offsets that advance. Payment and service delivery remain separate facts.
+
+### Military service
+
+The Act is still created because the study was delivered, but `charge_amount=0`:
+
+- no commercial revenue movement;
+- no patient charge;
+- equipment workload and staff output are still recorded.
+
+This preserves operational statistics without inventing a patient receivable.
+
+## Immutability and correction
+
+After the Act is posted, ordinary booking edits cannot silently change the economic execution snapshot:
+
+- `performed_at`;
+- service code/name;
+- amount used for the charge;
+- patient category;
+- equipment;
+- duration;
+- anatomical region count;
+- assigned radiologist/radiographer.
+
+Medical/reference metadata that is not part of the business posting, such as `external_reference`, remains independently editable.
+
+A future correction must be an explicit correction/storno document. A money refund does not automatically reverse recognized revenue, because returning money is not the same event as cancelling a performed service.
+
+## Printed Act
+
+`service_act` is a first-class versioned printed form. The first render stores an append-only `printed_form_snapshots` payload with:
+
+- tenant + exact service-delivery document;
+- document state;
+- template version;
+- generated-by/time;
+- SHA-256;
+- the historical Act payload required for reprint.
+
+Reprinting a posted Act returns the original snapshot even if non-economic master/display data changes later. D1 rejects a `service_act` snapshot linked to a non-service document.
+
+## Security
+
+- all documents and registers are `organization_id` scoped;
+- the service journal and Act print endpoints require the finance-management capability (`admin` or `registrar`);
+- clinicians do not receive the finance/business journal through these endpoints;
+- forged register movements must match the exact posted registrar snapshot or D1 aborts;
+- business register rows and printed snapshots are append-only;
+- the public site cannot create a service-delivery Act or post any of these registers.

--- a/drizzle/0066_service_delivery_registers.sql
+++ b/drizzle/0066_service_delivery_registers.sql
@@ -1,0 +1,341 @@
+-- BAS-style service delivery registrar.
+-- A service act is created only from the canonical execution_recorded event after performed_at exists.
+-- Historical performed bookings are not backfilled heuristically.
+
+CREATE TABLE IF NOT EXISTS `service_delivery_details` (
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `patient_id` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `service_name` text NOT NULL,
+  `patient_category` text NOT NULL,
+  `charge_amount` integer DEFAULT 0 NOT NULL CHECK (`charge_amount` >= 0),
+  `currency` text DEFAULT 'UAH' NOT NULL,
+  `equipment_id` text NOT NULL,
+  `duration_minutes` integer NOT NULL CHECK (`duration_minutes` > 0),
+  `performed_at` text NOT NULL,
+  `anatomical_regions_count` integer DEFAULT 1 NOT NULL CHECK (`anatomical_regions_count` BETWEEN 1 AND 20),
+  `radiologist_email` text DEFAULT '' NOT NULL,
+  `radiographer_email` text DEFAULT '' NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`document_id`),
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`booking_id`) REFERENCES `bookings`(`id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `service_delivery_booking_idx`
+  ON `service_delivery_details` (`organization_id`,`booking_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `service_delivery_time_idx`
+  ON `service_delivery_details` (`organization_id`,`performed_at` DESC,`document_id` DESC);
+--> statement-breakpoint
+
+-- Positive revenue is recognized only when a chargeable civilian service is actually performed.
+CREATE TABLE IF NOT EXISTS `revenue_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `movement_type` text NOT NULL CHECK (`movement_type` IN ('service_charge','service_reversal')),
+  `amount_delta` integer NOT NULL CHECK (`amount_delta` <> 0),
+  `currency` text DEFAULT 'UAH' NOT NULL,
+  `service_code` text NOT NULL,
+  `actor_email` text NOT NULL,
+  `occurred_at` text NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `revenue_document_idx`
+  ON `revenue_movements` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `revenue_time_idx`
+  ON `revenue_movements` (`organization_id`,`occurred_at` DESC,`id` DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `equipment_workload_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `equipment_id` text NOT NULL,
+  `study_count` integer DEFAULT 1 NOT NULL CHECK (`study_count` = 1),
+  `duration_minutes` integer NOT NULL CHECK (`duration_minutes` > 0),
+  `anatomical_regions_count` integer NOT NULL CHECK (`anatomical_regions_count` BETWEEN 1 AND 20),
+  `performed_at` text NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `equipment_workload_document_idx`
+  ON `equipment_workload_movements` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `equipment_workload_equipment_idx`
+  ON `equipment_workload_movements` (`organization_id`,`equipment_id`,`performed_at` DESC,`id` DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `staff_output_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `staff_email` text NOT NULL,
+  `staff_role` text NOT NULL CHECK (`staff_role` IN ('radiologist','radiographer')),
+  `study_count` integer DEFAULT 1 NOT NULL CHECK (`study_count` = 1),
+  `anatomical_regions_count` integer NOT NULL CHECK (`anatomical_regions_count` BETWEEN 1 AND 20),
+  `performed_at` text NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `staff_output_document_role_idx`
+  ON `staff_output_movements` (`organization_id`,`document_id`,`staff_role`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_output_staff_idx`
+  ON `staff_output_movements` (`organization_id`,`staff_email`,`performed_at` DESC,`id` DESC);
+--> statement-breakpoint
+
+-- Exact snapshot integrity: the service act must describe the already-recorded execution fact.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_integrity_insert`
+BEFORE INSERT ON `service_delivery_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+  ) THEN RAISE(ABORT,'service_delivery_document_invalid') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `bookings` b
+    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id
+      AND b.performed_at<>'' AND b.performed_at=NEW.performed_at
+      AND b.patient_id=NEW.patient_id
+      AND b.service_code=NEW.service_code AND b.service=NEW.service_name
+      AND b.patient_category=NEW.patient_category
+      AND b.equipment_id=NEW.equipment_id AND b.duration_minutes=NEW.duration_minutes
+      AND b.anatomical_regions_count=NEW.anatomical_regions_count
+      AND b.assigned_radiologist_email=NEW.radiologist_email
+      AND b.assigned_radiographer_email=NEW.radiographer_email
+      AND NEW.charge_amount=CASE WHEN b.patient_category='civilian' THEN b.payment_amount ELSE 0 END
+      AND NEW.currency='UAH'
+  ) THEN RAISE(ABORT,'service_delivery_booking_mismatch') END;
+  SELECT CASE WHEN NEW.radiologist_email<>'' AND NOT EXISTS (
+    SELECT 1 FROM `memberships` m
+    WHERE m.organization_id=NEW.organization_id AND m.member_email=NEW.radiologist_email AND m.role='radiologist'
+  ) THEN RAISE(ABORT,'service_delivery_radiologist_tenant_mismatch') END;
+  SELECT CASE WHEN NEW.radiographer_email<>'' AND NOT EXISTS (
+    SELECT 1 FROM `memberships` m
+    WHERE m.organization_id=NEW.organization_id AND m.member_email=NEW.radiographer_email AND m.role='radiographer'
+  ) THEN RAISE(ABORT,'service_delivery_radiographer_tenant_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_no_update`
+BEFORE UPDATE ON `service_delivery_details`
+BEGIN SELECT RAISE(ABORT,'service_delivery_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_no_delete`
+BEFORE DELETE ON `service_delivery_details`
+BEGIN SELECT RAISE(ABORT,'service_delivery_immutable'); END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `revenue_service_delivery_integrity`
+BEFORE INSERT ON `revenue_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND s.charge_amount>0
+      AND NEW.movement_type='service_charge' AND NEW.amount_delta=s.charge_amount
+      AND NEW.currency=s.currency AND NEW.service_code=s.service_code AND NEW.occurred_at=s.performed_at
+  ) THEN RAISE(ABORT,'revenue_service_delivery_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_workload_service_delivery_integrity`
+BEFORE INSERT ON `equipment_workload_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND NEW.equipment_id=s.equipment_id
+      AND NEW.study_count=1 AND NEW.duration_minutes=s.duration_minutes
+      AND NEW.anatomical_regions_count=s.anatomical_regions_count AND NEW.performed_at=s.performed_at
+  ) THEN RAISE(ABORT,'equipment_workload_service_delivery_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_output_service_delivery_integrity`
+BEFORE INSERT ON `staff_output_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND NEW.study_count=1
+      AND NEW.anatomical_regions_count=s.anatomical_regions_count AND NEW.performed_at=s.performed_at
+      AND (
+        (NEW.staff_role='radiologist' AND NEW.staff_email=s.radiologist_email AND s.radiologist_email<>'')
+        OR
+        (NEW.staff_role='radiographer' AND NEW.staff_email=s.radiographer_email AND s.radiographer_email<>'')
+      )
+  ) THEN RAISE(ABORT,'staff_output_service_delivery_mismatch') END;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `revenue_movements_no_update`
+BEFORE UPDATE ON `revenue_movements`
+BEGIN SELECT RAISE(ABORT,'revenue_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `revenue_movements_no_delete`
+BEFORE DELETE ON `revenue_movements`
+BEGIN SELECT RAISE(ABORT,'revenue_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_workload_movements_no_update`
+BEFORE UPDATE ON `equipment_workload_movements`
+BEGIN SELECT RAISE(ABORT,'equipment_workload_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_workload_movements_no_delete`
+BEFORE DELETE ON `equipment_workload_movements`
+BEGIN SELECT RAISE(ABORT,'equipment_workload_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_output_movements_no_update`
+BEFORE UPDATE ON `staff_output_movements`
+BEGIN SELECT RAISE(ABORT,'staff_output_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_output_movements_no_delete`
+BEFORE DELETE ON `staff_output_movements`
+BEGIN SELECT RAISE(ABORT,'staff_output_movement_immutable'); END;
+--> statement-breakpoint
+
+-- 0063 originally guarded all patient settlement inserts as finance payment/refund movements.
+-- Narrow that guard and add the service-delivery charge contract explicitly.
+DROP TRIGGER IF EXISTS `patient_settlement_finance_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `patient_settlement_finance_integrity`
+BEFORE INSERT ON `patient_settlement_movements`
+WHEN NEW.movement_type IN ('payment','refund')
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `business_documents` d
+    JOIN `finance_document_details` f
+      ON f.document_id=d.id AND f.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND f.booking_id=NEW.booking_id
+      AND f.patient_id=NEW.patient_id
+      AND f.currency=NEW.currency
+      AND (
+        (d.document_type='payment' AND NEW.movement_type='payment' AND NEW.amount_delta=-f.amount)
+        OR
+        (d.document_type='refund' AND NEW.movement_type='refund' AND NEW.amount_delta=f.amount)
+      )
+  ) THEN RAISE(ABORT,'patient_settlement_document_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_settlement_service_delivery_integrity`
+BEFORE INSERT ON `patient_settlement_movements`
+WHEN NEW.movement_type='charge'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND s.patient_id=NEW.patient_id
+      AND s.currency=NEW.currency AND s.charge_amount>0 AND NEW.amount_delta=s.charge_amount
+  ) THEN RAISE(ABORT,'patient_settlement_service_delivery_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- Once an act exists, the economic/execution snapshot is immutable through ordinary booking edits.
+CREATE TRIGGER IF NOT EXISTS `booking_service_delivery_fact_immutable`
+BEFORE UPDATE OF `performed_at`,`service_code`,`service`,`payment_amount`,`patient_category`,`equipment_id`,
+  `duration_minutes`,`anatomical_regions_count`,`assigned_radiologist_email`,`assigned_radiographer_email`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1 FROM `service_delivery_details` s
+  JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+  WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id AND d.state='posted'
+)
+BEGIN
+  SELECT CASE WHEN
+    NEW.performed_at<>OLD.performed_at OR NEW.service_code<>OLD.service_code OR NEW.service<>OLD.service
+    OR NEW.payment_amount<>OLD.payment_amount OR NEW.patient_category<>OLD.patient_category
+    OR NEW.equipment_id<>OLD.equipment_id OR NEW.duration_minutes<>OLD.duration_minutes
+    OR NEW.anatomical_regions_count<>OLD.anatomical_regions_count
+    OR NEW.assigned_radiologist_email<>OLD.assigned_radiologist_email
+    OR NEW.assigned_radiographer_email<>OLD.assigned_radiographer_email
+  THEN RAISE(ABORT,'service_delivery_booking_fact_immutable') END;
+END;
+--> statement-breakpoint
+
+-- Canonical registrar: only an explicit execution_recorded event for a booking with performed_at creates the act.
+-- Duplicate execution events are idempotent because service_delivery_details owns a unique booking claim.
+CREATE TRIGGER IF NOT EXISTS `booking_execution_posts_service_delivery`
+AFTER INSERT ON `booking_events`
+WHEN NEW.action='execution_recorded'
+  AND EXISTS (
+    SELECT 1 FROM `bookings` b
+    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id AND b.performed_at<>''
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id
+  )
+BEGIN
+  INSERT INTO `business_documents`
+    (`organization_id`,`document_type`,`number`,`occurred_at`,`state`,`comment`,`created_by`,`posted_by`,`posted_at`)
+  SELECT b.organization_id,'service_delivery','АКТ-' || printf('%06d',b.id),b.performed_at,'posted',
+         'Надання послуги ' || b.service_code,
+         CASE WHEN NEW.actor<>'' THEN NEW.actor ELSE 'system:execution' END,
+         CASE WHEN NEW.actor<>'' THEN NEW.actor ELSE 'system:execution' END,
+         CURRENT_TIMESTAMP
+  FROM `bookings` b
+  WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id AND b.performed_at<>'';
+
+  INSERT INTO `service_delivery_details`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`service_name`,`patient_category`,
+     `charge_amount`,`currency`,`equipment_id`,`duration_minutes`,`performed_at`,`anatomical_regions_count`,
+     `radiologist_email`,`radiographer_email`)
+  SELECT b.organization_id,d.id,b.id,b.patient_id,b.service_code,b.service,b.patient_category,
+         CASE WHEN b.patient_category='civilian' THEN b.payment_amount ELSE 0 END,'UAH',
+         b.equipment_id,b.duration_minutes,b.performed_at,b.anatomical_regions_count,
+         b.assigned_radiologist_email,b.assigned_radiographer_email
+  FROM `bookings` b
+  JOIN `business_documents` d
+    ON d.organization_id=b.organization_id AND d.document_type='service_delivery'
+   AND d.number='АКТ-' || printf('%06d',b.id)
+  WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id;
+
+  INSERT INTO `revenue_movements`
+    (`organization_id`,`document_id`,`booking_id`,`movement_type`,`amount_delta`,`currency`,`service_code`,`actor_email`,`occurred_at`)
+  SELECT s.organization_id,s.document_id,s.booking_id,'service_charge',s.charge_amount,s.currency,s.service_code,
+         CASE WHEN NEW.actor<>'' THEN NEW.actor ELSE 'system:execution' END,s.performed_at
+  FROM `service_delivery_details` s
+  WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id AND s.charge_amount>0;
+
+  INSERT INTO `patient_settlement_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`movement_type`,`amount_delta`,`currency`,`actor_email`,`occurred_at`)
+  SELECT s.organization_id,s.document_id,s.booking_id,s.patient_id,'charge',s.charge_amount,s.currency,
+         CASE WHEN NEW.actor<>'' THEN NEW.actor ELSE 'system:execution' END,s.performed_at
+  FROM `service_delivery_details` s
+  WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id AND s.charge_amount>0;
+
+  INSERT INTO `equipment_workload_movements`
+    (`organization_id`,`document_id`,`booking_id`,`equipment_id`,`study_count`,`duration_minutes`,`anatomical_regions_count`,`performed_at`)
+  SELECT s.organization_id,s.document_id,s.booking_id,s.equipment_id,1,s.duration_minutes,s.anatomical_regions_count,s.performed_at
+  FROM `service_delivery_details` s
+  WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id;
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`staff_email`,`staff_role`,`study_count`,`anatomical_regions_count`,`performed_at`)
+  SELECT s.organization_id,s.document_id,s.booking_id,s.radiologist_email,'radiologist',1,s.anatomical_regions_count,s.performed_at
+  FROM `service_delivery_details` s
+  WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id AND s.radiologist_email<>'';
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`staff_email`,`staff_role`,`study_count`,`anatomical_regions_count`,`performed_at`)
+  SELECT s.organization_id,s.document_id,s.booking_id,s.radiographer_email,'radiographer',1,s.anatomical_regions_count,s.performed_at
+  FROM `service_delivery_details` s
+  WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id AND s.radiographer_email<>'';
+END;

--- a/drizzle/0067_service_delivery_print_integrity.sql
+++ b/drizzle/0067_service_delivery_print_integrity.sql
@@ -1,0 +1,12 @@
+-- A printed service act snapshot must belong to the exact service_delivery document and state.
+CREATE TRIGGER IF NOT EXISTS `printed_service_act_snapshot_integrity`
+BEFORE INSERT ON `printed_form_snapshots`
+WHEN NEW.form_type='service_act'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state=NEW.document_state
+  ) THEN RAISE(ABORT,'printed_form_document_mismatch') END;
+END;

--- a/drizzle/0068_service_delivery_reversal_and_actor_guard.sql
+++ b/drizzle/0068_service_delivery_reversal_and_actor_guard.sql
@@ -9,7 +9,8 @@ END;
 --> statement-breakpoint
 
 -- `execution_recorded` is the medical-to-business bridge. Its actor must be an active staff member
--- of the same tenant with one of the existing roles that may record execution facts.
+-- of the same tenant. Clinical actors must also be assigned to that exact booking; admin/registrar
+-- keep their tenant-wide execution-recording authority from the existing API contract.
 CREATE TRIGGER IF NOT EXISTS `execution_recorded_actor_guard`
 BEFORE INSERT ON `booking_events`
 WHEN NEW.action='execution_recorded'
@@ -18,7 +19,29 @@ BEGIN
     SELECT 1
     FROM `memberships` m
     JOIN `staff_members` s ON s.email=m.member_email AND s.active=1
+    JOIN `bookings` b ON b.id=NEW.booking_id AND b.organization_id=NEW.organization_id
     WHERE m.organization_id=NEW.organization_id AND m.member_email=NEW.actor AND m.active=1
-      AND m.role IN ('admin','registrar','radiologist','radiographer')
+      AND (
+        m.role IN ('admin','registrar')
+        OR (m.role='radiologist' AND b.assigned_radiologist_email=NEW.actor)
+        OR (m.role='radiographer' AND b.assigned_radiographer_email=NEW.actor)
+      )
   ) THEN RAISE(ABORT,'execution_recorded_actor_invalid') END;
+END;
+--> statement-breakpoint
+
+-- A service Act detail cannot be manufactured independently of the explicit execution event.
+-- The posted document's author must be the actor of an execution_recorded event for this exact booking/tenant.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_requires_execution_event`
+BEFORE INSERT ON `service_delivery_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `business_documents` d
+    JOIN `booking_events` e
+      ON e.organization_id=d.organization_id AND e.booking_id=NEW.booking_id
+     AND e.action='execution_recorded' AND e.actor=d.created_by
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+  ) THEN RAISE(ABORT,'service_delivery_execution_event_missing') END;
 END;

--- a/drizzle/0068_service_delivery_reversal_and_actor_guard.sql
+++ b/drizzle/0068_service_delivery_reversal_and_actor_guard.sql
@@ -1,0 +1,24 @@
+-- Until explicit service correction/storno movements exist, a posted service Act cannot be marked reversed.
+-- Otherwise the document state could diverge from append-only revenue/workload/output movements.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_direct_reversal_blocked`
+BEFORE UPDATE OF `state` ON `business_documents`
+WHEN OLD.document_type='service_delivery' AND OLD.state='posted' AND NEW.state='reversed'
+BEGIN
+  SELECT RAISE(ABORT,'service_delivery_requires_correction_document');
+END;
+--> statement-breakpoint
+
+-- `execution_recorded` is the medical-to-business bridge. Its actor must be an active staff member
+-- of the same tenant with one of the existing roles that may record execution facts.
+CREATE TRIGGER IF NOT EXISTS `execution_recorded_actor_guard`
+BEFORE INSERT ON `booking_events`
+WHEN NEW.action='execution_recorded'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `memberships` m
+    JOIN `staff_members` s ON s.email=m.member_email AND s.active=1
+    WHERE m.organization_id=NEW.organization_id AND m.member_email=NEW.actor AND m.active=1
+      AND m.role IN ('admin','registrar','radiologist','radiographer')
+  ) THEN RAISE(ABORT,'execution_recorded_actor_invalid') END;
+END;

--- a/lib/business-core.ts
+++ b/lib/business-core.ts
@@ -170,7 +170,9 @@ export function requiresCorrectionDocument(state: DocumentState): boolean {
 }
 
 export const DOCUMENT_REGISTER_MAP: Readonly<Partial<Record<DocumentType, readonly RegisterType[]>>> = {
-  service_delivery: ["services_delivered", "revenue", "patient_settlements", "equipment_load", "staff_output", "studies_performed"],
+  // The medical execution event is the source fact; the posted service act owns only economic/operational
+  // business movements. We deliberately do not create a second "performed study" truth in this posting.
+  service_delivery: ["revenue", "patient_settlements", "equipment_load", "staff_output"],
   payment: ["cash", "patient_settlements"],
   // A money refund reverses cash/settlement only. Revenue is corrected by a service correction/storno,
   // not merely because money was returned.

--- a/lib/service-delivery.ts
+++ b/lib/service-delivery.ts
@@ -115,7 +115,7 @@ export async function listStaffOutput(db:D1Database,organizationId:number,limit=
 }
 
 export async function serviceDeliveryTotals(db:D1Database,organizationId:number) {
-  const [documents,revenue,workload,staff]=await Promise.all([
+  const [documents,revenue,workload,staff,unposted]=await Promise.all([
     db.prepare(
       `SELECT COUNT(*) AS acts,
               SUM(CASE WHEN s.patient_category='civilian' THEN 1 ELSE 0 END) AS civilianActs,
@@ -136,6 +136,15 @@ export async function serviceDeliveryTotals(db:D1Database,organizationId:number)
     db.prepare(
       `SELECT COALESCE(SUM(study_count),0) AS assignments FROM staff_output_movements WHERE organization_id=?`
     ).bind(organizationId).first<{assignments:number}>(),
+    db.prepare(
+      `SELECT COUNT(*) AS count
+       FROM bookings b
+       WHERE b.organization_id=? AND b.performed_at<>''
+         AND NOT EXISTS (
+           SELECT 1 FROM service_delivery_details s
+           WHERE s.organization_id=b.organization_id AND s.booking_id=b.id
+         )`
+    ).bind(organizationId).first<{count:number}>(),
   ]);
   return {
     acts:Number(documents?.acts || 0),
@@ -146,5 +155,6 @@ export async function serviceDeliveryTotals(db:D1Database,organizationId:number)
     minutes:Number(workload?.minutes || 0),
     regions:Number(workload?.regions || 0),
     staffAssignments:Number(staff?.assignments || 0),
+    unpostedPerformedCount:Number(unposted?.count || 0),
   };
 }

--- a/lib/service-delivery.ts
+++ b/lib/service-delivery.ts
@@ -1,0 +1,150 @@
+export type ServiceDeliveryDocument = {
+  id:number;
+  number:string;
+  occurredAt:string;
+  state:string;
+  createdBy:string;
+  postedBy:string;
+  postedAt:string;
+  bookingId:number;
+  bookingCode:string;
+  patientName:string;
+  patientId:string;
+  serviceCode:string;
+  serviceName:string;
+  patientCategory:string;
+  chargeAmount:number;
+  currency:string;
+  equipmentId:string;
+  durationMinutes:number;
+  performedAt:string;
+  anatomicalRegionsCount:number;
+  radiologistEmail:string;
+  radiographerEmail:string;
+};
+
+function boundedLimit(value:number,max:number) {
+  return Math.max(1,Math.min(max,Math.trunc(value)));
+}
+
+export async function getServiceDeliveryDocument(
+  db:D1Database,
+  organizationId:number,
+  documentId:number,
+):Promise<ServiceDeliveryDocument|null> {
+  const row=await db.prepare(
+    `SELECT d.id,d.number,d.occurred_at AS occurredAt,d.state,d.created_by AS createdBy,
+            d.posted_by AS postedBy,d.posted_at AS postedAt,
+            s.booking_id AS bookingId,b.code AS bookingCode,b.name AS patientName,
+            s.patient_id AS patientId,s.service_code AS serviceCode,s.service_name AS serviceName,
+            s.patient_category AS patientCategory,s.charge_amount AS chargeAmount,s.currency,
+            s.equipment_id AS equipmentId,s.duration_minutes AS durationMinutes,
+            s.performed_at AS performedAt,s.anatomical_regions_count AS anatomicalRegionsCount,
+            s.radiologist_email AS radiologistEmail,s.radiographer_email AS radiographerEmail
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     JOIN bookings b ON b.id=s.booking_id AND b.organization_id=s.organization_id
+     WHERE d.organization_id=? AND d.id=? AND d.document_type='service_delivery' LIMIT 1`
+  ).bind(organizationId,documentId).first<ServiceDeliveryDocument>();
+  return row || null;
+}
+
+export async function listServiceDeliveryDocuments(db:D1Database,organizationId:number,limit=250) {
+  const safeLimit=boundedLimit(limit,500);
+  const rows=await db.prepare(
+    `SELECT d.id,d.number,d.occurred_at AS occurredAt,d.state,d.created_by AS createdBy,
+            d.posted_by AS postedBy,d.posted_at AS postedAt,
+            s.booking_id AS bookingId,b.code AS bookingCode,b.name AS patientName,
+            s.patient_id AS patientId,s.service_code AS serviceCode,s.service_name AS serviceName,
+            s.patient_category AS patientCategory,s.charge_amount AS chargeAmount,s.currency,
+            s.equipment_id AS equipmentId,s.duration_minutes AS durationMinutes,
+            s.performed_at AS performedAt,s.anatomical_regions_count AS anatomicalRegionsCount,
+            s.radiologist_email AS radiologistEmail,s.radiographer_email AS radiographerEmail
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     JOIN bookings b ON b.id=s.booking_id AND b.organization_id=s.organization_id
+     WHERE d.organization_id=? AND d.document_type='service_delivery'
+     ORDER BY s.performed_at DESC,d.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}
+
+export async function listRevenueMovements(db:D1Database,organizationId:number,limit=300) {
+  const safeLimit=boundedLimit(limit,700);
+  const rows=await db.prepare(
+    `SELECT r.id,r.document_id AS documentId,d.number AS documentNumber,r.booking_id AS bookingId,
+            b.code AS bookingCode,b.name AS patientName,r.movement_type AS movementType,
+            r.amount_delta AS amountDelta,r.currency,r.service_code AS serviceCode,
+            r.actor_email AS actorEmail,r.occurred_at AS occurredAt
+     FROM revenue_movements r
+     JOIN business_documents d ON d.id=r.document_id AND d.organization_id=r.organization_id
+     JOIN bookings b ON b.id=r.booking_id AND b.organization_id=r.organization_id
+     WHERE r.organization_id=? ORDER BY r.occurred_at DESC,r.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}
+
+export async function listEquipmentWorkload(db:D1Database,organizationId:number,limit=300) {
+  const safeLimit=boundedLimit(limit,700);
+  const rows=await db.prepare(
+    `SELECT w.id,w.document_id AS documentId,d.number AS documentNumber,w.booking_id AS bookingId,
+            b.code AS bookingCode,w.equipment_id AS equipmentId,w.study_count AS studyCount,
+            w.duration_minutes AS durationMinutes,w.anatomical_regions_count AS anatomicalRegionsCount,
+            w.performed_at AS performedAt
+     FROM equipment_workload_movements w
+     JOIN business_documents d ON d.id=w.document_id AND d.organization_id=w.organization_id
+     JOIN bookings b ON b.id=w.booking_id AND b.organization_id=w.organization_id
+     WHERE w.organization_id=? ORDER BY w.performed_at DESC,w.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}
+
+export async function listStaffOutput(db:D1Database,organizationId:number,limit=500) {
+  const safeLimit=boundedLimit(limit,1000);
+  const rows=await db.prepare(
+    `SELECT o.id,o.document_id AS documentId,d.number AS documentNumber,o.booking_id AS bookingId,
+            b.code AS bookingCode,o.staff_email AS staffEmail,o.staff_role AS staffRole,
+            o.study_count AS studyCount,o.anatomical_regions_count AS anatomicalRegionsCount,
+            o.performed_at AS performedAt
+     FROM staff_output_movements o
+     JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+     JOIN bookings b ON b.id=o.booking_id AND b.organization_id=o.organization_id
+     WHERE o.organization_id=? ORDER BY o.performed_at DESC,o.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}
+
+export async function serviceDeliveryTotals(db:D1Database,organizationId:number) {
+  const [documents,revenue,workload,staff]=await Promise.all([
+    db.prepare(
+      `SELECT COUNT(*) AS acts,
+              SUM(CASE WHEN s.patient_category='civilian' THEN 1 ELSE 0 END) AS civilianActs,
+              SUM(CASE WHEN s.patient_category='military' THEN 1 ELSE 0 END) AS militaryActs
+       FROM service_delivery_details s
+       JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+       WHERE s.organization_id=? AND d.state='posted'`
+    ).bind(organizationId).first<{acts:number;civilianActs:number;militaryActs:number}>(),
+    db.prepare(
+      `SELECT COALESCE(SUM(amount_delta),0) AS revenue FROM revenue_movements WHERE organization_id=?`
+    ).bind(organizationId).first<{revenue:number}>(),
+    db.prepare(
+      `SELECT COALESCE(SUM(study_count),0) AS studies,
+              COALESCE(SUM(duration_minutes),0) AS minutes,
+              COALESCE(SUM(anatomical_regions_count),0) AS regions
+       FROM equipment_workload_movements WHERE organization_id=?`
+    ).bind(organizationId).first<{studies:number;minutes:number;regions:number}>(),
+    db.prepare(
+      `SELECT COALESCE(SUM(study_count),0) AS assignments FROM staff_output_movements WHERE organization_id=?`
+    ).bind(organizationId).first<{assignments:number}>(),
+  ]);
+  return {
+    acts:Number(documents?.acts || 0),
+    civilianActs:Number(documents?.civilianActs || 0),
+    militaryActs:Number(documents?.militaryActs || 0),
+    revenue:Number(revenue?.revenue || 0),
+    studies:Number(workload?.studies || 0),
+    minutes:Number(workload?.minutes || 0),
+    regions:Number(workload?.regions || 0),
+    staffAssignments:Number(staff?.assignments || 0),
+  };
+}

--- a/tests/service-delivery-api.behavior.test.mjs
+++ b/tests/service-delivery-api.behavior.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function seedOrgBooking(db,{organizationId,code,time,rad,tech,name}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,duration_minutes,
+      desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,status,
+      assigned_radiologist_email,assigned_radiographer_email,anatomical_regions_count,performed_at
+    ) VALUES (?,?,?,'+380501234567','380501234567','КТ органів грудної клітки','ct-chest','ct',30,
+      '2026-08-25',?,'civilian','pending',2100,0,'completed',?,?,2,?)`
+  ).bind(organizationId,code,name,time,rad,tech,`2026-08-25T${time}:00`).run();
+  const id=Number(result.meta.last_row_id);
+  await db.prepare(
+    `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+     VALUES (?,?,'execution_recorded','api test',?)`
+  ).bind(organizationId,id,rad).run();
+  return id;
+}
+
+test("service-delivery journal is finance-role gated and tenant scoped",async()=>{
+  await withD1(async(db)=>{
+    await db.prepare("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Other Clinic','other-clinic',1)").run();
+
+    const org1Registrar=await seedStaffSession(db,{email:"act-reg-1@example.com",role:"registrar",organizationId:1});
+    const org1RadCookie=await seedStaffSession(db,{email:"act-rad-1@example.com",role:"radiologist",organizationId:1});
+    await seedStaffSession(db,{email:"act-tech-1@example.com",role:"radiographer",organizationId:1});
+
+    const org2Registrar=await seedStaffSession(db,{email:"act-reg-2@example.com",role:"registrar",organizationId:2});
+    await seedStaffSession(db,{email:"act-rad-2@example.com",role:"radiologist",organizationId:2});
+    await seedStaffSession(db,{email:"act-tech-2@example.com",role:"radiographer",organizationId:2});
+
+    await seedOrgBooking(db,{
+      organizationId:1,code:"RD-ACT-ORG1",time:"09:00",name:"Org One Patient",
+      rad:"act-rad-1@example.com",tech:"act-tech-1@example.com",
+    });
+    await seedOrgBooking(db,{
+      organizationId:2,code:"RD-ACT-ORG2",time:"10:00",name:"Org Two Patient",
+      rad:"act-rad-2@example.com",tech:"act-tech-2@example.com",
+    });
+
+    const denied=await callWorker(new Request("http://localhost/api/staff/service-delivery",{
+      headers:{cookie:org1RadCookie},
+    }),db);
+    assert.equal(denied.status,403);
+
+    const org1=await callWorker(new Request("http://localhost/api/staff/service-delivery",{
+      headers:{cookie:org1Registrar},
+    }),db);
+    assert.equal(org1.status,200);
+    const body1=await org1.json();
+    assert.equal(body1.totals.acts,1);
+    assert.equal(body1.documents.length,1);
+    assert.equal(body1.documents[0].bookingCode,"RD-ACT-ORG1");
+    assert.equal(JSON.stringify(body1).includes("Org Two Patient"),false);
+
+    const org2=await callWorker(new Request("http://localhost/api/staff/service-delivery",{
+      headers:{cookie:org2Registrar},
+    }),db);
+    assert.equal(org2.status,200);
+    const body2=await org2.json();
+    assert.equal(body2.totals.acts,1);
+    assert.equal(body2.documents[0].bookingCode,"RD-ACT-ORG2");
+    assert.equal(JSON.stringify(body2).includes("Org One Patient"),false);
+  });
+});

--- a/tests/service-delivery-print.behavior.test.mjs
+++ b/tests/service-delivery-print.behavior.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedAct(db,{organizationId=1,code="RD-ACT-PRINT",name="Пацієнт Акт",time="14:00"}={}) {
+  const rad=`act-print-rad-${organizationId}@example.com`;
+  const tech=`act-print-tech-${organizationId}@example.com`;
+  await seedStaffSession(db,{email:rad,role:"radiologist",organizationId});
+  await seedStaffSession(db,{email:tech,role:"radiographer",organizationId});
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,duration_minutes,
+      desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,status,
+      assigned_radiologist_email,assigned_radiographer_email,anatomical_regions_count,performed_at
+    ) VALUES (?,?,?,'+380501234567','380501234567','КТ органів грудної клітки','ct-chest','ct',30,
+      '2026-08-26',?,'civilian','pending',2700,0,'completed',?,?,2,?)`
+  ).bind(organizationId,code,name,time,rad,tech,`2026-08-26T${time}:00`).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+     VALUES (?,?,'execution_recorded','print test',?)`
+  ).bind(organizationId,bookingId,rad).run();
+  const act=await db.prepare(
+    `SELECT document_id AS documentId FROM service_delivery_details
+     WHERE organization_id=? AND booking_id=? LIMIT 1`
+  ).bind(organizationId,bookingId).first();
+  return {bookingId,documentId:Number(act?.documentId || 0)};
+}
+
+async function printAct(db,cookie,documentId) {
+  return callWorker(jsonRequest("/api/staff/service-delivery/print",{documentId},{headers:{cookie}}),db);
+}
+
+test("posted service act reuses one immutable historical snapshot",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"act-print-reg@example.com",role:"registrar",organizationId:1});
+    const {bookingId,documentId}=await seedAct(db);
+    assert.ok(documentId>0);
+
+    const first=await printAct(db,cookie,documentId);
+    assert.equal(first.status,201);
+    const form1=await first.json();
+    assert.equal(form1.snapshot.formType,"service_act");
+    assert.equal(form1.snapshot.documentState,"posted");
+    assert.equal(form1.snapshot.templateVersion,1);
+    assert.equal(form1.snapshot.sha256.length,64);
+    assert.equal(form1.payload.booking.patientName,"Пацієнт Акт");
+    assert.equal(form1.payload.service.name,"КТ органів грудної клітки");
+    assert.equal(form1.payload.service.chargeAmount,2700);
+    assert.equal(form1.payload.execution.anatomicalRegionsCount,2);
+
+    // Patient display name is not an economic posting field; an exact reprint must still use the historical snapshot.
+    await db.prepare("UPDATE bookings SET name='Пацієнт Після Зміни' WHERE organization_id=1 AND id=?")
+      .bind(bookingId).run();
+    const again=await printAct(db,cookie,documentId);
+    assert.equal(again.status,200);
+    const form2=await again.json();
+    assert.equal(form2.snapshot.id,form1.snapshot.id);
+    assert.equal(form2.snapshot.sha256,form1.snapshot.sha256);
+    assert.equal(form2.payload.booking.patientName,"Пацієнт Акт");
+
+    assert.throws(
+      ()=>raw.prepare("UPDATE printed_form_snapshots SET generated_by='tamper@example.com' WHERE id=?").run(form1.snapshot.id),
+      /printed_form_snapshot_immutable/,
+    );
+    assert.throws(
+      ()=>raw.prepare("DELETE FROM printed_form_snapshots WHERE id=?").run(form1.snapshot.id),
+      /printed_form_snapshot_immutable/,
+    );
+  });
+});
+
+test("service act snapshots are role gated and tenant scoped",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Act Print Org 2','act-print-org-2',1)");
+    const org2=await seedStaffSession(db,{email:"act-print-org2@example.com",role:"registrar",organizationId:2});
+    const org1=await seedStaffSession(db,{email:"act-print-org1@example.com",role:"registrar",organizationId:1});
+    const clinician=await seedStaffSession(db,{email:"act-print-clinician@example.com",role:"radiologist",organizationId:1});
+    const {documentId}=await seedAct(db,{organizationId:2,code:"RD-ACT-PRINT-ORG2",name:"Інша Організація",time:"15:00"});
+
+    const printed=await printAct(db,org2,documentId);
+    assert.equal(printed.status,201);
+    const {snapshot}=await printed.json();
+
+    const foreign=await callWorker(new Request(
+      `http://localhost/api/staff/service-delivery/print?snapshotId=${snapshot.id}`,
+      {headers:{cookie:org1}},
+    ),db);
+    assert.equal(foreign.status,404);
+
+    const denied=await callWorker(new Request(
+      `http://localhost/api/staff/service-delivery/print?snapshotId=${snapshot.id}`,
+      {headers:{cookie:clinician}},
+    ),db);
+    assert.equal(denied.status,403);
+  });
+});
+
+test("D1 rejects a service_act snapshot linked to a non-service document",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"act-print-forge@example.com",role:"registrar",organizationId:1});
+    const {documentId}=await seedAct(db,{code:"RD-ACT-PRINT-D1",time:"16:00"});
+    const printed=await printAct(db,cookie,documentId);
+    assert.equal(printed.status,201);
+
+    const payment=raw.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,state,created_by,posted_by,posted_at)
+       VALUES (1,'payment','FORGED-PAY','posted','x','x',CURRENT_TIMESTAMP)`
+    ).run();
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO printed_form_snapshots
+       (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,sha256)
+       VALUES (1,?,'service_act',1,'posted','{}','x','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')`
+    ).run(Number(payment.lastInsertRowid)),/printed_form_document_mismatch/);
+  });
+});

--- a/tests/service-delivery-security.behavior.test.mjs
+++ b/tests/service-delivery-security.behavior.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db,{code="RD-ACT-GUARD",time="17:00"}={}) {
+  const rad="act-guard-rad@example.com";
+  const tech="act-guard-tech@example.com";
+  await seedStaffSession(db,{email:rad,role:"radiologist",organizationId:1});
+  await seedStaffSession(db,{email:tech,role:"radiographer",organizationId:1});
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,duration_minutes,
+      desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,status,
+      assigned_radiologist_email,assigned_radiographer_email,anatomical_regions_count,performed_at
+    ) VALUES (1,?,'Guard Patient','+380501234567','380501234567','КТ ОГК','ct-chest','ct',30,
+      '2026-08-27',?,'civilian','pending',2400,0,'completed',?,?,1,?)`
+  ).bind(code,time,rad,tech,`2026-08-27T${time}:00`).run();
+  return {bookingId:Number(result.meta.last_row_id),rad};
+}
+
+test("execution_recorded requires an active same-tenant staff actor",async()=>{
+  await withD1(async(db,raw)=>{
+    const {bookingId}=await seedBooking(db);
+    await assert.rejects(
+      db.prepare(
+        `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+         VALUES (1,?,'execution_recorded','forged','attacker@example.com')`
+      ).bind(bookingId).run(),
+      /execution_recorded_actor_invalid/,
+    );
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(bookingId).n,0);
+  });
+});
+
+test("posted service Act cannot be directly reversed before a correction flow exists",async()=>{
+  await withD1(async(db,raw)=>{
+    const {bookingId,rad}=await seedBooking(db,{code:"RD-ACT-REVERSAL",time:"18:00"});
+    await db.prepare(
+      `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+       VALUES (1,?,'execution_recorded','valid',?)`
+    ).bind(bookingId,rad).run();
+    const act=raw.prepare(
+      "SELECT document_id AS documentId FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(bookingId);
+    assert.ok(act?.documentId);
+    assert.throws(
+      ()=>raw.prepare("UPDATE business_documents SET state='reversed' WHERE id=?").run(act.documentId),
+      /service_delivery_requires_correction_document/,
+    );
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(act.documentId).state,"posted");
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM revenue_movements WHERE document_id=?").get(act.documentId).n,1);
+  });
+});

--- a/tests/service-delivery-security.behavior.test.mjs
+++ b/tests/service-delivery-security.behavior.test.mjs
@@ -15,7 +15,7 @@ async function seedBooking(db,{code="RD-ACT-GUARD",time="17:00"}={}) {
     ) VALUES (1,?,'Guard Patient','+380501234567','380501234567','КТ ОГК','ct-chest','ct',30,
       '2026-08-27',?,'civilian','pending',2400,0,'completed',?,?,1,?)`
   ).bind(code,time,rad,tech,`2026-08-27T${time}:00`).run();
-  return {bookingId:Number(result.meta.last_row_id),rad};
+  return {bookingId:Number(result.meta.last_row_id),rad,tech};
 }
 
 test("execution_recorded requires an active same-tenant staff actor",async()=>{
@@ -31,6 +31,46 @@ test("execution_recorded requires an active same-tenant staff actor",async()=>{
     assert.equal(raw.prepare(
       "SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
     ).get(bookingId).n,0);
+  });
+});
+
+test("an unassigned clinician cannot post another clinician's execution fact",async()=>{
+  await withD1(async(db,raw)=>{
+    const {bookingId}=await seedBooking(db,{code:"RD-ACT-ASSIGNMENT",time:"17:30"});
+    await seedStaffSession(db,{email:"other-rad@example.com",role:"radiologist",organizationId:1});
+    await assert.rejects(
+      db.prepare(
+        `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+         VALUES (1,?,'execution_recorded','unassigned','other-rad@example.com')`
+      ).bind(bookingId).run(),
+      /execution_recorded_actor_invalid/,
+    );
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(bookingId).n,0);
+  });
+});
+
+test("service Act details require the exact explicit execution event",async()=>{
+  await withD1(async(db,raw)=>{
+    const {bookingId,rad}=await seedBooking(db,{code:"RD-ACT-NO-EVENT",time:"17:45"});
+    const created=raw.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,occurred_at,state,created_by,posted_by,posted_at)
+       VALUES (1,'service_delivery','FORGED-ACT','2026-08-27T17:45:00','posted',?, ?, CURRENT_TIMESTAMP)`
+    ).run(rad,rad);
+    const documentId=Number(created.lastInsertRowid);
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO service_delivery_details
+       (organization_id,document_id,booking_id,patient_id,service_code,service_name,patient_category,
+        charge_amount,currency,equipment_id,duration_minutes,performed_at,anatomical_regions_count,
+        radiologist_email,radiographer_email)
+       SELECT organization_id,?,id,patient_id,service_code,service,patient_category,payment_amount,'UAH',
+              equipment_id,duration_minutes,performed_at,anatomical_regions_count,
+              assigned_radiologist_email,assigned_radiographer_email
+       FROM bookings WHERE organization_id=1 AND id=?`
+    ).run(documentId,bookingId),/service_delivery_execution_event_missing/);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_delivery_details WHERE document_id=?").get(documentId).n,0);
   });
 });
 

--- a/tests/service-delivery.behavior.test.mjs
+++ b/tests/service-delivery.behavior.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function seedExecutionStaff(db) {
+  await seedStaffSession(db,{email:"rad-act@example.com",role:"radiologist",organizationId:1});
+  await seedStaffSession(db,{email:"tech-act@example.com",role:"radiographer",organizationId:1});
+  await seedStaffSession(db,{email:"registrar-act@example.com",role:"registrar",organizationId:1});
+}
+
+async function seedBooking(db,{
+  code="RD-ACT-1",
+  category="civilian",
+  amount=2500,
+  time="09:00",
+}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,duration_minutes,
+      desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,status,
+      assigned_radiologist_email,assigned_radiographer_email,anatomical_regions_count
+    ) VALUES (
+      1,?,'Act Patient','+380501234567','380501234567','КТ органів грудної клітки','ct-chest','ct',30,
+      '2026-08-24',?,?, 'pending',?,0,'confirmed','rad-act@example.com','tech-act@example.com',1
+    )`
+  ).bind(code,time,category,amount).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function recordExecution(db,bookingId,performedAt="2026-08-24T09:05:00",regions=2) {
+  await db.prepare(
+    `UPDATE bookings SET performed_at=?,anatomical_regions_count=?,status='completed'
+     WHERE organization_id=1 AND id=?`
+  ).bind(performedAt,regions,bookingId).run();
+  await db.prepare(
+    `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+     VALUES (1,?,'execution_recorded','test execution','registrar-act@example.com')`
+  ).bind(bookingId).run();
+}
+
+test("execution_recorded posts exactly one service act and business registers",async()=>{
+  await withD1(async(db,raw)=>{
+    await seedExecutionStaff(db);
+    const bookingId=await seedBooking(db);
+    await recordExecution(db,bookingId);
+
+    const act=raw.prepare(
+      `SELECT d.id,d.document_type AS type,d.number,d.state,d.created_by AS createdBy,d.posted_by AS postedBy,
+              s.charge_amount AS chargeAmount,s.service_code AS serviceCode,s.equipment_id AS equipmentId,
+              s.anatomical_regions_count AS regions,s.performed_at AS performedAt
+       FROM business_documents d
+       JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+       WHERE d.organization_id=1 AND s.booking_id=?`
+    ).get(bookingId);
+    assert.ok(act);
+    assert.equal(act.type,"service_delivery");
+    assert.equal(act.state,"posted");
+    assert.equal(act.number,`АКТ-${String(bookingId).padStart(6,"0")}`);
+    assert.equal(act.createdBy,"registrar-act@example.com");
+    assert.equal(act.postedBy,"registrar-act@example.com");
+    assert.equal(act.chargeAmount,2500);
+    assert.equal(act.serviceCode,"ct-chest");
+    assert.equal(act.equipmentId,"ct");
+    assert.equal(act.regions,2);
+
+    const revenue=raw.prepare(
+      `SELECT amount_delta AS amountDelta,movement_type AS movementType FROM revenue_movements
+       WHERE organization_id=1 AND document_id=?`
+    ).get(act.id);
+    assert.deepEqual(revenue,{amountDelta:2500,movementType:"service_charge"});
+
+    const settlement=raw.prepare(
+      `SELECT amount_delta AS amountDelta,movement_type AS movementType FROM patient_settlement_movements
+       WHERE organization_id=1 AND document_id=?`
+    ).get(act.id);
+    assert.deepEqual(settlement,{amountDelta:2500,movementType:"charge"});
+
+    const workload=raw.prepare(
+      `SELECT study_count AS studyCount,duration_minutes AS durationMinutes,anatomical_regions_count AS regions
+       FROM equipment_workload_movements WHERE organization_id=1 AND document_id=?`
+    ).get(act.id);
+    assert.deepEqual(workload,{studyCount:1,durationMinutes:30,regions:2});
+
+    const staff=raw.prepare(
+      `SELECT staff_email AS email,staff_role AS role,study_count AS studyCount,anatomical_regions_count AS regions
+       FROM staff_output_movements WHERE organization_id=1 AND document_id=? ORDER BY staff_role`
+    ).all(act.id);
+    assert.deepEqual(staff,[
+      {email:"rad-act@example.com",role:"radiologist",studyCount:1,regions:2},
+      {email:"tech-act@example.com",role:"radiographer",studyCount:1,regions:2},
+    ]);
+
+    await db.prepare(
+      `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+       VALUES (1,?,'execution_recorded','duplicate retry','registrar-act@example.com')`
+    ).bind(bookingId).run();
+    assert.equal(raw.prepare(
+      `SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?`
+    ).get(bookingId).n,1);
+    assert.equal(raw.prepare(
+      `SELECT COUNT(*) AS n FROM revenue_movements WHERE organization_id=1 AND booking_id=?`
+    ).get(bookingId).n,1);
+  });
+});
+
+test("military execution posts workload and staff output without commercial revenue or patient charge",async()=>{
+  await withD1(async(db,raw)=>{
+    await seedExecutionStaff(db);
+    const bookingId=await seedBooking(db,{code:"RD-ACT-MIL",category:"military",amount:3200,time:"10:00"});
+    await recordExecution(db,bookingId,"2026-08-24T10:03:00",1);
+
+    const act=raw.prepare(
+      `SELECT d.id,s.charge_amount AS chargeAmount FROM business_documents d
+       JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+       WHERE d.organization_id=1 AND s.booking_id=?`
+    ).get(bookingId);
+    assert.ok(act);
+    assert.equal(act.chargeAmount,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM revenue_movements WHERE document_id=?").get(act.id).n,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM patient_settlement_movements WHERE document_id=?").get(act.id).n,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM equipment_workload_movements WHERE document_id=?").get(act.id).n,1);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_output_movements WHERE document_id=?").get(act.id).n,2);
+  });
+});
+
+test("manual completed status without performed_at is not an economic service fact",async()=>{
+  await withD1(async(db,raw)=>{
+    await seedExecutionStaff(db);
+    const bookingId=await seedBooking(db,{code:"RD-NO-ACT",time:"11:00"});
+    await db.prepare("UPDATE bookings SET status='completed' WHERE organization_id=1 AND id=?").bind(bookingId).run();
+    await db.prepare(
+      `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)
+       VALUES (1,?,'status_changed','completed','registrar-act@example.com')`
+    ).bind(bookingId).run();
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(bookingId).n,0);
+  });
+});
+
+test("posted service act freezes the economic execution snapshot but not unrelated medical reference metadata",async()=>{
+  await withD1(async(db,raw)=>{
+    await seedExecutionStaff(db);
+    const bookingId=await seedBooking(db,{code:"RD-ACT-LOCK",time:"12:00"});
+    await recordExecution(db,bookingId,"2026-08-24T12:01:00",3);
+
+    assert.throws(()=>raw.prepare("UPDATE bookings SET performed_at='2026-08-24T12:09:00' WHERE id=?").run(bookingId),/service_delivery_booking_fact_immutable/);
+    assert.throws(()=>raw.prepare("UPDATE bookings SET payment_amount=9999 WHERE id=?").run(bookingId),/service_delivery_booking_fact_immutable/);
+    assert.throws(()=>raw.prepare("UPDATE bookings SET anatomical_regions_count=4 WHERE id=?").run(bookingId),/service_delivery_booking_fact_immutable/);
+    assert.throws(()=>raw.prepare("UPDATE bookings SET service_code='ct-head' WHERE id=?").run(bookingId),/service_delivery_booking_fact_immutable/);
+
+    raw.prepare("UPDATE bookings SET external_reference='PACS-UPDATED' WHERE id=?").run(bookingId);
+    assert.equal(raw.prepare("SELECT external_reference AS ref FROM bookings WHERE id=?").get(bookingId).ref,"PACS-UPDATED");
+  });
+});
+
+test("service delivery registers reject forged movements and remain append-only",async()=>{
+  await withD1(async(db,raw)=>{
+    await seedExecutionStaff(db);
+    const bookingId=await seedBooking(db,{code:"RD-ACT-SEC",time:"13:00"});
+    await recordExecution(db,bookingId,"2026-08-24T13:02:00",2);
+    const act=raw.prepare(
+      "SELECT document_id AS documentId FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(bookingId);
+
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO revenue_movements
+       (organization_id,document_id,booking_id,movement_type,amount_delta,currency,service_code,actor_email,occurred_at)
+       VALUES (1,?,?,'service_charge',1,'UAH','ct-chest','attacker@example.com','2026-08-24T13:02:00')`
+    ).run(act.documentId,bookingId),/revenue_service_delivery_mismatch/);
+
+    assert.throws(()=>raw.prepare("UPDATE revenue_movements SET amount_delta=1 WHERE document_id=?").run(act.documentId),/revenue_movement_immutable/);
+    assert.throws(()=>raw.prepare("DELETE FROM equipment_workload_movements WHERE document_id=?").run(act.documentId),/equipment_workload_movement_immutable/);
+    assert.throws(()=>raw.prepare("UPDATE staff_output_movements SET anatomical_regions_count=1 WHERE document_id=?").run(act.documentId),/staff_output_movement_immutable/);
+  });
+});

--- a/tests/service-delivery.behavior.test.mjs
+++ b/tests/service-delivery.behavior.test.mjs
@@ -67,28 +67,40 @@ test("execution_recorded posts exactly one service act and business registers",a
       `SELECT amount_delta AS amountDelta,movement_type AS movementType FROM revenue_movements
        WHERE organization_id=1 AND document_id=?`
     ).get(act.id);
-    assert.deepEqual(revenue,{amountDelta:2500,movementType:"service_charge"});
+    assert.ok(revenue);
+    assert.equal(revenue.amountDelta,2500);
+    assert.equal(revenue.movementType,"service_charge");
 
     const settlement=raw.prepare(
       `SELECT amount_delta AS amountDelta,movement_type AS movementType FROM patient_settlement_movements
        WHERE organization_id=1 AND document_id=?`
     ).get(act.id);
-    assert.deepEqual(settlement,{amountDelta:2500,movementType:"charge"});
+    assert.ok(settlement);
+    assert.equal(settlement.amountDelta,2500);
+    assert.equal(settlement.movementType,"charge");
 
     const workload=raw.prepare(
       `SELECT study_count AS studyCount,duration_minutes AS durationMinutes,anatomical_regions_count AS regions
        FROM equipment_workload_movements WHERE organization_id=1 AND document_id=?`
     ).get(act.id);
-    assert.deepEqual(workload,{studyCount:1,durationMinutes:30,regions:2});
+    assert.ok(workload);
+    assert.equal(workload.studyCount,1);
+    assert.equal(workload.durationMinutes,30);
+    assert.equal(workload.regions,2);
 
     const staff=raw.prepare(
       `SELECT staff_email AS email,staff_role AS role,study_count AS studyCount,anatomical_regions_count AS regions
        FROM staff_output_movements WHERE organization_id=1 AND document_id=? ORDER BY staff_role`
     ).all(act.id);
-    assert.deepEqual(staff,[
-      {email:"rad-act@example.com",role:"radiologist",studyCount:1,regions:2},
-      {email:"tech-act@example.com",role:"radiographer",studyCount:1,regions:2},
-    ]);
+    assert.equal(staff.length,2);
+    assert.equal(staff[0].email,"rad-act@example.com");
+    assert.equal(staff[0].role,"radiologist");
+    assert.equal(staff[0].studyCount,1);
+    assert.equal(staff[0].regions,2);
+    assert.equal(staff[1].email,"tech-act@example.com");
+    assert.equal(staff[1].role,"radiographer");
+    assert.equal(staff[1].studyCount,1);
+    assert.equal(staff[1].regions,2);
 
     await db.prepare(
       `INSERT INTO booking_events (organization_id,booking_id,action,details,actor)


### PR DESCRIPTION
## Goal
Continue the BAS-style business core after finance documents with an explicit `service_delivery` Act.

## Canonical boundary
- medical execution remains `performed_at` + `execution_recorded`
- economic service delivery is posted only from that explicit execution fact
- manual `status=completed` alone is not an economic fact
- DICOM/PACS/protocol lifecycle remains medical-domain data and does not post revenue
- public site never posts a service Act or business registers

## Posting
- one posted `service_delivery` Act per executed booking
- civilian: `revenue` + patient settlement `charge`
- military: zero commercial charge/revenue, but still equipment workload + staff output
- payment and service delivery remain separate facts; advance payment nets against the later charge
- refund alone never rewrites recognized service revenue

## Integrity
- duplicate execution events are idempotent
- no heuristic backfill of historical performed bookings
- journal exposes `unpostedPerformedCount` instead of inventing historical Acts
- posted execution/service/price/category/equipment/regions/performer snapshot cannot be silently edited
- register movements and printed snapshots are append-only and tenant-scoped
- D1 validates exact registrar ↔ movement and service-act print links

## UX / evidence
- `/staff/service-delivery` BAS journal: Acts / Revenue / Equipment / Staff output
- accessible from Finance
- versioned A4 `service_act` with immutable historical payload + SHA-256
- exact reprint reuses the original snapshot

## Verification
Draft until exact-head CI + CodeQL + final security diff review are green.

Production deploy is out of scope and must remain untouched.