### PR TITLE
Post completed services through BAS delivery documents

### DIFF
--- a/app/api/staff/service-deliveries/route.ts
+++ b/app/api/staff/service-deliveries/route.ts
@@ -1,0 +1,52 @@
+import { dbBinding } from "../../../../lib/db";
+import { canAccessBooking, canManageFinance, canWriteNotes } from "../../../../lib/staff-auth";
+import { listServiceDeliveries, postServiceDelivery } from "../../../../lib/service-deliveries";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+export async function GET(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canManageFinance(ctx.member.role)) {
+    return Response.json({error:"Журнал наданих послуг доступний реєстратору або адміністратору"},{status:403});
+  }
+  return Response.json({documents:await listServiceDeliveries(db,ctx.organizationId)});
+}
+
+export async function POST(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canWriteNotes(ctx.member.role)) return Response.json({error:"Недостатньо прав"},{status:403});
+
+  const body=await request.json().catch(()=>({})) as {bookingId?:number};
+  const bookingId=Number(body.bookingId);
+  if(!Number.isInteger(bookingId) || bookingId<=0) {
+    return Response.json({error:"Некоректна заявка"},{status:400});
+  }
+  if(!(await canAccessBooking(db,ctx.member,bookingId,ctx.organizationId))) {
+    return Response.json({error:"Заявку не знайдено або її не призначено вам"},{status:404});
+  }
+
+  try {
+    const result=await postServiceDelivery(db,{
+      organizationId:ctx.organizationId,
+      bookingId,
+      actorEmail:ctx.member.email,
+    });
+    return Response.json({ok:true,...result});
+  } catch(error) {
+    const code=error instanceof Error ? error.message:String(error);
+    if(code==="booking_not_found") return Response.json({error:"Заявку не знайдено"},{status:404});
+    if(code==="service_not_performed") {
+      return Response.json({error:"Надання послуги можна провести лише після фактичного виконання дослідження"},{status:409});
+    }
+    if(code==="service_delivery_in_progress" || code==="service_delivery_already_exists") {
+      return Response.json({error:"Документ надання послуги вже створюється або проведений"},{status:409});
+    }
+    console.error("service_delivery_post_failed",code);
+    return Response.json({error:"Не вдалося провести надання послуги"},{status:500});
+  }
+}

--- a/drizzle/0066_service_delivery_documents.sql
+++ b/drizzle/0066_service_delivery_documents.sql
@@ -1,0 +1,292 @@
+-- BAS-style service delivery registrar.
+-- The medical workflow proves that a study/service was performed; this business document
+-- records the economic/operational fact. Payment remains a separate cash fact.
+
+CREATE TABLE IF NOT EXISTS `service_delivery_details` (
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `patient_id` text DEFAULT '' NOT NULL,
+  `patient_category` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `service_title` text NOT NULL,
+  `equipment_id` text NOT NULL,
+  `duration_minutes` integer NOT NULL CHECK (`duration_minutes` > 0),
+  `anatomical_regions_count` integer DEFAULT 1 NOT NULL CHECK (`anatomical_regions_count` > 0),
+  `performed_at` text NOT NULL,
+  `radiologist_email` text DEFAULT '' NOT NULL,
+  `radiographer_email` text DEFAULT '' NOT NULL,
+  `price_amount` integer DEFAULT 0 NOT NULL CHECK (`price_amount` >= 0),
+  `charge_amount` integer DEFAULT 0 NOT NULL CHECK (`charge_amount` >= 0),
+  `currency` text DEFAULT 'UAH' NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`document_id`),
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`booking_id`) REFERENCES `bookings`(`id`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `service_delivery_booking_idx`
+  ON `service_delivery_details` (`organization_id`,`booking_id`,`document_id` DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `services_delivered_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `patient_id` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `equipment_id` text NOT NULL,
+  `quantity` integer DEFAULT 1 NOT NULL CHECK (`quantity` > 0),
+  `anatomical_regions_count` integer DEFAULT 1 NOT NULL CHECK (`anatomical_regions_count` > 0),
+  `performed_at` text NOT NULL,
+  `actor_email` text NOT NULL,
+  `occurred_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `services_delivered_document_idx`
+  ON `services_delivered_movements` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `services_delivered_service_idx`
+  ON `services_delivered_movements` (`organization_id`,`service_code`,`performed_at` DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `revenue_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `patient_id` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `movement_type` text NOT NULL CHECK (`movement_type` IN ('service_delivery','service_correction')),
+  `amount_delta` integer NOT NULL CHECK (`amount_delta` <> 0),
+  `currency` text DEFAULT 'UAH' NOT NULL,
+  `actor_email` text NOT NULL,
+  `occurred_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `revenue_document_idx`
+  ON `revenue_movements` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `revenue_time_idx`
+  ON `revenue_movements` (`organization_id`,`occurred_at` DESC,`id` DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `equipment_load_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `equipment_id` text NOT NULL,
+  `minutes_delta` integer NOT NULL CHECK (`minutes_delta` <> 0),
+  `performed_at` text NOT NULL,
+  `actor_email` text NOT NULL,
+  `occurred_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `equipment_load_document_idx`
+  ON `equipment_load_movements` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `equipment_load_equipment_idx`
+  ON `equipment_load_movements` (`organization_id`,`equipment_id`,`performed_at` DESC);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `staff_output_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `member_email` text NOT NULL,
+  `staff_role` text NOT NULL CHECK (`staff_role` IN ('radiologist','radiographer')),
+  `units_delta` integer DEFAULT 1 NOT NULL CHECK (`units_delta` <> 0),
+  `anatomical_regions_count` integer DEFAULT 1 NOT NULL CHECK (`anatomical_regions_count` > 0),
+  `performed_at` text NOT NULL,
+  `actor_email` text NOT NULL,
+  `occurred_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `staff_output_document_role_idx`
+  ON `staff_output_movements` (`organization_id`,`document_id`,`staff_role`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_output_member_idx`
+  ON `staff_output_movements` (`organization_id`,`member_email`,`performed_at` DESC);
+--> statement-breakpoint
+
+-- Only a completed/performed booking can be turned into a service-delivery document.
+-- Draft creation also snapshots the exact business-relevant booking facts.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_integrity_insert`
+BEFORE INSERT ON `service_delivery_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='draft'
+  ) THEN RAISE(ABORT,'service_delivery_document_invalid') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `bookings` b
+    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id
+      AND b.status='completed' AND b.performed_at<>''
+      AND b.patient_id=NEW.patient_id
+      AND b.patient_category=NEW.patient_category
+      AND b.service_code=NEW.service_code
+      AND b.service=NEW.service_title
+      AND b.equipment_id=NEW.equipment_id
+      AND b.duration_minutes=NEW.duration_minutes
+      AND b.anatomical_regions_count=NEW.anatomical_regions_count
+      AND b.performed_at=NEW.performed_at
+      AND b.assigned_radiologist_email=NEW.radiologist_email
+      AND b.assigned_radiographer_email=NEW.radiographer_email
+      AND b.payment_amount=NEW.price_amount
+  ) THEN RAISE(ABORT,'service_delivery_booking_snapshot_mismatch') END;
+  SELECT CASE WHEN NEW.charge_amount <> CASE WHEN NEW.patient_category='civilian' THEN NEW.price_amount ELSE 0 END
+    THEN RAISE(ABORT,'service_delivery_charge_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+    WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id
+      AND d.state IN ('draft','posted')
+  ) THEN RAISE(ABORT,'service_delivery_already_exists') END;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_no_update_posted`
+BEFORE UPDATE ON `service_delivery_details`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `business_documents` d
+  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+)
+BEGIN SELECT RAISE(ABORT,'service_delivery_not_draft'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_no_delete_posted`
+BEFORE DELETE ON `service_delivery_details`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `business_documents` d
+  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+)
+BEGIN SELECT RAISE(ABORT,'service_delivery_not_draft'); END;
+--> statement-breakpoint
+
+-- Operational/revenue registers are append-only evidence.
+CREATE TRIGGER IF NOT EXISTS `services_delivered_no_update` BEFORE UPDATE ON `services_delivered_movements`
+BEGIN SELECT RAISE(ABORT,'services_delivered_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `services_delivered_no_delete` BEFORE DELETE ON `services_delivered_movements`
+BEGIN SELECT RAISE(ABORT,'services_delivered_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `revenue_no_update` BEFORE UPDATE ON `revenue_movements`
+BEGIN SELECT RAISE(ABORT,'revenue_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `revenue_no_delete` BEFORE DELETE ON `revenue_movements`
+BEGIN SELECT RAISE(ABORT,'revenue_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_load_no_update` BEFORE UPDATE ON `equipment_load_movements`
+BEGIN SELECT RAISE(ABORT,'equipment_load_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_load_no_delete` BEFORE DELETE ON `equipment_load_movements`
+BEGIN SELECT RAISE(ABORT,'equipment_load_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_output_no_update` BEFORE UPDATE ON `staff_output_movements`
+BEGIN SELECT RAISE(ABORT,'staff_output_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_output_no_delete` BEFORE DELETE ON `staff_output_movements`
+BEGIN SELECT RAISE(ABORT,'staff_output_movement_immutable'); END;
+--> statement-breakpoint
+
+-- Every movement must exactly match its posted registrar snapshot.
+CREATE TRIGGER IF NOT EXISTS `services_delivered_integrity_insert`
+BEFORE INSERT ON `services_delivered_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND s.patient_id=NEW.patient_id
+      AND s.service_code=NEW.service_code AND s.equipment_id=NEW.equipment_id
+      AND NEW.quantity=1 AND s.anatomical_regions_count=NEW.anatomical_regions_count
+      AND s.performed_at=NEW.performed_at
+  ) THEN RAISE(ABORT,'services_delivered_document_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `revenue_integrity_insert`
+BEFORE INSERT ON `revenue_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND s.patient_id=NEW.patient_id
+      AND s.service_code=NEW.service_code AND s.currency=NEW.currency
+      AND NEW.movement_type='service_delivery' AND NEW.amount_delta=s.charge_amount AND s.charge_amount>0
+  ) THEN RAISE(ABORT,'revenue_document_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_load_integrity_insert`
+BEFORE INSERT ON `equipment_load_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND s.equipment_id=NEW.equipment_id
+      AND NEW.minutes_delta=s.duration_minutes AND s.performed_at=NEW.performed_at
+  ) THEN RAISE(ABORT,'equipment_load_document_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_output_integrity_insert`
+BEFORE INSERT ON `staff_output_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND s.booking_id=NEW.booking_id AND s.performed_at=NEW.performed_at
+      AND s.anatomical_regions_count=NEW.anatomical_regions_count AND NEW.units_delta=1
+      AND (
+        (NEW.staff_role='radiologist' AND NEW.member_email<>'' AND NEW.member_email=s.radiologist_email)
+        OR
+        (NEW.staff_role='radiographer' AND NEW.member_email<>'' AND NEW.member_email=s.radiographer_email)
+      )
+  ) THEN RAISE(ABORT,'staff_output_document_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- Extend the shared patient-settlement registrar: service delivery adds the charge;
+-- payments/refunds keep the existing finance-document rules.
+DROP TRIGGER IF EXISTS `patient_settlement_finance_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `patient_settlement_finance_integrity`
+BEFORE INSERT ON `patient_settlement_movements`
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1
+      FROM `business_documents` d
+      JOIN `finance_document_details` f ON f.document_id=d.id AND f.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+        AND f.booking_id=NEW.booking_id AND f.patient_id=NEW.patient_id AND f.currency=NEW.currency
+        AND (
+          (d.document_type='payment' AND NEW.movement_type='payment' AND NEW.amount_delta=-f.amount)
+          OR
+          (d.document_type='refund' AND NEW.movement_type='refund' AND NEW.amount_delta=f.amount)
+        )
+    )
+    OR
+    EXISTS (
+      SELECT 1
+      FROM `business_documents` d
+      JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND s.booking_id=NEW.booking_id AND s.patient_id=NEW.patient_id AND s.currency=NEW.currency
+        AND NEW.movement_type='charge' AND NEW.amount_delta=s.charge_amount AND s.charge_amount>0
+    )
+  ) THEN RAISE(ABORT,'patient_settlement_document_mismatch') END;
+END;

--- a/drizzle/0067_service_delivery_draft_integrity.sql
+++ b/drizzle/0067_service_delivery_draft_integrity.sql
@@ -1,0 +1,35 @@
+-- Draft service-delivery snapshots remain editable only while they continue to match
+-- the exact completed booking facts. This closes direct-D1 tampering before posting.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_integrity_update`
+BEFORE UPDATE ON `service_delivery_details`
+WHEN EXISTS (
+  SELECT 1 FROM `business_documents` d
+  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+)
+BEGIN
+  SELECT CASE WHEN NEW.organization_id <> OLD.organization_id OR NEW.document_id <> OLD.document_id
+    THEN RAISE(ABORT,'service_delivery_document_identity_immutable') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='draft'
+  ) THEN RAISE(ABORT,'service_delivery_document_invalid') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `bookings` b
+    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id
+      AND b.status='completed' AND b.performed_at<>''
+      AND b.patient_id=NEW.patient_id
+      AND b.patient_category=NEW.patient_category
+      AND b.service_code=NEW.service_code
+      AND b.service=NEW.service_title
+      AND b.equipment_id=NEW.equipment_id
+      AND b.duration_minutes=NEW.duration_minutes
+      AND b.anatomical_regions_count=NEW.anatomical_regions_count
+      AND b.performed_at=NEW.performed_at
+      AND b.assigned_radiologist_email=NEW.radiologist_email
+      AND b.assigned_radiographer_email=NEW.radiographer_email
+      AND b.payment_amount=NEW.price_amount
+  ) THEN RAISE(ABORT,'service_delivery_booking_snapshot_mismatch') END;
+  SELECT CASE WHEN NEW.charge_amount <> CASE WHEN NEW.patient_category='civilian' THEN NEW.price_amount ELSE 0 END
+    THEN RAISE(ABORT,'service_delivery_charge_mismatch') END;
+END;

--- a/drizzle/0068_service_delivery_execution_posting.sql
+++ b/drizzle/0068_service_delivery_execution_posting.sql
@@ -1,0 +1,129 @@
+-- The clinical execution transition and the economic service-delivery registrar must not diverge.
+-- New completions are posted atomically by D1. Historical completed bookings are deliberately
+-- left legacy/unlinked; the staff service-delivery endpoint can post them explicitly later.
+
+CREATE TRIGGER IF NOT EXISTS `booking_service_delivery_snapshot_immutable`
+BEFORE UPDATE OF
+  `patient_id`,`patient_category`,`service`,`service_code`,`equipment_id`,`duration_minutes`,
+  `anatomical_regions_count`,`performed_at`,`assigned_radiologist_email`,`assigned_radiographer_email`,
+  `payment_amount`,`status`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1
+  FROM `service_delivery_details` s
+  JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+  WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id
+    AND d.document_type='service_delivery' AND d.state='posted'
+)
+AND (
+  NEW.organization_id IS NOT OLD.organization_id
+  OR NEW.patient_id IS NOT OLD.patient_id
+  OR NEW.patient_category IS NOT OLD.patient_category
+  OR NEW.service IS NOT OLD.service
+  OR NEW.service_code IS NOT OLD.service_code
+  OR NEW.equipment_id IS NOT OLD.equipment_id
+  OR NEW.duration_minutes IS NOT OLD.duration_minutes
+  OR NEW.anatomical_regions_count IS NOT OLD.anatomical_regions_count
+  OR NEW.performed_at IS NOT OLD.performed_at
+  OR NEW.assigned_radiologist_email IS NOT OLD.assigned_radiologist_email
+  OR NEW.assigned_radiographer_email IS NOT OLD.assigned_radiographer_email
+  OR NEW.payment_amount IS NOT OLD.payment_amount
+  OR NEW.status IS NOT OLD.status
+)
+BEGIN
+  SELECT RAISE(ABORT,'service_delivery_booking_immutable');
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `booking_service_delivery_auto_post`
+AFTER UPDATE OF `performed_at`,`status` ON `bookings`
+WHEN NEW.status='completed' AND NEW.performed_at<>''
+  AND NOT EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+    WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.id
+      AND d.document_type='service_delivery' AND d.state IN ('draft','posted')
+  )
+BEGIN
+  INSERT INTO `business_documents`
+    (`organization_id`,`document_type`,`number`,`occurred_at`,`state`,`comment`,`created_by`)
+  VALUES (
+    NEW.organization_id,'service_delivery',printf('НП-%06d',NEW.id),NEW.performed_at,'draft',
+    'Автоматично з факту виконання дослідження','system:execution'
+  );
+
+  INSERT INTO `service_delivery_details`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`patient_category`,`service_code`,`service_title`,
+     `equipment_id`,`duration_minutes`,`anatomical_regions_count`,`performed_at`,`radiologist_email`,
+     `radiographer_email`,`price_amount`,`charge_amount`,`currency`)
+  SELECT
+    NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.patient_category,NEW.service_code,NEW.service,
+    NEW.equipment_id,NEW.duration_minutes,NEW.anatomical_regions_count,NEW.performed_at,
+    NEW.assigned_radiologist_email,NEW.assigned_radiographer_email,NEW.payment_amount,
+    CASE WHEN NEW.patient_category='civilian' THEN NEW.payment_amount ELSE 0 END,'UAH'
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='draft';
+
+  UPDATE `business_documents`
+  SET state='posted',posted_by='system:execution',posted_at=CURRENT_TIMESTAMP
+  WHERE organization_id=NEW.organization_id AND document_type='service_delivery'
+    AND number=printf('НП-%06d',NEW.id) AND state='draft';
+
+  INSERT INTO `services_delivered_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`equipment_id`,`quantity`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.service_code,NEW.equipment_id,1,
+         NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted';
+
+  INSERT INTO `equipment_load_movements`
+    (`organization_id`,`document_id`,`booking_id`,`equipment_id`,`minutes_delta`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.equipment_id,NEW.duration_minutes,NEW.performed_at,
+         'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted';
+
+  INSERT INTO `revenue_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`movement_type`,`amount_delta`,
+     `currency`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.service_code,'service_delivery',NEW.payment_amount,
+         'UAH','system:execution',NEW.performed_at
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND NEW.patient_category='civilian' AND NEW.payment_amount>0;
+
+  INSERT INTO `patient_settlement_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`movement_type`,`amount_delta`,`currency`,
+     `actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,'charge',NEW.payment_amount,'UAH',
+         'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND NEW.patient_category='civilian' AND NEW.payment_amount>0;
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`member_email`,`staff_role`,`units_delta`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.assigned_radiologist_email,'radiologist',1,
+         NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND NEW.assigned_radiologist_email<>'';
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`member_email`,`staff_role`,`units_delta`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.assigned_radiographer_email,'radiographer',1,
+         NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND NEW.assigned_radiographer_email<>'';
+END;

--- a/drizzle/0068_service_delivery_execution_posting.sql
+++ b/drizzle/0068_service_delivery_execution_posting.sql
@@ -45,12 +45,19 @@ WHEN NEW.status='completed' AND NEW.performed_at<>''
       AND d.document_type='service_delivery' AND d.state IN ('draft','posted')
   )
 BEGIN
+  -- Number every service-delivery document from the business-document sequence itself.
+  -- This keeps automatic and explicit/legacy posting in one collision-free journal.
   INSERT INTO `business_documents`
     (`organization_id`,`document_type`,`number`,`occurred_at`,`state`,`comment`,`created_by`)
   VALUES (
-    NEW.organization_id,'service_delivery',printf('НП-%06d',NEW.id),NEW.performed_at,'draft',
+    NEW.organization_id,'service_delivery','',NEW.performed_at,'draft',
     'Автоматично з факту виконання дослідження','system:execution'
   );
+
+  UPDATE `business_documents`
+  SET number=printf('НП-%06d',id)
+  WHERE id=last_insert_rowid() AND organization_id=NEW.organization_id
+    AND document_type='service_delivery' AND state='draft' AND number='';
 
   INSERT INTO `service_delivery_details`
     (`organization_id`,`document_id`,`booking_id`,`patient_id`,`patient_category`,`service_code`,`service_title`,
@@ -62,13 +69,17 @@ BEGIN
     NEW.assigned_radiologist_email,NEW.assigned_radiographer_email,NEW.payment_amount,
     CASE WHEN NEW.patient_category='civilian' THEN NEW.payment_amount ELSE 0 END,'UAH'
   FROM `business_documents` d
-  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='draft';
+  WHERE d.id=last_insert_rowid() AND d.organization_id=NEW.organization_id
+    AND d.document_type='service_delivery' AND d.state='draft';
 
   UPDATE `business_documents`
   SET state='posted',posted_by='system:execution',posted_at=CURRENT_TIMESTAMP
-  WHERE organization_id=NEW.organization_id AND document_type='service_delivery'
-    AND number=printf('НП-%06d',NEW.id) AND state='draft';
+  WHERE organization_id=NEW.organization_id AND document_type='service_delivery' AND state='draft'
+    AND id=(
+      SELECT s.document_id FROM `service_delivery_details` s
+      WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.id
+      ORDER BY s.document_id DESC LIMIT 1
+    );
 
   INSERT INTO `services_delivered_movements`
     (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`equipment_id`,`quantity`,
@@ -76,16 +87,18 @@ BEGIN
   SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.service_code,NEW.equipment_id,1,
          NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
   FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
   WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted';
+    AND s.booking_id=NEW.id AND d.state='posted';
 
   INSERT INTO `equipment_load_movements`
     (`organization_id`,`document_id`,`booking_id`,`equipment_id`,`minutes_delta`,`performed_at`,`actor_email`,`occurred_at`)
   SELECT NEW.organization_id,d.id,NEW.id,NEW.equipment_id,NEW.duration_minutes,NEW.performed_at,
          'system:execution',NEW.performed_at
   FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
   WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted';
+    AND s.booking_id=NEW.id AND d.state='posted';
 
   INSERT INTO `revenue_movements`
     (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`movement_type`,`amount_delta`,
@@ -93,8 +106,9 @@ BEGIN
   SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.service_code,'service_delivery',NEW.payment_amount,
          'UAH','system:execution',NEW.performed_at
   FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
   WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND s.booking_id=NEW.id AND d.state='posted'
     AND NEW.patient_category='civilian' AND NEW.payment_amount>0;
 
   INSERT INTO `patient_settlement_movements`
@@ -103,8 +117,9 @@ BEGIN
   SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,'charge',NEW.payment_amount,'UAH',
          'system:execution',NEW.performed_at
   FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
   WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND s.booking_id=NEW.id AND d.state='posted'
     AND NEW.patient_category='civilian' AND NEW.payment_amount>0;
 
   INSERT INTO `staff_output_movements`
@@ -113,8 +128,9 @@ BEGIN
   SELECT NEW.organization_id,d.id,NEW.id,NEW.assigned_radiologist_email,'radiologist',1,
          NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
   FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
   WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+    AND s.booking_id=NEW.id AND d.state='posted'
     AND NEW.assigned_radiologist_email<>'';
 
   INSERT INTO `staff_output_movements`
@@ -123,7 +139,8 @@ BEGIN
   SELECT NEW.organization_id,d.id,NEW.id,NEW.assigned_radiographer_email,'radiographer',1,
          NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
   FROM `business_documents` d
-  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
-    AND d.number=printf('НП-%06d',NEW.id) AND d.state='posted'
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organizationId AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted'
     AND NEW.assigned_radiographer_email<>'';
 END;

--- a/drizzle/0068_service_delivery_execution_posting.sql
+++ b/drizzle/0068_service_delivery_execution_posting.sql
@@ -140,7 +140,7 @@ BEGIN
          NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
   FROM `business_documents` d
   JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
-  WHERE d.organization_id=NEW.organizationId AND d.document_type='service_delivery'
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
     AND s.booking_id=NEW.id AND d.state='posted'
     AND NEW.assigned_radiographer_email<>'';
 END;

--- a/lib/service-deliveries.ts
+++ b/lib/service-deliveries.ts
@@ -1,0 +1,226 @@
+export type ServiceDeliveryBooking = {
+  id:number;
+  organizationId:number;
+  code:string;
+  patientId:string;
+  patientCategory:string;
+  serviceCode:string;
+  serviceTitle:string;
+  equipmentId:string;
+  durationMinutes:number;
+  anatomicalRegionsCount:number;
+  performedAt:string;
+  radiologistEmail:string;
+  radiographerEmail:string;
+  paymentAmount:number;
+  status:string;
+};
+
+export type ServiceDeliveryDocument = {
+  id:number;
+  organizationId:number;
+  number:string;
+  state:string;
+  bookingId:number;
+  chargeAmount:number;
+  priceAmount:number;
+};
+
+function actor(value:unknown) {
+  return String(value ?? "").trim().toLowerCase().slice(0,254);
+}
+
+export async function serviceDeliveryBooking(
+  db:D1Database,
+  organizationId:number,
+  bookingId:number,
+):Promise<ServiceDeliveryBooking|null> {
+  const row=await db.prepare(
+    `SELECT id,organization_id AS organizationId,code,patient_id AS patientId,
+            patient_category AS patientCategory,service_code AS serviceCode,service AS serviceTitle,
+            equipment_id AS equipmentId,duration_minutes AS durationMinutes,
+            anatomical_regions_count AS anatomicalRegionsCount,performed_at AS performedAt,
+            assigned_radiologist_email AS radiologistEmail,
+            assigned_radiographer_email AS radiographerEmail,
+            payment_amount AS paymentAmount,status
+     FROM bookings WHERE organization_id=? AND id=? LIMIT 1`
+  ).bind(organizationId,bookingId).first<ServiceDeliveryBooking>();
+  return row || null;
+}
+
+export async function existingServiceDelivery(
+  db:D1Database,
+  organizationId:number,
+  bookingId:number,
+):Promise<ServiceDeliveryDocument|null> {
+  const row=await db.prepare(
+    `SELECT d.id,d.organization_id AS organizationId,d.number,d.state,s.booking_id AS bookingId,
+            s.charge_amount AS chargeAmount,s.price_amount AS priceAmount
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery'
+       AND d.state IN ('draft','posted')
+     ORDER BY d.id DESC LIMIT 1`
+  ).bind(organizationId,bookingId).first<ServiceDeliveryDocument>();
+  return row || null;
+}
+
+async function cleanupDraft(db:D1Database,organizationId:number,documentId:number) {
+  const row=await db.prepare(
+    "SELECT state FROM business_documents WHERE organization_id=? AND id=? LIMIT 1"
+  ).bind(organizationId,documentId).first<{state:string}>();
+  if(!row || row.state!=="draft") return;
+  await db.prepare("DELETE FROM service_delivery_details WHERE organization_id=? AND document_id=?")
+    .bind(organizationId,documentId).run().catch(()=>{});
+  await db.prepare("DELETE FROM business_documents WHERE organization_id=? AND id=? AND state='draft'")
+    .bind(organizationId,documentId).run().catch(()=>{});
+}
+
+export async function postServiceDelivery(
+  db:D1Database,
+  input:{organizationId:number;bookingId:number;actorEmail:string},
+) {
+  const existing=await existingServiceDelivery(db,input.organizationId,input.bookingId);
+  if(existing?.state === "posted") return {document:existing,created:false};
+  if(existing) throw new Error("service_delivery_in_progress");
+
+  const booking=await serviceDeliveryBooking(db,input.organizationId,input.bookingId);
+  if(!booking) throw new Error("booking_not_found");
+  if(booking.status!=="completed" || !booking.performedAt) throw new Error("service_not_performed");
+  if(!Number.isInteger(booking.durationMinutes) || booking.durationMinutes<=0) throw new Error("service_duration_invalid");
+  if(!Number.isInteger(booking.anatomicalRegionsCount) || booking.anatomicalRegionsCount<=0) throw new Error("service_regions_invalid");
+  if(!Number.isInteger(booking.paymentAmount) || booking.paymentAmount<0) throw new Error("service_price_invalid");
+
+  const createdBy=actor(input.actorEmail);
+  if(!createdBy) throw new Error("service_actor_required");
+  const chargeAmount=booking.patientCategory === "civilian" ? booking.paymentAmount : 0;
+
+  const created=await db.prepare(
+    `INSERT INTO business_documents
+      (organization_id,document_type,number,occurred_at,state,comment,created_by)
+     VALUES (?,'service_delivery','',?,'draft',?,?)`
+  ).bind(input.organizationId,booking.performedAt,`Надання послуги за заявкою ${booking.code}`,createdBy).run();
+  const documentId=Number(created.meta.last_row_id || 0);
+  if(!documentId) throw new Error("service_delivery_create_failed");
+  const number=`НП-${String(documentId).padStart(6,"0")}`;
+
+  try {
+    await db.prepare(
+      "UPDATE business_documents SET number=? WHERE organization_id=? AND id=? AND state='draft'"
+    ).bind(number,input.organizationId,documentId).run();
+    await db.prepare(
+      `INSERT INTO service_delivery_details
+       (organization_id,document_id,booking_id,patient_id,patient_category,service_code,service_title,
+        equipment_id,duration_minutes,anatomical_regions_count,performed_at,radiologist_email,
+        radiographer_email,price_amount,charge_amount,currency)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'UAH')`
+    ).bind(
+      input.organizationId,documentId,booking.id,booking.patientId || "",booking.patientCategory,
+      booking.serviceCode,booking.serviceTitle,booking.equipmentId,booking.durationMinutes,
+      booking.anatomicalRegionsCount,booking.performedAt,booking.radiologistEmail || "",
+      booking.radiographerEmail || "",booking.paymentAmount,chargeAmount,
+    ).run();
+
+    const postedAt=new Date().toISOString();
+    const statements:unknown[]=[
+      db.prepare(
+        `UPDATE business_documents SET state='posted',posted_by=?,posted_at=?
+         WHERE organization_id=? AND id=? AND state='draft'`
+      ).bind(createdBy,postedAt,input.organizationId,documentId),
+      db.prepare(
+        `INSERT INTO services_delivered_movements
+         (organization_id,document_id,booking_id,patient_id,service_code,equipment_id,quantity,
+          anatomical_regions_count,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,?,?,1,?,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,booking.id,booking.patientId || "",booking.serviceCode,
+        booking.equipmentId,booking.anatomicalRegionsCount,booking.performedAt,createdBy,booking.performedAt,
+      ),
+      db.prepare(
+        `INSERT INTO equipment_load_movements
+         (organization_id,document_id,booking_id,equipment_id,minutes_delta,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,booking.id,booking.equipmentId,booking.durationMinutes,
+        booking.performedAt,createdBy,booking.performedAt,
+      ),
+    ];
+
+    if(chargeAmount>0) {
+      statements.push(
+        db.prepare(
+          `INSERT INTO revenue_movements
+           (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email,occurred_at)
+           VALUES (?,?,?,?,?,'service_delivery',?,'UAH',?,?)`
+        ).bind(
+          input.organizationId,documentId,booking.id,booking.patientId || "",booking.serviceCode,
+          chargeAmount,createdBy,booking.performedAt,
+        ),
+        db.prepare(
+          `INSERT INTO patient_settlement_movements
+           (organization_id,document_id,booking_id,patient_id,movement_type,amount_delta,currency,actor_email,occurred_at)
+           VALUES (?,?,?,?,'charge',?,'UAH',?,?)`
+        ).bind(
+          input.organizationId,documentId,booking.id,booking.patientId || "",chargeAmount,createdBy,booking.performedAt,
+        ),
+      );
+    }
+    if(booking.radiologistEmail) {
+      statements.push(db.prepare(
+        `INSERT INTO staff_output_movements
+         (organization_id,document_id,booking_id,member_email,staff_role,units_delta,anatomical_regions_count,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,'radiologist',1,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,booking.id,booking.radiologistEmail,
+        booking.anatomicalRegionsCount,booking.performedAt,createdBy,booking.performedAt,
+      ));
+    }
+    if(booking.radiographerEmail) {
+      statements.push(db.prepare(
+        `INSERT INTO staff_output_movements
+         (organization_id,document_id,booking_id,member_email,staff_role,units_delta,anatomical_regions_count,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,'radiographer',1,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,booking.id,booking.radiographerEmail,
+        booking.anatomicalRegionsCount,booking.performedAt,createdBy,booking.performedAt,
+      ));
+    }
+    await db.batch(statements);
+  } catch(error) {
+    await cleanupDraft(db,input.organizationId,documentId);
+    const message=String(error).toLowerCase();
+    if(message.includes("service_delivery_already_exists")) {
+      const race=await existingServiceDelivery(db,input.organizationId,input.bookingId);
+      if(race?.state === "posted") return {document:race,created:false};
+    }
+    throw error;
+  }
+
+  return {
+    document:{
+      id:documentId,organizationId:input.organizationId,number,state:"posted",
+      bookingId:booking.id,chargeAmount,priceAmount:booking.paymentAmount,
+    } satisfies ServiceDeliveryDocument,
+    created:true,
+  };
+}
+
+export async function listServiceDeliveries(db:D1Database,organizationId:number,limit=200) {
+  const safeLimit=Math.max(1,Math.min(500,Math.trunc(limit)));
+  const rows=await db.prepare(
+    `SELECT d.id,d.number,d.occurred_at AS occurredAt,d.state,d.posted_by AS postedBy,
+            s.booking_id AS bookingId,b.code AS bookingCode,b.name AS patientName,
+            s.patient_id AS patientId,s.patient_category AS patientCategory,
+            s.service_code AS serviceCode,s.service_title AS serviceTitle,s.equipment_id AS equipmentId,
+            s.duration_minutes AS durationMinutes,s.anatomical_regions_count AS anatomicalRegionsCount,
+            s.performed_at AS performedAt,s.radiologist_email AS radiologistEmail,
+            s.radiographer_email AS radiographerEmail,s.price_amount AS priceAmount,
+            s.charge_amount AS chargeAmount,s.currency
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     JOIN bookings b ON b.id=s.booking_id AND b.organization_id=s.organization_id
+     WHERE d.organization_id=? AND d.document_type='service_delivery'
+     ORDER BY d.occurred_at DESC,d.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}

--- a/lib/service-deliveries.ts
+++ b/lib/service-deliveries.ts
@@ -131,7 +131,7 @@ export async function postServiceDelivery(
         `INSERT INTO services_delivered_movements
          (organization_id,document_id,booking_id,patient_id,service_code,equipment_id,quantity,
           anatomical_regions_count,performed_at,actor_email,occurred_at)
-         VALUES (?,?,?,?,?,?,1,?,?,?,?,?)`
+         VALUES (?,?,?,?,?,?,1,?,?,?,?)`
       ).bind(
         input.organizationId,documentId,booking.id,booking.patientId || "",booking.serviceCode,
         booking.equipmentId,booking.anatomicalRegionsCount,booking.performedAt,createdBy,booking.performedAt,

--- a/lib/service-deliveries.ts
+++ b/lib/service-deliveries.ts
@@ -122,7 +122,7 @@ export async function postServiceDelivery(
     ).run();
 
     const postedAt=new Date().toISOString();
-    const statements:unknown[]=[
+    const statements:D1PreparedStatement[]=[
       db.prepare(
         `UPDATE business_documents SET state='posted',posted_by=?,posted_at=?
          WHERE organization_id=? AND id=? AND state='draft'`

--- a/tests/service-delivery-execution-posting.behavior.test.mjs
+++ b/tests/service-delivery-execution-posting.behavior.test.mjs
@@ -29,7 +29,7 @@ test("marking a study completed atomically posts its BAS service-delivery docume
        WHERE d.organization_id=1 AND s.booking_id=? AND d.document_type='service_delivery'`
     ).get(bookingId);
     assert.ok(doc?.id>0);
-    assert.equal(doc.number,`НП-${String(bookingId).padStart(6,"0")}`);
+    assert.equal(doc.number,`НП-${String(doc.id).padStart(6,"0")}`);
     assert.equal(doc.state,"posted");
     assert.equal(doc.chargeAmount,2500);
 

--- a/tests/service-delivery-execution-posting.behavior.test.mjs
+++ b/tests/service-delivery-execution-posting.behavior.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db,{code="RD-SVC-AUTO",category="civilian",amount=2500}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (1,?,'Auto Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-20','10:00',?,'pending',?,0,'confirmed',2,'doctor@example.com','tech@example.com')`
+  ).bind(code,category,amount).run();
+  return Number(result.meta.last_row_id);
+}
+
+test("marking a study completed atomically posts its BAS service-delivery document",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db);
+    await db.prepare(
+      `UPDATE bookings SET performed_at='2026-08-20T10:05:00',status='completed'
+       WHERE organization_id=1 AND id=?`
+    ).bind(bookingId).run();
+
+    const doc=raw.prepare(
+      `SELECT d.id,d.number,d.state,s.charge_amount AS chargeAmount
+       FROM business_documents d
+       JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+       WHERE d.organization_id=1 AND s.booking_id=? AND d.document_type='service_delivery'`
+    ).get(bookingId);
+    assert.ok(doc?.id>0);
+    assert.equal(doc.number,`НП-${String(bookingId).padStart(6,"0")}`);
+    assert.equal(doc.state,"posted");
+    assert.equal(doc.chargeAmount,2500);
+
+    assert.equal(raw.prepare("SELECT amount_delta FROM revenue_movements WHERE document_id=?").get(doc.id).amount_delta,2500);
+    assert.equal(raw.prepare("SELECT amount_delta FROM patient_settlement_movements WHERE document_id=?").get(doc.id).amount_delta,2500);
+    assert.equal(raw.prepare("SELECT minutes_delta FROM equipment_load_movements WHERE document_id=?").get(doc.id).minutes_delta,30);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM staff_output_movements WHERE document_id=?").get(doc.id).n,2);
+  });
+});
+
+test("posted service delivery freezes the booking facts that define revenue and output",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-SVC-FREEZE"});
+    await db.prepare(
+      `UPDATE bookings SET performed_at='2026-08-20T10:05:00',status='completed'
+       WHERE organization_id=1 AND id=?`
+    ).bind(bookingId).run();
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET payment_amount=1 WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/service_delivery_booking_immutable/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET assigned_radiologist_email='other@example.com' WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/service_delivery_booking_immutable/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET performed_at='2026-08-20T11:00:00' WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/service_delivery_booking_immutable/);
+
+    const facts=raw.prepare(
+      "SELECT payment_amount,assigned_radiologist_email,performed_at FROM bookings WHERE id=?"
+    ).get(bookingId);
+    assert.equal(facts.payment_amount,2500);
+    assert.equal(facts.assigned_radiologist_email,"doctor@example.com");
+    assert.equal(facts.performed_at,"2026-08-20T10:05:00");
+  });
+});
+
+test("military completion auto-posts operational registers without revenue or patient charge",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-SVC-AUTO-MIL",category:"military",amount:2500});
+    await db.prepare(
+      `UPDATE bookings SET performed_at='2026-08-20T10:05:00',status='completed'
+       WHERE organization_id=1 AND id=?`
+    ).bind(bookingId).run();
+    const doc=raw.prepare(
+      `SELECT d.id,s.charge_amount AS chargeAmount
+       FROM business_documents d JOIN service_delivery_details s ON s.document_id=d.id
+       WHERE s.booking_id=? AND d.document_type='service_delivery'`
+    ).get(bookingId);
+    assert.equal(doc.chargeAmount,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM services_delivered_movements WHERE document_id=?").get(doc.id).n,1);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM revenue_movements WHERE document_id=?").get(doc.id).n,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM patient_settlement_movements WHERE document_id=?").get(doc.id).n,0);
+  });
+});

--- a/tests/service-delivery-security.behavior.test.mjs
+++ b/tests/service-delivery-security.behavior.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1 } from "./helpers/d1.mjs";
+
+test("draft service-delivery snapshot cannot be forged before posting",async()=>{
+  await withD1(async(db,raw)=>{
+    const booking=await db.prepare(
+      `INSERT INTO bookings (
+        organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+        duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+        status,performed_at,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+       ) VALUES (1,'RD-SVC-DRAFT-GUARD','Guard Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+         '2026-08-20','10:00','civilian','pending',2200,0,'completed','2026-08-20T10:05:00',2,
+         'doctor@example.com','tech@example.com')`
+    ).run();
+    const bookingId=Number(booking.meta.last_row_id);
+    const document=await db.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,occurred_at,state,comment,created_by)
+       VALUES (1,'service_delivery','НП-DRAFT-GUARD','2026-08-20T10:05:00','draft','','guard@example.com')`
+    ).run();
+    const documentId=Number(document.meta.last_row_id);
+
+    await db.prepare(
+      `INSERT INTO service_delivery_details
+       (organization_id,document_id,booking_id,patient_id,patient_category,service_code,service_title,
+        equipment_id,duration_minutes,anatomical_regions_count,performed_at,radiologist_email,
+        radiographer_email,price_amount,charge_amount,currency)
+       VALUES (1,?,?,?,'civilian','ct-chest','КТ ОГК','ct',30,2,'2026-08-20T10:05:00',
+         'doctor@example.com','tech@example.com',2200,2200,'UAH')`
+    ).bind(documentId,bookingId,"").run();
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE service_delivery_details SET charge_amount=1 WHERE organization_id=1 AND document_id=?"
+    ).run(documentId),/service_delivery_charge_mismatch/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE service_delivery_details SET service_code='forged' WHERE organization_id=1 AND document_id=?"
+    ).run(documentId),/service_delivery_booking_snapshot_mismatch/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE service_delivery_details SET organization_id=2 WHERE organization_id=1 AND document_id=?"
+    ).run(documentId),/service_delivery_document_identity_immutable/);
+
+    const unchanged=raw.prepare(
+      "SELECT service_code,charge_amount FROM service_delivery_details WHERE organization_id=1 AND document_id=?"
+    ).get(documentId);
+    assert.equal(unchanged.service_code,"ct-chest");
+    assert.equal(unchanged.charge_amount,2200);
+  });
+});

--- a/tests/service-delivery.behavior.test.mjs
+++ b/tests/service-delivery.behavior.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompletedBooking(db,{
+  code="RD-SVC-001",amount=2400,category="civilian",organizationId=1,
+  radiologist="doctor@example.com",radiographer="tech@example.com",
+}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,performed_at,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,'Service Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-20','10:00',?,'pending',?,0,'completed','2026-08-20T10:05:00',2,?,?)`
+  ).bind(organizationId,code,category,amount,radiologist,radiographer).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function post(db,cookie,bookingId) {
+  return callWorker(jsonRequest("/api/staff/service-deliveries",{bookingId},{headers:{cookie}}),db);
+}
+
+test("completed civilian service posts one BAS service document and all business registers",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedCompletedBooking(db);
+    const cookie=await seedStaffSession(db,{email:"registrar-service@example.com",role:"registrar",organizationId:1});
+
+    const first=await post(db,cookie,bookingId);
+    assert.equal(first.status,200);
+    const firstBody=await first.json();
+    assert.equal(firstBody.created,true);
+    assert.match(firstBody.document.number,/^НП-\d{6}$/);
+    assert.equal(firstBody.document.chargeAmount,2400);
+
+    const second=await post(db,cookie,bookingId);
+    assert.equal(second.status,200);
+    const secondBody=await second.json();
+    assert.equal(secondBody.created,false);
+    assert.equal(secondBody.document.id,firstBody.document.id);
+
+    const doc=raw.prepare(
+      "SELECT document_type,state FROM business_documents WHERE organization_id=1 AND id=?"
+    ).get(firstBody.document.id);
+    assert.equal(doc.document_type,"service_delivery");
+    assert.equal(doc.state,"posted");
+
+    const detail=raw.prepare(
+      `SELECT booking_id,service_code,equipment_id,duration_minutes,anatomical_regions_count,
+              price_amount,charge_amount,performed_at
+       FROM service_delivery_details WHERE organization_id=1 AND document_id=?`
+    ).get(firstBody.document.id);
+    assert.equal(detail.booking_id,bookingId);
+    assert.equal(detail.service_code,"ct-chest");
+    assert.equal(detail.equipment_id,"ct");
+    assert.equal(detail.duration_minutes,30);
+    assert.equal(detail.anatomical_regions_count,2);
+    assert.equal(detail.price_amount,2400);
+    assert.equal(detail.charge_amount,2400);
+    assert.equal(detail.performed_at,"2026-08-20T10:05:00");
+
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM services_delivered_movements WHERE organization_id=1 AND document_id=?"
+    ).get(firstBody.document.id).n,1);
+    assert.equal(raw.prepare(
+      "SELECT minutes_delta FROM equipment_load_movements WHERE organization_id=1 AND document_id=?"
+    ).get(firstBody.document.id).minutes_delta,30);
+    assert.equal(raw.prepare(
+      "SELECT amount_delta FROM revenue_movements WHERE organization_id=1 AND document_id=?"
+    ).get(firstBody.document.id).amount_delta,2400);
+    assert.equal(raw.prepare(
+      "SELECT amount_delta FROM patient_settlement_movements WHERE organization_id=1 AND document_id=?"
+    ).get(firstBody.document.id).amount_delta,2400);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM staff_output_movements WHERE organization_id=1 AND document_id=?"
+    ).get(firstBody.document.id).n,2);
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE revenue_movements SET amount_delta=1 WHERE document_id=?"
+    ).run(firstBody.document.id),/revenue_movement_immutable/);
+    assert.throws(()=>raw.prepare(
+      "DELETE FROM equipment_load_movements WHERE document_id=?"
+    ).run(firstBody.document.id),/equipment_load_movement_immutable/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE service_delivery_details SET charge_amount=1 WHERE document_id=?"
+    ).run(firstBody.document.id),/service_delivery_not_draft/);
+  });
+});
+
+test("free military service records operational output without inventing revenue or patient debt",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedCompletedBooking(db,{code:"RD-SVC-MIL",amount:2400,category:"military"});
+    const cookie=await seedStaffSession(db,{email:"registrar-military@example.com",role:"registrar",organizationId:1});
+    const response=await post(db,cookie,bookingId);
+    assert.equal(response.status,200);
+    const body=await response.json();
+    assert.equal(body.document.chargeAmount,0);
+
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM services_delivered_movements WHERE document_id=?"
+    ).get(body.document.id).n,1);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM equipment_load_movements WHERE document_id=?"
+    ).get(body.document.id).n,1);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM staff_output_movements WHERE document_id=?"
+    ).get(body.document.id).n,2);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM revenue_movements WHERE document_id=?"
+    ).get(body.document.id).n,0);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM patient_settlement_movements WHERE document_id=?"
+    ).get(body.document.id).n,0);
+  });
+});
+
+test("service delivery fails closed before the study is actually performed",async()=>{
+  await withD1(async(db,raw)=>{
+    const result=await db.prepare(
+      `INSERT INTO bookings (
+        organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+        duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,status
+       ) VALUES (1,'RD-SVC-NOT-DONE','Pending Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+         '2026-08-20','11:00','civilian','pending',1800,0,'confirmed')`
+    ).run();
+    const bookingId=Number(result.meta.last_row_id);
+    const cookie=await seedStaffSession(db,{email:"registrar-pending@example.com",role:"registrar",organizationId:1});
+
+    const response=await post(db,cookie,bookingId);
+    assert.equal(response.status,409);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM business_documents WHERE organization_id=1 AND document_type='service_delivery'"
+    ).get().n,0);
+  });
+});
+
+test("service delivery journal is tenant scoped",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Service Org 2','service-org-2',1)");
+    const booking1=await seedCompletedBooking(db,{code:"RD-SVC-T1",organizationId:1});
+    const booking2=await seedCompletedBooking(db,{code:"RD-SVC-T2",organizationId:2});
+    const staff1=await seedStaffSession(db,{email:"service-org1@example.com",role:"registrar",organizationId:1});
+    const staff2=await seedStaffSession(db,{email:"service-org2@example.com",role:"registrar",organizationId:2});
+    assert.equal((await post(db,staff1,booking1)).status,200);
+    assert.equal((await post(db,staff2,booking2)).status,200);
+
+    const list=await callWorker(new Request("http://localhost/api/staff/service-deliveries",{headers:{cookie:staff1}}),db);
+    assert.equal(list.status,200);
+    const body=await list.json();
+    assert.equal(body.documents.length,1);
+    assert.equal(body.documents[0].bookingCode,"RD-SVC-T1");
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_delivery_details").get().n,2);
+  });
+});
+
+test("D1 rejects forged service register movements that do not match the posted registrar",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedCompletedBooking(db,{code:"RD-SVC-FORGE",amount:2100});
+    const cookie=await seedStaffSession(db,{email:"service-forge@example.com",role:"registrar",organizationId:1});
+    const response=await post(db,cookie,bookingId);
+    const body=await response.json();
+    assert.equal(response.status,200);
+
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO revenue_movements
+       (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email,occurred_at)
+       VALUES (1,?,?,?,'ct-chest','service_delivery',1,'UAH','attacker@example.com','2026-08-20T10:05:00')`
+    ).run(body.document.id,bookingId,""),/revenue_document_mismatch/);
+
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO equipment_load_movements
+       (organization_id,document_id,booking_id,equipment_id,minutes_delta,performed_at,actor_email,occurred_at)
+       VALUES (1,?,?,'ct',1,'2026-08-20T10:05:00','attacker@example.com','2026-08-20T10:05:00')`
+    ).run(body.document.id,bookingId),/equipment_load_document_mismatch/);
+  });
+});


### PR DESCRIPTION
## Goal
Continue the BAS-style business core with the authoritative `service_delivery` economic/operational document.

## Implemented
- completed service posts as one tenant-scoped `service_delivery` business document
- execution transition (`completed + performed_at`) and posting are atomic at D1 level
- exact booking snapshot is persisted in `service_delivery_details`
- posting creates append-only `services_delivered`, `equipment_load`, and `staff_output` movements
- priced civilian service creates `revenue` and a positive patient-settlement charge
- military/free service records operational output without inventing patient debt or cash revenue
- explicit posting remains available for legacy completed bookings and is idempotent/fail-closed
- posted service facts freeze the booking fields that define revenue/output; later corrections require an explicit correction model rather than silent edits
- draft snapshots and all register movements are protected by D1 integrity/immutability triggers
- one `business_documents.id` sequence owns `НП-xxxxxx` numbering for both automatic and explicit posting
- staff API is booking-access scoped; journal read is finance-role scoped

## Accounting boundary
- service delivery is the source of revenue/receivable
- payment is a separate cash fact that reduces the receivable
- refund does not automatically reverse revenue

## Verification
- behavioral coverage for civilian, military/free, legacy explicit posting, tenant isolation, forged movements, draft tampering, atomic execution posting and immutable posted facts
- CI and CodeQL required on exact PR head before merge
- final manual security diff review found and fixed draft-tampering and numbering-collision cases

## Follow-up
- service-act immutable print snapshot and finance journal presentation can be added as the next business-core UX block
- explicit service correction/storno document will be needed for legitimate post-fact changes

## Boundaries
- no production deploy
- DICOM/PACS/protocols/results remain medical-domain modules and are not finance documents