### PR TITLE
Add BAS service-delivery journal and immutable service acts

### DIFF
--- a/app/api/staff/service-deliveries/print/route.ts
+++ b/app/api/staff/service-deliveries/print/route.ts
@@ -1,0 +1,195 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import { canManageFinance } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+const TEMPLATE_VERSION=1;
+const FORM_TYPE="service_act";
+
+type SnapshotRow={
+  id:number;documentId:number;formType:string;templateVersion:number;documentState:string;
+  payloadJson:string;generatedBy:string;generatedAt:string;storageKey:string;sha256:string;
+};
+
+type ServiceActSource={
+  documentId:number;documentNumber:string;occurredAt:string;documentState:string;comment:string;
+  createdBy:string;createdAt:string;postedBy:string;postedAt:string;
+  bookingId:number;bookingCode:string;patientName:string;patientId:string;patientCategory:string;
+  serviceCode:string;serviceTitle:string;equipmentId:string;durationMinutes:number;anatomicalRegionsCount:number;
+  performedAt:string;radiologistEmail:string;radiographerEmail:string;priceAmount:number;chargeAmount:number;currency:string;
+  organizationName:string;
+};
+
+function int(value:unknown) {
+  const n=Number(value);
+  return Number.isInteger(n)&&n>0?n:null;
+}
+
+async function sha256(value:string) {
+  const bytes=new TextEncoder().encode(value);
+  const digest=await crypto.subtle.digest("SHA-256",bytes);
+  return Array.from(new Uint8Array(digest),b=>b.toString(16).padStart(2,"0")).join("");
+}
+
+function publicSnapshot(row:SnapshotRow) {
+  const {payloadJson:_,...snapshot}=row;
+  void _;
+  return snapshot;
+}
+
+async function sourceForDocument(db:D1Database,organizationId:number,documentId:number) {
+  const row=await db.prepare(
+    `SELECT d.id AS documentId,d.number AS documentNumber,d.occurred_at AS occurredAt,
+            d.state AS documentState,d.comment,d.created_by AS createdBy,d.created_at AS createdAt,
+            d.posted_by AS postedBy,d.posted_at AS postedAt,
+            s.booking_id AS bookingId,b.code AS bookingCode,b.name AS patientName,
+            s.patient_id AS patientId,s.patient_category AS patientCategory,
+            s.service_code AS serviceCode,s.service_title AS serviceTitle,s.equipment_id AS equipmentId,
+            s.duration_minutes AS durationMinutes,s.anatomical_regions_count AS anatomicalRegionsCount,
+            s.performed_at AS performedAt,s.radiologist_email AS radiologistEmail,
+            s.radiographer_email AS radiographerEmail,s.price_amount AS priceAmount,
+            s.charge_amount AS chargeAmount,s.currency,
+            COALESCE(o.name,'Організація') AS organizationName
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     JOIN bookings b ON b.id=s.booking_id AND b.organization_id=s.organization_id
+     LEFT JOIN organizations o ON o.id=d.organization_id
+     WHERE d.organization_id=? AND d.id=? AND d.document_type='service_delivery'
+     LIMIT 1`
+  ).bind(organizationId,documentId).first<ServiceActSource>();
+  return row || null;
+}
+
+function renderPayload(source:ServiceActSource) {
+  return {
+    templateVersion:TEMPLATE_VERSION,
+    formType:FORM_TYPE,
+    organization:{name:source.organizationName || "Організація"},
+    document:{
+      id:source.documentId,
+      number:source.documentNumber,
+      occurredAt:source.occurredAt,
+      state:source.documentState,
+      comment:source.comment,
+      createdBy:source.createdBy,
+      createdAt:source.createdAt,
+      postedBy:source.postedBy,
+      postedAt:source.postedAt,
+    },
+    booking:{
+      id:source.bookingId,
+      code:source.bookingCode,
+      patientName:source.patientName,
+      patientId:source.patientId,
+      patientCategory:source.patientCategory,
+    },
+    service:{
+      code:source.serviceCode,
+      title:source.serviceTitle,
+      equipmentId:source.equipmentId,
+      durationMinutes:source.durationMinutes,
+      anatomicalRegionsCount:source.anatomicalRegionsCount,
+      performedAt:source.performedAt,
+      radiologistEmail:source.radiologistEmail,
+      radiographerEmail:source.radiographerEmail,
+      priceAmount:source.priceAmount,
+      chargeAmount:source.chargeAmount,
+      currency:source.currency,
+    },
+  };
+}
+
+async function serviceActContext(request:Request) {
+  const db=dbBinding();
+  if(!db) return {response:Response.json({error:"База тимчасово недоступна"},{status:503})} as const;
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return {response:Response.json({error:"Доступ лише для персоналу"},{status:403})} as const;
+  if(!canManageFinance(ctx.member.role)) {
+    return {response:Response.json({error:"Акти наданих послуг доступні реєстратору або адміністратору"},{status:403})} as const;
+  }
+  return {db,ctx} as const;
+}
+
+export async function GET(request:Request) {
+  const auth=await serviceActContext(request);
+  if("response" in auth) return auth.response;
+  const {db,ctx}=auth;
+  const url=new URL(request.url);
+  const snapshotId=int(url.searchParams.get("snapshotId"));
+  if(!snapshotId) return Response.json({error:"Некоректна друкована форма"},{status:400});
+  const row=await db.prepare(
+    `SELECT s.id,s.document_id AS documentId,s.form_type AS formType,s.template_version AS templateVersion,
+            s.document_state AS documentState,s.payload_json AS payloadJson,s.generated_by AS generatedBy,
+            s.generated_at AS generatedAt,s.storage_key AS storageKey,s.sha256
+     FROM printed_form_snapshots s
+     JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+     WHERE s.organization_id=? AND s.id=? AND s.form_type=? AND d.document_type='service_delivery'
+     LIMIT 1`
+  ).bind(ctx.organizationId,snapshotId,FORM_TYPE).first<SnapshotRow>();
+  if(!row) return Response.json({error:"Акт наданих послуг не знайдено"},{status:404});
+  return Response.json({snapshot:publicSnapshot(row),payload:JSON.parse(row.payloadJson)});
+}
+
+export async function POST(request:Request) {
+  const auth=await serviceActContext(request);
+  if("response" in auth) return auth.response;
+  const {db,ctx}=auth;
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const documentId=int(body.documentId);
+  if(!documentId) return Response.json({error:"Некоректний документ"},{status:400});
+
+  const source=await sourceForDocument(db,ctx.organizationId,documentId);
+  if(!source) return Response.json({error:"Документ надання послуги не знайдено"},{status:404});
+  if(source.documentState!=="posted" && source.documentState!=="reversed") {
+    return Response.json({error:"Акт формується лише для проведеного або сторнованого документа"},{status:409});
+  }
+
+  const existing=await db.prepare(
+    `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+            document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+            generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=? AND form_type=? AND template_version=? AND document_state=?
+     ORDER BY id ASC LIMIT 1`
+  ).bind(ctx.organizationId,documentId,FORM_TYPE,TEMPLATE_VERSION,source.documentState).first<SnapshotRow>();
+  if(existing) {
+    await audit(db,{
+      organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+      action:"printed_form_reprinted",resource:"business_document",targetId:documentId,
+      details:{formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,snapshotId:existing.id},
+    });
+    return Response.json({snapshot:publicSnapshot(existing),payload:JSON.parse(existing.payloadJson)});
+  }
+
+  const payload=renderPayload(source);
+  const payloadJson=JSON.stringify(payload);
+  const hash=await sha256(payloadJson);
+  const inserted=await db.prepare(
+    `INSERT OR IGNORE INTO printed_form_snapshots
+      (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,sha256)
+     VALUES (?,?,?,?,?,?,?,?)`
+  ).bind(
+    ctx.organizationId,documentId,FORM_TYPE,TEMPLATE_VERSION,source.documentState,payloadJson,ctx.member.email,hash,
+  ).run();
+  const snapshot=await db.prepare(
+    `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+            document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+            generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=? AND form_type=? AND template_version=? AND document_state=?
+     ORDER BY id ASC LIMIT 1`
+  ).bind(ctx.organizationId,documentId,FORM_TYPE,TEMPLATE_VERSION,source.documentState).first<SnapshotRow>();
+  if(!snapshot) return Response.json({error:"Не вдалося зберегти акт наданих послуг"},{status:500});
+
+  const created=Number(inserted.meta.changes || 0)>0;
+  await audit(db,{
+    organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+    action:created?"printed_form_generated":"printed_form_reprinted",
+    resource:"business_document",targetId:documentId,
+    details:{formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,snapshotId:snapshot.id},
+  });
+  return Response.json(
+    {snapshot:publicSnapshot(snapshot),payload:JSON.parse(snapshot.payloadJson)},
+    {status:created?201:200},
+  );
+}

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -93,7 +93,7 @@ export default function FinancePage() {
   return <StaffWorkspaceShell
     active="finance"
     title="Фінанси"
-    description="BAS-подібний журнал оплат, повернень, рухів грошей і взаєморозрахунків."
+    description="BAS-подібний журнал наданих послуг, оплат, повернень, рухів грошей і взаєморозрахунків."
   >
     <section className="financeSummary" aria-label="Підсумок фінансового регістру">
       <article><span>Надійшло</span><b>{money(totals.incoming)}</b><small>за BAS-документами</small></article>
@@ -113,6 +113,7 @@ export default function FinancePage() {
           <button type="button" className={tab==="documents"?"active":""} onClick={()=>setTab("documents")}>Документи</button>
           <button type="button" className={tab==="cash"?"active":""} onClick={()=>setTab("cash")}>Рухи грошей</button>
           <button type="button" className={tab==="settlements"?"active":""} onClick={()=>setTab("settlements")}>Взаєморозрахунки</button>
+          <button type="button" onClick={()=>window.location.assign("/staff/finance/services")}>Надані послуги ↗</button>
         </div>
         <input value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Пошук: документ, RD, пацієнт…" aria-label="Пошук у фінансовому журналі"/>
         <button type="button" onClick={()=>void load()}>Оновити</button>

--- a/app/staff/finance/services/page.tsx
+++ b/app/staff/finance/services/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback,useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type ServiceDelivery={
+  id:number;number:string;occurredAt:string;state:string;postedBy:string;
+  bookingId:number;bookingCode:string;patientName:string;patientId:string;patientCategory:string;
+  serviceCode:string;serviceTitle:string;equipmentId:string;durationMinutes:number;anatomicalRegionsCount:number;
+  performedAt:string;radiologistEmail:string;radiographerEmail:string;priceAmount:number;chargeAmount:number;currency:string;
+};
+type Payload={documents:ServiceDelivery[];error?:string};
+
+const STATE_UK:Record<string,string>={draft:"Чернетка",posted:"Проведено",reversed:"Сторновано",cancelled:"Скасовано"};
+
+function money(value:number,currency="UAH") {
+  return new Intl.NumberFormat("uk-UA",{style:"currency",currency,maximumFractionDigits:0}).format(Number(value||0));
+}
+function dateTime(value:string) {
+  const date=new Date(value);
+  return Number.isNaN(date.getTime())?value:date.toLocaleString("uk-UA",{dateStyle:"medium",timeStyle:"short"});
+}
+
+export default function ServiceDeliveryJournalPage() {
+  const [data,setData]=useState<Payload|null>(null);
+  const [error,setError]=useState("");
+  const [query,setQuery]=useState("");
+
+  const load=useCallback(async()=>{
+    try {
+      const response=await fetch("/api/staff/service-deliveries",{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as Payload;
+      if(!response.ok) throw new Error(payload.error || "Не вдалося завантажити журнал наданих послуг");
+      setData(payload);setError("");
+    } catch(e) {
+      setError(e instanceof Error?e.message:"Не вдалося завантажити журнал наданих послуг");
+    }
+  },[]);
+
+  useEffect(()=>{
+    const timer=window.setTimeout(()=>{void load();},0);
+    return()=>window.clearTimeout(timer);
+  },[load]);
+
+  const q=query.trim().toLowerCase();
+  const rows=useMemo(()=>{
+    const source=data?.documents || [];
+    if(!q)return source;
+    return source.filter((row)=>`${row.number} ${row.bookingCode} ${row.patientName} ${row.serviceTitle} ${row.serviceCode} ${row.equipmentId} ${row.radiologistEmail} ${row.radiographerEmail}`.toLowerCase().includes(q));
+  },[data,q]);
+
+  const totals=useMemo(()=>{
+    const source=data?.documents || [];
+    return {
+      count:source.length,
+      charge:source.reduce((sum,row)=>sum+Number(row.chargeAmount||0),0),
+      free:source.filter((row)=>Number(row.chargeAmount||0)===0).length,
+      minutes:source.reduce((sum,row)=>sum+Number(row.durationMinutes||0),0),
+      regions:source.reduce((sum,row)=>sum+Number(row.anatomicalRegionsCount||0),0),
+    };
+  },[data]);
+
+  function printAct(id:number) {
+    window.open(`/staff/finance/services/print?id=${id}`,"_blank","noopener,noreferrer");
+  }
+
+  return <StaffWorkspaceShell
+    active="finance"
+    title="Надані послуги"
+    description="BAS-журнал проведених медичних послуг: один документ — один операційний та економічний факт."
+  >
+    <section className="financeSummary" aria-label="Підсумок журналу наданих послуг">
+      <article><span>Документів</span><b>{totals.count}</b><small>проведених надань</small></article>
+      <article><span>Нараховано</span><b>{money(totals.charge)}</b><small>цивільні платні послуги</small></article>
+      <article><span>Без нарахування</span><b>{totals.free}</b><small>військові / безоплатні</small></article>
+      <article><span>Навантаження</span><b>{totals.minutes} хв</b><small>{totals.regions} анатомічних ділянок</small></article>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div>
+          <b>Журнал документів «Надання послуг»</b>
+          <small>Дані формуються з проведених business documents, не з ручних підсумків.</small>
+        </div>
+        <input value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Пошук: НП, RD, пацієнт, послуга…" aria-label="Пошук у журналі наданих послуг"/>
+        <button type="button" onClick={()=>void load()}>Оновити</button>
+      </header>
+
+      {error&&<p className="financeError">{error}</p>}
+      {!data&&!error&&<p className="financeLoading">Завантаження журналу…</p>}
+
+      {data&&<div className="financeTableWrap"><table className="financeTable">
+        <thead><tr>
+          <th>Документ</th><th>Виконано</th><th>Заявка / пацієнт</th><th>Послуга</th><th>Апарат</th>
+          <th>Виконавці</th><th className="num">Нарахування</th><th>Стан</th><th/>
+        </tr></thead>
+        <tbody>{rows.map((row)=><tr key={row.id}>
+          <td><b>{row.number}</b><small>Надання послуги</small></td>
+          <td>{dateTime(row.performedAt)}<small>{row.durationMinutes} хв · {row.anatomicalRegionsCount} зон.</small></td>
+          <td><b>{row.bookingCode}</b><small>{row.patientName}</small></td>
+          <td><b>{row.serviceTitle}</b><small>{row.serviceCode}</small></td>
+          <td>{row.equipmentId}</td>
+          <td>
+            <small>{row.radiologistEmail?`Лікар: ${row.radiologistEmail}`:"Лікар: —"}</small>
+            <small>{row.radiographerEmail?`Лаборант: ${row.radiographerEmail}`:"Лаборант: —"}</small>
+          </td>
+          <td className={`num ${row.chargeAmount>0?"positive":""}`}>{row.chargeAmount>0?money(row.chargeAmount,row.currency):"Безоплатно"}</td>
+          <td><span className={`financeState state-${row.state}`}>{STATE_UK[row.state]||row.state}</span></td>
+          <td><button type="button" onClick={()=>printAct(row.id)}>Акт</button></td>
+        </tr>)}</tbody>
+      </table>{rows.length===0&&<p className="financeEmpty">Документів за цим відбором немає.</p>}</div>}
+    </section>
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/finance/services/print/page.tsx
+++ b/app/staff/finance/services/print/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect,useState } from "react";
+
+type PrintPayload={
+  templateVersion:number;
+  formType:"service_act";
+  organization:{name:string};
+  document:{id:number;number:string;occurredAt:string;state:string;comment:string;createdBy:string;createdAt:string;postedBy:string;postedAt:string};
+  booking:{id:number;code:string;patientName:string;patientId:string;patientCategory:string};
+  service:{
+    code:string;title:string;equipmentId:string;durationMinutes:number;anatomicalRegionsCount:number;performedAt:string;
+    radiologistEmail:string;radiographerEmail:string;priceAmount:number;chargeAmount:number;currency:string;
+  };
+};
+type Snapshot={id:number;documentId:number;formType:string;templateVersion:number;documentState:string;generatedBy:string;generatedAt:string;storageKey:string;sha256:string};
+type ResponsePayload={snapshot:Snapshot;payload:PrintPayload;error?:string};
+
+const STATE_UK:Record<string,string>={posted:"Проведено",reversed:"СТОРНО",draft:"ЧЕРНЕТКА",cancelled:"Скасовано"};
+function money(value:number,currency="UAH"){return new Intl.NumberFormat("uk-UA",{style:"currency",currency,maximumFractionDigits:0}).format(Number(value||0));}
+function fmtDate(value:string){const d=new Date(value);return Number.isNaN(d.getTime())?value:d.toLocaleString("uk-UA",{dateStyle:"medium",timeStyle:"short"});}
+
+export default function ServiceActPrintPage(){
+  const [data,setData]=useState<ResponsePayload|null>(null);
+  const [error,setError]=useState("");
+
+  useEffect(()=>{
+    const controller=new AbortController();
+    const timer=window.setTimeout(()=>{
+      const id=Number(new URLSearchParams(window.location.search).get("id"));
+      if(!Number.isInteger(id)||id<1){setError("Некоректний документ надання послуги");return;}
+      void fetch("/api/staff/service-deliveries/print",{
+        method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({documentId:id}),signal:controller.signal,
+      }).then(async response=>{
+        const payload=await response.json().catch(()=>({})) as ResponsePayload;
+        if(!response.ok)throw new Error(payload.error||"Не вдалося сформувати акт");
+        setData(payload);
+      }).catch(e=>{if(e?.name!=="AbortError")setError(e instanceof Error?e.message:"Помилка друку");});
+    },0);
+    return()=>{window.clearTimeout(timer);controller.abort();};
+  },[]);
+
+  if(error)return <main className="financePrintPage"><div className="financePrintSheet"><h1>Не вдалося сформувати акт</h1><p>{error}</p></div></main>;
+  if(!data)return <main className="financePrintPage"><div className="financePrintSheet"><p>Формування акта наданих послуг…</p></div></main>;
+
+  const {payload,snapshot}=data;
+  const paid=payload.service.chargeAmount>0;
+  return <main className="financePrintPage">
+    <div className="financePrintToolbar"><button onClick={()=>window.close()}>Закрити</button><button onClick={()=>window.print()}>Друкувати / PDF</button></div>
+    <article className="financePrintSheet">
+      <header>
+        <div><small>{payload.organization.name}</small><h1>Акт наданих послуг</h1><p>Документ {payload.document.number}</p></div>
+        <strong>{STATE_UK[payload.document.state]||payload.document.state}</strong>
+      </header>
+
+      <section className="financePrintMeta">
+        <div><span>Номер</span><b>{payload.document.number}</b></div><div><span>Дата документа</span><b>{fmtDate(payload.document.occurredAt)}</b></div>
+        <div><span>Заявка</span><b>{payload.booking.code}</b></div><div><span>Пацієнт</span><b>{payload.booking.patientName}</b></div>
+        <div><span>Категорія</span><b>{payload.booking.patientCategory==="military"?"Військовослужбовець":"Цивільний"}</b></div>
+        <div><span>Виконано</span><b>{fmtDate(payload.service.performedAt)}</b></div>
+      </section>
+
+      <section className="financePrintDetails">
+        <p><span>Послуга</span><b>{payload.service.title}</b></p>
+        <p><span>Код послуги</span><b>{payload.service.code}</b></p>
+        <p><span>Апарат / кабінет</span><b>{payload.service.equipmentId}</b></p>
+        <p><span>Тривалість</span><b>{payload.service.durationMinutes} хв</b></p>
+        <p><span>Анатомічних ділянок</span><b>{payload.service.anatomicalRegionsCount}</b></p>
+        <p><span>Лікар</span><b>{payload.service.radiologistEmail||"—"}</b></p>
+        <p><span>Рентгенолаборант</span><b>{payload.service.radiographerEmail||"—"}</b></p>
+      </section>
+
+      <section className="financePrintAmount">
+        <span>{paid?"Нараховано":"Умови надання"}</span>
+        <b>{paid?money(payload.service.chargeAmount,payload.service.currency):"Безоплатно"}</b>
+      </section>
+
+      {payload.document.comment&&<section className="financePrintDetails"><p><span>Примітка</span><b>{payload.document.comment}</b></p></section>}
+
+      <section className="financePrintFooter">
+        <div><span>Відповідальний за проведення</span><b>{payload.document.postedBy||payload.document.createdBy}</b></div>
+        <div><span>Підпис</span><i/></div>
+      </section>
+      <p className="financePrintVersion">Форма v{snapshot.templateVersion} · snapshot #{snapshot.id} · SHA-256 {snapshot.sha256.slice(0,12)}…</p>
+    </article>
+  </main>;
+}

--- a/docs/bas-service-delivery-journal.md
+++ b/docs/bas-service-delivery-journal.md
@@ -1,0 +1,18 @@
+# BAS service-delivery journal
+
+`service_delivery` is the authoritative document for a performed service. The staff journal at `/staff/finance/services` reads posted service-delivery documents rather than reconstructing the business fact from bookings.
+
+## Printed act
+
+`service_act` uses the shared `printed_form_snapshots` evidence store.
+
+- first print of a posted/reversed document captures the render payload and SHA-256;
+- later reprints reuse the same snapshot for the same document state and template version;
+- snapshots are append-only and cannot be updated or deleted;
+- D1 validates that the captured payload matches the exact service-delivery registrar, booking, tenant and service values at generation time;
+- a foreign tenant cannot read or generate the act;
+- the act is a finance/business document and does not replace the medical protocol or result.
+
+## Accounting boundary
+
+The act displays the `charge_amount` from the posted service-delivery registrar. A payment receipt is a separate printed form for a separate `payment`/`refund` document. Printing an act never creates or changes revenue, cash or settlement movements.

--- a/docs/changelog-service-delivery-journal.md
+++ b/docs/changelog-service-delivery-journal.md
@@ -1,0 +1,6 @@
+## Service-delivery journal and act
+
+- Added a dedicated BAS-style journal for posted `service_delivery` documents.
+- Added immutable `service_act` printed snapshots with SHA-256 and exact historical reprint.
+- Service acts are tenant- and finance-role scoped and cannot mutate accounting registers.
+- D1 rejects a `service_act` payload that does not match the posted service-delivery registrar.

--- a/drizzle/0069_service_delivery_printed_forms.sql
+++ b/drizzle/0069_service_delivery_printed_forms.sql
@@ -1,0 +1,47 @@
+-- Service-delivery acts are immutable printed snapshots of the posted economic document.
+-- One canonical snapshot is kept for each document state/template version; reprints reuse it.
+CREATE UNIQUE INDEX IF NOT EXISTS `printed_service_act_state_unique`
+  ON `printed_form_snapshots` (`organization_id`,`document_id`,`form_type`,`template_version`,`document_state`)
+  WHERE `form_type`='service_act' AND `document_state` IN ('posted','reversed');
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `printed_service_act_snapshot_integrity`
+BEFORE INSERT ON `printed_form_snapshots`
+WHEN NEW.form_type='service_act'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `business_documents` d
+    JOIN `service_delivery_details` s
+      ON s.document_id=d.id AND s.organization_id=d.organization_id
+    JOIN `bookings` b
+      ON b.id=s.booking_id AND b.organization_id=s.organization_id
+    LEFT JOIN `organizations` o ON o.id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery'
+      AND d.state=NEW.document_state
+      AND d.state IN ('posted','reversed')
+      AND CAST(json_extract(NEW.payload_json,'$.templateVersion') AS INTEGER)=NEW.template_version
+      AND json_extract(NEW.payload_json,'$.formType')='service_act'
+      AND CAST(json_extract(NEW.payload_json,'$.document.id') AS INTEGER)=d.id
+      AND json_extract(NEW.payload_json,'$.document.number')=d.number
+      AND json_extract(NEW.payload_json,'$.document.state')=d.state
+      AND CAST(json_extract(NEW.payload_json,'$.booking.id') AS INTEGER)=s.booking_id
+      AND json_extract(NEW.payload_json,'$.booking.code')=b.code
+      AND json_extract(NEW.payload_json,'$.booking.patientName')=b.name
+      AND json_extract(NEW.payload_json,'$.booking.patientId')=s.patient_id
+      AND json_extract(NEW.payload_json,'$.booking.patientCategory')=s.patient_category
+      AND json_extract(NEW.payload_json,'$.service.code')=s.service_code
+      AND json_extract(NEW.payload_json,'$.service.title')=s.service_title
+      AND json_extract(NEW.payload_json,'$.service.equipmentId')=s.equipment_id
+      AND CAST(json_extract(NEW.payload_json,'$.service.durationMinutes') AS INTEGER)=s.duration_minutes
+      AND CAST(json_extract(NEW.payload_json,'$.service.anatomicalRegionsCount') AS INTEGER)=s.anatomical_regions_count
+      AND json_extract(NEW.payload_json,'$.service.performedAt')=s.performed_at
+      AND json_extract(NEW.payload_json,'$.service.radiologistEmail')=s.radiologist_email
+      AND json_extract(NEW.payload_json,'$.service.radiographerEmail')=s.radiographer_email
+      AND CAST(json_extract(NEW.payload_json,'$.service.priceAmount') AS INTEGER)=s.price_amount
+      AND CAST(json_extract(NEW.payload_json,'$.service.chargeAmount') AS INTEGER)=s.charge_amount
+      AND json_extract(NEW.payload_json,'$.service.currency')=s.currency
+      AND json_extract(NEW.payload_json,'$.organization.name')=COALESCE(o.name,'Організація')
+  ) THEN RAISE(ABORT,'printed_service_act_document_mismatch') END;
+END;

--- a/tests/service-delivery-journal-ui.behavior.test.mjs
+++ b/tests/service-delivery-journal-ui.behavior.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompleted(db,raw,{organizationId=1,code="RD-SVC-JOURNAL",amount=2200}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count
+     ) VALUES (?,?,'Journal Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-20','15:00','civilian','pending',?,0,'confirmed',1)`
+  ).bind(organizationId,code,amount).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    "UPDATE bookings SET performed_at='2026-08-20T15:05:00',status='completed' WHERE organization_id=? AND id=?"
+  ).bind(organizationId,bookingId).run();
+  const document=raw.prepare(
+    `SELECT d.id FROM business_documents d JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery'`
+  ).get(organizationId,bookingId);
+  return {bookingId,documentId:document.id};
+}
+
+test("service delivery journal returns posted business documents for the active tenant",async()=>{
+  await withD1(async(db,raw)=>{
+    const own=await seedCompleted(db,raw,{code:"RD-SVC-JOURNAL-OWN"});
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Journal Org 2','journal-org-2',1)");
+    await seedCompleted(db,raw,{organizationId:2,code:"RD-SVC-JOURNAL-FOREIGN",amount:3300});
+    const cookie=await seedStaffSession(db,{email:"journal@example.com",role:"registrar",organizationId:1});
+
+    const response=await callWorker(new Request("http://localhost/api/staff/service-deliveries",{headers:{cookie}}),db);
+    assert.equal(response.status,200);
+    const body=await response.json();
+    assert.ok(body.documents.some((row)=>row.id===own.documentId && row.bookingCode==="RD-SVC-JOURNAL-OWN"));
+    assert.equal(body.documents.some((row)=>row.bookingCode==="RD-SVC-JOURNAL-FOREIGN"),false);
+  });
+});
+
+test("service delivery journal remains finance-role scoped",async()=>{
+  await withD1(async(db,raw)=>{
+    await seedCompleted(db,raw,{code:"RD-SVC-JOURNAL-ROLE"});
+    const doctor=await seedStaffSession(db,{email:"journal-doctor@example.com",role:"radiologist",organizationId:1});
+    const response=await callWorker(new Request("http://localhost/api/staff/service-deliveries",{headers:{cookie:doctor}}),db);
+    assert.equal(response.status,403);
+  });
+});

--- a/tests/service-delivery-printed-forms.behavior.test.mjs
+++ b/tests/service-delivery-printed-forms.behavior.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompletedService(db,raw,{organizationId=1,code="RD-SVC-ACT",category="civilian",amount=2900,name="Пацієнт для Акта"}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,?,'+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-20','14:00',?,'pending',?,0,'confirmed',2,'doctor-act@example.com','tech-act@example.com')`
+  ).bind(organizationId,code,name,category,amount).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    `UPDATE bookings SET performed_at='2026-08-20T14:05:00',status='completed'
+     WHERE organization_id=? AND id=?`
+  ).bind(organizationId,bookingId).run();
+  const document=raw.prepare(
+    `SELECT d.id,d.number
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery'`
+  ).get(organizationId,bookingId);
+  return {bookingId,documentId:document.id,documentNumber:document.number};
+}
+
+async function printAct(db,cookie,documentId) {
+  return callWorker(jsonRequest("/api/staff/service-deliveries/print",{documentId},{headers:{cookie}}),db);
+}
+
+test("posted service act reuses one immutable historical snapshot",async()=>{
+  await withD1(async(db,raw)=>{
+    const service=await seedCompletedService(db,raw);
+    const cookie=await seedStaffSession(db,{email:"service-act@example.com",role:"registrar",organizationId:1});
+
+    const first=await printAct(db,cookie,service.documentId);
+    assert.equal(first.status,201);
+    const form1=await first.json();
+    assert.equal(form1.snapshot.formType,"service_act");
+    assert.equal(form1.snapshot.documentState,"posted");
+    assert.equal(form1.snapshot.templateVersion,1);
+    assert.equal(form1.snapshot.sha256.length,64);
+    assert.equal(form1.payload.document.number,service.documentNumber);
+    assert.equal(form1.payload.booking.patientName,"Пацієнт для Акта");
+    assert.equal(form1.payload.service.title,"КТ ОГК");
+    assert.equal(form1.payload.service.chargeAmount,2900);
+    assert.equal(form1.payload.service.anatomicalRegionsCount,2);
+
+    // Name is master-data presentation, not a posted economic field. Historical reprint must still
+    // preserve the name captured by the first printed snapshot.
+    await db.prepare("UPDATE bookings SET name='Пацієнт Перейменований' WHERE organization_id=1 AND id=?")
+      .bind(service.bookingId).run();
+
+    const again=await printAct(db,cookie,service.documentId);
+    assert.equal(again.status,200);
+    const form2=await again.json();
+    assert.equal(form2.snapshot.id,form1.snapshot.id);
+    assert.equal(form2.snapshot.sha256,form1.snapshot.sha256);
+    assert.equal(form2.payload.booking.patientName,"Пацієнт для Акта");
+
+    assert.equal(raw.prepare(
+      `SELECT COUNT(*) AS n FROM printed_form_snapshots
+       WHERE organization_id=1 AND document_id=? AND form_type='service_act' AND document_state='posted'`
+    ).get(service.documentId).n,1);
+    assert.throws(
+      ()=>raw.prepare("UPDATE printed_form_snapshots SET generated_by='tamper@example.com' WHERE id=?").run(form1.snapshot.id),
+      /printed_form_snapshot_immutable/,
+    );
+    assert.throws(
+      ()=>raw.prepare("DELETE FROM printed_form_snapshots WHERE id=?").run(form1.snapshot.id),
+      /printed_form_snapshot_immutable/,
+    );
+  });
+});
+
+test("D1 rejects a forged service-act payload even for a real posted document",async()=>{
+  await withD1(async(db,raw)=>{
+    const service=await seedCompletedService(db,raw,{code:"RD-SVC-ACT-FORGE"});
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO printed_form_snapshots
+       (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,sha256)
+       VALUES (1,?,'service_act',1,'posted','{}','attacker@example.com',?)`
+    ).run(service.documentId,"0".repeat(64)),/printed_service_act_document_mismatch/);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM printed_form_snapshots WHERE document_id=? AND form_type='service_act'"
+    ).get(service.documentId).n,0);
+  });
+});
+
+test("service-act snapshots are tenant scoped",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Service Act Org 2','service-act-org-2',1)");
+    const service=await seedCompletedService(db,raw,{organizationId:2,code:"RD-SVC-ACT-ORG2",amount:1800});
+    const org2=await seedStaffSession(db,{email:"act-org2@example.com",role:"registrar",organizationId:2});
+    const org1=await seedStaffSession(db,{email:"act-org1@example.com",role:"registrar",organizationId:1});
+
+    const printed=await printAct(db,org2,service.documentId);
+    assert.equal(printed.status,201);
+    const {snapshot}=await printed.json();
+
+    const foreign=await callWorker(new Request(
+      `http://localhost/api/staff/service-deliveries/print?snapshotId=${snapshot.id}`,
+      {headers:{cookie:org1}},
+    ),db);
+    assert.equal(foreign.status,404);
+
+    const own=await callWorker(new Request(
+      `http://localhost/api/staff/service-deliveries/print?snapshotId=${snapshot.id}`,
+      {headers:{cookie:org2}},
+    ),db);
+    assert.equal(own.status,200);
+  });
+});
+
+test("clinical-only staff cannot print the finance service act",async()=>{
+  await withD1(async(db,raw)=>{
+    const service=await seedCompletedService(db,raw,{code:"RD-SVC-ACT-ROLE"});
+    const doctor=await seedStaffSession(db,{email:"doctor-act-role@example.com",role:"radiologist",organizationId:1});
+    const response=await printAct(db,doctor,service.documentId);
+    assert.equal(response.status,403);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM printed_form_snapshots WHERE document_id=? AND form_type='service_act'"
+    ).get(service.documentId).n,0);
+  });
+});


### PR DESCRIPTION
## Goal
Continue the BAS-style business core after PR #323 by making posted `service_delivery` documents visible as a real journal and printable as immutable business evidence.

## Implemented
- dedicated `/staff/finance/services` journal sourced from posted `service_delivery` documents
- journal summary for count, civilian charge, free/military services, minutes and anatomical regions
- finance workspace links to the service journal
- `service_act` printed form using the shared append-only `printed_form_snapshots` store
- first print captures payload + SHA-256; reprints reuse the exact historical snapshot
- D1 validates the service-act payload against tenant, document, booking and service registrar values
- one canonical service-act snapshot per document state/template version
- tenant isolation and finance-role authorization for journal and print API

## Accounting boundary
- printing an act never creates or changes revenue, cash or settlement movements
- the act displays the charge from the already-posted `service_delivery`
- payment/refund receipts remain separate documents/forms
- the act does not replace the medical protocol/result

## Verification
- immutable historical reprint — covered
- direct-D1 forged payload rejection — covered
- tenant isolation — covered
- role scope — covered
- journal tenant scope — covered
- CI #1031 — success on exact head `67bc1bede6d4bc1d73c61f9515ce826c1e260c59`
- CodeQL #946 — success on exact head
- final manual security diff review: no register mutation path from print; no cross-tenant snapshot read/generation found

## Boundary
- no production deploy