### PR TITLE
Add BAS Patient Order as commercial document root

### DIFF
--- a/docs/bas-patient-order-root.md
+++ b/docs/bas-patient-order-root.md
@@ -1,0 +1,54 @@
+# BAS Patient Order root
+
+`patient_order` (`ЗП-xxxxxx`) is the commercial root for every **new** booking created after this migration. Existing historical bookings are not backfilled: RadiologyOS does not invent retrospective business documents.
+
+## Lifecycle
+
+1. Inserting a new booking automatically creates one draft Patient Order in D1.
+2. While the order is draft, commercial booking fields keep its typed snapshot synchronized.
+3. The first posted payment or completed study posts/freezes the Patient Order.
+4. After the order is posted, commercial terms cannot drift through booking edits. Appointment time may still be rescheduled because scheduling is not a commercial order term.
+5. A service-delivery registrar then points to the Patient Order as its canonical basis.
+
+## Canonical document basis
+
+`business_documents.basis_document_id` is a tenant-scoped, immutable part of document identity after posting.
+
+For the new BAS contour:
+
+- `patient_order` → no basis;
+- `payment` → Patient Order;
+- `service_delivery` → Patient Order;
+- `refund` → source Payment;
+- `service_correction` → source Service Delivery.
+
+Typed D1 triggers assign and validate those links. API code does not get to invent the graph. Legacy bookings without a Patient Order may continue to create legacy-compatible payment/service registrars with no order basis; no automatic historical adoption is performed.
+
+## Patient Order snapshot
+
+The typed detail stores the business terms needed to explain downstream finance/operations:
+
+- booking id;
+- patient id when already known;
+- patient category;
+- service code/title;
+- equipment;
+- duration;
+- price;
+- charge amount (`0` for military/free route);
+- currency.
+
+Appointment date/time deliberately stays outside this immutable commercial snapshot so a paid patient can be rescheduled without rewriting the order.
+
+## Security and integrity
+
+- one Patient Order per tenant/booking;
+- basis cannot cross tenants or self-reference;
+- wrong basis type is rejected by D1;
+- payment/service basis must match the exact booking's Patient Order;
+- refund basis must be the source payment;
+- storno basis must be the exact source service-delivery document;
+- typed basis is frozen once its detail exists;
+- after posting, generic document immutability also freezes both `basis_document_id` and `reversed_document_id`.
+
+The unified business-document journal reads this same basis field to show the document tree without maintaining a second relation store.

--- a/drizzle/0073_patient_order_root.sql
+++ b/drizzle/0073_patient_order_root.sql
@@ -1,0 +1,396 @@
+-- BAS commercial root: every new booking receives one Patient Order (Замовлення пацієнта).
+-- Historical bookings are deliberately NOT backfilled: no retrospective business facts are invented.
+
+ALTER TABLE `business_documents` ADD COLUMN `basis_document_id` integer;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `business_documents_basis_idx`
+  ON `business_documents` (`organization_id`,`basis_document_id`,`id`)
+  WHERE `basis_document_id` IS NOT NULL;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `patient_order_details` (
+  `organization_id` integer NOT NULL,
+  `document_id` integer NOT NULL,
+  `booking_id` integer NOT NULL,
+  `patient_id` text DEFAULT '' NOT NULL,
+  `patient_category` text DEFAULT '' NOT NULL,
+  `service_code` text NOT NULL,
+  `service_title` text NOT NULL,
+  `equipment_id` text NOT NULL,
+  `duration_minutes` integer NOT NULL CHECK (`duration_minutes` > 0),
+  `price_amount` integer DEFAULT 0 NOT NULL CHECK (`price_amount` >= 0),
+  `charge_amount` integer DEFAULT 0 NOT NULL CHECK (`charge_amount` >= 0),
+  `currency` text DEFAULT 'UAH' NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`document_id`),
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`booking_id`) REFERENCES `bookings`(`id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `patient_order_booking_unique`
+  ON `patient_order_details` (`organization_id`,`booking_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `patient_order_patient_idx`
+  ON `patient_order_details` (`organization_id`,`patient_id`,`document_id` DESC);
+--> statement-breakpoint
+
+-- Generic basis is part of document identity and must remain inside the tenant.
+CREATE TRIGGER IF NOT EXISTS `business_document_basis_tenant_insert`
+BEFORE INSERT ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'business_document_basis_tenant_mismatch') END;
+  SELECT CASE WHEN NEW.id IS NOT NULL AND NEW.id=NEW.basis_document_id
+    THEN RAISE(ABORT,'business_document_basis_self_reference') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `business_document_basis_tenant_update`
+BEFORE UPDATE OF `basis_document_id`,`organization_id` ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'business_document_basis_tenant_mismatch') END;
+  SELECT CASE WHEN NEW.id=NEW.basis_document_id
+    THEN RAISE(ABORT,'business_document_basis_self_reference') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `business_document_basis_type_insert`
+BEFORE INSERT ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.document_type='payment' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.document_type='patient_order'
+  ) THEN RAISE(ABORT,'payment_basis_must_be_patient_order') END;
+  SELECT CASE WHEN NEW.document_type='refund' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.document_type='payment'
+  ) THEN RAISE(ABORT,'refund_basis_must_be_payment') END;
+  SELECT CASE WHEN NEW.document_type='service_delivery' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.document_type IN ('patient_order','service_delivery')
+  ) THEN RAISE(ABORT,'service_delivery_basis_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `business_document_basis_type_update`
+BEFORE UPDATE OF `basis_document_id`,`document_type`,`organization_id` ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.document_type='payment' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.document_type='patient_order'
+  ) THEN RAISE(ABORT,'payment_basis_must_be_patient_order') END;
+  SELECT CASE WHEN NEW.document_type='refund' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.document_type='payment'
+  ) THEN RAISE(ABORT,'refund_basis_must_be_payment') END;
+  SELECT CASE WHEN NEW.document_type='service_delivery' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.document_type IN ('patient_order','service_delivery')
+  ) THEN RAISE(ABORT,'service_delivery_basis_invalid') END;
+END;
+--> statement-breakpoint
+
+-- basis_document_id and reversed_document_id are immutable evidence after posting too.
+DROP TRIGGER IF EXISTS `business_documents_immutable_after_draft`;
+--> statement-breakpoint
+CREATE TRIGGER `business_documents_immutable_after_draft`
+BEFORE UPDATE ON `business_documents`
+WHEN OLD.state <> 'draft'
+BEGIN
+  SELECT CASE WHEN NOT (
+    OLD.state='posted' AND NEW.state='reversed'
+    AND NEW.organization_id=OLD.organization_id
+    AND NEW.document_type=OLD.document_type
+    AND NEW.number=OLD.number
+    AND NEW.occurred_at=OLD.occurred_at
+    AND NEW.comment=OLD.comment
+    AND NEW.created_by=OLD.created_by
+    AND NEW.created_at=OLD.created_at
+    AND NEW.posted_by=OLD.posted_by
+    AND NEW.posted_at=OLD.posted_at
+    AND NEW.reversed_document_id IS OLD.reversed_document_id
+    AND NEW.basis_document_id IS OLD.basis_document_id
+  ) THEN RAISE(ABORT,'business_document_immutable') END;
+END;
+--> statement-breakpoint
+
+-- Patient-order details are an exact mutable snapshot only while the order is draft.
+CREATE TRIGGER IF NOT EXISTS `patient_order_details_integrity_insert`
+BEFORE INSERT ON `patient_order_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='patient_order' AND d.state='draft' AND d.basis_document_id IS NULL
+  ) THEN RAISE(ABORT,'patient_order_document_invalid') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id
+      AND b.patient_id=NEW.patient_id
+      AND b.patient_category=NEW.patient_category
+      AND b.service_code=NEW.service_code
+      AND b.service=NEW.service_title
+      AND b.equipment_id=NEW.equipment_id
+      AND b.duration_minutes=NEW.duration_minutes
+      AND b.payment_amount=NEW.price_amount
+      AND NEW.charge_amount=CASE WHEN b.patient_category='civilian' THEN b.payment_amount ELSE 0 END
+  ) THEN RAISE(ABORT,'patient_order_booking_snapshot_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_order_details_integrity_update`
+BEFORE UPDATE ON `patient_order_details`
+BEGIN
+  SELECT CASE WHEN NEW.organization_id<>OLD.organization_id OR NEW.document_id<>OLD.document_id OR NEW.booking_id<>OLD.booking_id
+    THEN RAISE(ABORT,'patient_order_identity_immutable') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id
+      AND d.document_type='patient_order' AND d.state='draft'
+  ) THEN RAISE(ABORT,'patient_order_not_draft') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM bookings b
+    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id
+      AND b.patient_id=NEW.patient_id
+      AND b.patient_category=NEW.patient_category
+      AND b.service_code=NEW.service_code
+      AND b.service=NEW.service_title
+      AND b.equipment_id=NEW.equipment_id
+      AND b.duration_minutes=NEW.duration_minutes
+      AND b.payment_amount=NEW.price_amount
+      AND NEW.charge_amount=CASE WHEN b.patient_category='civilian' THEN b.payment_amount ELSE 0 END
+  ) THEN RAISE(ABORT,'patient_order_booking_snapshot_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `patient_order_details_no_delete_posted`
+BEFORE DELETE ON `patient_order_details`
+WHEN NOT EXISTS (
+  SELECT 1 FROM business_documents d
+  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+)
+BEGIN SELECT RAISE(ABORT,'patient_order_not_draft'); END;
+--> statement-breakpoint
+
+-- Every new booking gets exactly one draft Patient Order. Existing bookings are untouched by migration.
+CREATE TRIGGER IF NOT EXISTS `booking_patient_order_auto_create`
+AFTER INSERT ON `bookings`
+WHEN NOT EXISTS (
+  SELECT 1 FROM patient_order_details o WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.id
+)
+BEGIN
+  INSERT INTO business_documents
+    (organization_id,document_type,number,occurred_at,state,comment,created_by)
+  VALUES (
+    NEW.organization_id,'patient_order','',NEW.created_at,'draft',
+    'Автоматично з заявки '||NEW.code,'system:booking'
+  );
+  UPDATE business_documents
+  SET number=printf('ЗП-%06d',id)
+  WHERE id=last_insert_rowid() AND organization_id=NEW.organization_id
+    AND document_type='patient_order' AND state='draft' AND number='';
+  INSERT INTO patient_order_details
+    (organization_id,document_id,booking_id,patient_id,patient_category,service_code,service_title,
+     equipment_id,duration_minutes,price_amount,charge_amount,currency)
+  VALUES (
+    NEW.organization_id,last_insert_rowid(),NEW.id,NEW.patient_id,NEW.patient_category,
+    NEW.service_code,NEW.service,NEW.equipment_id,NEW.duration_minutes,NEW.payment_amount,
+    CASE WHEN NEW.patient_category='civilian' THEN NEW.payment_amount ELSE 0 END,'UAH'
+  );
+END;
+--> statement-breakpoint
+
+-- Before the first downstream economic fact, booking changes keep the draft order snapshot in sync.
+CREATE TRIGGER IF NOT EXISTS `booking_patient_order_sync_draft`
+AFTER UPDATE OF `patient_id`,`patient_category`,`service`,`service_code`,`equipment_id`,`duration_minutes`,`payment_amount`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1 FROM patient_order_details o
+  JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+  WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.id AND d.state='draft'
+)
+BEGIN
+  UPDATE patient_order_details
+  SET patient_id=NEW.patient_id,
+      patient_category=NEW.patient_category,
+      service_code=NEW.service_code,
+      service_title=NEW.service,
+      equipment_id=NEW.equipment_id,
+      duration_minutes=NEW.duration_minutes,
+      price_amount=NEW.payment_amount,
+      charge_amount=CASE WHEN NEW.patient_category='civilian' THEN NEW.payment_amount ELSE 0 END
+  WHERE organization_id=NEW.organization_id AND booking_id=NEW.id;
+END;
+--> statement-breakpoint
+
+-- Completion freezes/posts the order before the service-delivery AFTER trigger runs.
+CREATE TRIGGER IF NOT EXISTS `booking_patient_order_post_before_completion`
+BEFORE UPDATE OF `status`,`performed_at` ON `bookings`
+WHEN NEW.status='completed' AND NEW.performed_at<>''
+  AND EXISTS (
+    SELECT 1 FROM patient_order_details o
+    JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+    WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.id AND d.state='draft'
+  )
+BEGIN
+  UPDATE patient_order_details
+  SET patient_id=NEW.patient_id,
+      patient_category=NEW.patient_category,
+      service_code=NEW.service_code,
+      service_title=NEW.service,
+      equipment_id=NEW.equipment_id,
+      duration_minutes=NEW.duration_minutes,
+      price_amount=NEW.payment_amount,
+      charge_amount=CASE WHEN NEW.patient_category='civilian' THEN NEW.payment_amount ELSE 0 END
+  WHERE organization_id=NEW.organization_id AND booking_id=NEW.id;
+
+  UPDATE business_documents
+  SET state='posted',posted_by='system:execution',posted_at=CURRENT_TIMESTAMP
+  WHERE organization_id=NEW.organization_id AND document_type='patient_order' AND state='draft'
+    AND id=(SELECT document_id FROM patient_order_details WHERE organization_id=NEW.organization_id AND booking_id=NEW.id LIMIT 1);
+END;
+--> statement-breakpoint
+
+-- Once the order is posted, its commercial terms cannot drift through later booking edits.
+CREATE TRIGGER IF NOT EXISTS `booking_posted_patient_order_terms_immutable`
+BEFORE UPDATE OF `patient_category`,`service`,`service_code`,`equipment_id`,`duration_minutes`,`payment_amount`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1 FROM patient_order_details o
+  JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+  WHERE o.organization_id=OLD.organization_id AND o.booking_id=OLD.id AND d.state='posted'
+)
+AND (
+  NEW.organization_id IS NOT OLD.organization_id
+  OR NEW.patient_category IS NOT OLD.patient_category
+  OR NEW.service IS NOT OLD.service
+  OR NEW.service_code IS NOT OLD.service_code
+  OR NEW.equipment_id IS NOT OLD.equipment_id
+  OR NEW.duration_minutes IS NOT OLD.duration_minutes
+  OR NEW.payment_amount IS NOT OLD.payment_amount
+)
+BEGIN SELECT RAISE(ABORT,'patient_order_booking_terms_immutable'); END;
+--> statement-breakpoint
+
+-- A paid booking posts/freezes its order in the same finance posting transaction.
+CREATE TRIGGER IF NOT EXISTS `payment_posts_patient_order`
+AFTER UPDATE OF `state` ON `business_documents`
+WHEN OLD.state='draft' AND NEW.state='posted' AND NEW.document_type='payment' AND NEW.basis_document_id IS NOT NULL
+BEGIN
+  UPDATE business_documents
+  SET state='posted',posted_by=NEW.posted_by,posted_at=NEW.posted_at
+  WHERE id=NEW.basis_document_id AND organization_id=NEW.organization_id
+    AND document_type='patient_order' AND state='draft';
+END;
+--> statement-breakpoint
+
+-- New service-delivery documents created automatically from completed bookings carry the Patient Order as basis.
+DROP TRIGGER IF EXISTS `booking_service_delivery_auto_post`;
+--> statement-breakpoint
+CREATE TRIGGER `booking_service_delivery_auto_post`
+AFTER UPDATE OF `performed_at`,`status` ON `bookings`
+WHEN NEW.status='completed' AND NEW.performed_at<>''
+  AND NOT EXISTS (
+    SELECT 1 FROM `service_delivery_details` s
+    JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+    WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.id
+      AND d.document_type='service_delivery' AND d.state IN ('draft','posted')
+  )
+BEGIN
+  INSERT INTO `business_documents`
+    (`organization_id`,`document_type`,`number`,`occurred_at`,`state`,`comment`,`created_by`,`basis_document_id`)
+  VALUES (
+    NEW.organization_id,'service_delivery','',NEW.performed_at,'draft',
+    'Автоматично з факту виконання дослідження','system:execution',
+    (SELECT o.document_id FROM patient_order_details o
+     WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.id LIMIT 1)
+  );
+
+  UPDATE `business_documents`
+  SET number=printf('НП-%06d',id)
+  WHERE id=last_insert_rowid() AND organization_id=NEW.organization_id
+    AND document_type='service_delivery' AND state='draft' AND number='';
+
+  INSERT INTO `service_delivery_details`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`patient_category`,`service_code`,`service_title`,
+     `equipment_id`,`duration_minutes`,`anatomical_regions_count`,`performed_at`,`radiologist_email`,
+     `radiographer_email`,`price_amount`,`charge_amount`,`currency`)
+  SELECT
+    NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.patient_category,NEW.service_code,NEW.service,
+    NEW.equipment_id,NEW.duration_minutes,NEW.anatomical_regions_count,NEW.performed_at,
+    NEW.assigned_radiologist_email,NEW.assigned_radiographer_email,NEW.payment_amount,
+    CASE WHEN NEW.patient_category='civilian' THEN NEW.payment_amount ELSE 0 END,'UAH'
+  FROM `business_documents` d
+  WHERE d.id=last_insert_rowid() AND d.organization_id=NEW.organization_id
+    AND d.document_type='service_delivery' AND d.state='draft';
+
+  UPDATE `business_documents`
+  SET state='posted',posted_by='system:execution',posted_at=CURRENT_TIMESTAMP
+  WHERE organization_id=NEW.organization_id AND document_type='service_delivery' AND state='draft'
+    AND id=(
+      SELECT s.document_id FROM `service_delivery_details` s
+      WHERE s.organization_id=NEW.organization_id AND s.booking_id=NEW.id
+      ORDER BY s.document_id DESC LIMIT 1
+    );
+
+  INSERT INTO `services_delivered_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`equipment_id`,`quantity`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.service_code,NEW.equipment_id,1,
+         NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted';
+
+  INSERT INTO `equipment_load_movements`
+    (`organization_id`,`document_id`,`booking_id`,`equipment_id`,`minutes_delta`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.equipment_id,NEW.duration_minutes,NEW.performed_at,
+         'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted';
+
+  INSERT INTO `revenue_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`service_code`,`movement_type`,`amount_delta`,
+     `currency`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,NEW.service_code,'service_delivery',NEW.payment_amount,
+         'UAH','system:execution',NEW.performed_at
+  FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted'
+    AND NEW.patient_category='civilian' AND NEW.payment_amount>0;
+
+  INSERT INTO `patient_settlement_movements`
+    (`organization_id`,`document_id`,`booking_id`,`patient_id`,`movement_type`,`amount_delta`,`currency`,
+     `actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.patient_id,'charge',NEW.payment_amount,'UAH',
+         'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted'
+    AND NEW.patient_category='civilian' AND NEW.payment_amount>0;
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`member_email`,`staff_role`,`units_delta`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.assigned_radiologist_email,'radiologist',1,
+         NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted'
+    AND NEW.assigned_radiologist_email<>'';
+
+  INSERT INTO `staff_output_movements`
+    (`organization_id`,`document_id`,`booking_id`,`member_email`,`staff_role`,`units_delta`,
+     `anatomical_regions_count`,`performed_at`,`actor_email`,`occurred_at`)
+  SELECT NEW.organization_id,d.id,NEW.id,NEW.assigned_radiographer_email,'radiographer',1,
+         NEW.anatomical_regions_count,NEW.performed_at,'system:execution',NEW.performed_at
+  FROM `business_documents` d
+  JOIN `service_delivery_details` s ON s.document_id=d.id AND s.organization_id=d.organization_id
+  WHERE d.organization_id=NEW.organization_id AND d.document_type='service_delivery'
+    AND s.booking_id=NEW.id AND d.state='posted'
+    AND NEW.assigned_radiographer_email<>'';
+END;

--- a/drizzle/0074_patient_order_basis_integrity.sql
+++ b/drizzle/0074_patient_order_basis_integrity.sql
@@ -1,0 +1,124 @@
+-- Typed registrars own their canonical basis. API callers do not get to invent the document graph.
+
+-- New payments are based on the Patient Order when one exists. Legacy bookings without an order
+-- remain basis-less; the migration intentionally performs no retrospective backfill.
+CREATE TRIGGER IF NOT EXISTS `finance_document_assign_basis`
+BEFORE INSERT ON `finance_document_details`
+BEGIN
+  UPDATE business_documents
+  SET basis_document_id=(
+    CASE
+      WHEN document_type='payment' THEN (
+        SELECT o.document_id FROM patient_order_details o
+        WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id LIMIT 1
+      )
+      WHEN document_type='refund' THEN NEW.source_document_id
+      ELSE basis_document_id
+    END
+  )
+  WHERE id=NEW.document_id AND organization_id=NEW.organization_id
+    AND state='draft' AND basis_document_id IS NULL;
+
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='payment'
+  ) AND EXISTS (
+    SELECT 1 FROM patient_order_details o
+    WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id
+  ) AND NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    JOIN patient_order_details o ON o.document_id=d.basis_document_id AND o.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='payment' AND o.booking_id=NEW.booking_id
+  ) THEN RAISE(ABORT,'payment_patient_order_basis_mismatch') END;
+
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='payment'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM patient_order_details o
+    WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id
+  ) AND EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.basis_document_id IS NOT NULL
+  ) THEN RAISE(ABORT,'legacy_payment_basis_forbidden') END;
+
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='refund'
+      AND d.basis_document_id IS NOT NEW.source_document_id
+  ) THEN RAISE(ABORT,'refund_payment_basis_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- A service delivery is based on its Patient Order when the booking belongs to the new BAS contour.
+CREATE TRIGGER IF NOT EXISTS `service_delivery_assign_order_basis`
+BEFORE INSERT ON `service_delivery_details`
+BEGIN
+  UPDATE business_documents
+  SET basis_document_id=(
+    SELECT o.document_id FROM patient_order_details o
+    WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id LIMIT 1
+  )
+  WHERE id=NEW.document_id AND organization_id=NEW.organization_id
+    AND document_type='service_delivery' AND state='draft'
+    AND reversed_document_id IS NULL AND basis_document_id IS NULL
+    AND EXISTS (
+      SELECT 1 FROM patient_order_details o
+      WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id
+    );
+
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM patient_order_details o
+    WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id
+  ) AND NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    JOIN patient_order_details o ON o.document_id=d.basis_document_id AND o.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.reversed_document_id IS NULL
+      AND o.booking_id=NEW.booking_id
+  ) THEN RAISE(ABORT,'service_delivery_patient_order_basis_mismatch') END;
+
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM patient_order_details o
+    WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.booking_id
+  ) AND EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.reversed_document_id IS NULL
+      AND d.basis_document_id IS NOT NULL
+  ) THEN RAISE(ABORT,'legacy_service_delivery_basis_forbidden') END;
+END;
+--> statement-breakpoint
+
+-- Service storno is based on the exact service-delivery document it reverses.
+CREATE TRIGGER IF NOT EXISTS `service_correction_assign_basis`
+BEFORE INSERT ON `service_correction_details`
+BEGIN
+  UPDATE business_documents
+  SET basis_document_id=NEW.source_document_id
+  WHERE id=NEW.document_id AND organization_id=NEW.organization_id
+    AND document_type='service_delivery' AND state='draft'
+    AND reversed_document_id=NEW.source_document_id AND basis_document_id IS NULL;
+
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='service_delivery' AND d.state='draft'
+      AND d.reversed_document_id=NEW.source_document_id
+      AND d.basis_document_id=NEW.source_document_id
+  ) THEN RAISE(ABORT,'service_correction_basis_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- Once a typed detail exists, the draft basis is frozen as part of registrar identity.
+CREATE TRIGGER IF NOT EXISTS `typed_document_basis_draft_frozen`
+BEFORE UPDATE OF `basis_document_id` ON `business_documents`
+WHEN OLD.state='draft' AND OLD.basis_document_id IS NOT NEW.basis_document_id
+  AND (
+    EXISTS (SELECT 1 FROM patient_order_details o WHERE o.document_id=OLD.id AND o.organization_id=OLD.organization_id)
+    OR EXISTS (SELECT 1 FROM finance_document_details f WHERE f.document_id=OLD.id AND f.organization_id=OLD.organization_id)
+    OR EXISTS (SELECT 1 FROM service_delivery_details s WHERE s.document_id=OLD.id AND s.organization_id=OLD.organization_id)
+    OR EXISTS (SELECT 1 FROM service_correction_details c WHERE c.document_id=OLD.id AND c.organization_id=OLD.organization_id)
+  )
+BEGIN SELECT RAISE(ABORT,'business_document_basis_frozen'); END;

--- a/drizzle/0075_patient_order_guard_precedence.sql
+++ b/drizzle/0075_patient_order_guard_precedence.sql
@@ -1,0 +1,28 @@
+-- Patient Order protects commercial terms after payment and before service execution.
+-- Once a service-delivery registrar exists, its stricter execution snapshot guard owns those facts.
+DROP TRIGGER IF EXISTS `booking_posted_patient_order_terms_immutable`;
+--> statement-breakpoint
+CREATE TRIGGER `booking_posted_patient_order_terms_immutable`
+BEFORE UPDATE OF `patient_category`,`service`,`service_code`,`equipment_id`,`duration_minutes`,`payment_amount`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1 FROM patient_order_details o
+  JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+  WHERE o.organization_id=OLD.organization_id AND o.booking_id=OLD.id AND d.state='posted'
+)
+AND NOT EXISTS (
+  SELECT 1 FROM service_delivery_details s
+  JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+  WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id
+    AND d.document_type='service_delivery' AND d.state IN ('posted','reversed')
+)
+AND (
+  NEW.organization_id IS NOT OLD.organization_id
+  OR NEW.patient_category IS NOT OLD.patient_category
+  OR NEW.service IS NOT OLD.service
+  OR NEW.service_code IS NOT OLD.service_code
+  OR NEW.equipment_id IS NOT OLD.equipment_id
+  OR NEW.duration_minutes IS NOT OLD.duration_minutes
+  OR NEW.payment_amount IS NOT OLD.payment_amount
+)
+BEGIN SELECT RAISE(ABORT,'patient_order_booking_terms_immutable'); END;

--- a/drizzle/0076_business_document_basis_guard_order.sql
+++ b/drizzle/0076_business_document_basis_guard_order.sql
@@ -1,0 +1,75 @@
+-- Keep basis validation deterministic inside one trigger. SQLite does not guarantee
+-- an application-level contract for the relative execution order of separate BEFORE triggers.
+-- A missing/cross-tenant basis must therefore be rejected before document-type validation.
+
+DROP TRIGGER IF EXISTS `business_document_basis_tenant_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `business_document_basis_type_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `business_document_basis_tenant_update`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `business_document_basis_type_update`;
+--> statement-breakpoint
+
+CREATE TRIGGER `business_document_basis_integrity_insert`
+BEFORE INSERT ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.id IS NOT NULL AND NEW.id=NEW.basis_document_id
+    THEN RAISE(ABORT,'business_document_basis_self_reference') END;
+
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'business_document_basis_tenant_mismatch') END;
+
+  SELECT CASE WHEN NEW.document_type='payment' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type='patient_order'
+  ) THEN RAISE(ABORT,'payment_basis_must_be_patient_order') END;
+
+  SELECT CASE WHEN NEW.document_type='refund' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type='payment'
+  ) THEN RAISE(ABORT,'refund_basis_must_be_payment') END;
+
+  SELECT CASE WHEN NEW.document_type='service_delivery' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type IN ('patient_order','service_delivery')
+  ) THEN RAISE(ABORT,'service_delivery_basis_invalid') END;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `business_document_basis_integrity_update`
+BEFORE UPDATE OF `basis_document_id`,`document_type`,`organization_id` ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.id=NEW.basis_document_id
+    THEN RAISE(ABORT,'business_document_basis_self_reference') END;
+
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'business_document_basis_tenant_mismatch') END;
+
+  SELECT CASE WHEN NEW.document_type='payment' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type='patient_order'
+  ) THEN RAISE(ABORT,'payment_basis_must_be_patient_order') END;
+
+  SELECT CASE WHEN NEW.document_type='refund' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type='payment'
+  ) THEN RAISE(ABORT,'refund_basis_must_be_payment') END;
+
+  SELECT CASE WHEN NEW.document_type='service_delivery' AND NOT EXISTS (
+    SELECT 1 FROM business_documents src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type IN ('patient_order','service_delivery')
+  ) THEN RAISE(ABORT,'service_delivery_basis_invalid') END;
+END;

--- a/lib/business-document-journal.ts
+++ b/lib/business-document-journal.ts
@@ -1,6 +1,6 @@
 export type BusinessJournalDocument={
   id:number;documentType:string;journalType:string;number:string;occurredAt:string;state:string;comment:string;
-  createdBy:string;createdAt:string;postedBy:string;postedAt:string;reversedDocumentId:number|null;
+  createdBy:string;createdAt:string;postedBy:string;postedAt:string;reversedDocumentId:number|null;basisDocumentId:number|null;
   bookingId:number|null;bookingCode:string;patientName:string;patientId:string;subject:string;
   amount:number;currency:string;sourceDocumentId:number|null;relationType:string;lineCount:number;totalQuantity:number;
 };
@@ -15,22 +15,26 @@ const SUMMARY_SELECT=`
          CASE WHEN c.document_id IS NOT NULL THEN 'service_correction' ELSE d.document_type END AS journalType,
          d.number,d.occurred_at AS occurredAt,d.state,d.comment,d.created_by AS createdBy,
          d.created_at AS createdAt,d.posted_by AS postedBy,d.posted_at AS postedAt,
-         d.reversed_document_id AS reversedDocumentId,
-         COALESCE(s.booking_id,c.booking_id,f.booking_id) AS bookingId,
+         d.reversed_document_id AS reversedDocumentId,d.basis_document_id AS basisDocumentId,
+         COALESCE(o.booking_id,s.booking_id,c.booking_id,f.booking_id) AS bookingId,
          COALESCE(b.code,'') AS bookingCode,COALESCE(b.name,'') AS patientName,
-         COALESCE(s.patient_id,c.patient_id,f.patient_id,'') AS patientId,
-         COALESCE(s.service_title,c.service_title,b.service,'') AS subject,
-         COALESCE(s.charge_amount,c.charge_amount,f.amount,0) AS amount,
-         COALESCE(s.currency,c.currency,f.currency,'UAH') AS currency,
-         CASE
-           WHEN c.document_id IS NOT NULL THEN c.source_document_id
-           WHEN f.source_document_id IS NOT NULL THEN f.source_document_id
-           WHEN d.reversed_document_id IS NOT NULL THEN d.reversed_document_id
-           ELSE NULL
-         END AS sourceDocumentId,
+         COALESCE(o.patient_id,s.patient_id,c.patient_id,f.patient_id,'') AS patientId,
+         COALESCE(o.service_title,s.service_title,c.service_title,b.service,'') AS subject,
+         COALESCE(o.charge_amount,s.charge_amount,c.charge_amount,f.amount,0) AS amount,
+         COALESCE(o.currency,s.currency,c.currency,f.currency,'UAH') AS currency,
+         COALESCE(
+           d.basis_document_id,
+           CASE
+             WHEN c.document_id IS NOT NULL THEN c.source_document_id
+             WHEN f.source_document_id IS NOT NULL THEN f.source_document_id
+             WHEN d.reversed_document_id IS NOT NULL THEN d.reversed_document_id
+             ELSE NULL
+           END
+         ) AS sourceDocumentId,
          CASE
            WHEN c.document_id IS NOT NULL THEN 'storno_of'
            WHEN d.document_type='refund' AND f.source_document_id IS NOT NULL THEN 'refund_of'
+           WHEN d.basis_document_id IS NOT NULL THEN 'based_on'
            WHEN d.reversed_document_id IS NOT NULL THEN 'reversal_of'
            ELSE ''
          END AS relationType,
@@ -39,6 +43,8 @@ const SUMMARY_SELECT=`
          COALESCE((SELECT SUM(il.quantity) FROM inventory_document_lines il
           WHERE il.organization_id=d.organization_id AND il.document_id=d.id),0) AS totalQuantity
   FROM business_documents d
+  LEFT JOIN patient_order_details o
+    ON o.document_id=d.id AND o.organization_id=d.organization_id
   LEFT JOIN service_delivery_details s
     ON s.document_id=d.id AND s.organization_id=d.organization_id
   LEFT JOIN service_correction_details c
@@ -47,7 +53,7 @@ const SUMMARY_SELECT=`
     ON f.document_id=d.id AND f.organization_id=d.organization_id
   LEFT JOIN bookings b
     ON b.organization_id=d.organization_id
-   AND b.id=COALESCE(s.booking_id,c.booking_id,f.booking_id)`;
+   AND b.id=COALESCE(o.booking_id,s.booking_id,c.booking_id,f.booking_id)`;
 
 export async function listBusinessDocuments(db:D1Database,organizationId:number,limit=250) {
   const rows=await db.prepare(
@@ -95,6 +101,7 @@ export async function getBusinessDocumentRelations(db:D1Database,organizationId:
             CASE
               WHEN c.source_document_id=? THEN 'storno'
               WHEN d.document_type='refund' AND f.source_document_id=? THEN 'refund'
+              WHEN d.basis_document_id=? THEN 'based_on'
               WHEN d.reversed_document_id=? THEN 'reversal'
               ELSE 'related'
             END AS relationType
@@ -103,12 +110,12 @@ export async function getBusinessDocumentRelations(db:D1Database,organizationId:
        ON c.document_id=d.id AND c.organization_id=d.organization_id
      LEFT JOIN finance_document_details f
        ON f.document_id=d.id AND f.organization_id=d.organization_id
-     WHERE d.organization_id=?
-       AND (c.source_document_id=? OR f.source_document_id=? OR d.reversed_document_id=?)
+     WHERE d.organization_id=? AND d.id<>?
+       AND (d.basis_document_id=? OR c.source_document_id=? OR f.source_document_id=? OR d.reversed_document_id=?)
      ORDER BY d.occurred_at,d.id`
   ).bind(
-    document.id,document.id,document.id,
-    organizationId,document.id,document.id,document.id,
+    document.id,document.id,document.id,document.id,
+    organizationId,document.id,document.id,document.id,document.id,document.id,
   ).all<RelatedDocument>();
   return {parent,children:children.results};
 }

--- a/lib/patient-orders.ts
+++ b/lib/patient-orders.ts
@@ -1,0 +1,42 @@
+export type PatientOrderRow={
+  id:number;organizationId:number;number:string;state:string;occurredAt:string;createdBy:string;postedBy:string;postedAt:string;
+  bookingId:number;patientId:string;patientCategory:string;serviceCode:string;serviceTitle:string;equipmentId:string;
+  durationMinutes:number;priceAmount:number;chargeAmount:number;currency:string;
+};
+
+export async function getPatientOrderForBooking(
+  db:D1Database,
+  organizationId:number,
+  bookingId:number,
+):Promise<PatientOrderRow|null>{
+  const row=await db.prepare(
+    `SELECT d.id,d.organization_id AS organizationId,d.number,d.state,d.occurred_at AS occurredAt,
+            d.created_by AS createdBy,d.posted_by AS postedBy,d.posted_at AS postedAt,
+            o.booking_id AS bookingId,o.patient_id AS patientId,o.patient_category AS patientCategory,
+            o.service_code AS serviceCode,o.service_title AS serviceTitle,o.equipment_id AS equipmentId,
+            o.duration_minutes AS durationMinutes,o.price_amount AS priceAmount,o.charge_amount AS chargeAmount,o.currency
+     FROM patient_order_details o
+     JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+     WHERE o.organization_id=? AND o.booking_id=? AND d.document_type='patient_order'
+     LIMIT 1`
+  ).bind(organizationId,bookingId).first<PatientOrderRow>();
+  return row||null;
+}
+
+export async function listPatientOrders(db:D1Database,organizationId:number,limit=250){
+  const safeLimit=Math.max(1,Math.min(500,Math.trunc(limit)));
+  const rows=await db.prepare(
+    `SELECT d.id,d.organization_id AS organizationId,d.number,d.state,d.occurred_at AS occurredAt,
+            d.created_by AS createdBy,d.posted_by AS postedBy,d.posted_at AS postedAt,
+            o.booking_id AS bookingId,o.patient_id AS patientId,o.patient_category AS patientCategory,
+            o.service_code AS serviceCode,o.service_title AS serviceTitle,o.equipment_id AS equipmentId,
+            o.duration_minutes AS durationMinutes,o.price_amount AS priceAmount,o.charge_amount AS chargeAmount,o.currency,
+            b.code AS bookingCode,b.name AS patientName
+     FROM patient_order_details o
+     JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+     JOIN bookings b ON b.id=o.booking_id AND b.organization_id=o.organization_id
+     WHERE o.organization_id=? AND d.document_type='patient_order'
+     ORDER BY d.occurred_at DESC,d.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all();
+  return rows.results;
+}

--- a/tests/finance-printed-forms.behavior.test.mjs
+++ b/tests/finance-printed-forms.behavior.test.mjs
@@ -43,7 +43,7 @@ test("posted payment receipt reuses its immutable historical snapshot",async()=>
     assert.equal(form1.payload.payment.amount,2800);
 
     await db.prepare(
-      "UPDATE bookings SET name='Пацієнт Перейменований',service='Інша назва послуги' WHERE organization_id=1 AND id=?"
+      "UPDATE bookings SET name='Пацієнт Перейменований' WHERE organization_id=1 AND id=?"
     ).bind(bookingId).run();
 
     const again=await printDocument(db,cookie,paid.documentId);

--- a/tests/patient-order-root.behavior.test.mjs
+++ b/tests/patient-order-root.behavior.test.mjs
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db,{organizationId=1,code="RD-ORDER-001",amount=2600,category="civilian",status="confirmed"}={}){
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,'Order Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-25','10:00',?,'pending',?,0,?,2,'order-doctor@example.com','order-tech@example.com')`
+  ).bind(organizationId,code,category,amount,status).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function orderFor(raw,organizationId,bookingId){
+  return raw.prepare(
+    `SELECT d.id,d.number,d.state,d.basis_document_id AS basisDocumentId,
+            o.booking_id AS bookingId,o.patient_category AS patientCategory,
+            o.service_code AS serviceCode,o.service_title AS serviceTitle,o.equipment_id AS equipmentId,
+            o.duration_minutes AS durationMinutes,o.price_amount AS priceAmount,o.charge_amount AS chargeAmount
+     FROM patient_order_details o
+     JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+     WHERE o.organization_id=? AND o.booking_id=?`
+  ).get(organizationId,bookingId);
+}
+
+async function pay(db,cookie,bookingId,reference="ORDER-PAY"){
+  return callWorker(jsonRequest("/api/staff/payments",{
+    bookingId,method:"bank_transfer",providerReference:reference,
+  },{headers:{cookie}}),db);
+}
+
+async function refund(db,cookie,bookingId){
+  return callWorker(new Request("http://localhost/api/staff/payments",{
+    method:"DELETE",headers:{"content-type":"application/json",cookie},body:JSON.stringify({bookingId}),
+  }),db);
+}
+
+async function storno(db,cookie,sourceDocumentId){
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{
+    sourceDocumentId,reason:"Сторно для перевірки Patient Order root",
+  },{headers:{cookie}}),db);
+}
+
+async function journal(db,cookie,id){
+  return callWorker(new Request(`http://localhost/api/staff/business-documents?id=${id}`,{headers:{cookie}}),db);
+}
+
+test("every new booking automatically gets one draft Patient Order without an API-specific write path",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db);
+    const order=orderFor(raw,1,bookingId);
+    assert.ok(order?.id>0);
+    assert.equal(order.number,`ЗП-${String(order.id).padStart(6,"0")}`);
+    assert.equal(order.state,"draft");
+    assert.equal(order.basisDocumentId,null);
+    assert.equal(order.bookingId,bookingId);
+    assert.equal(order.patientCategory,"civilian");
+    assert.equal(order.serviceCode,"ct-chest");
+    assert.equal(order.serviceTitle,"КТ ОГК");
+    assert.equal(order.equipmentId,"ct");
+    assert.equal(order.durationMinutes,30);
+    assert.equal(order.priceAmount,2600);
+    assert.equal(order.chargeAmount,2600);
+    assert.equal(raw.prepare(
+      "SELECT COUNT(*) AS n FROM patient_order_details WHERE organization_id=1 AND booking_id=?"
+    ).get(bookingId).n,1);
+  });
+});
+
+test("draft Patient Order follows commercial booking terms, then payment posts and freezes them",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-ORDER-PAY",amount:2400});
+    let order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"draft");
+
+    await db.prepare(
+      `UPDATE bookings SET service='КТ головного мозку',service_code='ct-brain',duration_minutes=25,payment_amount=2800
+       WHERE organization_id=1 AND id=?`
+    ).bind(bookingId).run();
+    order=orderFor(raw,1,bookingId);
+    assert.equal(order.serviceCode,"ct-brain");
+    assert.equal(order.serviceTitle,"КТ головного мозку");
+    assert.equal(order.durationMinutes,25);
+    assert.equal(order.priceAmount,2800);
+    assert.equal(order.chargeAmount,2800);
+
+    const cookie=await seedStaffSession(db,{email:"order-pay@example.com",role:"registrar",organizationId:1});
+    const paymentResponse=await pay(db,cookie,bookingId,"ORDER-ROOT-PAY");
+    assert.equal(paymentResponse.status,200);
+    const payment=await paymentResponse.json();
+    order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"posted");
+
+    const paymentDoc=raw.prepare(
+      "SELECT basis_document_id AS basisDocumentId,state FROM business_documents WHERE id=?"
+    ).get(payment.documentId);
+    assert.equal(paymentDoc.state,"posted");
+    assert.equal(paymentDoc.basisDocumentId,order.id);
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET payment_amount=1 WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/patient_order_booking_terms_immutable/);
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET service_code='changed' WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/patient_order_booking_terms_immutable/);
+
+    // Appointment timing is not a commercial term of the Patient Order and may still be rescheduled.
+    raw.prepare("UPDATE bookings SET desired_time='11:30' WHERE organization_id=1 AND id=?").run(bookingId);
+    assert.equal(raw.prepare("SELECT desired_time FROM bookings WHERE id=?").get(bookingId).desired_time,"11:30");
+  });
+});
+
+test("study completion posts the Patient Order first and service delivery is based on that root",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-ORDER-SERVICE",amount:3100});
+    const draft=orderFor(raw,1,bookingId);
+    assert.equal(draft.state,"draft");
+
+    await db.prepare(
+      `UPDATE bookings SET performed_at='2026-08-25T10:05:00',status='completed'
+       WHERE organization_id=1 AND id=?`
+    ).bind(bookingId).run();
+    const order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"posted");
+    const service=raw.prepare(
+      `SELECT d.id,d.number,d.state,d.basis_document_id AS basisDocumentId
+       FROM business_documents d JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+       WHERE d.organization_id=1 AND s.booking_id=? AND d.document_type='service_delivery'`
+    ).get(bookingId);
+    assert.equal(service.state,"posted");
+    assert.equal(service.basisDocumentId,order.id);
+    assert.match(service.number,/^НП-\d{6}$/);
+  });
+});
+
+test("refund and service storno keep immediate basis while Patient Order remains the commercial root",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-ORDER-CHAIN",amount:3300});
+    const cookie=await seedStaffSession(db,{email:"order-chain@example.com",role:"registrar",organizationId:1});
+    const paymentResponse=await pay(db,cookie,bookingId,"ORDER-CHAIN-PAY");
+    const payment=await paymentResponse.json();
+    const order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"posted");
+
+    const refundResponse=await refund(db,cookie,bookingId);
+    assert.equal(refundResponse.status,200);
+    const returned=await refundResponse.json();
+    const refundDoc=raw.prepare(
+      "SELECT basis_document_id AS basisDocumentId FROM business_documents WHERE id=?"
+    ).get(returned.documentId);
+    assert.equal(refundDoc.basisDocumentId,payment.documentId);
+
+    await db.prepare(
+      `UPDATE bookings SET performed_at='2026-08-25T10:05:00',status='completed'
+       WHERE organization_id=1 AND id=?`
+    ).bind(bookingId).run();
+    const service=raw.prepare(
+      `SELECT d.id,d.basis_document_id AS basisDocumentId
+       FROM business_documents d JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+       WHERE s.organization_id=1 AND s.booking_id=? AND d.document_type='service_delivery'`
+    ).get(bookingId);
+    assert.equal(service.basisDocumentId,order.id);
+
+    const stornoResponse=await storno(db,cookie,service.id);
+    assert.equal(stornoResponse.status,201);
+    const correction=await stornoResponse.json();
+    const correctionDoc=raw.prepare(
+      "SELECT basis_document_id AS basisDocumentId,reversed_document_id AS reversedDocumentId FROM business_documents WHERE id=?"
+    ).get(correction.document.id);
+    assert.equal(correctionDoc.basisDocumentId,service.id);
+    assert.equal(correctionDoc.reversedDocumentId,service.id);
+  });
+});
+
+test("unified document structure exposes Patient Order -> payment/service -> refund/storno chain",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-ORDER-JOURNAL",amount:2900});
+    const cookie=await seedStaffSession(db,{email:"order-journal@example.com",role:"registrar",organizationId:1});
+    const paymentResponse=await pay(db,cookie,bookingId,"ORDER-JOURNAL-PAY");
+    const payment=await paymentResponse.json();
+    const refundResponse=await refund(db,cookie,bookingId);const returned=await refundResponse.json();
+    await db.prepare(
+      "UPDATE bookings SET performed_at='2026-08-25T10:05:00',status='completed' WHERE organization_id=1 AND id=?"
+    ).bind(bookingId).run();
+    const service=raw.prepare(
+      `SELECT d.id FROM business_documents d JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+       WHERE s.organization_id=1 AND s.booking_id=? AND d.document_type='service_delivery'`
+    ).get(bookingId);
+    const stornoResponse=await storno(db,cookie,service.id);const correction=await stornoResponse.json();
+    const order=orderFor(raw,1,bookingId);
+
+    const rootResponse=await journal(db,cookie,order.id);
+    assert.equal(rootResponse.status,200);
+    const root=await rootResponse.json();
+    assert.equal(root.document.journalType,"patient_order");
+    assert.equal(root.document.bookingCode,"RD-ORDER-JOURNAL");
+    assert.equal(root.document.amount,2900);
+    assert.ok(root.relations.children.some(row=>row.id===payment.documentId&&row.relationType==="based_on"));
+    assert.ok(root.relations.children.some(row=>row.id===service.id&&row.relationType==="based_on"));
+
+    const paymentDetail=await (await journal(db,cookie,payment.documentId)).json();
+    assert.ok(paymentDetail.relations.parent.some(row=>row.id===order.id&&row.relationType==="based_on"));
+    assert.ok(paymentDetail.relations.children.some(row=>row.id===returned.documentId&&row.relationType==="refund"));
+
+    const serviceDetail=await (await journal(db,cookie,service.id)).json();
+    assert.ok(serviceDetail.relations.parent.some(row=>row.id===order.id&&row.relationType==="based_on"));
+    assert.ok(serviceDetail.relations.children.some(row=>row.id===correction.document.id&&row.relationType==="storno"));
+  });
+});
+
+test("D1 rejects a document that points at another booking's Patient Order",async()=>{
+  await withD1(async(db,raw)=>{
+    const first=await seedBooking(db,{code:"RD-ORDER-BASIS-1",amount:1500});
+    const second=await seedBooking(db,{code:"RD-ORDER-BASIS-2",amount:1700});
+    const wrongOrder=orderFor(raw,1,second);
+    const created=raw.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,occurred_at,state,comment,created_by,basis_document_id)
+       VALUES (1,'payment','ОП-FORGE',CURRENT_TIMESTAMP,'draft','forged','attacker@example.com',?)`
+    ).run(wrongOrder.id);
+    const docId=Number(created.lastInsertRowid);
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO finance_document_details
+       (organization_id,document_id,booking_id,patient_id,amount,currency,method,provider,provider_reference)
+       VALUES (1,?,?, '',1500,'UAH','cash','manual','FORGE')`
+    ).run(docId,first),/payment_patient_order_basis_mismatch/);
+  });
+});
+
+test("basis is tenant scoped and immutable after document posting",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Order Org 2','order-org-2',1)");
+    const one=await seedBooking(db,{code:"RD-ORDER-ORG1"});
+    const two=await seedBooking(db,{organizationId:2,code:"RD-ORDER-ORG2"});
+    const order1=orderFor(raw,1,one);const order2=orderFor(raw,2,two);
+
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,occurred_at,state,comment,created_by,basis_document_id)
+       VALUES (1,'payment','ОП-CROSS',CURRENT_TIMESTAMP,'draft','cross','attacker@example.com',?)`
+    ).run(order2.id),/business_document_basis_tenant_mismatch/);
+
+    const cookie=await seedStaffSession(db,{email:"order-freeze@example.com",role:"registrar",organizationId:1});
+    const paid=await pay(db,cookie,one,"ORDER-FREEZE-PAY");const body=await paid.json();
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET basis_document_id=NULL WHERE organization_id=1 AND id=?"
+    ).run(body.documentId),/business_document_immutable/);
+    assert.equal(raw.prepare("SELECT basis_document_id AS basis FROM business_documents WHERE id=?").get(body.documentId).basis,order1.id);
+  });
+});

--- a/tests/patient-order-root.behavior.test.mjs
+++ b/tests/patient-order-root.behavior.test.mjs
@@ -2,19 +2,19 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
 
-async function seedBooking(db,{organizationId=1,code="RD-ORDER-001",amount=2600,category="civilian",status="confirmed"}={}){
+async function seedBooking(db,{organizationId=1,code="RD-ORDER-001",amount=2600,category="civilian",status="confirmed",desiredTime="10:00"}={}){
   const result=await db.prepare(
     `INSERT INTO bookings (
       organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
       duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
       status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
      ) VALUES (?,?,'Order Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
-       '2026-08-25','10:00',?,'pending',?,0,?,2,'order-doctor@example.com','order-tech@example.com')`
-  ).bind(organizationId,code,category,amount,status).run();
+       '2026-08-25',?,?,'pending',?,0,?,2,'order-doctor@example.com','order-tech@example.com')`
+  ).bind(organizationId,code,desiredTime,category,amount,status).run();
   return Number(result.meta.last_row_id);
 }
 
-async function orderFor(raw,organizationId,bookingId){
+function orderFor(raw,organizationId,bookingId){
   return raw.prepare(
     `SELECT d.id,d.number,d.state,d.basis_document_id AS basisDocumentId,
             o.booking_id AS bookingId,o.patient_category AS patientCategory,
@@ -213,8 +213,8 @@ test("unified document structure exposes Patient Order -> payment/service -> ref
 
 test("D1 rejects a document that points at another booking's Patient Order",async()=>{
   await withD1(async(db,raw)=>{
-    const first=await seedBooking(db,{code:"RD-ORDER-BASIS-1",amount:1500});
-    const second=await seedBooking(db,{code:"RD-ORDER-BASIS-2",amount:1700});
+    const first=await seedBooking(db,{code:"RD-ORDER-BASIS-1",amount:1500,desiredTime:"10:00"});
+    const second=await seedBooking(db,{code:"RD-ORDER-BASIS-2",amount:1700,desiredTime:"10:30"});
     const wrongOrder=orderFor(raw,1,second);
     const created=raw.prepare(
       `INSERT INTO business_documents

--- a/tests/payment-ledger.behavior.test.mjs
+++ b/tests/payment-ledger.behavior.test.mjs
@@ -104,6 +104,9 @@ test("manual confirmation creates one paid ledger entry and updates booking aggr
 
 test("the same provider reference may exist independently in another tenant", async () => {
   await withD1(async (db) => {
+    await db.prepare(
+      "INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Payment Org 2','payment-org-2',1)",
+    ).run();
     const one = await seedBooking(db, { organizationId: 1, code: "PAY-D1", amount: 1200 });
     const two = await seedBooking(db, { organizationId: 2, code: "PAY-D2", amount: 1300 });
     await createPendingPayment(db, {

--- a/tests/tenant-scoping-crm.test.mjs
+++ b/tests/tenant-scoping-crm.test.mjs
@@ -21,6 +21,7 @@ async function freshDb() {
 }
 
 function seedTwoOrgs(db) {
+  db.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'CRM Org 2','crm-org-2',1)");
   const ins = db.prepare(
     `INSERT INTO bookings (organization_id, code, name, phone, phone_normalized, service, desired_date, desired_time, status)
      VALUES (?,?,?,?,?,?,?,?,?)`


### PR DESCRIPTION
## Goal
Introduce `Patient Order` (`ЗП-xxxxxx`) as the canonical commercial root for new bookings so service, payment, refund and storno form one BAS-style document chain.

## Implemented
- every new booking automatically receives one draft `patient_order` in D1
- typed `patient_order_details` snapshot of patient category, service, equipment, duration, price, charge and currency
- no historical booking backfill; legacy rows are not retroactively converted
- new `business_documents.basis_document_id` as canonical document basis
- generic tenant/type/self-reference guards for basis
- generic posted-document immutability now also freezes basis and reversed-document identity
- draft Patient Order follows commercial booking terms until first downstream economic fact
- payment or study completion posts/freezes the Patient Order
- service/payment basis is the exact booking Patient Order
- refund basis is source payment
- service storno basis is source service-delivery document
- typed D1 triggers assign/validate/freeze basis rather than trusting API callers
- unified document journal now includes Patient Orders and uses canonical basis for parent/child structure

## Boundaries
- appointment date/time is not part of immutable commercial order terms, so rescheduling remains possible
- after service delivery exists, its stricter execution snapshot guard owns the completed-study facts
- legacy bookings without Patient Order remain compatible and basis-less; no retrospective inference

## Verification in this PR
- automatic one-order-per-new-booking creation
- draft order commercial-term synchronization
- payment posts order and freezes commercial terms
- rescheduling after payment remains allowed
- completion posts order and service delivery points to root
- refund/storno keep immediate basis while order stays root
- unified Patient Order -> payment/service -> refund/storno structure
- wrong-booking basis rejected in D1
- cross-tenant basis rejected
- posted basis immutable
- full existing test suite + CI/CodeQL on exact head before merge

## Boundary
- no production deploy