### PR TITLE
Add BAS register turnover and balance reports

### DIFF
--- a/app/api/staff/reports/registers/route.ts
+++ b/app/api/staff/reports/registers/route.ts
@@ -1,0 +1,28 @@
+import { dbBinding } from "../../../../../lib/db";
+import { buildRegisterTurnoverReport,normalizeRegisterPeriod } from "../../../../../lib/register-turnover-report";
+import { canViewReports } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+function kyivToday() {
+  return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+
+export async function GET(request:Request) {
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canViewReports(ctx.member.role))return Response.json({error:"Обороти регістрів доступні адміністратору"},{status:403});
+
+  const url=new URL(request.url);
+  const today=kyivToday();
+  const defaultFrom=`${today.slice(0,7)}-01`;
+  try{
+    const period=normalizeRegisterPeriod(url.searchParams.get("from")||defaultFrom,url.searchParams.get("to")||today);
+    return Response.json(await buildRegisterTurnoverReport(db,ctx.organizationId,period));
+  }catch(error){
+    const code=error instanceof Error?error.message:String(error);
+    if(code==="report_period_too_large")return Response.json({error:"Період звіту не може перевищувати 366 днів"},{status:400});
+    return Response.json({error:"Некоректний період звіту"},{status:400});
+  }
+}

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -115,6 +115,7 @@ export default function FinancePage() {
           <button type="button" className={tab==="settlements"?"active":""} onClick={()=>setTab("settlements")}>Взаєморозрахунки</button>
           <button type="button" onClick={()=>window.location.assign("/staff/finance/services")}>Надані послуги ↗</button>
           <button type="button" onClick={()=>window.location.assign("/staff/documents")}>Усі документи ↗</button>
+          <button type="button" onClick={()=>window.location.assign("/staff/reports/registers")}>Обороти регістрів · admin ↗</button>
         </div>
         <input value={query} onChange={(event)=>setQuery(event.target.value)} placeholder="Пошук: документ, RD, пацієнт…" aria-label="Пошук у фінансовому журналі"/>
         <button type="button" onClick={()=>void load()}>Оновити</button>

--- a/app/staff/reports/registers/page.tsx
+++ b/app/staff/reports/registers/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect,useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type Turnover={increase:number;decrease:number;net:number};
+type Balance=Turnover&{opening:number;closing:number};
+type Report={
+  period:{from:string;to:string};generatedAt:string;
+  registers:{
+    revenue:Turnover;cash:Turnover;settlements:Balance;
+    services:Turnover&{regionsNet:number};equipment:Turnover;staff:Turnover;
+  };
+  breakdowns:{
+    revenueByService:Array<{serviceCode:string;accrued:number;reversed:number;net:number}>;
+    cashByMethod:Array<{method:string;incoming:number;outgoing:number;net:number}>;
+    equipment:Array<{equipmentId:string;loadedMinutes:number;reversedMinutes:number;netMinutes:number}>;
+    staff:Array<{memberEmail:string;staffRole:string;performed:number;reversed:number;net:number}>;
+    inventory:Array<{itemId:number;sku:string;name:string;unit:string;opening:number;incoming:number;outgoing:number;closing:number}>;
+  };
+  error?:string;
+};
+
+function todayInKyiv(){return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());}
+const today=todayInKyiv();
+const monthStart=`${today.slice(0,7)}-01`;
+function money(value:number){return new Intl.NumberFormat("uk-UA",{style:"currency",currency:"UAH",maximumFractionDigits:0}).format(Number(value||0));}
+function number(value:number){return new Intl.NumberFormat("uk-UA",{maximumFractionDigits:2}).format(Number(value||0));}
+const METHOD_UK:Record<string,string>={cash:"Готівка",card:"Картка",bank_transfer:"Банківський переказ",privat_link:"Privat24",other:"Інше"};
+const ROLE_UK:Record<string,string>={radiologist:"Лікар-рентгенолог",radiographer:"Рентгенолаборант"};
+
+export default function RegisterTurnoverPage(){
+  const [from,setFrom]=useState(monthStart);
+  const [to,setTo]=useState(today);
+  const [data,setData]=useState<Report|null>(null);
+  const [error,setError]=useState("");
+  const [loading,setLoading]=useState(true);
+
+  async function load(){
+    setLoading(true);setError("");
+    try{
+      const params=new URLSearchParams({from,to});
+      const response=await fetch(`/api/staff/reports/registers?${params}`,{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as Report;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося сформувати обороти регістрів");
+      setData(payload);
+    }catch(e){setData(null);setError(e instanceof Error?e.message:"Не вдалося сформувати обороти регістрів");}
+    finally{setLoading(false);}
+  }
+
+  useEffect(()=>{const timer=window.setTimeout(()=>{void load();},0);return()=>window.clearTimeout(timer);/* eslint-disable-next-line react-hooks/exhaustive-deps */},[]);
+
+  return <StaffWorkspaceShell
+    active="reports"
+    title="Обороти і залишки"
+    description="BAS-звіт без ручних KPI: показники обчислюються безпосередньо з immutable регістрів рухів."
+  >
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div><b>Період звіту</b><small>До 366 днів. Сторно та повернення потрапляють у період за датою власного руху.</small></div>
+        <label><span>Від</span><input type="date" value={from} onChange={e=>setFrom(e.target.value)}/></label>
+        <label><span>До</span><input type="date" value={to} onChange={e=>setTo(e.target.value)}/></label>
+        <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
+      </header>
+      {error&&<p className="financeError">{error}</p>}
+    </section>
+
+    {data&&<>
+      <section className="financeSummary" aria-label="Обороти регістрів">
+        <article><span>Дохід, нетто</span><b>{money(data.registers.revenue.net)}</b><small>+{money(data.registers.revenue.increase)} · сторно {money(data.registers.revenue.decrease)}</small></article>
+        <article><span>Гроші, нетто</span><b>{money(data.registers.cash.net)}</b><small>вхід {money(data.registers.cash.increase)} · вихід {money(data.registers.cash.decrease)}</small></article>
+        <article><span>Борг / кредит пацієнтів</span><b>{money(data.registers.settlements.closing)}</b><small>початок {money(data.registers.settlements.opening)}</small></article>
+        <article><span>Послуги, нетто</span><b>{number(data.registers.services.net)}</b><small>виконано {number(data.registers.services.increase)} · сторно {number(data.registers.services.decrease)} · зон {number(data.registers.services.regionsNet)}</small></article>
+        <article><span>Навантаження обладнання</span><b>{number(data.registers.equipment.net)} хв</b><small>+{number(data.registers.equipment.increase)} · сторно {number(data.registers.equipment.decrease)}</small></article>
+        <article><span>Виробіток персоналу</span><b>{number(data.registers.staff.net)}</b><small>+{number(data.registers.staff.increase)} · сторно {number(data.registers.staff.decrease)}</small></article>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Взаєморозрахунки з пацієнтами</b><small>Додатне сальдо — пацієнти винні організації; від’ємне — кредит пацієнтів.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Початкове сальдо</th><th className="num">Збільшення боргу</th><th className="num">Зменшення / оплати</th><th className="num">Оборот нетто</th><th className="num">Кінцеве сальдо</th></tr></thead><tbody><tr>
+          <td className="num">{money(data.registers.settlements.opening)}</td><td className="num positive">+{money(data.registers.settlements.increase)}</td><td className="num negative">−{money(data.registers.settlements.decrease)}</td><td className="num">{money(data.registers.settlements.net)}</td><td className="num"><b>{money(data.registers.settlements.closing)}</b></td>
+        </tr></tbody></table></div>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Дохід за послугами</b><small>Нарахування і сторно з `revenue_movements`.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Код послуги</th><th className="num">Нараховано</th><th className="num">Сторновано</th><th className="num">Нетто</th></tr></thead><tbody>
+          {data.breakdowns.revenueByService.map(row=><tr key={row.serviceCode}><td><b>{row.serviceCode}</b></td><td className="num positive">{money(row.accrued)}</td><td className="num negative">{money(row.reversed)}</td><td className="num"><b>{money(row.net)}</b></td></tr>)}
+          {data.breakdowns.revenueByService.length===0&&<tr><td colSpan={4}>Рухів доходу за період немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Гроші за способом оплати</b><small>Cash — окремий регістр; сторно послуги тут нічого не змінює.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Спосіб</th><th className="num">Надійшло</th><th className="num">Повернено</th><th className="num">Нетто</th></tr></thead><tbody>
+          {data.breakdowns.cashByMethod.map(row=><tr key={row.method}><td>{METHOD_UK[row.method]||row.method||"—"}</td><td className="num positive">{money(row.incoming)}</td><td className="num negative">{money(row.outgoing)}</td><td className="num"><b>{money(row.net)}</b></td></tr>)}
+          {data.breakdowns.cashByMethod.length===0&&<tr><td colSpan={4}>Рухів грошей за період немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Навантаження обладнання</b><small>Фактичні хвилини виконання мінус сторно.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Апарат</th><th className="num">Нараховано хв</th><th className="num">Сторно хв</th><th className="num">Нетто хв</th></tr></thead><tbody>
+          {data.breakdowns.equipment.map(row=><tr key={row.equipmentId}><td><b>{row.equipmentId}</b></td><td className="num">{number(row.loadedMinutes)}</td><td className="num">{number(row.reversedMinutes)}</td><td className="num"><b>{number(row.netMinutes)}</b></td></tr>)}
+          {data.breakdowns.equipment.length===0&&<tr><td colSpan={4}>Рухів обладнання за період немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Виробіток персоналу</b><small>Проведені одиниці мінус сторно.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Працівник</th><th>Роль</th><th className="num">Виконано</th><th className="num">Сторно</th><th className="num">Нетто</th></tr></thead><tbody>
+          {data.breakdowns.staff.map(row=><tr key={`${row.memberEmail}-${row.staffRole}`}><td><b>{row.memberEmail}</b></td><td>{ROLE_UK[row.staffRole]||row.staffRole}</td><td className="num">{number(row.performed)}</td><td className="num">{number(row.reversed)}</td><td className="num"><b>{number(row.net)}</b></td></tr>)}
+          {data.breakdowns.staff.length===0&&<tr><td colSpan={5}>Рухів персоналу за період немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Склад: обороти і залишки</b><small>Залишок рахується з `inventory_movements`, а не з поля “поточна кількість”.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Матеріал</th><th>Од.</th><th className="num">На початок</th><th className="num">Надійшло</th><th className="num">Вибуло</th><th className="num">На кінець</th></tr></thead><tbody>
+          {data.breakdowns.inventory.map(row=><tr key={row.itemId}><td><b>{row.name}</b><small>{row.sku||`#${row.itemId}`}</small></td><td>{row.unit}</td><td className="num">{number(row.opening)}</td><td className="num positive">{number(row.incoming)}</td><td className="num negative">{number(row.outgoing)}</td><td className="num"><b>{number(row.closing)}</b></td></tr>)}
+          {data.breakdowns.inventory.length===0&&<tr><td colSpan={6}>Складських рухів і залишків немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+    </>}
+  </StaffWorkspaceShell>;
+}

--- a/docs/bas-register-turnover-report.md
+++ b/docs/bas-register-turnover-report.md
@@ -1,0 +1,23 @@
+# BAS register turnover and balance report
+
+`/staff/reports/registers` is a read-only report layer over immutable movement ledgers. It deliberately does not calculate finance from bookings or manually maintained KPI fields.
+
+## Period semantics
+
+The report accepts an inclusive `from` / `to` calendar period up to 366 days. A movement belongs to the period by its own registrar timestamp. Therefore a service performed in one period and storno posted in another correctly appear in different turnovers.
+
+## Registers
+
+- Revenue: accrued service revenue, storno, net turnover.
+- Cash: incoming payments, outgoing refunds, net cash movement.
+- Patient settlements: opening balance, increases, decreases, period net, closing balance. Positive balance means patients owe the organization; negative means patient credit.
+- Services: performed service count and storno count, including net anatomical regions.
+- Equipment load: positive performed minutes and negative storno minutes.
+- Staff output: performed units and storno units.
+- Inventory: opening quantity, receipts, issues, closing quantity per item/unit.
+
+## Boundaries
+
+Service storno changes revenue/settlements/operations but never cash. Refund changes cash and settlements but is a separate document. The report preserves that separation because each number comes from its own register.
+
+The report is aggregate and currently uses the existing `canViewReports` authority (`admin`). All queries are tenant-scoped. No report endpoint mutates documents, balances or movements.

--- a/lib/register-turnover-report.ts
+++ b/lib/register-turnover-report.ts
@@ -1,0 +1,163 @@
+const DATE_RE=/^\d{4}-\d{2}-\d{2}$/;
+
+export type RegisterPeriod={from:string;to:string};
+
+function validDate(value:string) {
+  if(!DATE_RE.test(value))return false;
+  const d=new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(d.getTime())&&d.toISOString().slice(0,10)===value;
+}
+
+export function normalizeRegisterPeriod(fromValue:unknown,toValue:unknown):RegisterPeriod {
+  const from=typeof fromValue==="string"?fromValue.trim():"";
+  const to=typeof toValue==="string"?toValue.trim():"";
+  if(!validDate(from)||!validDate(to)||from>to)throw new Error("invalid_report_period");
+  const days=Math.floor((Date.parse(`${to}T00:00:00Z`)-Date.parse(`${from}T00:00:00Z`))/86400000)+1;
+  if(days>366)throw new Error("report_period_too_large");
+  return {from,to};
+}
+
+type Turnover={increase:number;decrease:number;net:number};
+type BalanceTurnover=Turnover&{opening:number;closing:number};
+
+async function deltaTurnover(
+  db:D1Database,table:string,column:string,organizationId:number,period:RegisterPeriod,dateColumn="occurred_at",
+):Promise<Turnover> {
+  const row=await db.prepare(
+    `SELECT
+       COALESCE(SUM(CASE WHEN ${column}>0 THEN ${column} ELSE 0 END),0) AS increase,
+       COALESCE(SUM(CASE WHEN ${column}<0 THEN -${column} ELSE 0 END),0) AS decrease,
+       COALESCE(SUM(${column}),0) AS net
+     FROM ${table}
+     WHERE organization_id=? AND substr(${dateColumn},1,10) BETWEEN ? AND ?`
+  ).bind(organizationId,period.from,period.to).first<Turnover>();
+  return {increase:Number(row?.increase||0),decrease:Number(row?.decrease||0),net:Number(row?.net||0)};
+}
+
+async function settlementTurnover(db:D1Database,organizationId:number,period:RegisterPeriod):Promise<BalanceTurnover> {
+  const row=await db.prepare(
+    `SELECT
+       COALESCE(SUM(CASE WHEN substr(occurred_at,1,10)<? THEN amount_delta ELSE 0 END),0) AS opening,
+       COALESCE(SUM(CASE WHEN substr(occurred_at,1,10) BETWEEN ? AND ? AND amount_delta>0 THEN amount_delta ELSE 0 END),0) AS increase,
+       COALESCE(SUM(CASE WHEN substr(occurred_at,1,10) BETWEEN ? AND ? AND amount_delta<0 THEN -amount_delta ELSE 0 END),0) AS decrease,
+       COALESCE(SUM(CASE WHEN substr(occurred_at,1,10)<=? THEN amount_delta ELSE 0 END),0) AS closing
+     FROM patient_settlement_movements WHERE organization_id=?`
+  ).bind(period.from,period.from,period.to,period.from,period.to,period.to,organizationId).first<BalanceTurnover>();
+  const opening=Number(row?.opening||0),increase=Number(row?.increase||0),decrease=Number(row?.decrease||0),closing=Number(row?.closing||0);
+  return {opening,increase,decrease,net:increase-decrease,closing};
+}
+
+async function serviceTurnover(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const row=await db.prepare(
+    `SELECT
+       COALESCE(SUM(CASE WHEN quantity_delta>0 THEN quantity_delta ELSE 0 END),0) AS increase,
+       COALESCE(SUM(CASE WHEN quantity_delta<0 THEN -quantity_delta ELSE 0 END),0) AS decrease,
+       COALESCE(SUM(quantity_delta),0) AS net,
+       COALESCE(SUM(regions_delta),0) AS regionsNet
+     FROM (
+       SELECT quantity AS quantity_delta,anatomical_regions_count AS regions_delta,occurred_at
+       FROM services_delivered_movements WHERE organization_id=?
+       UNION ALL
+       SELECT quantity_delta,anatomical_regions_delta AS regions_delta,occurred_at
+       FROM service_correction_movements WHERE organization_id=?
+     ) x
+     WHERE substr(occurred_at,1,10) BETWEEN ? AND ?`
+  ).bind(organizationId,organizationId,period.from,period.to).first<Turnover&{regionsNet:number}>();
+  return {
+    increase:Number(row?.increase||0),decrease:Number(row?.decrease||0),net:Number(row?.net||0),regionsNet:Number(row?.regionsNet||0),
+  };
+}
+
+async function inventoryBalances(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT i.id AS itemId,i.sku,i.name,i.unit,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10)<? THEN m.quantity_delta ELSE 0 END),0) AS opening,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10) BETWEEN ? AND ? AND m.quantity_delta>0 THEN m.quantity_delta ELSE 0 END),0) AS incoming,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10) BETWEEN ? AND ? AND m.quantity_delta<0 THEN -m.quantity_delta ELSE 0 END),0) AS outgoing,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10)<=? THEN m.quantity_delta ELSE 0 END),0) AS closing
+     FROM inventory_items i
+     LEFT JOIN inventory_movements m
+       ON m.organization_id=i.organization_id AND m.item_id=i.id AND substr(m.created_at,1,10)<=?
+     WHERE i.organization_id=?
+     GROUP BY i.id,i.sku,i.name,i.unit
+     HAVING opening<>0 OR incoming<>0 OR outgoing<>0 OR closing<>0
+     ORDER BY i.name,i.id LIMIT 300`
+  ).bind(
+    period.from,period.from,period.to,period.from,period.to,period.to,period.to,organizationId,
+  ).all();
+  return rows.results;
+}
+
+async function revenueByService(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT service_code AS serviceCode,
+       COALESCE(SUM(CASE WHEN amount_delta>0 THEN amount_delta ELSE 0 END),0) AS accrued,
+       COALESCE(SUM(CASE WHEN amount_delta<0 THEN -amount_delta ELSE 0 END),0) AS reversed,
+       COALESCE(SUM(amount_delta),0) AS net
+     FROM revenue_movements
+     WHERE organization_id=? AND substr(occurred_at,1,10) BETWEEN ? AND ?
+     GROUP BY service_code ORDER BY ABS(net) DESC,service_code LIMIT 100`
+  ).bind(organizationId,period.from,period.to).all();
+  return rows.results;
+}
+
+async function cashByMethod(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT method,
+       COALESCE(SUM(CASE WHEN amount_delta>0 THEN amount_delta ELSE 0 END),0) AS incoming,
+       COALESCE(SUM(CASE WHEN amount_delta<0 THEN -amount_delta ELSE 0 END),0) AS outgoing,
+       COALESCE(SUM(amount_delta),0) AS net
+     FROM cash_movements
+     WHERE organization_id=? AND substr(occurred_at,1,10) BETWEEN ? AND ?
+     GROUP BY method ORDER BY ABS(net) DESC,method LIMIT 50`
+  ).bind(organizationId,period.from,period.to).all();
+  return rows.results;
+}
+
+async function equipmentByUnit(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT equipment_id AS equipmentId,
+       COALESCE(SUM(CASE WHEN minutes_delta>0 THEN minutes_delta ELSE 0 END),0) AS loadedMinutes,
+       COALESCE(SUM(CASE WHEN minutes_delta<0 THEN -minutes_delta ELSE 0 END),0) AS reversedMinutes,
+       COALESCE(SUM(minutes_delta),0) AS netMinutes
+     FROM equipment_load_movements
+     WHERE organization_id=? AND substr(occurred_at,1,10) BETWEEN ? AND ?
+     GROUP BY equipment_id ORDER BY ABS(netMinutes) DESC,equipment_id LIMIT 100`
+  ).bind(organizationId,period.from,period.to).all();
+  return rows.results;
+}
+
+async function staffByMember(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT member_email AS memberEmail,staff_role AS staffRole,
+       COALESCE(SUM(CASE WHEN units_delta>0 THEN units_delta ELSE 0 END),0) AS performed,
+       COALESCE(SUM(CASE WHEN units_delta<0 THEN -units_delta ELSE 0 END),0) AS reversed,
+       COALESCE(SUM(units_delta),0) AS net
+     FROM staff_output_movements
+     WHERE organization_id=? AND substr(occurred_at,1,10) BETWEEN ? AND ?
+     GROUP BY member_email,staff_role ORDER BY ABS(net) DESC,member_email LIMIT 200`
+  ).bind(organizationId,period.from,period.to).all();
+  return rows.results;
+}
+
+export async function buildRegisterTurnoverReport(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const [revenue,cash,settlements,services,equipment,staff,inventory,revenueServices,cashMethods,equipmentRows,staffRows]=await Promise.all([
+    deltaTurnover(db,"revenue_movements","amount_delta",organizationId,period),
+    deltaTurnover(db,"cash_movements","amount_delta",organizationId,period),
+    settlementTurnover(db,organizationId,period),
+    serviceTurnover(db,organizationId,period),
+    deltaTurnover(db,"equipment_load_movements","minutes_delta",organizationId,period),
+    deltaTurnover(db,"staff_output_movements","units_delta",organizationId,period),
+    inventoryBalances(db,organizationId,period),
+    revenueByService(db,organizationId,period),
+    cashByMethod(db,organizationId,period),
+    equipmentByUnit(db,organizationId,period),
+    staffByMember(db,organizationId,period),
+  ]);
+  return {
+    period,
+    generatedAt:new Date().toISOString(),
+    registers:{revenue,cash,settlements,services,equipment,staff},
+    breakdowns:{revenueByService:revenueServices,cashByMethod:cashMethods,equipment:equipmentRows,staff:staffRows,inventory},
+  };
+}

--- a/tests/register-turnover-report.behavior.test.mjs
+++ b/tests/register-turnover-report.behavior.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompleted(db,{organizationId=1,code,amount=0,category="civilian",performedAt,duration=30,regions=2}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,?,'+380501112233','380501112233','КТ ОГК','ct-chest','ct',?,
+       ?,? ,?,'pending',?,0,'confirmed',?,'turnover-doctor@example.com','turnover-tech@example.com')`
+  ).bind(
+    organizationId,code,`Patient ${code}`,duration,performedAt.slice(0,10),performedAt.slice(11,16),category,amount,regions,
+  ).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    "UPDATE bookings SET performed_at=?,status='completed' WHERE organization_id=? AND id=?"
+  ).bind(performedAt,organizationId,bookingId).run();
+  return bookingId;
+}
+
+async function serviceDocumentId(db,organizationId,bookingId) {
+  const row=await db.prepare(
+    `SELECT d.id FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery' LIMIT 1`
+  ).bind(organizationId,bookingId).first();
+  return Number(row.id);
+}
+
+async function pay(db,cookie,bookingId,reference) {
+  return callWorker(jsonRequest("/api/staff/payments",{
+    bookingId,method:"bank_transfer",providerReference:reference,
+  },{headers:{cookie}}),db);
+}
+
+async function refund(db,cookie,bookingId) {
+  return callWorker(new Request("http://localhost/api/staff/payments",{
+    method:"DELETE",headers:{"content-type":"application/json",cookie},body:JSON.stringify({bookingId}),
+  }),db);
+}
+
+async function storno(db,cookie,sourceDocumentId) {
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{
+    sourceDocumentId,reason:"Сторно для оборотно-сальдового звіту",
+  },{headers:{cookie}}),db);
+}
+
+async function report(db,cookie,from="2026-08-01",to="2026-08-31") {
+  return callWorker(new Request(`http://localhost/api/staff/reports/registers?from=${from}&to=${to}`,{headers:{cookie}}),db);
+}
+
+async function seedInventory(db,organizationId=1) {
+  const itemResult=await db.prepare(
+    `INSERT INTO inventory_items (organization_id,sku,name,category,unit,min_stock,active)
+     VALUES (?,'TURN-ITEM','Контраст тестовий','contrast','фл',0,1)`
+  ).bind(organizationId).run();
+  const itemId=Number(itemResult.meta.last_row_id);
+  const lotResult=await db.prepare(
+    `INSERT INTO inventory_lots (organization_id,item_id,lot_number,expires_on,supplier)
+     VALUES (?,?,'TURN-LOT','2027-12-31','Test Supplier')`
+  ).bind(organizationId,itemId).run();
+  const lotId=Number(lotResult.meta.last_row_id);
+  for(const movement of [
+    {date:"2026-07-31 09:00:00",delta:10,type:"receipt"},
+    {date:"2026-08-05 09:00:00",delta:5,type:"receipt"},
+    {date:"2026-08-10 09:00:00",delta:-3,type:"writeoff"},
+  ]){
+    await db.prepare(
+      `INSERT INTO inventory_movements
+       (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,actor_email,created_at)
+       VALUES (?,?,?,?,?,'turnover test','turnover@example.com',?)`
+    ).bind(organizationId,itemId,lotId,movement.type,movement.delta,movement.date).run();
+  }
+  return itemId;
+}
+
+test("register report derives opening, period turnovers and closing balances from immutable movements",async()=>{
+  await withD1(async(db)=>{
+    const admin=await seedStaffSession(db,{email:"turnover-admin@example.com",role:"admin",organizationId:1});
+
+    // Previous-period unpaid civilian service creates opening patient debt of 1000.
+    await seedCompleted(db,{code:"RD-TURN-JUL",amount:1000,performedAt:"2026-07-31T10:00:00",duration:25,regions:1});
+
+    // August civilian service is fully neutralized by payment + refund + service storno.
+    const civilian=await seedCompleted(db,{code:"RD-TURN-AUG",amount:3000,performedAt:"2026-08-10T10:00:00",duration:30,regions:2});
+    const paid=await pay(db,admin,civilian,"TURNOVER-PAY");
+    assert.equal(paid.status,200);
+    const returned=await refund(db,admin,civilian);
+    assert.equal(returned.status,200);
+    const sourceId=await serviceDocumentId(db,1,civilian);
+    const reversed=await storno(db,admin,sourceId);
+    assert.equal(reversed.status,201);
+
+    // Military service has operational movements but no revenue/settlement charge.
+    await seedCompleted(db,{code:"RD-TURN-MIL",amount:5000,category:"military",performedAt:"2026-08-12T12:00:00",duration:20,regions:1});
+    const itemId=await seedInventory(db);
+
+    const response=await report(db,admin);
+    assert.equal(response.status,200);
+    const body=await response.json();
+
+    assert.deepEqual(body.period,{from:"2026-08-01",to:"2026-08-31"});
+    assert.equal(body.registers.revenue.increase,3000);
+    assert.equal(body.registers.revenue.decrease,3000);
+    assert.equal(body.registers.revenue.net,0);
+    assert.equal(body.registers.cash.increase,3000);
+    assert.equal(body.registers.cash.decrease,3000);
+    assert.equal(body.registers.cash.net,0);
+
+    assert.equal(body.registers.settlements.opening,1000);
+    assert.equal(body.registers.settlements.increase,6000); // service charge + refund
+    assert.equal(body.registers.settlements.decrease,6000); // payment + service storno
+    assert.equal(body.registers.settlements.net,0);
+    assert.equal(body.registers.settlements.closing,1000);
+
+    assert.equal(body.registers.services.increase,2);
+    assert.equal(body.registers.services.decrease,1);
+    assert.equal(body.registers.services.net,1);
+    assert.equal(body.registers.services.regionsNet,1);
+    assert.equal(body.registers.equipment.increase,50);
+    assert.equal(body.registers.equipment.decrease,30);
+    assert.equal(body.registers.equipment.net,20);
+    assert.equal(body.registers.staff.increase,4);
+    assert.equal(body.registers.staff.decrease,2);
+    assert.equal(body.registers.staff.net,2);
+
+    const revenue=body.breakdowns.revenueByService.find(row=>row.serviceCode==="ct-chest");
+    assert.equal(revenue.accrued,3000);
+    assert.equal(revenue.reversed,3000);
+    assert.equal(revenue.net,0);
+    const cash=body.breakdowns.cashByMethod.find(row=>row.method==="bank_transfer");
+    assert.equal(cash.incoming,3000);
+    assert.equal(cash.outgoing,3000);
+    assert.equal(cash.net,0);
+    const equipment=body.breakdowns.equipment.find(row=>row.equipmentId==="ct");
+    assert.equal(equipment.netMinutes,20);
+    assert.ok(body.breakdowns.staff.every(row=>row.net===1));
+
+    const stock=body.breakdowns.inventory.find(row=>row.itemId===itemId);
+    assert.equal(stock.opening,10);
+    assert.equal(stock.incoming,5);
+    assert.equal(stock.outgoing,3);
+    assert.equal(stock.closing,12);
+  });
+});
+
+test("register report is tenant scoped and excludes another organization movements",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Turnover Org 2','turnover-org-2',1)");
+    const org1=await seedStaffSession(db,{email:"turnover-org1@example.com",role:"admin",organizationId:1});
+    const org2=await seedStaffSession(db,{email:"turnover-org2@example.com",role:"admin",organizationId:2});
+    await seedCompleted(db,{organizationId:1,code:"RD-TURN-ORG1",amount:1200,performedAt:"2026-08-05T10:00:00",regions:1});
+    await seedCompleted(db,{organizationId:2,code:"RD-TURN-ORG2",amount:8800,performedAt:"2026-08-05T10:00:00",regions:1});
+
+    const one=await report(db,org1);const oneBody=await one.json();
+    const two=await report(db,org2);const twoBody=await two.json();
+    assert.equal(oneBody.registers.revenue.net,1200);
+    assert.equal(twoBody.registers.revenue.net,8800);
+  });
+});
+
+test("register report rejects invalid or excessive periods",async()=>{
+  await withD1(async(db)=>{
+    const admin=await seedStaffSession(db,{email:"turnover-period@example.com",role:"admin",organizationId:1});
+    assert.equal((await report(db,admin,"2026-08-31","2026-08-01")).status,400);
+    assert.equal((await report(db,admin,"2025-01-01","2026-08-31")).status,400);
+    assert.equal((await report(db,admin,"bad","2026-08-31")).status,400);
+  });
+});
+
+test("register report remains restricted to report authority",async()=>{
+  await withD1(async(db)=>{
+    const registrar=await seedStaffSession(db,{email:"turnover-registrar@example.com",role:"registrar",organizationId:1});
+    const doctor=await seedStaffSession(db,{email:"turnover-doctor-role@example.com",role:"radiologist",organizationId:1});
+    assert.equal((await report(db,registrar)).status,403);
+    assert.equal((await report(db,doctor)).status,403);
+  });
+});


### PR DESCRIPTION
## Goal
Close the BAS chain `Document -> Register -> Report` with period-aware turnovers and balances calculated directly from immutable movement ledgers.

## Implemented
- `/staff/reports/registers` BAS-style turnover/balance report
- inclusive period filter up to 366 days
- revenue accrued / storno / net from `revenue_movements`
- cash incoming / refunds / net from `cash_movements`
- patient settlement opening / increase / decrease / net / closing balance
- service performed / storno / net count and net anatomical regions
- equipment loaded / reversed / net minutes
- staff performed / reversed / net units
- inventory opening / receipts / issues / closing quantity per item/unit
- breakdowns by service, payment method, equipment and staff member
- finance workspace link to the admin-only report

## Accounting boundary
- service storno never changes cash
- refund remains a separate cash/settlement movement
- positive patient balance means debt to organization; negative means patient credit
- report values come from register movements, not booking/payment status fields or manual KPI totals

## Verification
- previous-period unpaid service becomes opening patient balance — covered
- August service + payment + refund + storno nets correctly by register — covered
- military service adds operational movements without revenue/debt — covered
- inventory 10 opening +5 receipt -3 issue =12 closing — covered
- tenant isolation — covered
- invalid/excessive period rejection — covered
- report-role restriction — covered
- CI #1038 — success on exact head `cc35d3e7d093febb804dccbc9f9bdd6211e45f24`
- CodeQL #953 — success on exact head
- final manual review: read-only report, tenant-scoped queries, movement-ledgers remain the only report source

## Boundary
- read-only report layer
- no production deploy