### PR TITLE
Add BAS service-delivery storno and correction registers

### DIFF
--- a/app/api/staff/service-deliveries/corrections/route.ts
+++ b/app/api/staff/service-deliveries/corrections/route.ts
@@ -1,0 +1,64 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import { listServiceCorrections,postServiceStorno } from "../../../../../lib/service-corrections";
+import { canManageFinance } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+function int(value:unknown) {
+  const n=Number(value);
+  return Number.isInteger(n)&&n>0?n:null;
+}
+
+export async function GET(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canManageFinance(ctx.member.role)) {
+    return Response.json({error:"Журнал сторно доступний реєстратору або адміністратору"},{status:403});
+  }
+  return Response.json({documents:await listServiceCorrections(db,ctx.organizationId)});
+}
+
+export async function POST(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canManageFinance(ctx.member.role)) {
+    return Response.json({error:"Сторнувати надану послугу може реєстратор або адміністратор"},{status:403});
+  }
+
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const sourceDocumentId=int(body.sourceDocumentId);
+  const reason=typeof body.reason==="string"?body.reason.trim().slice(0,500):"";
+  if(!sourceDocumentId) return Response.json({error:"Некоректний документ-підстава"},{status:400});
+  if(reason.length<5) return Response.json({error:"Вкажіть причину сторно щонайменше 5 символів"},{status:400});
+
+  try {
+    const document=await postServiceStorno(db,{
+      organizationId:ctx.organizationId,
+      sourceDocumentId,
+      reason,
+      actorEmail:ctx.member.email,
+    });
+    await audit(db,{
+      organizationId:ctx.organizationId,
+      actorEmail:ctx.member.email,
+      action:document.created?"service_delivery_reversed":"service_delivery_reversal_reused",
+      resource:"business_document",
+      targetId:sourceDocumentId,
+      details:{correctionDocumentId:document.id,correctionNumber:document.number,reason:document.reason},
+    });
+    return Response.json({ok:true,document},{status:document.created?201:200});
+  } catch(error) {
+    const code=error instanceof Error?error.message:String(error);
+    if(code==="service_delivery_not_found") return Response.json({error:"Документ надання послуги не знайдено"},{status:404});
+    if(code==="service_delivery_not_posted") return Response.json({error:"Сторно можливе лише для проведеного надання послуги"},{status:409});
+    if(code==="service_delivery_already_reversed") return Response.json({error:"Документ уже сторновано"},{status:409});
+    if(code==="service_correction_in_progress") return Response.json({error:"Сторно цього документа вже створюється"},{status:409});
+    if(code==="service_correction_reason_required") return Response.json({error:"Вкажіть причину сторно"},{status:400});
+    console.error("service_delivery_storno_failed",code);
+    return Response.json({error:"Не вдалося провести сторно наданої послуги"},{status:500});
+  }
+}

--- a/app/api/staff/service-deliveries/route.ts
+++ b/app/api/staff/service-deliveries/route.ts
@@ -43,6 +43,9 @@ export async function POST(request:Request) {
     if(code==="service_not_performed") {
       return Response.json({error:"Надання послуги можна провести лише після фактичного виконання дослідження"},{status:409});
     }
+    if(code==="service_delivery_reversed") {
+      return Response.json({error:"Надання послуги вже сторновано. Повторне проведення того самого факту заборонене"},{status:409});
+    }
     if(code==="service_delivery_in_progress" || code==="service_delivery_already_exists") {
       return Response.json({error:"Документ надання послуги вже створюється або проведений"},{status:409});
     }

--- a/app/staff/finance/services/page.tsx
+++ b/app/staff/finance/services/page.tsx
@@ -9,7 +9,15 @@ type ServiceDelivery={
   serviceCode:string;serviceTitle:string;equipmentId:string;durationMinutes:number;anatomicalRegionsCount:number;
   performedAt:string;radiologistEmail:string;radiographerEmail:string;priceAmount:number;chargeAmount:number;currency:string;
 };
+type ServiceCorrection={
+  id:number;number:string;occurredAt:string;state:string;postedBy:string;
+  sourceDocumentId:number;sourceDocumentNumber:string;bookingId:number;bookingCode:string;patientName:string;
+  reason:string;patientId:string;patientCategory:string;serviceCode:string;serviceTitle:string;equipmentId:string;
+  durationMinutes:number;anatomicalRegionsCount:number;performedAt:string;radiologistEmail:string;
+  radiographerEmail:string;chargeAmount:number;currency:string;
+};
 type Payload={documents:ServiceDelivery[];error?:string};
+type CorrectionPayload={documents:ServiceCorrection[];error?:string};
 
 const STATE_UK:Record<string,string>={draft:"Чернетка",posted:"Проведено",reversed:"Сторновано",cancelled:"Скасовано"};
 
@@ -23,15 +31,26 @@ function dateTime(value:string) {
 
 export default function ServiceDeliveryJournalPage() {
   const [data,setData]=useState<Payload|null>(null);
+  const [corrections,setCorrections]=useState<ServiceCorrection[]>([]);
   const [error,setError]=useState("");
   const [query,setQuery]=useState("");
+  const [busyId,setBusyId]=useState<number|null>(null);
 
   const load=useCallback(async()=>{
     try {
-      const response=await fetch("/api/staff/service-deliveries",{cache:"no-store"});
-      const payload=await response.json().catch(()=>({})) as Payload;
-      if(!response.ok) throw new Error(payload.error || "Не вдалося завантажити журнал наданих послуг");
-      setData(payload);setError("");
+      const [servicesResponse,correctionsResponse]=await Promise.all([
+        fetch("/api/staff/service-deliveries",{cache:"no-store"}),
+        fetch("/api/staff/service-deliveries/corrections",{cache:"no-store"}),
+      ]);
+      const [servicesPayload,correctionsPayload]=await Promise.all([
+        servicesResponse.json().catch(()=>({})) as Promise<Payload>,
+        correctionsResponse.json().catch(()=>({})) as Promise<CorrectionPayload>,
+      ]);
+      if(!servicesResponse.ok) throw new Error(servicesPayload.error || "Не вдалося завантажити журнал наданих послуг");
+      if(!correctionsResponse.ok) throw new Error(correctionsPayload.error || "Не вдалося завантажити журнал сторно");
+      setData(servicesPayload);
+      setCorrections(correctionsPayload.documents || []);
+      setError("");
     } catch(e) {
       setError(e instanceof Error?e.message:"Не вдалося завантажити журнал наданих послуг");
     }
@@ -42,48 +61,84 @@ export default function ServiceDeliveryJournalPage() {
     return()=>window.clearTimeout(timer);
   },[load]);
 
+  const correctionBySource=useMemo(()=>{
+    const map=new Map<number,ServiceCorrection>();
+    for(const correction of corrections) map.set(correction.sourceDocumentId,correction);
+    return map;
+  },[corrections]);
+
   const q=query.trim().toLowerCase();
   const rows=useMemo(()=>{
     const source=data?.documents || [];
     if(!q)return source;
-    return source.filter((row)=>`${row.number} ${row.bookingCode} ${row.patientName} ${row.serviceTitle} ${row.serviceCode} ${row.equipmentId} ${row.radiologistEmail} ${row.radiographerEmail}`.toLowerCase().includes(q));
-  },[data,q]);
+    return source.filter((row)=>{
+      const correction=correctionBySource.get(row.id);
+      return `${row.number} ${row.bookingCode} ${row.patientName} ${row.serviceTitle} ${row.serviceCode} ${row.equipmentId} ${row.radiologistEmail} ${row.radiographerEmail} ${correction?.number||""} ${correction?.reason||""}`.toLowerCase().includes(q);
+    });
+  },[data,q,correctionBySource]);
 
   const totals=useMemo(()=>{
-    const source=data?.documents || [];
+    const active=(data?.documents || []).filter((row)=>row.state==="posted");
     return {
-      count:source.length,
-      charge:source.reduce((sum,row)=>sum+Number(row.chargeAmount||0),0),
-      free:source.filter((row)=>Number(row.chargeAmount||0)===0).length,
-      minutes:source.reduce((sum,row)=>sum+Number(row.durationMinutes||0),0),
-      regions:source.reduce((sum,row)=>sum+Number(row.anatomicalRegionsCount||0),0),
+      count:active.length,
+      charge:active.reduce((sum,row)=>sum+Number(row.chargeAmount||0),0),
+      free:active.filter((row)=>Number(row.chargeAmount||0)===0).length,
+      minutes:active.reduce((sum,row)=>sum+Number(row.durationMinutes||0),0),
+      regions:active.reduce((sum,row)=>sum+Number(row.anatomicalRegionsCount||0),0),
+      corrections:corrections.length,
     };
-  },[data]);
+  },[data,corrections]);
 
   function printAct(id:number) {
     window.open(`/staff/finance/services/print?id=${id}`,"_blank","noopener,noreferrer");
   }
 
+  async function reverseService(row:ServiceDelivery) {
+    if(row.state!=="posted" || correctionBySource.has(row.id) || busyId!==null) return;
+    const reason=window.prompt(`Причина сторно документа ${row.number}:`,"")?.trim();
+    if(reason===undefined) return;
+    if(reason.length<5) {
+      setError("Причина сторно має містити щонайменше 5 символів.");
+      return;
+    }
+    setBusyId(row.id);
+    setError("");
+    try {
+      const response=await fetch("/api/staff/service-deliveries/corrections",{
+        method:"POST",
+        headers:{"content-type":"application/json"},
+        body:JSON.stringify({sourceDocumentId:row.id,reason}),
+      });
+      const payload=await response.json().catch(()=>({})) as {error?:string};
+      if(!response.ok) throw new Error(payload.error || "Не вдалося провести сторно");
+      await load();
+    } catch(e) {
+      setError(e instanceof Error?e.message:"Не вдалося провести сторно");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
   return <StaffWorkspaceShell
     active="finance"
     title="Надані послуги"
-    description="BAS-журнал проведених медичних послуг: один документ — один операційний та економічний факт."
+    description="BAS-журнал проведених медичних послуг і окремих документів сторно. Проведені факти не редагуються заднім числом."
   >
     <section className="financeSummary" aria-label="Підсумок журналу наданих послуг">
-      <article><span>Документів</span><b>{totals.count}</b><small>проведених надань</small></article>
-      <article><span>Нараховано</span><b>{money(totals.charge)}</b><small>цивільні платні послуги</small></article>
-      <article><span>Без нарахування</span><b>{totals.free}</b><small>військові / безоплатні</small></article>
-      <article><span>Навантаження</span><b>{totals.minutes} хв</b><small>{totals.regions} анатомічних ділянок</small></article>
+      <article><span>Чинних надань</span><b>{totals.count}</b><small>{totals.free} безоплатних</small></article>
+      <article><span>Чинне нарахування</span><b>{money(totals.charge)}</b><small>без сторнованих документів</small></article>
+      <article><span>Сторно</span><b>{totals.corrections}</b><small>окремих документів-коректорів</small></article>
+      <article><span>Чинне навантаження</span><b>{totals.minutes} хв</b><small>{totals.regions} анатомічних ділянок</small></article>
     </section>
 
     <section className="financeJournal">
       <header className="financeToolbar">
         <div>
           <b>Журнал документів «Надання послуг»</b>
-          <small>Дані формуються з проведених business documents, не з ручних підсумків.</small>
+          <small>Сторно створює окремий документ і негативні рухи; оригінал залишається в історії.</small>
         </div>
-        <input value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Пошук: НП, RD, пацієнт, послуга…" aria-label="Пошук у журналі наданих послуг"/>
-        <button type="button" onClick={()=>void load()}>Оновити</button>
+        <input value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Пошук: НП, СТ, RD, пацієнт, причина…" aria-label="Пошук у журналі наданих послуг"/>
+        <button type="button" onClick={()=>void load()} disabled={busyId!==null}>Оновити</button>
       </header>
 
       {error&&<p className="financeError">{error}</p>}
@@ -92,22 +147,33 @@ export default function ServiceDeliveryJournalPage() {
       {data&&<div className="financeTableWrap"><table className="financeTable">
         <thead><tr>
           <th>Документ</th><th>Виконано</th><th>Заявка / пацієнт</th><th>Послуга</th><th>Апарат</th>
-          <th>Виконавці</th><th className="num">Нарахування</th><th>Стан</th><th/>
+          <th>Виконавці</th><th className="num">Нарахування</th><th>Стан / корекція</th><th/>
         </tr></thead>
-        <tbody>{rows.map((row)=><tr key={row.id}>
-          <td><b>{row.number}</b><small>Надання послуги</small></td>
-          <td>{dateTime(row.performedAt)}<small>{row.durationMinutes} хв · {row.anatomicalRegionsCount} зон.</small></td>
-          <td><b>{row.bookingCode}</b><small>{row.patientName}</small></td>
-          <td><b>{row.serviceTitle}</b><small>{row.serviceCode}</small></td>
-          <td>{row.equipmentId}</td>
-          <td>
-            <small>{row.radiologistEmail?`Лікар: ${row.radiologistEmail}`:"Лікар: —"}</small>
-            <small>{row.radiographerEmail?`Лаборант: ${row.radiographerEmail}`:"Лаборант: —"}</small>
-          </td>
-          <td className={`num ${row.chargeAmount>0?"positive":""}`}>{row.chargeAmount>0?money(row.chargeAmount,row.currency):"Безоплатно"}</td>
-          <td><span className={`financeState state-${row.state}`}>{STATE_UK[row.state]||row.state}</span></td>
-          <td><button type="button" onClick={()=>printAct(row.id)}>Акт</button></td>
-        </tr>)}</tbody>
+        <tbody>{rows.map((row)=>{
+          const correction=correctionBySource.get(row.id);
+          return <tr key={row.id}>
+            <td><b>{row.number}</b><small>Надання послуги</small></td>
+            <td>{dateTime(row.performedAt)}<small>{row.durationMinutes} хв · {row.anatomicalRegionsCount} зон.</small></td>
+            <td><b>{row.bookingCode}</b><small>{row.patientName}</small></td>
+            <td><b>{row.serviceTitle}</b><small>{row.serviceCode}</small></td>
+            <td>{row.equipmentId}</td>
+            <td>
+              <small>{row.radiologistEmail?`Лікар: ${row.radiologistEmail}`:"Лікар: —"}</small>
+              <small>{row.radiographerEmail?`Лаборант: ${row.radiographerEmail}`:"Лаборант: —"}</small>
+            </td>
+            <td className={`num ${row.state==="posted"&&row.chargeAmount>0?"positive":""}`}>
+              {row.state==="reversed"?<><s>{row.chargeAmount>0?money(row.chargeAmount,row.currency):"Безоплатно"}</s><small>сторновано</small></>:row.chargeAmount>0?money(row.chargeAmount,row.currency):"Безоплатно"}
+            </td>
+            <td>
+              <span className={`financeState state-${row.state}`}>{STATE_UK[row.state]||row.state}</span>
+              {correction&&<><small><b>{correction.number}</b> · {dateTime(correction.occurredAt)}</small><small>{correction.reason}</small></>}
+            </td>
+            <td>
+              <button type="button" onClick={()=>printAct(row.id)}>Акт</button>
+              {row.state==="posted"&&!correction&&<button type="button" disabled={busyId!==null} onClick={()=>void reverseService(row)}>{busyId===row.id?"Сторно…":"Сторно"}</button>}
+            </td>
+          </tr>;
+        })}</tbody>
       </table>{rows.length===0&&<p className="financeEmpty">Документів за цим відбором немає.</p>}</div>}
     </section>
   </StaffWorkspaceShell>;

--- a/docs/bas-service-delivery-storno.md
+++ b/docs/bas-service-delivery-storno.md
@@ -1,0 +1,31 @@
+# BAS service-delivery storno
+
+A posted `service_delivery` is never edited or deleted. A correction is prepared as a separate business document linked to the source and the source is then moved `posted -> reversed`.
+
+## Posting boundary
+
+The source state transition is the D1 posting boundary. D1 requires an exact draft correction, posts that correction, and writes all negative movements in the same SQLite transaction. If any register insert fails, source reversal and correction posting fail together.
+
+The correction reverses:
+
+- rendered-service count through `service_correction_movements`;
+- revenue through a negative `revenue_movements` entry;
+- patient accrual through a negative `adjustment` in `patient_settlement_movements`;
+- equipment load through negative minutes;
+- radiologist/radiographer output through negative units.
+
+Military/free services reverse operational output without inventing revenue or patient debt.
+
+## Cash boundary
+
+Service storno is not a refund. If a service was already paid, storno removes the charge/revenue and leaves the cash movement untouched. The patient balance therefore becomes a credit until a separate `refund` document returns money.
+
+## Invariants
+
+- source cannot enter `reversed` without an exact draft correction;
+- correction cannot be manually posted while source is still posted;
+- after correction details are captured, correction identity is frozen;
+- negative register movements require the exact reversed source and posted correction;
+- reversed service facts remain immutable and cannot be posted again;
+- an interrupted exact draft correction can be safely resumed by a later request;
+- tenant and finance-role scope apply to correction API/journal access.

--- a/drizzle/0070_service_delivery_storno.sql
+++ b/drizzle/0070_service_delivery_storno.sql
@@ -1,0 +1,351 @@
+-- BAS-style storno for a posted service delivery.
+-- A correction is a separate business_documents row in the service_delivery family, linked through
+-- reversed_document_id and service_correction_details. The original document is preserved and marked reversed.
+
+CREATE TABLE IF NOT EXISTS `service_correction_details` (
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `source_document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `correction_kind` text DEFAULT 'storno' NOT NULL CHECK (`correction_kind`='storno'),
+  `reason` text NOT NULL CHECK (length(trim(`reason`)) >= 5),
+  `patient_id` text DEFAULT '' NOT NULL,
+  `patient_category` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `service_title` text NOT NULL,
+  `equipment_id` text NOT NULL,
+  `duration_minutes` integer NOT NULL CHECK (`duration_minutes` > 0),
+  `anatomical_regions_count` integer NOT NULL CHECK (`anatomical_regions_count` > 0),
+  `performed_at` text NOT NULL,
+  `radiologist_email` text DEFAULT '' NOT NULL,
+  `radiographer_email` text DEFAULT '' NOT NULL,
+  `charge_amount` integer DEFAULT 0 NOT NULL CHECK (`charge_amount` >= 0),
+  `currency` text DEFAULT 'UAH' NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`document_id`),
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`source_document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`booking_id`) REFERENCES `bookings`(`id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `service_correction_source_unique`
+  ON `service_correction_details` (`organization_id`,`source_document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `service_correction_booking_idx`
+  ON `service_correction_details` (`organization_id`,`booking_id`,`document_id` DESC);
+--> statement-breakpoint
+
+-- Separate service-count correction register because the original services_delivered register is append-only
+-- and intentionally stores only positive performed facts.
+CREATE TABLE IF NOT EXISTS `service_correction_movements` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `source_document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `patient_id` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `equipment_id` text NOT NULL,
+  `quantity_delta` integer NOT NULL CHECK (`quantity_delta`=-1),
+  `anatomical_regions_delta` integer NOT NULL CHECK (`anatomical_regions_delta` < 0),
+  `reason` text NOT NULL,
+  `actor_email` text NOT NULL,
+  `occurred_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`source_document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `service_correction_movement_document_idx`
+  ON `service_correction_movements` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `service_correction_movement_source_idx`
+  ON `service_correction_movements` (`organization_id`,`source_document_id`);
+--> statement-breakpoint
+
+-- Correction details must copy the exact posted source registrar. The correction business document is
+-- a distinct row in the same service_delivery family and must link to that source via reversed_document_id.
+CREATE TRIGGER IF NOT EXISTS `service_correction_details_integrity_insert`
+BEFORE INSERT ON `service_correction_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `business_documents` d
+    JOIN `business_documents` src
+      ON src.id=NEW.source_document_id AND src.organization_id=d.organization_id
+    JOIN `service_delivery_details` s
+      ON s.document_id=src.id AND s.organization_id=src.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='draft'
+      AND d.reversed_document_id=NEW.source_document_id
+      AND src.document_type='service_delivery' AND src.state='posted'
+      AND s.booking_id=NEW.booking_id
+      AND s.patient_id=NEW.patient_id
+      AND s.patient_category=NEW.patient_category
+      AND s.service_code=NEW.service_code
+      AND s.service_title=NEW.service_title
+      AND s.equipment_id=NEW.equipment_id
+      AND s.duration_minutes=NEW.duration_minutes
+      AND s.anatomical_regions_count=NEW.anatomical_regions_count
+      AND s.performed_at=NEW.performed_at
+      AND s.radiologist_email=NEW.radiologist_email
+      AND s.radiographer_email=NEW.radiographer_email
+      AND s.charge_amount=NEW.charge_amount
+      AND s.currency=NEW.currency
+      AND NEW.correction_kind='storno'
+      AND length(trim(NEW.reason))>=5
+  ) THEN RAISE(ABORT,'service_correction_source_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_correction_details_no_update`
+BEFORE UPDATE ON `service_correction_details`
+BEGIN SELECT RAISE(ABORT,'service_correction_detail_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_correction_details_no_delete_posted`
+BEFORE DELETE ON `service_correction_details`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `business_documents` d
+  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+)
+BEGIN SELECT RAISE(ABORT,'service_correction_detail_immutable'); END;
+--> statement-breakpoint
+
+-- A correction document must never also acquire a normal service_delivery_details row.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_details_not_correction`
+BEFORE INSERT ON `service_delivery_details`
+WHEN EXISTS (
+  SELECT 1 FROM `business_documents` d
+  WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+    AND d.document_type='service_delivery' AND d.reversed_document_id IS NOT NULL
+)
+BEGIN SELECT RAISE(ABORT,'service_delivery_correction_cannot_be_delivery'); END;
+--> statement-breakpoint
+
+-- Once a booking has a reversed service-delivery registrar, that same performed fact may not be posted again.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_no_repost_after_reversal`
+BEFORE INSERT ON `service_delivery_details`
+WHEN EXISTS (
+  SELECT 1 FROM `service_delivery_details` s
+  JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+  WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.booking_id
+    AND d.document_type='service_delivery' AND d.state='reversed'
+)
+BEGIN SELECT RAISE(ABORT,'service_delivery_reversed'); END;
+--> statement-breakpoint
+
+-- Reversed source facts remain immutable; storno is not permission to rewrite history.
+CREATE TRIGGER IF NOT EXISTS `booking_reversed_service_snapshot_immutable`
+BEFORE UPDATE OF
+  `patient_id`,`patient_category`,`service`,`service_code`,`equipment_id`,`duration_minutes`,
+  `anatomical_regions_count`,`performed_at`,`assigned_radiologist_email`,`assigned_radiographer_email`,
+  `payment_amount`,`status`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1
+  FROM `service_delivery_details` s
+  JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+  WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id
+    AND d.document_type='service_delivery' AND d.state='reversed'
+)
+AND (
+  NEW.organization_id IS NOT OLD.organization_id
+  OR NEW.patient_id IS NOT OLD.patient_id
+  OR NEW.patient_category IS NOT OLD.patient_category
+  OR NEW.service IS NOT OLD.service
+  OR NEW.service_code IS NOT OLD.service_code
+  OR NEW.equipment_id IS NOT OLD.equipment_id
+  OR NEW.duration_minutes IS NOT OLD.duration_minutes
+  OR NEW.anatomical_regions_count IS NOT OLD.anatomical_regions_count
+  OR NEW.performed_at IS NOT OLD.performed_at
+  OR NEW.assigned_radiologist_email IS NOT OLD.assigned_radiologist_email
+  OR NEW.assigned_radiographer_email IS NOT OLD.assigned_radiographer_email
+  OR NEW.payment_amount IS NOT OLD.payment_amount
+  OR NEW.status IS NOT OLD.status
+)
+BEGIN SELECT RAISE(ABORT,'service_delivery_booking_immutable'); END;
+--> statement-breakpoint
+
+-- Even a no-op execution update must not re-trigger automatic posting after storno.
+CREATE TRIGGER IF NOT EXISTS `booking_reversed_service_no_repost`
+BEFORE UPDATE OF `performed_at`,`status` ON `bookings`
+WHEN NEW.status='completed' AND NEW.performed_at<>''
+  AND EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+    WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id
+      AND d.document_type='service_delivery' AND d.state='reversed'
+  )
+BEGIN SELECT RAISE(ABORT,'service_delivery_reversed'); END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `service_correction_movements_no_update`
+BEFORE UPDATE ON `service_correction_movements`
+BEGIN SELECT RAISE(ABORT,'service_correction_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_correction_movements_no_delete`
+BEFORE DELETE ON `service_correction_movements`
+BEGIN SELECT RAISE(ABORT,'service_correction_movement_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `service_correction_movement_integrity`
+BEFORE INSERT ON `service_correction_movements`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `business_documents` d
+    JOIN `service_correction_details` c
+      ON c.document_id=d.id AND c.organization_id=d.organization_id
+    JOIN `business_documents` src
+      ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='posted'
+      AND d.reversed_document_id=c.source_document_id
+      AND src.state='reversed'
+      AND c.source_document_id=NEW.source_document_id
+      AND c.booking_id=NEW.booking_id
+      AND c.patient_id=NEW.patient_id
+      AND c.service_code=NEW.service_code
+      AND c.equipment_id=NEW.equipment_id
+      AND NEW.quantity_delta=-1
+      AND NEW.anatomical_regions_delta=-c.anatomical_regions_count
+      AND NEW.reason=c.reason
+  ) THEN RAISE(ABORT,'service_correction_movement_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- Extend existing operational/economic register guards with the negative storno path.
+DROP TRIGGER IF EXISTS `revenue_integrity_insert`;
+--> statement-breakpoint
+CREATE TRIGGER `revenue_integrity_insert`
+BEFORE INSERT ON `revenue_movements`
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1 FROM `business_documents` d
+      JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND s.booking_id=NEW.booking_id AND s.patient_id=NEW.patient_id
+        AND s.service_code=NEW.service_code AND s.currency=NEW.currency
+        AND NEW.movement_type='service_delivery' AND NEW.amount_delta=s.charge_amount AND s.charge_amount>0
+    )
+    OR
+    EXISTS (
+      SELECT 1 FROM `business_documents` d
+      JOIN `service_correction_details` c ON c.document_id=d.id AND c.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND d.reversed_document_id=c.source_document_id
+        AND c.booking_id=NEW.booking_id AND c.patient_id=NEW.patient_id
+        AND c.service_code=NEW.service_code AND c.currency=NEW.currency
+        AND NEW.movement_type='service_correction' AND NEW.amount_delta=-c.charge_amount AND c.charge_amount>0
+    )
+  ) THEN RAISE(ABORT,'revenue_document_mismatch') END;
+END;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS `equipment_load_integrity_insert`;
+--> statement-breakpoint
+CREATE TRIGGER `equipment_load_integrity_insert`
+BEFORE INSERT ON `equipment_load_movements`
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1 FROM `business_documents` d
+      JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND s.booking_id=NEW.booking_id AND s.equipment_id=NEW.equipment_id
+        AND NEW.minutes_delta=s.duration_minutes AND s.performed_at=NEW.performed_at
+    )
+    OR
+    EXISTS (
+      SELECT 1 FROM `business_documents` d
+      JOIN `service_correction_details` c ON c.document_id=d.id AND c.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND d.reversed_document_id=c.source_document_id
+        AND c.booking_id=NEW.booking_id AND c.equipment_id=NEW.equipment_id
+        AND NEW.minutes_delta=-c.duration_minutes AND c.performed_at=NEW.performed_at
+    )
+  ) THEN RAISE(ABORT,'equipment_load_document_mismatch') END;
+END;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS `staff_output_integrity_insert`;
+--> statement-breakpoint
+CREATE TRIGGER `staff_output_integrity_insert`
+BEFORE INSERT ON `staff_output_movements`
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1 FROM `business_documents` d
+      JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND s.booking_id=NEW.booking_id AND s.performed_at=NEW.performed_at
+        AND s.anatomical_regions_count=NEW.anatomical_regions_count AND NEW.units_delta=1
+        AND (
+          (NEW.staff_role='radiologist' AND NEW.member_email<>'' AND NEW.member_email=s.radiologist_email)
+          OR
+          (NEW.staff_role='radiographer' AND NEW.member_email<>'' AND NEW.member_email=s.radiographer_email)
+        )
+    )
+    OR
+    EXISTS (
+      SELECT 1 FROM `business_documents` d
+      JOIN `service_correction_details` c ON c.document_id=d.id AND c.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND d.reversed_document_id=c.source_document_id
+        AND c.booking_id=NEW.booking_id AND c.performed_at=NEW.performed_at
+        AND c.anatomical_regions_count=NEW.anatomical_regions_count AND NEW.units_delta=-1
+        AND (
+          (NEW.staff_role='radiologist' AND NEW.member_email<>'' AND NEW.member_email=c.radiologist_email)
+          OR
+          (NEW.staff_role='radiographer' AND NEW.member_email<>'' AND NEW.member_email=c.radiographer_email)
+        )
+    )
+  ) THEN RAISE(ABORT,'staff_output_document_mismatch') END;
+END;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS `patient_settlement_finance_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `patient_settlement_finance_integrity`
+BEFORE INSERT ON `patient_settlement_movements`
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1
+      FROM `business_documents` d
+      JOIN `finance_document_details` f ON f.document_id=d.id AND f.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+        AND f.booking_id=NEW.booking_id AND f.patient_id=NEW.patient_id AND f.currency=NEW.currency
+        AND (
+          (d.document_type='payment' AND NEW.movement_type='payment' AND NEW.amount_delta=-f.amount)
+          OR
+          (d.document_type='refund' AND NEW.movement_type='refund' AND NEW.amount_delta=f.amount)
+        )
+    )
+    OR
+    EXISTS (
+      SELECT 1
+      FROM `business_documents` d
+      JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND s.booking_id=NEW.booking_id AND s.patient_id=NEW.patient_id AND s.currency=NEW.currency
+        AND NEW.movement_type='charge' AND NEW.amount_delta=s.charge_amount AND s.charge_amount>0
+    )
+    OR
+    EXISTS (
+      SELECT 1
+      FROM `business_documents` d
+      JOIN `service_correction_details` c ON c.document_id=d.id AND c.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+        AND d.document_type='service_delivery' AND d.state='posted'
+        AND d.reversed_document_id=c.source_document_id
+        AND c.booking_id=NEW.booking_id AND c.patient_id=NEW.patient_id AND c.currency=NEW.currency
+        AND NEW.movement_type='adjustment' AND NEW.amount_delta=-c.charge_amount AND c.charge_amount>0
+    )
+  ) THEN RAISE(ABORT,'patient_settlement_document_mismatch') END;
+END;

--- a/drizzle/0071_service_storno_atomic_posting.sql
+++ b/drizzle/0071_service_storno_atomic_posting.sql
@@ -1,0 +1,163 @@
+-- Harden service storno into one D1 posting boundary.
+-- Reversing the original posted service is the posting action: D1 requires an exact draft correction,
+-- posts that correction, and writes every negative register movement in the same SQLite transaction.
+
+CREATE TRIGGER IF NOT EXISTS `service_delivery_reverse_requires_correction`
+BEFORE UPDATE OF `state` ON `business_documents`
+WHEN OLD.state='posted' AND NEW.state='reversed' AND OLD.document_type='service_delivery'
+  AND EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    WHERE s.document_id=OLD.id AND s.organization_id=OLD.organization_id
+  )
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `service_correction_details` c
+    JOIN `business_documents` d
+      ON d.id=c.document_id AND d.organization_id=c.organization_id
+    WHERE c.organization_id=OLD.organization_id AND c.source_document_id=OLD.id
+      AND d.document_type='service_delivery' AND d.state='draft'
+      AND d.reversed_document_id=OLD.id
+  ) THEN RAISE(ABORT,'service_delivery_reversal_requires_correction') END;
+END;
+--> statement-breakpoint
+
+-- A negative movement is valid only after the exact source service has actually entered reversed state.
+CREATE TRIGGER IF NOT EXISTS `revenue_correction_requires_reversed_source`
+BEFORE INSERT ON `revenue_movements`
+WHEN NEW.movement_type='service_correction'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `service_correction_details` c
+    JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+    JOIN `business_documents` src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND src.state='reversed' AND d.reversed_document_id=src.id
+      AND c.booking_id=NEW.booking_id AND c.patient_id=NEW.patient_id
+      AND c.service_code=NEW.service_code AND c.currency=NEW.currency
+      AND NEW.amount_delta=-c.charge_amount AND c.charge_amount>0
+  ) THEN RAISE(ABORT,'service_correction_source_not_reversed') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `equipment_correction_requires_reversed_source`
+BEFORE INSERT ON `equipment_load_movements`
+WHEN NEW.minutes_delta<0
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `service_correction_details` c
+    JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+    JOIN `business_documents` src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND src.state='reversed' AND d.reversed_document_id=src.id
+      AND c.booking_id=NEW.booking_id AND c.equipment_id=NEW.equipment_id
+      AND NEW.minutes_delta=-c.duration_minutes AND c.performed_at=NEW.performed_at
+  ) THEN RAISE(ABORT,'service_correction_source_not_reversed') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `staff_correction_requires_reversed_source`
+BEFORE INSERT ON `staff_output_movements`
+WHEN NEW.units_delta<0
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `service_correction_details` c
+    JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+    JOIN `business_documents` src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND src.state='reversed' AND d.reversed_document_id=src.id
+      AND c.booking_id=NEW.booking_id AND NEW.units_delta=-1
+      AND c.anatomical_regions_count=NEW.anatomical_regions_count AND c.performed_at=NEW.performed_at
+      AND (
+        (NEW.staff_role='radiologist' AND NEW.member_email=c.radiologist_email AND NEW.member_email<>'')
+        OR
+        (NEW.staff_role='radiographer' AND NEW.member_email=c.radiographer_email AND NEW.member_email<>'')
+      )
+  ) THEN RAISE(ABORT,'service_correction_source_not_reversed') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `settlement_correction_requires_reversed_source`
+BEFORE INSERT ON `patient_settlement_movements`
+WHEN NEW.movement_type='adjustment' AND NEW.amount_delta<0
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `service_correction_details` c
+    JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+    JOIN `business_documents` src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND src.state='reversed' AND d.reversed_document_id=src.id
+      AND c.booking_id=NEW.booking_id AND c.patient_id=NEW.patient_id AND c.currency=NEW.currency
+      AND NEW.amount_delta=-c.charge_amount AND c.charge_amount>0
+  ) THEN RAISE(ABORT,'service_correction_source_not_reversed') END;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `service_delivery_reverse_posts_correction`
+AFTER UPDATE OF `state` ON `business_documents`
+WHEN OLD.state='posted' AND NEW.state='reversed' AND OLD.document_type='service_delivery'
+  AND EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    WHERE s.document_id=NEW.id AND s.organization_id=NEW.organization_id
+  )
+BEGIN
+  UPDATE `business_documents`
+  SET state='posted',posted_by=created_by,posted_at=CURRENT_TIMESTAMP
+  WHERE organization_id=NEW.organization_id AND document_type='service_delivery' AND state='draft'
+    AND id=(
+      SELECT c.document_id FROM `service_correction_details` c
+      WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id
+      LIMIT 1
+    );
+
+  INSERT INTO `service_correction_movements`
+    (`organization_id`,`document_id`,`source_document_id`,`booking_id`,`patient_id`,`service_code`,`equipment_id`,
+     `quantity_delta`,`anatomical_regions_delta`,`reason`,`actor_email`,`occurred_at`)
+  SELECT c.organization_id,c.document_id,c.source_document_id,c.booking_id,c.patient_id,c.service_code,c.equipment_id,
+         -1,-c.anatomical_regions_count,c.reason,d.created_by,d.occurred_at
+  FROM `service_correction_details` c
+  JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+  WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id AND d.state='posted';
+
+  INSERT INTO `equipment_load_movements`
+    (`organization_id`,`document_id`,`booking_id`,`equipment_id`,`minutes_delta`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT c.organization_id,c.document_id,c.booking_id,c.equipment_id,-c.duration_minutes,c.performed_at,d.created_by,d.occurred_at
+  FROM `service_correction_details` c
+  JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+  WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id AND d.state='posted';
+
+  INSERT INTO `revenue_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`movement_type`,`amount_delta`,`currency`,`actor_email`,`occurred_at`)
+  SELECT c.organization_id,c.document_id,c.booking_id,c.patient_id,c.service_code,'service_correction',-c.charge_amount,
+         c.currency,d.created_by,d.occurred_at
+  FROM `service_correction_details` c
+  JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+  WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id
+    AND d.state='posted' AND c.charge_amount>0;
+
+  INSERT INTO `patient_settlement_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`movement_type`,`amount_delta`,`currency`,`actor_email`,`occurred_at`)
+  SELECT c.organization_id,c.document_id,c.booking_id,c.patient_id,'adjustment',-c.charge_amount,
+         c.currency,d.created_by,d.occurred_at
+  FROM `service_correction_details` c
+  JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+  WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id
+    AND d.state='posted' AND c.charge_amount>0;
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`member_email`,`staff_role`,`units_delta`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT c.organization_id,c.document_id,c.booking_id,c.radiologist_email,'radiologist',-1,
+         c.anatomical_regions_count,c.performed_at,d.created_by,d.occurred_at
+  FROM `service_correction_details` c
+  JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+  WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id
+    AND d.state='posted' AND c.radiologist_email<>'';
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`member_email`,`staff_role`,`units_delta`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT c.organization_id,c.document_id,c.booking_id,c.radiographer_email,'radiographer',-1,
+         c.anatomical_regions_count,c.performed_at,d.created_by,d.occurred_at
+  FROM `service_correction_details` c
+  JOIN `business_documents` d ON d.id=c.document_id AND d.organization_id=c.organization_id
+  WHERE c.organization_id=NEW.organization_id AND c.source_document_id=NEW.id
+    AND d.state='posted' AND c.radiographer_email<>'';
+END;

--- a/drizzle/0071_service_storno_atomic_posting.sql
+++ b/drizzle/0071_service_storno_atomic_posting.sql
@@ -22,6 +22,27 @@ BEGIN
 END;
 --> statement-breakpoint
 
+-- A correction document cannot be posted independently. It is posted only from the AFTER trigger
+-- of the source transition, where the source row is already visible as reversed.
+CREATE TRIGGER IF NOT EXISTS `service_correction_post_requires_reversed_source`
+BEFORE UPDATE OF `state` ON `business_documents`
+WHEN OLD.state='draft' AND NEW.state='posted'
+  AND EXISTS (
+    SELECT 1 FROM `service_correction_details` c
+    WHERE c.document_id=OLD.id AND c.organization_id=OLD.organization_id
+  )
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `service_correction_details` c
+    JOIN `business_documents` src
+      ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+    WHERE c.document_id=OLD.id AND c.organization_id=OLD.organization_id
+      AND OLD.reversed_document_id=src.id AND src.state='reversed'
+  ) THEN RAISE(ABORT,'service_correction_requires_reversed_source') END;
+END;
+--> statement-breakpoint
+
 -- A negative movement is valid only after the exact source service has actually entered reversed state.
 CREATE TRIGGER IF NOT EXISTS `revenue_correction_requires_reversed_source`
 BEFORE INSERT ON `revenue_movements`

--- a/drizzle/0072_service_storno_draft_hardening.sql
+++ b/drizzle/0072_service_storno_draft_hardening.sql
@@ -1,0 +1,24 @@
+-- Once exact correction details exist, the draft registrar identity is frozen.
+-- The only allowed update is the D1-controlled draft -> posted transition after the source is reversed.
+CREATE TRIGGER IF NOT EXISTS `service_correction_document_draft_frozen`
+BEFORE UPDATE ON `business_documents`
+WHEN OLD.state='draft'
+  AND EXISTS (
+    SELECT 1 FROM `service_correction_details` c
+    WHERE c.document_id=OLD.id AND c.organization_id=OLD.organization_id
+  )
+BEGIN
+  SELECT CASE WHEN NOT (
+    NEW.state='posted'
+    AND NEW.organization_id=OLD.organization_id
+    AND NEW.document_type=OLD.document_type
+    AND NEW.number=OLD.number
+    AND NEW.occurred_at=OLD.occurred_at
+    AND NEW.comment=OLD.comment
+    AND NEW.created_by=OLD.created_by
+    AND NEW.created_at=OLD.created_at
+    AND NEW.reversed_document_id IS OLD.reversed_document_id
+    AND NEW.posted_by=OLD.created_by
+    AND NEW.posted_at<>''
+  ) THEN RAISE(ABORT,'service_correction_document_frozen') END;
+END;

--- a/lib/service-corrections.ts
+++ b/lib/service-corrections.ts
@@ -1,0 +1,226 @@
+export type ServiceCorrectionSource={
+  documentId:number;documentNumber:string;documentState:string;bookingId:number;patientId:string;patientCategory:string;
+  serviceCode:string;serviceTitle:string;equipmentId:string;durationMinutes:number;anatomicalRegionsCount:number;
+  performedAt:string;radiologistEmail:string;radiographerEmail:string;chargeAmount:number;currency:string;
+};
+
+export type ServiceCorrectionDocument={
+  id:number;number:string;state:string;sourceDocumentId:number;sourceDocumentNumber:string;bookingId:number;
+  reason:string;chargeAmount:number;currency:string;created:false|true;
+};
+
+function clean(value:unknown,max:number) {
+  return typeof value==="string"?value.trim().slice(0,max):"";
+}
+
+function actor(value:unknown) {
+  return clean(value,254).toLowerCase();
+}
+
+export async function serviceCorrectionSource(
+  db:D1Database,
+  organizationId:number,
+  sourceDocumentId:number,
+):Promise<ServiceCorrectionSource|null> {
+  const row=await db.prepare(
+    `SELECT d.id AS documentId,d.number AS documentNumber,d.state AS documentState,
+            s.booking_id AS bookingId,s.patient_id AS patientId,s.patient_category AS patientCategory,
+            s.service_code AS serviceCode,s.service_title AS serviceTitle,s.equipment_id AS equipmentId,
+            s.duration_minutes AS durationMinutes,s.anatomical_regions_count AS anatomicalRegionsCount,
+            s.performed_at AS performedAt,s.radiologist_email AS radiologistEmail,
+            s.radiographer_email AS radiographerEmail,s.charge_amount AS chargeAmount,s.currency
+     FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND d.id=? AND d.document_type='service_delivery'
+     LIMIT 1`
+  ).bind(organizationId,sourceDocumentId).first<ServiceCorrectionSource>();
+  return row || null;
+}
+
+export async function existingServiceCorrection(
+  db:D1Database,
+  organizationId:number,
+  sourceDocumentId:number,
+) {
+  const row=await db.prepare(
+    `SELECT d.id,d.number,d.state,c.source_document_id AS sourceDocumentId,src.number AS sourceDocumentNumber,
+            c.booking_id AS bookingId,c.reason,c.charge_amount AS chargeAmount,c.currency
+     FROM service_correction_details c
+     JOIN business_documents d ON d.id=c.document_id AND d.organization_id=c.organization_id
+     JOIN business_documents src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+     WHERE c.organization_id=? AND c.source_document_id=?
+     ORDER BY d.id DESC LIMIT 1`
+  ).bind(organizationId,sourceDocumentId).first<{
+    id:number;number:string;state:string;sourceDocumentId:number;sourceDocumentNumber:string;
+    bookingId:number;reason:string;chargeAmount:number;currency:string;
+  }>();
+  return row || null;
+}
+
+async function cleanupDraft(db:D1Database,organizationId:number,documentId:number) {
+  const row=await db.prepare(
+    "SELECT state FROM business_documents WHERE organization_id=? AND id=? LIMIT 1"
+  ).bind(organizationId,documentId).first<{state:string}>();
+  if(!row || row.state!=="draft") return;
+  await db.prepare("DELETE FROM service_correction_details WHERE organization_id=? AND document_id=?")
+    .bind(organizationId,documentId).run().catch(()=>{});
+  await db.prepare("DELETE FROM business_documents WHERE organization_id=? AND id=? AND state='draft'")
+    .bind(organizationId,documentId).run().catch(()=>{});
+}
+
+export async function postServiceStorno(
+  db:D1Database,
+  input:{organizationId:number;sourceDocumentId:number;reason:string;actorEmail:string},
+):Promise<ServiceCorrectionDocument> {
+  const reason=clean(input.reason,500);
+  if(reason.length<5) throw new Error("service_correction_reason_required");
+  const createdBy=actor(input.actorEmail);
+  if(!createdBy) throw new Error("service_correction_actor_required");
+
+  const existing=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
+  if(existing?.state==="posted") return {...existing,created:false};
+  if(existing) throw new Error("service_correction_in_progress");
+
+  const source=await serviceCorrectionSource(db,input.organizationId,input.sourceDocumentId);
+  if(!source) throw new Error("service_delivery_not_found");
+  if(source.documentState==="reversed") {
+    const reversed=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
+    if(reversed?.state==="posted") return {...reversed,created:false};
+    throw new Error("service_delivery_already_reversed");
+  }
+  if(source.documentState!=="posted") throw new Error("service_delivery_not_posted");
+
+  const occurredAt=new Date().toISOString();
+  const created=await db.prepare(
+    `INSERT INTO business_documents
+      (organization_id,document_type,number,occurred_at,state,comment,created_by,reversed_document_id)
+     VALUES (?,'service_delivery','',?,'draft',?,?,?)`
+  ).bind(
+    input.organizationId,occurredAt,`Сторно ${source.documentNumber}: ${reason}`,createdBy,source.documentId,
+  ).run();
+  const documentId=Number(created.meta.last_row_id || 0);
+  if(!documentId) throw new Error("service_correction_create_failed");
+  const number=`СТ-${String(documentId).padStart(6,"0")}`;
+
+  try {
+    await db.prepare(
+      "UPDATE business_documents SET number=? WHERE organization_id=? AND id=? AND state='draft'"
+    ).bind(number,input.organizationId,documentId).run();
+    await db.prepare(
+      `INSERT INTO service_correction_details
+       (organization_id,document_id,source_document_id,booking_id,correction_kind,reason,patient_id,patient_category,
+        service_code,service_title,equipment_id,duration_minutes,anatomical_regions_count,performed_at,
+        radiologist_email,radiographer_email,charge_amount,currency)
+       VALUES (?,?,?,?,'storno',?,?,?,?,?,?,?,?,?,?,?,?,?)`
+    ).bind(
+      input.organizationId,documentId,source.documentId,source.bookingId,reason,source.patientId,source.patientCategory,
+      source.serviceCode,source.serviceTitle,source.equipmentId,source.durationMinutes,source.anatomicalRegionsCount,
+      source.performedAt,source.radiologistEmail,source.radiographerEmail,source.chargeAmount,source.currency,
+    ).run();
+
+    const statements:D1PreparedStatement[]=[
+      db.prepare(
+        `UPDATE business_documents SET state='posted',posted_by=?,posted_at=?
+         WHERE organization_id=? AND id=? AND state='draft'`
+      ).bind(createdBy,occurredAt,input.organizationId,documentId),
+      db.prepare(
+        `UPDATE business_documents SET state='reversed'
+         WHERE organization_id=? AND id=? AND state='posted' AND document_type='service_delivery'`
+      ).bind(input.organizationId,source.documentId),
+      db.prepare(
+        `INSERT INTO service_correction_movements
+         (organization_id,document_id,source_document_id,booking_id,patient_id,service_code,equipment_id,
+          quantity_delta,anatomical_regions_delta,reason,actor_email,occurred_at)
+         VALUES (?,?,?,?,?,?,?,-1,?,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,source.documentId,source.bookingId,source.patientId,source.serviceCode,
+        source.equipmentId,-source.anatomicalRegionsCount,reason,createdBy,occurredAt,
+      ),
+      db.prepare(
+        `INSERT INTO equipment_load_movements
+         (organization_id,document_id,booking_id,equipment_id,minutes_delta,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,source.bookingId,source.equipmentId,-source.durationMinutes,
+        source.performedAt,createdBy,occurredAt,
+      ),
+    ];
+
+    if(source.chargeAmount>0) {
+      statements.push(
+        db.prepare(
+          `INSERT INTO revenue_movements
+           (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email,occurred_at)
+           VALUES (?,?,?,?,?,'service_correction',?,?,?,?)`
+        ).bind(
+          input.organizationId,documentId,source.bookingId,source.patientId,source.serviceCode,-source.chargeAmount,
+          source.currency,createdBy,occurredAt,
+        ),
+        db.prepare(
+          `INSERT INTO patient_settlement_movements
+           (organization_id,document_id,booking_id,patient_id,movement_type,amount_delta,currency,actor_email,occurred_at)
+           VALUES (?,?,?,?,'adjustment',?,?,?,?)`
+        ).bind(
+          input.organizationId,documentId,source.bookingId,source.patientId,-source.chargeAmount,
+          source.currency,createdBy,occurredAt,
+        ),
+      );
+    }
+    if(source.radiologistEmail) {
+      statements.push(db.prepare(
+        `INSERT INTO staff_output_movements
+         (organization_id,document_id,booking_id,member_email,staff_role,units_delta,anatomical_regions_count,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,'radiologist',-1,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,source.bookingId,source.radiologistEmail,
+        source.anatomicalRegionsCount,source.performedAt,createdBy,occurredAt,
+      ));
+    }
+    if(source.radiographerEmail) {
+      statements.push(db.prepare(
+        `INSERT INTO staff_output_movements
+         (organization_id,document_id,booking_id,member_email,staff_role,units_delta,anatomical_regions_count,performed_at,actor_email,occurred_at)
+         VALUES (?,?,?,?,'radiographer',-1,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,source.bookingId,source.radiographerEmail,
+        source.anatomicalRegionsCount,source.performedAt,createdBy,occurredAt,
+      ));
+    }
+    await db.batch(statements);
+  } catch(error) {
+    await cleanupDraft(db,input.organizationId,documentId);
+    const text=String(error).toLowerCase();
+    if(text.includes("service_correction_source_unique") || text.includes("unique constraint")) {
+      const race=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
+      if(race?.state==="posted") return {...race,created:false};
+    }
+    throw error;
+  }
+
+  return {
+    id:documentId,number,state:"posted",sourceDocumentId:source.documentId,
+    sourceDocumentNumber:source.documentNumber,bookingId:source.bookingId,reason,
+    chargeAmount:source.chargeAmount,currency:source.currency,created:true,
+  };
+}
+
+export async function listServiceCorrections(db:D1Database,organizationId:number,limit=200) {
+  const safeLimit=Math.max(1,Math.min(500,Math.trunc(limit)));
+  const rows=await db.prepare(
+    `SELECT d.id,d.number,d.occurred_at AS occurredAt,d.state,d.posted_by AS postedBy,
+            c.source_document_id AS sourceDocumentId,src.number AS sourceDocumentNumber,
+            c.booking_id AS bookingId,b.code AS bookingCode,b.name AS patientName,
+            c.reason,c.patient_id AS patientId,c.patient_category AS patientCategory,
+            c.service_code AS serviceCode,c.service_title AS serviceTitle,c.equipment_id AS equipmentId,
+            c.duration_minutes AS durationMinutes,c.anatomical_regions_count AS anatomicalRegionsCount,
+            c.performed_at AS performedAt,c.radiologist_email AS radiologistEmail,
+            c.radiographer_email AS radiographerEmail,c.charge_amount AS chargeAmount,c.currency
+     FROM service_correction_details c
+     JOIN business_documents d ON d.id=c.document_id AND d.organization_id=c.organization_id
+     JOIN business_documents src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
+     JOIN bookings b ON b.id=c.booking_id AND b.organization_id=c.organization_id
+     WHERE c.organization_id=?
+     ORDER BY d.occurred_at DESC,d.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}

--- a/lib/service-corrections.ts
+++ b/lib/service-corrections.ts
@@ -9,6 +9,8 @@ export type ServiceCorrectionDocument={
   reason:string;chargeAmount:number;currency:string;created:false|true;
 };
 
+type ExistingCorrection=Omit<ServiceCorrectionDocument,"created">;
+
 function clean(value:unknown,max:number) {
   return typeof value==="string"?value.trim().slice(0,max):"";
 }
@@ -41,7 +43,7 @@ export async function existingServiceCorrection(
   db:D1Database,
   organizationId:number,
   sourceDocumentId:number,
-) {
+):Promise<ExistingCorrection|null> {
   const row=await db.prepare(
     `SELECT d.id,d.number,d.state,c.source_document_id AS sourceDocumentId,src.number AS sourceDocumentNumber,
             c.booking_id AS bookingId,c.reason,c.charge_amount AS chargeAmount,c.currency
@@ -50,10 +52,7 @@ export async function existingServiceCorrection(
      JOIN business_documents src ON src.id=c.source_document_id AND src.organization_id=c.organization_id
      WHERE c.organization_id=? AND c.source_document_id=?
      ORDER BY d.id DESC LIMIT 1`
-  ).bind(organizationId,sourceDocumentId).first<{
-    id:number;number:string;state:string;sourceDocumentId:number;sourceDocumentNumber:string;
-    bookingId:number;reason:string;chargeAmount:number;currency:string;
-  }>();
+  ).bind(organizationId,sourceDocumentId).first<ExistingCorrection>();
   return row || null;
 }
 
@@ -68,6 +67,35 @@ async function cleanupDraft(db:D1Database,organizationId:number,documentId:numbe
     .bind(organizationId,documentId).run().catch(()=>{});
 }
 
+async function postExistingDraftCorrection(
+  db:D1Database,
+  organizationId:number,
+  sourceDocumentId:number,
+  existing:ExistingCorrection,
+) {
+  const source=await serviceCorrectionSource(db,organizationId,sourceDocumentId);
+  if(!source) throw new Error("service_delivery_not_found");
+  if(source.documentState!=="posted") {
+    const current=await existingServiceCorrection(db,organizationId,sourceDocumentId);
+    if(source.documentState==="reversed" && current?.state==="posted") return {...current,created:false as const};
+    throw new Error(source.documentState==="reversed"?"service_delivery_already_reversed":"service_delivery_not_posted");
+  }
+
+  const reversed=await db.prepare(
+    `UPDATE business_documents SET state='reversed'
+     WHERE organization_id=? AND id=? AND state='posted' AND document_type='service_delivery'`
+  ).bind(organizationId,sourceDocumentId).run();
+  if(!Number(reversed.meta.changes || 0)) {
+    const raced=await existingServiceCorrection(db,organizationId,sourceDocumentId);
+    if(raced?.state==="posted") return {...raced,created:false as const};
+    throw new Error("service_correction_in_progress");
+  }
+
+  const posted=await existingServiceCorrection(db,organizationId,sourceDocumentId);
+  if(!posted || posted.state!=="posted" || posted.id!==existing.id) throw new Error("service_correction_post_failed");
+  return {...posted,created:false as const};
+}
+
 export async function postServiceStorno(
   db:D1Database,
   input:{organizationId:number;sourceDocumentId:number;reason:string;actorEmail:string},
@@ -79,6 +107,9 @@ export async function postServiceStorno(
 
   const existing=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
   if(existing?.state==="posted") return {...existing,created:false};
+  if(existing?.state==="draft") return postExistingDraftCorrection(
+    db,input.organizationId,input.sourceDocumentId,existing,
+  );
   if(existing) throw new Error("service_correction_in_progress");
 
   const source=await serviceCorrectionSource(db,input.organizationId,input.sourceDocumentId);
@@ -136,6 +167,9 @@ export async function postServiceStorno(
     if(text.includes("unique constraint") || text.includes("service_correction_source_unique")) {
       const race=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
       if(race?.state==="posted") return {...race,created:false};
+      if(race?.state==="draft") return postExistingDraftCorrection(
+        db,input.organizationId,input.sourceDocumentId,race,
+      );
       throw new Error("service_correction_in_progress");
     }
     throw error;

--- a/lib/service-corrections.ts
+++ b/lib/service-corrections.ts
@@ -131,7 +131,7 @@ export async function postServiceStorno(
         `INSERT INTO service_correction_movements
          (organization_id,document_id,source_document_id,booking_id,patient_id,service_code,equipment_id,
           quantity_delta,anatomical_regions_delta,reason,actor_email,occurred_at)
-         VALUES (?,?,?,?,?,?,?,-1,?,?,?,?,?)`
+         VALUES (?,?,?,?,?,?,?,-1,?,?,?,?)`
       ).bind(
         input.organizationId,documentId,source.documentId,source.bookingId,source.patientId,source.serviceCode,
         source.equipmentId,-source.anatomicalRegionsCount,reason,createdBy,occurredAt,

--- a/lib/service-corrections.ts
+++ b/lib/service-corrections.ts
@@ -118,81 +118,25 @@ export async function postServiceStorno(
       source.performedAt,source.radiologistEmail,source.radiographerEmail,source.chargeAmount,source.currency,
     ).run();
 
-    const statements:D1PreparedStatement[]=[
-      db.prepare(
-        `UPDATE business_documents SET state='posted',posted_by=?,posted_at=?
-         WHERE organization_id=? AND id=? AND state='draft'`
-      ).bind(createdBy,occurredAt,input.organizationId,documentId),
-      db.prepare(
-        `UPDATE business_documents SET state='reversed'
-         WHERE organization_id=? AND id=? AND state='posted' AND document_type='service_delivery'`
-      ).bind(input.organizationId,source.documentId),
-      db.prepare(
-        `INSERT INTO service_correction_movements
-         (organization_id,document_id,source_document_id,booking_id,patient_id,service_code,equipment_id,
-          quantity_delta,anatomical_regions_delta,reason,actor_email,occurred_at)
-         VALUES (?,?,?,?,?,?,?,-1,?,?,?,?)`
-      ).bind(
-        input.organizationId,documentId,source.documentId,source.bookingId,source.patientId,source.serviceCode,
-        source.equipmentId,-source.anatomicalRegionsCount,reason,createdBy,occurredAt,
-      ),
-      db.prepare(
-        `INSERT INTO equipment_load_movements
-         (organization_id,document_id,booking_id,equipment_id,minutes_delta,performed_at,actor_email,occurred_at)
-         VALUES (?,?,?,?,?,?,?,?)`
-      ).bind(
-        input.organizationId,documentId,source.bookingId,source.equipmentId,-source.durationMinutes,
-        source.performedAt,createdBy,occurredAt,
-      ),
-    ];
+    // This one state transition is the D1 posting boundary. Migration 0071 requires the exact
+    // draft correction, posts it, and writes all negative registers atomically inside the trigger.
+    const reversed=await db.prepare(
+      `UPDATE business_documents SET state='reversed'
+       WHERE organization_id=? AND id=? AND state='posted' AND document_type='service_delivery'`
+    ).bind(input.organizationId,source.documentId).run();
+    if(!Number(reversed.meta.changes || 0)) throw new Error("service_delivery_not_posted");
 
-    if(source.chargeAmount>0) {
-      statements.push(
-        db.prepare(
-          `INSERT INTO revenue_movements
-           (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email,occurred_at)
-           VALUES (?,?,?,?,?,'service_correction',?,?,?,?)`
-        ).bind(
-          input.organizationId,documentId,source.bookingId,source.patientId,source.serviceCode,-source.chargeAmount,
-          source.currency,createdBy,occurredAt,
-        ),
-        db.prepare(
-          `INSERT INTO patient_settlement_movements
-           (organization_id,document_id,booking_id,patient_id,movement_type,amount_delta,currency,actor_email,occurred_at)
-           VALUES (?,?,?,?,'adjustment',?,?,?,?)`
-        ).bind(
-          input.organizationId,documentId,source.bookingId,source.patientId,-source.chargeAmount,
-          source.currency,createdBy,occurredAt,
-        ),
-      );
+    const posted=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
+    if(!posted || posted.state!=="posted" || posted.id!==documentId) {
+      throw new Error("service_correction_post_failed");
     }
-    if(source.radiologistEmail) {
-      statements.push(db.prepare(
-        `INSERT INTO staff_output_movements
-         (organization_id,document_id,booking_id,member_email,staff_role,units_delta,anatomical_regions_count,performed_at,actor_email,occurred_at)
-         VALUES (?,?,?,?,'radiologist',-1,?,?,?,?)`
-      ).bind(
-        input.organizationId,documentId,source.bookingId,source.radiologistEmail,
-        source.anatomicalRegionsCount,source.performedAt,createdBy,occurredAt,
-      ));
-    }
-    if(source.radiographerEmail) {
-      statements.push(db.prepare(
-        `INSERT INTO staff_output_movements
-         (organization_id,document_id,booking_id,member_email,staff_role,units_delta,anatomical_regions_count,performed_at,actor_email,occurred_at)
-         VALUES (?,?,?,?,'radiographer',-1,?,?,?,?)`
-      ).bind(
-        input.organizationId,documentId,source.bookingId,source.radiographerEmail,
-        source.anatomicalRegionsCount,source.performedAt,createdBy,occurredAt,
-      ));
-    }
-    await db.batch(statements);
   } catch(error) {
     await cleanupDraft(db,input.organizationId,documentId);
     const text=String(error).toLowerCase();
-    if(text.includes("service_correction_source_unique") || text.includes("unique constraint")) {
+    if(text.includes("unique constraint") || text.includes("service_correction_source_unique")) {
       const race=await existingServiceCorrection(db,input.organizationId,input.sourceDocumentId);
       if(race?.state==="posted") return {...race,created:false};
+      throw new Error("service_correction_in_progress");
     }
     throw error;
   }

--- a/lib/service-deliveries.ts
+++ b/lib/service-deliveries.ts
@@ -193,6 +193,7 @@ export async function postServiceDelivery(
       const race=await existingServiceDelivery(db,input.organizationId,input.bookingId);
       if(race?.state === "posted") return {document:race,created:false};
     }
+    if(message.includes("service_delivery_reversed")) throw new Error("service_delivery_reversed");
     throw error;
   }
 

--- a/tests/service-delivery-storno-integrity.behavior.test.mjs
+++ b/tests/service-delivery-storno-integrity.behavior.test.mjs
@@ -27,23 +27,23 @@ async function storno(db,cookie,sourceDocumentId,reason="Корекція для
   return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{sourceDocumentId,reason},{headers:{cookie}}),db);
 }
 
-function createExactDraftCorrection(raw,sourceDocumentId) {
+function createExactDraftCorrection(raw,sourceDocumentId,{number="СТ-FORGE",createdBy="attacker@example.com",reason="Шахрайська корекція"}={}) {
   const created=raw.prepare(
     `INSERT INTO business_documents
       (organization_id,document_type,number,occurred_at,state,comment,created_by,reversed_document_id)
-     VALUES (1,'service_delivery','СТ-FORGE',CURRENT_TIMESTAMP,'draft','forged draft','attacker@example.com',?)`
-  ).run(sourceDocumentId);
+     VALUES (1,'service_delivery',?,CURRENT_TIMESTAMP,'draft','prepared correction',?,?)`
+  ).run(number,createdBy,sourceDocumentId);
   const documentId=Number(created.lastInsertRowid);
   raw.prepare(
     `INSERT INTO service_correction_details
       (organization_id,document_id,source_document_id,booking_id,correction_kind,reason,patient_id,patient_category,
        service_code,service_title,equipment_id,duration_minutes,anatomical_regions_count,performed_at,
        radiologist_email,radiographer_email,charge_amount,currency)
-     SELECT 1,?,?,s.booking_id,'storno','Шахрайська корекція',s.patient_id,s.patient_category,
+     SELECT 1,?,?,s.booking_id,'storno',?,s.patient_id,s.patient_category,
             s.service_code,s.service_title,s.equipment_id,s.duration_minutes,s.anatomical_regions_count,s.performed_at,
             s.radiologist_email,s.radiographer_email,s.charge_amount,s.currency
      FROM service_delivery_details s WHERE s.organization_id=1 AND s.document_id=?`
-  ).run(documentId,sourceDocumentId,sourceDocumentId);
+  ).run(documentId,sourceDocumentId,reason,sourceDocumentId);
   return documentId;
 }
 
@@ -64,9 +64,47 @@ test("a correction document cannot be manually posted while its source is still 
     const correctionId=createExactDraftCorrection(raw,seeded.sourceDocumentId);
     assert.throws(()=>raw.prepare(
       "UPDATE business_documents SET state='posted' WHERE organization_id=1 AND id=?"
-    ).run(correctionId),/service_correction_requires_reversed_source/);
+    ).run(correctionId),/service_correction_document_frozen|service_correction_requires_reversed_source/);
     assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(correctionId).state,"draft");
     assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(seeded.sourceDocumentId).state,"posted");
+  });
+});
+
+test("prepared correction identity is frozen before posting",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-DRAFT-FREEZE"});
+    const correctionId=createExactDraftCorrection(raw,seeded.sourceDocumentId,{number:"СТ-FROZEN"});
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET created_by='changed@example.com' WHERE organization_id=1 AND id=?"
+    ).run(correctionId),/service_correction_document_frozen/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET number='СТ-CHANGED' WHERE organization_id=1 AND id=?"
+    ).run(correctionId),/service_correction_document_frozen/);
+    const correction=raw.prepare("SELECT number,created_by AS createdBy,state FROM business_documents WHERE id=?").get(correctionId);
+    assert.equal(correction.number,"СТ-FROZEN");
+    assert.equal(correction.createdBy,"attacker@example.com");
+    assert.equal(correction.state,"draft");
+  });
+});
+
+test("an interrupted exact draft storno is safely resumed on the next API call",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-RESUME",amount:2400});
+    const correctionId=createExactDraftCorrection(raw,seeded.sourceDocumentId,{
+      number:"СТ-RESUME",createdBy:"interrupted@example.com",reason:"Перерване сторно для відновлення",
+    });
+    const cookie=await seedStaffSession(db,{email:"resume-registrar@example.com",role:"registrar",organizationId:1});
+
+    const response=await storno(db,cookie,seeded.sourceDocumentId,"Новий текст не переписує вже підготовлений snapshot");
+    assert.equal(response.status,200);
+    const body=await response.json();
+    assert.equal(body.document.created,false);
+    assert.equal(body.document.id,correctionId);
+    assert.equal(body.document.reason,"Перерване сторно для відновлення");
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(seeded.sourceDocumentId).state,"reversed");
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(correctionId).state,"posted");
+    assert.equal(raw.prepare("SELECT SUM(amount_delta) AS total FROM revenue_movements WHERE booking_id=?").get(seeded.bookingId).total,0);
+    assert.equal(raw.prepare("SELECT SUM(minutes_delta) AS total FROM equipment_load_movements WHERE booking_id=?").get(seeded.bookingId).total,0);
   });
 });
 

--- a/tests/service-delivery-storno-integrity.behavior.test.mjs
+++ b/tests/service-delivery-storno-integrity.behavior.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompleted(db,raw,{code="RD-STORNO-INT",amount=2600}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (1,?,'Integrity Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-22','10:00','civilian','pending',?,0,'confirmed',2,'integrity-doctor@example.com','integrity-tech@example.com')`
+  ).bind(code,amount).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    `UPDATE bookings SET performed_at='2026-08-22T10:05:00',status='completed' WHERE organization_id=1 AND id=?`
+  ).bind(bookingId).run();
+  const source=raw.prepare(
+    `SELECT d.id,d.number FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=1 AND s.booking_id=? AND d.document_type='service_delivery'`
+  ).get(bookingId);
+  return {bookingId,sourceDocumentId:source.id,sourceNumber:source.number};
+}
+
+async function storno(db,cookie,sourceDocumentId,reason="Корекція для перевірки цілісності") {
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{sourceDocumentId,reason},{headers:{cookie}}),db);
+}
+
+function createExactDraftCorrection(raw,sourceDocumentId) {
+  const created=raw.prepare(
+    `INSERT INTO business_documents
+      (organization_id,document_type,number,occurred_at,state,comment,created_by,reversed_document_id)
+     VALUES (1,'service_delivery','СТ-FORGE',CURRENT_TIMESTAMP,'draft','forged draft','attacker@example.com',?)`
+  ).run(sourceDocumentId);
+  const documentId=Number(created.lastInsertRowid);
+  raw.prepare(
+    `INSERT INTO service_correction_details
+      (organization_id,document_id,source_document_id,booking_id,correction_kind,reason,patient_id,patient_category,
+       service_code,service_title,equipment_id,duration_minutes,anatomical_regions_count,performed_at,
+       radiologist_email,radiographer_email,charge_amount,currency)
+     SELECT 1,?,?,s.booking_id,'storno','Шахрайська корекція',s.patient_id,s.patient_category,
+            s.service_code,s.service_title,s.equipment_id,s.duration_minutes,s.anatomical_regions_count,s.performed_at,
+            s.radiologist_email,s.radiographer_email,s.charge_amount,s.currency
+     FROM service_delivery_details s WHERE s.organization_id=1 AND s.document_id=?`
+  ).run(documentId,sourceDocumentId,sourceDocumentId);
+  return documentId;
+}
+
+test("D1 refuses to reverse a posted service without an exact draft correction document",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-NO-DOC"});
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET state='reversed' WHERE organization_id=1 AND id=?"
+    ).run(seeded.sourceDocumentId),/service_delivery_reversal_requires_correction/);
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(seeded.sourceDocumentId).state,"posted");
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_correction_details WHERE organization_id=1").get().n,0);
+  });
+});
+
+test("a correction document cannot be manually posted while its source is still posted",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-MANUAL-POST"});
+    const correctionId=createExactDraftCorrection(raw,seeded.sourceDocumentId);
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET state='posted' WHERE organization_id=1 AND id=?"
+    ).run(correctionId),/service_correction_requires_reversed_source/);
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(correctionId).state,"draft");
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(seeded.sourceDocumentId).state,"posted");
+  });
+});
+
+test("a register failure rolls back source reversal and correction posting atomically",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-ROLLBACK",amount:2800});
+    const cookie=await seedStaffSession(db,{email:"storno-rollback@example.com",role:"registrar",organizationId:1});
+    raw.exec(`CREATE TRIGGER test_abort_service_storno_revenue
+      BEFORE INSERT ON revenue_movements
+      WHEN NEW.movement_type='service_correction'
+      BEGIN SELECT RAISE(ABORT,'test_storno_register_failure'); END;`);
+
+    const response=await storno(db,cookie,seeded.sourceDocumentId,"Сторно має повністю відкотитися");
+    assert.equal(response.status,500);
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(seeded.sourceDocumentId).state,"posted");
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_correction_details WHERE organization_id=1 AND source_document_id=?").get(seeded.sourceDocumentId).n,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_correction_movements WHERE organization_id=1 AND source_document_id=?").get(seeded.sourceDocumentId).n,0);
+    assert.equal(raw.prepare("SELECT SUM(amount_delta) AS total FROM revenue_movements WHERE organization_id=1 AND booking_id=?").get(seeded.bookingId).total,2800);
+    assert.equal(raw.prepare("SELECT SUM(minutes_delta) AS total FROM equipment_load_movements WHERE organization_id=1 AND booking_id=?").get(seeded.bookingId).total,30);
+  });
+});
+
+test("explicit service posting returns 409 after storno instead of recreating the same performed fact",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-REPOST"});
+    const cookie=await seedStaffSession(db,{email:"storno-repost@example.com",role:"registrar",organizationId:1});
+    const reversed=await storno(db,cookie,seeded.sourceDocumentId,"Сторно перед перевіркою повторного проведення");
+    assert.equal(reversed.status,201);
+
+    const repost=await callWorker(jsonRequest("/api/staff/service-deliveries",{
+      bookingId:seeded.bookingId,
+    },{headers:{cookie}}),db);
+    assert.equal(repost.status,409);
+    const body=await repost.json();
+    assert.match(body.error,/сторновано/i);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).n,1);
+  });
+});

--- a/tests/service-delivery-storno.behavior.test.mjs
+++ b/tests/service-delivery-storno.behavior.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompleted(db,raw,{code="RD-STORNO-001",amount=2500,category="civilian",organizationId=1}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,'Storno Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-21','10:00',?,'pending',?,0,'confirmed',2,'storno-doctor@example.com','storno-tech@example.com')`
+  ).bind(organizationId,code,category,amount).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    `UPDATE bookings SET performed_at='2026-08-21T10:05:00',status='completed'
+     WHERE organization_id=? AND id=?`
+  ).bind(organizationId,bookingId).run();
+  const source=raw.prepare(
+    `SELECT d.id,d.number FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery'`
+  ).get(organizationId,bookingId);
+  return {bookingId,sourceDocumentId:source.id,sourceNumber:source.number};
+}
+
+async function storno(db,cookie,sourceDocumentId,reason="Помилково виконане нарахування") {
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{
+    sourceDocumentId,reason,
+  },{headers:{cookie}}),db);
+}
+
+async function pay(db,cookie,bookingId,reference="STORNO-PAY") {
+  return callWorker(jsonRequest("/api/staff/payments",{
+    bookingId,method:"bank_transfer",providerReference:reference,
+  },{headers:{cookie}}),db);
+}
+
+test("storno posts a separate correction and nets revenue, settlement, equipment and staff output",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw);
+    const cookie=await seedStaffSession(db,{email:"storno@example.com",role:"registrar",organizationId:1});
+
+    const response=await storno(db,cookie,seeded.sourceDocumentId);
+    assert.equal(response.status,201);
+    const body=await response.json();
+    assert.equal(body.document.created,true);
+    assert.match(body.document.number,/^СТ-\d{6}$/);
+    assert.equal(body.document.sourceDocumentId,seeded.sourceDocumentId);
+
+    const source=raw.prepare("SELECT state FROM business_documents WHERE id=?").get(seeded.sourceDocumentId);
+    const correction=raw.prepare(
+      "SELECT state,reversed_document_id AS sourceDocumentId FROM business_documents WHERE id=?"
+    ).get(body.document.id);
+    assert.equal(source.state,"reversed");
+    assert.equal(correction.state,"posted");
+    assert.equal(correction.sourceDocumentId,seeded.sourceDocumentId);
+
+    const revenue=raw.prepare(
+      "SELECT COUNT(*) AS n,SUM(amount_delta) AS total FROM revenue_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId);
+    assert.equal(revenue.n,2);
+    assert.equal(revenue.total,0);
+
+    const settlement=raw.prepare(
+      "SELECT COUNT(*) AS n,SUM(amount_delta) AS total FROM patient_settlement_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId);
+    assert.equal(settlement.n,2);
+    assert.equal(settlement.total,0);
+
+    const load=raw.prepare(
+      "SELECT COUNT(*) AS n,SUM(minutes_delta) AS total FROM equipment_load_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId);
+    assert.equal(load.n,2);
+    assert.equal(load.total,0);
+
+    const output=raw.prepare(
+      "SELECT COUNT(*) AS n,SUM(units_delta) AS total FROM staff_output_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId);
+    assert.equal(output.n,4);
+    assert.equal(output.total,0);
+
+    const correctionMovement=raw.prepare(
+      `SELECT quantity_delta AS quantityDelta,anatomical_regions_delta AS regionsDelta,reason
+       FROM service_correction_movements WHERE organization_id=1 AND document_id=?`
+    ).get(body.document.id);
+    assert.equal(correctionMovement.quantityDelta,-1);
+    assert.equal(correctionMovement.regionsDelta,-2);
+    assert.match(correctionMovement.reason,/Помилково/);
+
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM cash_movements WHERE organization_id=1 AND booking_id=?").get(seeded.bookingId).n,0);
+
+    const again=await storno(db,cookie,seeded.sourceDocumentId,"Інша причина не повинна створити другий документ");
+    assert.equal(again.status,200);
+    const againBody=await again.json();
+    assert.equal(againBody.document.created,false);
+    assert.equal(againBody.document.id,body.document.id);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_correction_details WHERE organization_id=1 AND source_document_id=?").get(seeded.sourceDocumentId).n,1);
+  });
+});
+
+test("storno after payment creates patient credit but does not return cash",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-PAID",amount:3100});
+    const cookie=await seedStaffSession(db,{email:"storno-paid@example.com",role:"registrar",organizationId:1});
+    const paid=await pay(db,cookie,seeded.bookingId,"STORNO-PAID-REF");
+    assert.equal(paid.status,200);
+
+    assert.equal(raw.prepare(
+      "SELECT SUM(amount_delta) AS total FROM patient_settlement_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).total,0);
+    assert.equal(raw.prepare(
+      "SELECT SUM(amount_delta) AS total FROM cash_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).total,3100);
+
+    const reversed=await storno(db,cookie,seeded.sourceDocumentId,"Скасування оплаченої послуги");
+    assert.equal(reversed.status,201);
+
+    assert.equal(raw.prepare(
+      "SELECT SUM(amount_delta) AS total FROM revenue_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).total,0);
+    assert.equal(raw.prepare(
+      "SELECT SUM(amount_delta) AS total FROM patient_settlement_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).total,-3100);
+    assert.equal(raw.prepare(
+      "SELECT SUM(amount_delta) AS total FROM cash_movements WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).total,3100);
+  });
+});
+
+test("military storno reverses operational output without inventing revenue or settlement",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-MIL",category:"military",amount:2500});
+    const cookie=await seedStaffSession(db,{email:"storno-mil@example.com",role:"registrar",organizationId:1});
+    const response=await storno(db,cookie,seeded.sourceDocumentId,"Помилково зафіксоване виконання");
+    assert.equal(response.status,201);
+
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM revenue_movements WHERE booking_id=?").get(seeded.bookingId).n,0);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM patient_settlement_movements WHERE booking_id=?").get(seeded.bookingId).n,0);
+    assert.equal(raw.prepare("SELECT SUM(minutes_delta) AS total FROM equipment_load_movements WHERE booking_id=?").get(seeded.bookingId).total,0);
+    assert.equal(raw.prepare("SELECT SUM(units_delta) AS total FROM staff_output_movements WHERE booking_id=?").get(seeded.bookingId).total,0);
+  });
+});
+
+test("reversed service facts stay immutable and cannot be auto-posted again",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-FREEZE"});
+    const cookie=await seedStaffSession(db,{email:"storno-freeze@example.com",role:"registrar",organizationId:1});
+    const response=await storno(db,cookie,seeded.sourceDocumentId,"Помилкова послуга для перевірки блокування");
+    assert.equal(response.status,201);
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET payment_amount=1 WHERE organization_id=1 AND id=?"
+    ).run(seeded.bookingId),/service_delivery_booking_immutable/);
+    assert.throws(()=>raw.prepare(
+      `UPDATE bookings SET performed_at='2026-08-21T10:05:00',status='completed' WHERE organization_id=1 AND id=?`
+    ).run(seeded.bookingId),/service_delivery_reversed/);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM service_delivery_details WHERE organization_id=1 AND booking_id=?"
+    ).get(seeded.bookingId).n,1);
+  });
+});
+
+test("tenant and role scope prevent foreign or clinical-only storno",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Storno Org 2','storno-org-2',1)");
+    const foreign=await seedCompleted(db,raw,{organizationId:2,code:"RD-STORNO-ORG2"});
+    const org1=await seedStaffSession(db,{email:"storno-org1@example.com",role:"registrar",organizationId:1});
+    const doctor=await seedStaffSession(db,{email:"storno-doctor-role@example.com",role:"radiologist",organizationId:2});
+
+    const wrongTenant=await storno(db,org1,foreign.sourceDocumentId,"Спроба чужого сторно");
+    assert.equal(wrongTenant.status,404);
+    const wrongRole=await storno(db,doctor,foreign.sourceDocumentId,"Спроба лікаря сторнувати");
+    assert.equal(wrongRole.status,403);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM service_correction_details WHERE organization_id=2").get().n,0);
+  });
+});
+
+test("D1 rejects forged negative register movement without a posted correction registrar",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-FORGE",amount:2700});
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO revenue_movements
+       (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email)
+       VALUES (1,?,?,?,'ct-chest','service_correction',-2700,'UAH','attacker@example.com')`
+    ).run(seeded.sourceDocumentId,seeded.bookingId,""),/revenue_document_mismatch/);
+  });
+});

--- a/tests/service-delivery-storno.behavior.test.mjs
+++ b/tests/service-delivery-storno.behavior.test.mjs
@@ -179,10 +179,12 @@ test("tenant and role scope prevent foreign or clinical-only storno",async()=>{
 test("D1 rejects forged negative register movement without a posted correction registrar",async()=>{
   await withD1(async(db,raw)=>{
     const seeded=await seedCompleted(db,raw,{code:"RD-STORNO-FORGE",amount:2700});
+    // The storno precondition is stronger than the generic revenue registrar guard: a negative
+    // correction movement is rejected immediately unless the exact source is already reversed.
     assert.throws(()=>raw.prepare(
       `INSERT INTO revenue_movements
        (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email)
        VALUES (1,?,?,?,'ct-chest','service_correction',-2700,'UAH','attacker@example.com')`
-    ).run(seeded.sourceDocumentId,seeded.bookingId,""),/revenue_document_mismatch/);
+    ).run(seeded.sourceDocumentId,seeded.bookingId,""),/service_correction_source_not_reversed/);
   });
 });


### PR DESCRIPTION
## Goal
Add BAS-style correction/storno for posted `service_delivery` documents without mutating historical business facts.

## Implemented
- separate `СТ-xxxxxx` correction registrar linked to original service delivery through `reversed_document_id`
- exact immutable `service_correction_details` snapshot with mandatory reason
- source document transitions `posted -> reversed`; original facts stay preserved
- D1-atomic posting boundary: source reversal posts the correction and writes all negative registers in the same SQLite transaction
- service count correction register, negative revenue, patient-settlement adjustment, equipment-load correction, and staff-output correction
- military/free storno reverses operational output without inventing revenue/debt
- paid service storno leaves cash untouched and produces patient credit until a separate `refund`
- reversed service facts cannot be edited or posted again
- interrupted exact draft correction can be resumed safely
- finance-role + tenant-scoped correction API and storno action in the service journal

## D1 hardening
- source cannot enter `reversed` without exact draft correction
- correction cannot be independently posted while source is still posted
- prepared correction document identity is frozen
- negative register movements require a posted correction and actually reversed source
- register failure rolls back source reversal and correction posting

## Verification
- unpaid civilian storno nets revenue/settlement/load/staff output — covered
- paid storno creates patient credit while cash remains unchanged — covered
- military storno has no invented financial movement — covered
- duplicate/idempotent storno — covered
- tenant and role isolation — covered
- direct forged negative movement rejection — covered by stronger `service_correction_source_not_reversed` D1 guard
- direct source reversal rejection — covered
- direct correction-post rejection — covered
- draft identity freeze — covered
- interrupted-draft recovery — covered
- forced register failure rollback — covered
- explicit re-post after storno returns 409 — covered
- CI #1034 — success on exact head `10bbd6eb382ccdb34725f552a6bbed02eade0aeb`
- CodeQL #949 — success on exact head
- final manual diff review: cash boundary preserved; no clinical protocol/DICOM/result mutation path; tenant scoping preserved

## Boundary
- service storno is not a cash refund
- medical protocol/DICOM/result are not modified by this business correction
- no production deploy