### PR TITLE
Add unified BAS document journal and document structure

### DIFF
--- a/app/api/staff/business-documents/route.ts
+++ b/app/api/staff/business-documents/route.ts
@@ -1,0 +1,32 @@
+import { dbBinding } from "../../../../lib/db";
+import { getBusinessDocumentJournalDetail,listBusinessDocuments } from "../../../../lib/business-document-journal";
+import { canManageFinance } from "../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+function int(value:unknown) {
+  const n=Number(value);
+  return Number.isInteger(n)&&n>0?n:null;
+}
+
+export async function GET(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx) return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  // This journal exposes patient-level finance/business evidence. Keep it under the same narrow
+  // finance capability until subsystem-specific document visibility is introduced.
+  if(!canManageFinance(ctx.member.role)) {
+    return Response.json({error:"Журнал документів доступний реєстратору або адміністратору"},{status:403});
+  }
+
+  const url=new URL(request.url);
+  const documentId=int(url.searchParams.get("id"));
+  if(documentId) {
+    const detail=await getBusinessDocumentJournalDetail(db,ctx.organizationId,documentId);
+    if(!detail) return Response.json({error:"Документ не знайдено"},{status:404});
+    return Response.json(detail);
+  }
+
+  const limit=int(url.searchParams.get("limit")) || 250;
+  return Response.json({documents:await listBusinessDocuments(db,ctx.organizationId,limit)});
+}

--- a/app/staff/documents/page.tsx
+++ b/app/staff/documents/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback,useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type DocumentRow={
+  id:number;documentType:string;journalType:string;number:string;occurredAt:string;state:string;comment:string;
+  createdBy:string;createdAt:string;postedBy:string;postedAt:string;reversedDocumentId:number|null;
+  bookingId:number|null;bookingCode:string;patientName:string;patientId:string;subject:string;
+  amount:number;currency:string;sourceDocumentId:number|null;relationType:string;lineCount:number;totalQuantity:number;
+};
+type Related={id:number;documentType:string;journalType:string;number:string;occurredAt:string;state:string;relationType:string};
+type Detail={
+  document:DocumentRow;
+  relations:{parent:Related[];children:Related[]};
+  movements:Record<string,Array<Record<string,unknown>>>;
+  printedForms:Array<{id:number;formType:string;templateVersion:number;documentState:string;generatedBy:string;generatedAt:string;sha256:string}>;
+  error?:string;
+};
+type ListPayload={documents:DocumentRow[];error?:string};
+
+const TYPE_UK:Record<string,string>={
+  patient_order:"Замовлення пацієнта",appointment:"Запис",service_delivery:"Надання послуги",
+  service_correction:"Сторно послуги",payment:"Оплата",refund:"Повернення",
+  inventory_receipt:"Надходження на склад",inventory_writeoff:"Списання зі складу",
+  inventory_transfer:"Переміщення складу",inventory_count:"Інвентаризація",
+  study_performance:"Виконання дослідження",result_delivery:"Видача результату",
+};
+const STATE_UK:Record<string,string>={draft:"Чернетка",posted:"Проведено",reversed:"Сторновано",cancelled:"Скасовано"};
+const REL_UK:Record<string,string>={storno_of:"Сторно документа",refund_of:"Повернення за оплатою",reversal_of:"Сторно/реверс",storno:"Документ сторно",refund:"Документ повернення",reversal:"Реверс",source:"Підстава",related:"Пов’язаний"};
+const REGISTER_UK:Record<string,string>={
+  cash:"Гроші",settlement:"Взаєморозрахунки",revenue:"Дохід",services:"Надані послуги",
+  corrections:"Корекції послуг",equipment:"Навантаження обладнання",staff:"Виробіток персоналу",inventory:"Склад",
+};
+
+function dateTime(value:string) {
+  const d=new Date(value);
+  return Number.isNaN(d.getTime())?value:d.toLocaleString("uk-UA",{dateStyle:"medium",timeStyle:"short"});
+}
+function money(value:number,currency="UAH") {
+  return new Intl.NumberFormat("uk-UA",{style:"currency",currency,maximumFractionDigits:0}).format(Number(value||0));
+}
+function describeMovement(row:Record<string,unknown>) {
+  const parts:string[]=[];
+  if(row.movementType)parts.push(String(row.movementType));
+  if(typeof row.amountDelta==="number")parts.push(`${row.amountDelta>0?"+":""}${money(row.amountDelta,String(row.currency||"UAH"))}`);
+  if(typeof row.quantityDelta==="number")parts.push(`кількість ${row.quantityDelta>0?"+":""}${row.quantityDelta}`);
+  if(typeof row.quantity==="number")parts.push(`кількість ${row.quantity}`);
+  if(typeof row.minutesDelta==="number")parts.push(`${row.minutesDelta>0?"+":""}${row.minutesDelta} хв`);
+  if(typeof row.unitsDelta==="number")parts.push(`одиниць ${row.unitsDelta>0?"+":""}${row.unitsDelta}`);
+  if(row.serviceCode)parts.push(String(row.serviceCode));
+  if(row.itemName)parts.push(String(row.itemName));
+  if(row.memberEmail)parts.push(`${row.staffRole||"staff"}: ${row.memberEmail}`);
+  if(row.equipmentId)parts.push(`апарат ${row.equipmentId}`);
+  if(row.reason)parts.push(String(row.reason));
+  return parts.join(" · ") || "Рух регістру";
+}
+
+export default function BusinessDocumentsPage(){
+  const [data,setData]=useState<ListPayload|null>(null);
+  const [detail,setDetail]=useState<Detail|null>(null);
+  const [selectedId,setSelectedId]=useState<number|null>(null);
+  const [query,setQuery]=useState("");
+  const [error,setError]=useState("");
+  const [loadingDetail,setLoadingDetail]=useState(false);
+
+  const load=useCallback(async()=>{
+    try{
+      const response=await fetch("/api/staff/business-documents",{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as ListPayload;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося завантажити журнал документів");
+      setData(payload);setError("");
+    }catch(e){setError(e instanceof Error?e.message:"Не вдалося завантажити журнал документів");}
+  },[]);
+
+  useEffect(()=>{const timer=window.setTimeout(()=>{void load();},0);return()=>window.clearTimeout(timer);},[load]);
+
+  async function openDocument(id:number){
+    setSelectedId(id);setLoadingDetail(true);setError("");
+    try{
+      const response=await fetch(`/api/staff/business-documents?id=${id}`,{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as Detail;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося відкрити документ");
+      setDetail(payload);
+    }catch(e){setDetail(null);setError(e instanceof Error?e.message:"Не вдалося відкрити документ");}
+    finally{setLoadingDetail(false);}
+  }
+
+  const q=query.trim().toLowerCase();
+  const rows=useMemo(()=>{
+    const source=data?.documents||[];
+    if(!q)return source;
+    return source.filter((row)=>`${row.number} ${TYPE_UK[row.journalType]||row.journalType} ${row.bookingCode} ${row.patientName} ${row.subject} ${row.comment}`.toLowerCase().includes(q));
+  },[data,q]);
+
+  const totals=useMemo(()=>{
+    const source=data?.documents||[];
+    return {
+      all:source.length,
+      posted:source.filter(row=>row.state==="posted").length,
+      reversed:source.filter(row=>row.state==="reversed"||row.journalType==="service_correction").length,
+      types:new Set(source.map(row=>row.journalType)).size,
+    };
+  },[data]);
+
+  const movementGroups=detail?Object.entries(detail.movements).filter(([,items])=>items.length>0):[];
+
+  return <StaffWorkspaceShell
+    active="finance"
+    title="Журнал документів"
+    description="Єдиний BAS-журнал: документ, підстава, похідні документи, рухи по регістрах і друковані форми."
+  >
+    <section className="financeSummary" aria-label="Підсумок журналу документів">
+      <article><span>Документів</span><b>{totals.all}</b><small>в одному журналі</small></article>
+      <article><span>Проведено</span><b>{totals.posted}</b><small>активних registrar-фактів</small></article>
+      <article><span>Сторно / реверс</span><b>{totals.reversed}</b><small>історія не видаляється</small></article>
+      <article><span>Типів</span><b>{totals.types}</b><small>єдине business core</small></article>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div><b>Усі бізнес-документи</b><small>Сортування за датою документа. Журнал не створює нових даних — це read-model канонічних реєстраторів.</small></div>
+        <input value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пошук: НП, СТ, ОП, пацієнт, послуга…" aria-label="Пошук у журналі документів"/>
+        <button type="button" onClick={()=>void load()}>Оновити</button>
+      </header>
+      {error&&<p className="financeError">{error}</p>}
+      {!data&&!error&&<p className="financeLoading">Завантаження журналу…</p>}
+      {data&&<div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Документ</th><th>Дата</th><th>Заявка / пацієнт</th><th>Зміст</th><th className="num">Сума / кількість</th><th>Стан</th><th>Підстава</th><th/></tr></thead>
+        <tbody>{rows.map(row=><tr key={row.id}>
+          <td><b>{row.number||`#${row.id}`}</b><small>{TYPE_UK[row.journalType]||row.journalType}</small></td>
+          <td>{dateTime(row.occurredAt)}</td>
+          <td>{row.bookingCode?<><b>{row.bookingCode}</b><small>{row.patientName}</small></>:"—"}</td>
+          <td>{row.subject||row.comment||"—"}{row.lineCount>0&&<small>{row.lineCount} поз. · {row.totalQuantity} од.</small>}</td>
+          <td className="num">{row.amount>0?money(row.amount,row.currency):row.lineCount>0?`${row.totalQuantity} од.`:"—"}</td>
+          <td><span className={`financeState state-${row.state}`}>{STATE_UK[row.state]||row.state}</span></td>
+          <td>{row.sourceDocumentId?<><b>#{row.sourceDocumentId}</b><small>{REL_UK[row.relationType]||row.relationType}</small></>:"—"}</td>
+          <td><button type="button" className={selectedId===row.id?"active":""} onClick={()=>void openDocument(row.id)}>Структура</button></td>
+        </tr>)}</tbody>
+      </table>{rows.length===0&&<p className="financeEmpty">Документів за цим відбором немає.</p>}</div>}
+    </section>
+
+    {(loadingDetail||detail)&&<section className="financeJournal">
+      <header className="financeToolbar"><div><b>Структура підпорядкованості</b><small>{loadingDetail?"Завантаження…":detail?`${TYPE_UK[detail.document.journalType]||detail.document.journalType} ${detail.document.number}`:""}</small></div></header>
+      {detail&&!loadingDetail&&<>
+        <div className="financePrintDetails">
+          <p><span>Документ</span><b>{detail.document.number}</b></p>
+          <p><span>Тип / стан</span><b>{TYPE_UK[detail.document.journalType]||detail.document.journalType} · {STATE_UK[detail.document.state]||detail.document.state}</b></p>
+          <p><span>Створив</span><b>{detail.document.createdBy||"—"}</b></p>
+          <p><span>Провів</span><b>{detail.document.postedBy||"—"}</b></p>
+          {detail.document.comment&&<p><span>Коментар</span><b>{detail.document.comment}</b></p>}
+        </div>
+
+        <div className="financeTableWrap"><table className="financeTable">
+          <thead><tr><th>Напрям</th><th>Зв’язок</th><th>Документ</th><th>Тип</th><th>Стан</th><th/></tr></thead>
+          <tbody>
+            {detail.relations.parent.map(row=><tr key={`p-${row.id}`}><td>← Підстава</td><td>{REL_UK[row.relationType]||row.relationType}</td><td><b>{row.number}</b></td><td>{TYPE_UK[row.journalType]||row.journalType}</td><td>{STATE_UK[row.state]||row.state}</td><td><button onClick={()=>void openDocument(row.id)}>Відкрити</button></td></tr>)}
+            {detail.relations.children.map(row=><tr key={`c-${row.id}`}><td>→ Похідний</td><td>{REL_UK[row.relationType]||row.relationType}</td><td><b>{row.number}</b></td><td>{TYPE_UK[row.journalType]||row.journalType}</td><td>{STATE_UK[row.state]||row.state}</td><td><button onClick={()=>void openDocument(row.id)}>Відкрити</button></td></tr>)}
+            {detail.relations.parent.length+detail.relations.children.length===0&&<tr><td colSpan={6}>Пов’язаних бізнес-документів немає.</td></tr>}
+          </tbody>
+        </table></div>
+
+        <div className="financePrintDetails">
+          <p><span>Рухів регістрів</span><b>{movementGroups.reduce((sum,[,items])=>sum+items.length,0)}</b></p>
+          <p><span>Друкованих snapshot-ів</span><b>{detail.printedForms.length}</b></p>
+        </div>
+        {movementGroups.map(([register,items])=><div className="financeTableWrap" key={register}><table className="financeTable">
+          <thead><tr><th>{REGISTER_UK[register]||register}</th><th>Рух</th><th>Час</th></tr></thead>
+          <tbody>{items.map((item,index)=><tr key={`${register}-${String(item.id||index)}`}><td><b>#{String(item.id||index+1)}</b></td><td>{describeMovement(item)}</td><td>{item.occurredAt?dateTime(String(item.occurredAt)):"—"}</td></tr>)}</tbody>
+        </table></div>)}
+        {detail.printedForms.length>0&&<div className="financeTableWrap"><table className="financeTable">
+          <thead><tr><th>Друкована форма</th><th>Версія</th><th>Стан документа</th><th>Сформовано</th><th>SHA-256</th></tr></thead>
+          <tbody>{detail.printedForms.map(form=><tr key={form.id}><td>{form.formType}</td><td>v{form.templateVersion}</td><td>{STATE_UK[form.documentState]||form.documentState}</td><td>{dateTime(form.generatedAt)}<small>{form.generatedBy}</small></td><td>{form.sha256.slice(0,12)}…</td></tr>)}</tbody>
+        </table></div>}
+      </>}
+    </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -114,6 +114,7 @@ export default function FinancePage() {
           <button type="button" className={tab==="cash"?"active":""} onClick={()=>setTab("cash")}>Рухи грошей</button>
           <button type="button" className={tab==="settlements"?"active":""} onClick={()=>setTab("settlements")}>Взаєморозрахунки</button>
           <button type="button" onClick={()=>window.location.assign("/staff/finance/services")}>Надані послуги ↗</button>
+          <button type="button" onClick={()=>window.location.assign("/staff/documents")}>Усі документи ↗</button>
         </div>
         <input value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Пошук: документ, RD, пацієнт…" aria-label="Пошук у фінансовому журналі"/>
         <button type="button" onClick={()=>void load()}>Оновити</button>

--- a/docs/bas-document-journal.md
+++ b/docs/bas-document-journal.md
@@ -1,0 +1,36 @@
+# Unified BAS document journal
+
+The internal workspace exposes one read-only journal over canonical `business_documents` and their typed registrar/detail tables. It does **not** create a second relationship table or copy balances.
+
+## Journal identity
+
+The journal keeps the physical `business_documents.document_type` but derives a display `journalType` when a typed detail gives the document a more precise meaning. For example, a service storno is stored in the `service_delivery` document family but is displayed as `service_correction` because it has `service_correction_details`.
+
+## Structure of subordination
+
+Relationships are read from existing canonical fields:
+
+- `service_correction_details.source_document_id` → storno source;
+- `finance_document_details.source_document_id` → refund source payment;
+- `business_documents.reversed_document_id` → generic reversal source.
+
+The journal can therefore show both “basis/source” and “derived documents” without maintaining duplicate graph data.
+
+## Document movements
+
+Opening a document reads only movements whose `(organization_id, document_id)` matches that exact document from these registrars:
+
+- cash;
+- patient settlements;
+- revenue;
+- rendered services;
+- service corrections;
+- equipment load;
+- staff output;
+- inventory.
+
+Printed-form snapshots are shown alongside the document as immutable evidence.
+
+## Security boundary
+
+The journal is tenant-scoped in every query. Because the current journal includes patient-level financial/business evidence, access is initially limited to the existing finance capability (`admin` / `registrar`). Clinical-only roles do not receive this aggregate business view. Future subsystem-specific visibility can narrow or expand individual document families without changing the journal model.

--- a/lib/business-document-journal.ts
+++ b/lib/business-document-journal.ts
@@ -1,0 +1,197 @@
+export type BusinessJournalDocument={
+  id:number;documentType:string;journalType:string;number:string;occurredAt:string;state:string;comment:string;
+  createdBy:string;createdAt:string;postedBy:string;postedAt:string;reversedDocumentId:number|null;
+  bookingId:number|null;bookingCode:string;patientName:string;patientId:string;subject:string;
+  amount:number;currency:string;sourceDocumentId:number|null;relationType:string;lineCount:number;totalQuantity:number;
+};
+
+function safeLimit(value:number,defaultValue=250) {
+  const n=Number.isFinite(value)?Math.trunc(value):defaultValue;
+  return Math.max(1,Math.min(500,n));
+}
+
+const SUMMARY_SELECT=`
+  SELECT d.id,d.document_type AS documentType,
+         CASE WHEN c.document_id IS NOT NULL THEN 'service_correction' ELSE d.document_type END AS journalType,
+         d.number,d.occurred_at AS occurredAt,d.state,d.comment,d.created_by AS createdBy,
+         d.created_at AS createdAt,d.posted_by AS postedBy,d.posted_at AS postedAt,
+         d.reversed_document_id AS reversedDocumentId,
+         COALESCE(s.booking_id,c.booking_id,f.booking_id) AS bookingId,
+         COALESCE(b.code,'') AS bookingCode,COALESCE(b.name,'') AS patientName,
+         COALESCE(s.patient_id,c.patient_id,f.patient_id,'') AS patientId,
+         COALESCE(s.service_title,c.service_title,b.service,'') AS subject,
+         COALESCE(s.charge_amount,c.charge_amount,f.amount,0) AS amount,
+         COALESCE(s.currency,c.currency,f.currency,'UAH') AS currency,
+         CASE
+           WHEN c.document_id IS NOT NULL THEN c.source_document_id
+           WHEN f.source_document_id IS NOT NULL THEN f.source_document_id
+           WHEN d.reversed_document_id IS NOT NULL THEN d.reversed_document_id
+           ELSE NULL
+         END AS sourceDocumentId,
+         CASE
+           WHEN c.document_id IS NOT NULL THEN 'storno_of'
+           WHEN d.document_type='refund' AND f.source_document_id IS NOT NULL THEN 'refund_of'
+           WHEN d.reversed_document_id IS NOT NULL THEN 'reversal_of'
+           ELSE ''
+         END AS relationType,
+         (SELECT COUNT(*) FROM inventory_document_lines il
+          WHERE il.organization_id=d.organization_id AND il.document_id=d.id) AS lineCount,
+         COALESCE((SELECT SUM(il.quantity) FROM inventory_document_lines il
+          WHERE il.organization_id=d.organization_id AND il.document_id=d.id),0) AS totalQuantity
+  FROM business_documents d
+  LEFT JOIN service_delivery_details s
+    ON s.document_id=d.id AND s.organization_id=d.organization_id
+  LEFT JOIN service_correction_details c
+    ON c.document_id=d.id AND c.organization_id=d.organization_id
+  LEFT JOIN finance_document_details f
+    ON f.document_id=d.id AND f.organization_id=d.organization_id
+  LEFT JOIN bookings b
+    ON b.organization_id=d.organization_id
+   AND b.id=COALESCE(s.booking_id,c.booking_id,f.booking_id)`;
+
+export async function listBusinessDocuments(db:D1Database,organizationId:number,limit=250) {
+  const rows=await db.prepare(
+    `${SUMMARY_SELECT}
+     WHERE d.organization_id=?
+     ORDER BY d.occurred_at DESC,d.id DESC
+     LIMIT ${safeLimit(limit)}`
+  ).bind(organizationId).all<BusinessJournalDocument>();
+  return rows.results;
+}
+
+export async function getBusinessDocumentSummary(db:D1Database,organizationId:number,documentId:number) {
+  const row=await db.prepare(
+    `${SUMMARY_SELECT}
+     WHERE d.organization_id=? AND d.id=?
+     LIMIT 1`
+  ).bind(organizationId,documentId).first<BusinessJournalDocument>();
+  return row || null;
+}
+
+type RelatedDocument={
+  id:number;documentType:string;journalType:string;number:string;occurredAt:string;state:string;
+  relationType:string;
+};
+
+export async function getBusinessDocumentRelations(db:D1Database,organizationId:number,document:BusinessJournalDocument) {
+  const parent:RelatedDocument[]=[];
+  if(document.sourceDocumentId) {
+    const source=await db.prepare(
+      `SELECT d.id,d.document_type AS documentType,
+              CASE WHEN c.document_id IS NOT NULL THEN 'service_correction' ELSE d.document_type END AS journalType,
+              d.number,d.occurred_at AS occurredAt,d.state,? AS relationType
+       FROM business_documents d
+       LEFT JOIN service_correction_details c
+         ON c.document_id=d.id AND c.organization_id=d.organization_id
+       WHERE d.organization_id=? AND d.id=? LIMIT 1`
+    ).bind(document.relationType || "source",organizationId,document.sourceDocumentId).first<RelatedDocument>();
+    if(source) parent.push(source);
+  }
+
+  const children=await db.prepare(
+    `SELECT d.id,d.document_type AS documentType,
+            CASE WHEN c.document_id IS NOT NULL THEN 'service_correction' ELSE d.document_type END AS journalType,
+            d.number,d.occurred_at AS occurredAt,d.state,
+            CASE
+              WHEN c.source_document_id=? THEN 'storno'
+              WHEN d.document_type='refund' AND f.source_document_id=? THEN 'refund'
+              WHEN d.reversed_document_id=? THEN 'reversal'
+              ELSE 'related'
+            END AS relationType
+     FROM business_documents d
+     LEFT JOIN service_correction_details c
+       ON c.document_id=d.id AND c.organization_id=d.organization_id
+     LEFT JOIN finance_document_details f
+       ON f.document_id=d.id AND f.organization_id=d.organization_id
+     WHERE d.organization_id=?
+       AND (c.source_document_id=? OR f.source_document_id=? OR d.reversed_document_id=?)
+     ORDER BY d.occurred_at,d.id`
+  ).bind(
+    document.id,document.id,document.id,
+    organizationId,document.id,document.id,document.id,
+  ).all<RelatedDocument>();
+  return {parent,children:children.results};
+}
+
+export async function getBusinessDocumentMovements(db:D1Database,organizationId:number,documentId:number) {
+  const [cash,settlement,revenue,services,corrections,equipment,staff,inventory]=await Promise.all([
+    db.prepare(
+      `SELECT id,movement_type AS movementType,amount_delta AS amountDelta,currency,method,provider,
+              provider_reference AS providerReference,actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM cash_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT id,movement_type AS movementType,amount_delta AS amountDelta,currency,
+              actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM patient_settlement_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT id,movement_type AS movementType,amount_delta AS amountDelta,currency,service_code AS serviceCode,
+              actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM revenue_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT id,quantity,anatomical_regions_count AS anatomicalRegionsCount,service_code AS serviceCode,
+              equipment_id AS equipmentId,performed_at AS performedAt,actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM services_delivered_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT id,source_document_id AS sourceDocumentId,quantity_delta AS quantityDelta,
+              anatomical_regions_delta AS anatomicalRegionsDelta,service_code AS serviceCode,equipment_id AS equipmentId,
+              reason,actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM service_correction_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT id,minutes_delta AS minutesDelta,equipment_id AS equipmentId,performed_at AS performedAt,
+              actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM equipment_load_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT id,member_email AS memberEmail,staff_role AS staffRole,units_delta AS unitsDelta,
+              anatomical_regions_count AS anatomicalRegionsCount,performed_at AS performedAt,
+              actor_email AS actorEmail,occurred_at AS occurredAt
+       FROM staff_output_movements WHERE organization_id=? AND document_id=? ORDER BY id`
+    ).bind(organizationId,documentId).all(),
+    db.prepare(
+      `SELECT m.id,m.movement_type AS movementType,m.quantity_delta AS quantityDelta,m.item_id AS itemId,
+              i.name AS itemName,m.lot_id AS lotId,l.lot_number AS lotNumber,m.reason,m.booking_id AS bookingId,
+              m.actor_email AS actorEmail,m.created_at AS occurredAt
+       FROM inventory_movements m
+       JOIN inventory_items i ON i.id=m.item_id AND i.organization_id=m.organization_id
+       JOIN inventory_lots l ON l.id=m.lot_id AND l.organization_id=m.organization_id
+       WHERE m.organization_id=? AND m.document_id=? ORDER BY m.id`
+    ).bind(organizationId,documentId).all(),
+  ]);
+  return {
+    cash:cash.results,
+    settlement:settlement.results,
+    revenue:revenue.results,
+    services:services.results,
+    corrections:corrections.results,
+    equipment:equipment.results,
+    staff:staff.results,
+    inventory:inventory.results,
+  };
+}
+
+export async function getBusinessDocumentPrintedForms(db:D1Database,organizationId:number,documentId:number) {
+  const rows=await db.prepare(
+    `SELECT id,form_type AS formType,template_version AS templateVersion,document_state AS documentState,
+            generated_by AS generatedBy,generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=?
+     ORDER BY generated_at DESC,id DESC`
+  ).bind(organizationId,documentId).all();
+  return rows.results;
+}
+
+export async function getBusinessDocumentJournalDetail(db:D1Database,organizationId:number,documentId:number) {
+  const document=await getBusinessDocumentSummary(db,organizationId,documentId);
+  if(!document) return null;
+  const [relations,movements,printedForms]=await Promise.all([
+    getBusinessDocumentRelations(db,organizationId,document),
+    getBusinessDocumentMovements(db,organizationId,documentId),
+    getBusinessDocumentPrintedForms(db,organizationId,documentId),
+  ]);
+  return {document,relations,movements,printedForms};
+}

--- a/tests/business-document-journal.behavior.test.mjs
+++ b/tests/business-document-journal.behavior.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompleted(db,raw,{code="RD-DOC-JOURNAL",amount=3200,organizationId=1}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,'Journal Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-23','11:00','civilian','pending',?,0,'confirmed',2,'journal-doctor@example.com','journal-tech@example.com')`
+  ).bind(organizationId,code,amount).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    `UPDATE bookings SET performed_at='2026-08-23T11:05:00',status='completed'
+     WHERE organization_id=? AND id=?`
+  ).bind(organizationId,bookingId).run();
+  const service=raw.prepare(
+    `SELECT d.id,d.number FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery'`
+  ).get(organizationId,bookingId);
+  return {bookingId,serviceDocumentId:service.id,serviceNumber:service.number};
+}
+
+async function pay(db,cookie,bookingId,reference="DOC-JOURNAL-PAY") {
+  return callWorker(jsonRequest("/api/staff/payments",{
+    bookingId,method:"bank_transfer",providerReference:reference,
+  },{headers:{cookie}}),db);
+}
+
+async function refund(db,cookie,bookingId) {
+  return callWorker(new Request("http://localhost/api/staff/payments",{
+    method:"DELETE",headers:{"content-type":"application/json",cookie},body:JSON.stringify({bookingId}),
+  }),db);
+}
+
+async function storno(db,cookie,sourceDocumentId) {
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{
+    sourceDocumentId,reason:"Сторно для єдиного журналу документів",
+  },{headers:{cookie}}),db);
+}
+
+async function journal(db,cookie,id=null) {
+  const suffix=id?`?id=${id}`:"";
+  return callWorker(new Request(`http://localhost/api/staff/business-documents${suffix}`,{headers:{cookie}}),db);
+}
+
+test("unified journal exposes service, payment, refund and storno as one tenant-scoped document stream",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw);
+    const cookie=await seedStaffSession(db,{email:"doc-journal@example.com",role:"registrar",organizationId:1});
+
+    const paymentResponse=await pay(db,cookie,seeded.bookingId,"DOC-JOURNAL-PAY-1");
+    assert.equal(paymentResponse.status,200);
+    const payment=await paymentResponse.json();
+    const refundResponse=await refund(db,cookie,seeded.bookingId);
+    assert.equal(refundResponse.status,200);
+    const returned=await refundResponse.json();
+    const stornoResponse=await storno(db,cookie,seeded.serviceDocumentId);
+    assert.equal(stornoResponse.status,201);
+    const correction=await stornoResponse.json();
+
+    const response=await journal(db,cookie);
+    assert.equal(response.status,200);
+    const body=await response.json();
+    const rows=body.documents;
+
+    const service=rows.find(row=>row.id===seeded.serviceDocumentId);
+    const payRow=rows.find(row=>row.id===payment.documentId);
+    const refundRow=rows.find(row=>row.id===returned.documentId);
+    const stornoRow=rows.find(row=>row.id===correction.document.id);
+    assert.equal(service.journalType,"service_delivery");
+    assert.equal(service.state,"reversed");
+    assert.equal(service.bookingCode,"RD-DOC-JOURNAL");
+    assert.equal(service.amount,3200);
+    assert.equal(payRow.journalType,"payment");
+    assert.equal(refundRow.journalType,"refund");
+    assert.equal(refundRow.sourceDocumentId,payment.documentId);
+    assert.equal(refundRow.relationType,"refund_of");
+    assert.equal(stornoRow.journalType,"service_correction");
+    assert.equal(stornoRow.sourceDocumentId,seeded.serviceDocumentId);
+    assert.equal(stornoRow.relationType,"storno_of");
+    assert.equal(stornoRow.amount,3200);
+  });
+});
+
+test("document structure shows canonical parents, children and exact register movements",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-DOC-STRUCT",amount:2700});
+    const cookie=await seedStaffSession(db,{email:"doc-structure@example.com",role:"registrar",organizationId:1});
+    const paymentResponse=await pay(db,cookie,seeded.bookingId,"DOC-STRUCT-PAY");
+    const payment=await paymentResponse.json();
+    const refundResponse=await refund(db,cookie,seeded.bookingId);
+    const returned=await refundResponse.json();
+    const stornoResponse=await storno(db,cookie,seeded.serviceDocumentId);
+    const correction=await stornoResponse.json();
+
+    const serviceDetailResponse=await journal(db,cookie,seeded.serviceDocumentId);
+    assert.equal(serviceDetailResponse.status,200);
+    const serviceDetail=await serviceDetailResponse.json();
+    assert.ok(serviceDetail.relations.children.some(row=>row.id===correction.document.id && row.relationType==="storno"));
+    assert.equal(serviceDetail.movements.services.length,1);
+    assert.equal(serviceDetail.movements.revenue.length,1);
+    assert.equal(serviceDetail.movements.settlement.length,1);
+    assert.equal(serviceDetail.movements.equipment.length,1);
+    assert.equal(serviceDetail.movements.staff.length,2);
+    assert.equal(serviceDetail.movements.cash.length,0);
+
+    const correctionDetailResponse=await journal(db,cookie,correction.document.id);
+    assert.equal(correctionDetailResponse.status,200);
+    const correctionDetail=await correctionDetailResponse.json();
+    assert.ok(correctionDetail.relations.parent.some(row=>row.id===seeded.serviceDocumentId && row.relationType==="storno_of"));
+    assert.equal(correctionDetail.movements.corrections.length,1);
+    assert.equal(correctionDetail.movements.revenue[0].amountDelta,-2700);
+    assert.equal(correctionDetail.movements.settlement[0].amountDelta,-2700);
+    assert.equal(correctionDetail.movements.equipment[0].minutesDelta,-30);
+    assert.equal(correctionDetail.movements.staff.length,2);
+    assert.equal(correctionDetail.movements.cash.length,0);
+
+    const paymentDetailResponse=await journal(db,cookie,payment.documentId);
+    const paymentDetail=await paymentDetailResponse.json();
+    assert.ok(paymentDetail.relations.children.some(row=>row.id===returned.documentId && row.relationType==="refund"));
+    assert.equal(paymentDetail.movements.cash[0].amountDelta,2700);
+    assert.equal(paymentDetail.movements.settlement[0].amountDelta,-2700);
+
+    const refundDetailResponse=await journal(db,cookie,returned.documentId);
+    const refundDetail=await refundDetailResponse.json();
+    assert.ok(refundDetail.relations.parent.some(row=>row.id===payment.documentId && row.relationType==="refund_of"));
+    assert.equal(refundDetail.movements.cash[0].amountDelta,-2700);
+    assert.equal(refundDetail.movements.settlement[0].amountDelta,2700);
+  });
+});
+
+test("document structure includes immutable printed-form evidence",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-DOC-PRINT",amount:2300});
+    const cookie=await seedStaffSession(db,{email:"doc-print@example.com",role:"registrar",organizationId:1});
+    const printed=await callWorker(jsonRequest("/api/staff/service-deliveries/print",{
+      documentId:seeded.serviceDocumentId,
+    },{headers:{cookie}}),db);
+    assert.equal(printed.status,201);
+    const printBody=await printed.json();
+
+    const detailResponse=await journal(db,cookie,seeded.serviceDocumentId);
+    assert.equal(detailResponse.status,200);
+    const detail=await detailResponse.json();
+    assert.equal(detail.printedForms.length,1);
+    assert.equal(detail.printedForms[0].id,printBody.snapshot.id);
+    assert.equal(detail.printedForms[0].formType,"service_act");
+    assert.equal(detail.printedForms[0].sha256.length,64);
+  });
+});
+
+test("business document journal is tenant isolated for both list and detail",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Document Org 2','document-org-2',1)");
+    const foreign=await seedCompleted(db,raw,{organizationId:2,code:"RD-DOC-ORG2",amount:1900});
+    const org1=await seedStaffSession(db,{email:"doc-org1@example.com",role:"registrar",organizationId:1});
+    const org2=await seedStaffSession(db,{email:"doc-org2@example.com",role:"registrar",organizationId:2});
+
+    const list1=await journal(db,org1);
+    const body1=await list1.json();
+    assert.equal(body1.documents.some(row=>row.id===foreign.serviceDocumentId),false);
+
+    const foreignDetail=await journal(db,org1,foreign.serviceDocumentId);
+    assert.equal(foreignDetail.status,404);
+    const ownDetail=await journal(db,org2,foreign.serviceDocumentId);
+    assert.equal(ownDetail.status,200);
+  });
+});
+
+test("clinical-only role cannot read the patient-level business document journal",async()=>{
+  await withD1(async(db,raw)=>{
+    const seeded=await seedCompleted(db,raw,{code:"RD-DOC-ROLE"});
+    const doctor=await seedStaffSession(db,{email:"doc-role-doctor@example.com",role:"radiologist",organizationId:1});
+    const list=await journal(db,doctor);
+    assert.equal(list.status,403);
+    const detail=await journal(db,doctor,seeded.serviceDocumentId);
+    assert.equal(detail.status,403);
+  });
+});


### PR DESCRIPTION
## Goal
Make the BAS-style core visible as one internal document system instead of separate feature pages.

## Implemented
- `/staff/documents` unified business-document journal over canonical `business_documents`
- display typing for service storno (`service_correction`) without changing its physical registrar family
- document source/derived structure from existing canonical links (`service_correction_details.source_document_id`, `finance_document_details.source_document_id`, `business_documents.reversed_document_id`)
- per-document register movements: cash, patient settlements, revenue, rendered services, corrections, equipment load, staff output, inventory
- immutable printed-form snapshots shown with the exact document
- finance workspace links directly to the unified journal
- tenant-scoped list/detail API
- patient-level journal restricted to existing finance capability (`admin` / `registrar`)

## Architectural boundary
- no duplicate relationship table
- no duplicate balance/total store
- journal is a read-model; canonical documents/registers remain the only source of truth
- no clinical-only role receives the aggregate patient-level business journal

## Verification
- unified stream includes service delivery, payment, refund and service storno — covered
- service storno parent/child structure — covered
- payment/refund parent/child structure — covered
- exact register movement grouping per document — covered
- printed snapshot evidence — covered
- tenant isolation for list and detail — covered
- role restriction — covered
- CI #1036 — success on exact head `58336a25cc0170365d6aa0c560424ca4a426174f`
- CodeQL #951 — success on exact head
- final manual diff review: read-only API, tenant-scoped queries, no document/register mutation path

## Boundary
- no production deploy