### PR TITLE
Add BAS counterparty directory and supplier references

### DIFF
--- a/app/api/staff/counterparties/route.ts
+++ b/app/api/staff/counterparties/route.ts
@@ -1,0 +1,63 @@
+import { audit } from "../../../../lib/audit";
+import { createCounterparty,isCounterpartyKind,listCounterparties,updateCounterparty } from "../../../../lib/counterparties";
+import { dbBinding } from "../../../../lib/db";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+const READ_ROLES=new Set(["admin","registrar","radiographer"]);
+const MANAGE_ROLES=new Set(["admin","radiographer"]);
+function canRead(role:string){return READ_ROLES.has(role);}
+function canManage(role:string){return MANAGE_ROLES.has(role);}
+function int(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
+function clean(value:unknown,max:number){return String(value??"").trim().slice(0,max);}
+
+function errorResponse(error:unknown){
+  const code=String(error instanceof Error?error.message:error).toLowerCase();
+  if(code.includes("counterparty_name_required"))return Response.json({error:"Вкажіть назву контрагента"},{status:400});
+  if(code.includes("counterparty_email_invalid"))return Response.json({error:"Некоректна e-mail адреса"},{status:400});
+  if(code.includes("unique"))return Response.json({error:"Такий код контрагента вже існує"},{status:409});
+  return null;
+}
+
+export async function GET(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx||!canRead(ctx.role))return Response.json({error:"Довідник контрагентів доступний уповноваженому персоналу"},{status:403});
+  const url=new URL(request.url);
+  const rawKind=clean(url.searchParams.get("kind"),30);
+  const kind=rawKind==="supplier"?"supplier_or_both":isCounterpartyKind(rawKind)?rawKind:undefined;
+  const activeParam=url.searchParams.get("active");
+  const active=activeParam==="1"?true:activeParam==="0"?false:undefined;
+  const rows=await listCounterparties(db,ctx.organizationId,{kind,active,query:clean(url.searchParams.get("q"),100)});
+  return Response.json({counterparties:rows,staff:ctx.member,canManage:canManage(ctx.role)});
+}
+
+export async function POST(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx||!canManage(ctx.role))return Response.json({error:"Контрагентів можуть змінювати адміністратор або рентгенолаборант"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  try{
+    const row=await createCounterparty(db,{organizationId:ctx.organizationId,values:body});
+    if(!row)return Response.json({error:"Не вдалося створити контрагента"},{status:500});
+    await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"counterparty_created",resource:"counterparty",targetId:row.id,details:{kind:row.kind,active:!!row.active,hasCode:!!row.code}});
+    return Response.json({counterparty:row},{status:201});
+  }catch(error){const mapped=errorResponse(error);if(mapped)return mapped;throw error;}
+}
+
+export async function PATCH(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx||!canManage(ctx.role))return Response.json({error:"Контрагентів можуть змінювати адміністратор або рентгенолаборант"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const id=int(body.id);
+  if(!id)return Response.json({error:"Некоректний контрагент"},{status:400});
+  try{
+    const row=await updateCounterparty(db,{organizationId:ctx.organizationId,id,values:body});
+    if(!row)return Response.json({error:"Контрагента не знайдено"},{status:404});
+    await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"counterparty_updated",resource:"counterparty",targetId:id,details:{kind:row.kind,active:!!row.active,hasCode:!!row.code}});
+    return Response.json({counterparty:row});
+  }catch(error){const mapped=errorResponse(error);if(mapped)return mapped;throw error;}
+}

--- a/app/api/staff/inventory/documents/route.ts
+++ b/app/api/staff/inventory/documents/route.ts
@@ -28,6 +28,7 @@ function mapCreateError(error:unknown) {
   if (code.includes("item_required")) return [400,"Для надходження вкажіть матеріал"] as const;
   if (code.includes("item_not_found")) return [404,"Матеріал не знайдено або він неактивний"] as const;
   if (code.includes("invalid_expiry")) return [400,"Некоректний термін придатності"] as const;
+  if (code.includes("supplier_not_found")) return [404,"Постачальника не знайдено, він неактивний або не є постачальником"] as const;
   if (code.includes("lot_required")) return [400,"Для списання вкажіть партію"] as const;
   if (code.includes("lot_not_found")) return [404,"Партію не знайдено або матеріал неактивний"] as const;
   if (code.includes("booking_not_found")) return [400,"Дослідження не належить до цієї організації"] as const;

--- a/app/api/staff/inventory/route.ts
+++ b/app/api/staff/inventory/route.ts
@@ -15,13 +15,15 @@ type ItemRow = {
   stock:number; expiringStock:number; nextExpiry:string;
 };
 type LotRow = {
-  id:number; itemId:number; itemName:string; lotNumber:string; expiresOn:string; supplier:string; stock:number;
+  id:number; itemId:number; itemName:string; lotNumber:string; expiresOn:string; supplier:string;
+  supplierCounterpartyId:number|null; stock:number;
 };
 type MovementRow = {
   id:number; itemId:number; itemName:string; lotId:number; lotNumber:string; movementType:string;
   quantityDelta:number; unit:string; reason:string; bookingId:number|null; actorEmail:string; createdAt:string;
   documentId:number|null;
 };
+type SupplierRow={id:number;code:string;name:string};
 
 function cleanText(value:unknown,max:number) { return String(value || "").trim().slice(0,max); }
 function positiveNumber(value:unknown) {
@@ -43,6 +45,7 @@ function inventoryDocumentError(error:unknown) {
   const code = String(error instanceof Error ? error.message : error);
   if (code.includes("invalid_expiry")) return Response.json({ error:"Некоректний термін придатності" },{status:400});
   if (code.includes("item_not_found")) return Response.json({ error:"Матеріал не знайдено або він неактивний" },{status:404});
+  if (code.includes("supplier_not_found")) return Response.json({ error:"Постачальника не знайдено, він неактивний або не є постачальником" },{status:404});
   if (code.includes("lot_not_found")) return Response.json({ error:"Партію не знайдено" },{status:404});
   if (code.includes("booking_not_found")) return Response.json({ error:"Дослідження не належить до цієї організації" },{status:400});
   if (code.includes("reason_required")) return Response.json({ error:"Вкажіть причину списання" },{status:400});
@@ -70,7 +73,7 @@ export async function GET(request:Request) {
 
   const lots = await db.prepare(
     `SELECT l.id, l.item_id AS itemId, i.name AS itemName, l.lot_number AS lotNumber,
-            l.expires_on AS expiresOn, l.supplier,
+            l.expires_on AS expiresOn, l.supplier,l.supplier_counterparty_id AS supplierCounterpartyId,
             COALESCE(SUM(m.quantity_delta),0) AS stock
      FROM inventory_lots l
      JOIN inventory_items i ON i.id = l.item_id AND i.organization_id = l.organization_id
@@ -93,7 +96,12 @@ export async function GET(request:Request) {
      ORDER BY m.id DESC LIMIT 150`
   ).bind(ctx.organizationId).all<MovementRow>();
 
-  return Response.json({ items:items.results, lots:lots.results, movements:movements.results, staff:ctx.member, canManage:canManage(ctx.role) });
+  const counterparties = await db.prepare(
+    `SELECT id,code,name FROM counterparties
+     WHERE organization_id=? AND active=1 AND kind IN ('supplier','both') ORDER BY name,id LIMIT 500`
+  ).bind(ctx.organizationId).all<SupplierRow>();
+
+  return Response.json({ items:items.results, lots:lots.results, movements:movements.results, counterparties:counterparties.results, staff:ctx.member, canManage:canManage(ctx.role) });
 }
 
 export async function POST(request:Request) {
@@ -128,7 +136,7 @@ export async function POST(request:Request) {
   }
 
   // Compatibility actions: old callers still work, but every NEW movement is now registered by
-  // a BAS-style document and posting engine. The UI moves to explicit draft/post forms separately.
+  // a BAS-style document and posting engine. Legacy free-text supplier remains accepted here.
   if (action === "receive") {
     const itemId = Number(body.itemId);
     const quantity = positiveNumber(body.quantity);
@@ -143,6 +151,7 @@ export async function POST(request:Request) {
           lotNumber:cleanText(body.lotNumber,100),
           expiresOn:cleanText(body.expiresOn,10),
           supplier:cleanText(body.supplier,180),
+          supplierCounterpartyId:Number.isInteger(Number(body.supplierCounterpartyId))&&Number(body.supplierCounterpartyId)>0?Number(body.supplierCounterpartyId):null,
           reason:cleanText(body.reason,500) || "Надходження",
         }],
       });

--- a/app/staff/counterparties/page.tsx
+++ b/app/staff/counterparties/page.tsx
@@ -50,7 +50,7 @@ export default function CounterpartiesPage(){
     }finally{setBusy(false);}
   }
 
-  return <StaffWorkspaceShell active="finance" title="Контрагенти" description="BAS-довідник постачальників і платників. Документи посилаються на ID контрагента, а історичну назву зберігають snapshot-ом." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
+  return <StaffWorkspaceShell active="counterparties" title="Контрагенти" description="BAS-довідник постачальників і платників. Документи посилаються на ID контрагента, а історичну назву зберігають snapshot-ом." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
     {error&&<p className="financeError">{error}</p>}
     {!data&&!error&&<p className="financeLoading">Завантаження довідника…</p>}
     {data&&<div className="inventoryDocumentsLayout">

--- a/app/staff/counterparties/page.tsx
+++ b/app/staff/counterparties/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback,useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type Kind="supplier"|"payer"|"both"|"other";
+type Counterparty={id:number;code:string;name:string;kind:Kind;taxId:string;phone:string;email:string;address:string;active:number;createdAt:string;updatedAt:string};
+type Staff={email:string;displayName:string;role:string};
+type Payload={counterparties:Counterparty[];staff:Staff;canManage:boolean;error?:string};
+type Form={id:number|null;code:string;name:string;kind:Kind;taxId:string;phone:string;email:string;address:string;active:boolean};
+
+const EMPTY:Form={id:null,code:"",name:"",kind:"supplier",taxId:"",phone:"",email:"",address:"",active:true};
+const KIND_UK:Record<Kind,string>={supplier:"Постачальник",payer:"Платник",both:"Постачальник і платник",other:"Інший"};
+
+export default function CounterpartiesPage(){
+  const [data,setData]=useState<Payload|null>(null);
+  const [form,setForm]=useState<Form>(EMPTY);
+  const [query,setQuery]=useState("");
+  const [kind,setKind]=useState<"all"|Kind>("all");
+  const [error,setError]=useState("");
+  const [notice,setNotice]=useState("");
+  const [busy,setBusy]=useState(false);
+
+  const load=useCallback(async()=>{
+    const response=await fetch("/api/staff/counterparties",{cache:"no-store"});
+    const payload=await response.json().catch(()=>({})) as Payload;
+    if(!response.ok)throw new Error(payload.error||"Не вдалося завантажити контрагентів");
+    setData(payload);setError("");
+  },[]);
+  useEffect(()=>{const timer=window.setTimeout(()=>void load().catch(e=>setError(e instanceof Error?e.message:"Помилка")),0);return()=>window.clearTimeout(timer);},[load]);
+
+  const rows=useMemo(()=>{
+    const q=query.trim().toLowerCase();
+    return (data?.counterparties||[]).filter(row=>(kind==="all"||row.kind===kind||kind==="supplier"&&row.kind==="both")&&(!q||`${row.name} ${row.code} ${row.taxId}`.toLowerCase().includes(q)));
+  },[data,query,kind]);
+
+  function edit(row:Counterparty){setForm({id:row.id,code:row.code,name:row.name,kind:row.kind,taxId:row.taxId,phone:row.phone,email:row.email,address:row.address,active:!!row.active});setNotice("");}
+  function reset(){setForm(EMPTY);setNotice("");}
+
+  async function save(event:React.FormEvent){
+    event.preventDefault();if(!data?.canManage)return;
+    setBusy(true);setNotice("");
+    try{
+      const method=form.id?"PATCH":"POST";
+      const response=await fetch("/api/staff/counterparties",{method,headers:{"content-type":"application/json"},body:JSON.stringify(form)});
+      const payload=await response.json().catch(()=>({})) as {error?:string;counterparty?:Counterparty};
+      if(!response.ok){setNotice(`⚠ ${payload.error||"Не вдалося зберегти"}`);return;}
+      setNotice(`✓ ${form.id?"Контрагента оновлено":"Контрагента створено"}`);await load();
+      if(payload.counterparty)edit(payload.counterparty);
+    }finally{setBusy(false);}
+  }
+
+  return <StaffWorkspaceShell active="finance" title="Контрагенти" description="BAS-довідник постачальників і платників. Документи посилаються на ID контрагента, а історичну назву зберігають snapshot-ом." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
+    {error&&<p className="financeError">{error}</p>}
+    {!data&&!error&&<p className="financeLoading">Завантаження довідника…</p>}
+    {data&&<div className="inventoryDocumentsLayout">
+      <section className="financeJournal">
+        <header className="financeToolbar"><div className="financeTabs"><button type="button" onClick={()=>window.location.assign("/staff/inventory")}>← Склад</button><button type="button" onClick={()=>window.location.assign("/staff/finance")}>Фінанси</button></div><input type="search" value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пошук: назва, код, ЄДРПОУ…"/><select value={kind} onChange={e=>setKind(e.target.value as "all"|Kind)}><option value="all">Усі типи</option>{Object.entries(KIND_UK).map(([value,label])=><option key={value} value={value}>{label}</option>)}</select><button type="button" onClick={()=>void load()}>Оновити</button></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Контрагент</th><th>Тип</th><th>Код</th><th>ЄДРПОУ / ІПН</th><th>Контакт</th><th>Стан</th><th/></tr></thead><tbody>
+          {rows.map(row=><tr key={row.id}><td><b>{row.name}</b><small>ID {row.id}</small></td><td>{KIND_UK[row.kind]}</td><td>{row.code||"—"}</td><td>{row.taxId||"—"}</td><td>{row.phone||row.email||"—"}{row.phone&&row.email?<small>{row.email}</small>:null}</td><td><span className={`financeState ${row.active?"state-posted":"state-cancelled"}`}>{row.active?"Активний":"Неактивний"}</span></td><td><button type="button" onClick={()=>edit(row)}>Відкрити</button></td></tr>)}
+          {rows.length===0&&<tr><td colSpan={7}>Контрагентів за відбором немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="inventoryDocumentCard">
+        <header><div><small>Довідник</small><h2>{form.id?`Контрагент #${form.id}`:"Новий контрагент"}</h2><p>{data.canManage?"Реквізити можна змінювати; проведені документи зберігають власний snapshot.":"Режим перегляду"}</p></div></header>
+        {notice&&<p className={notice.startsWith("⚠")?"financeError":"notice"}>{notice}</p>}
+        <form className="inventoryOperations" onSubmit={save}><div><label>Назва<input required disabled={!data.canManage} value={form.name} onChange={e=>setForm({...form,name:e.target.value})}/></label><label>Код<input disabled={!data.canManage} value={form.code} onChange={e=>setForm({...form,code:e.target.value})}/></label><label>Тип<select disabled={!data.canManage} value={form.kind} onChange={e=>setForm({...form,kind:e.target.value as Kind})}>{Object.entries(KIND_UK).map(([value,label])=><option key={value} value={value}>{label}</option>)}</select></label><label>ЄДРПОУ / ІПН<input disabled={!data.canManage} value={form.taxId} onChange={e=>setForm({...form,taxId:e.target.value})}/></label><label>Телефон<input disabled={!data.canManage} value={form.phone} onChange={e=>setForm({...form,phone:e.target.value})}/></label><label>E-mail<input type="email" disabled={!data.canManage} value={form.email} onChange={e=>setForm({...form,email:e.target.value})}/></label><label>Адреса<input disabled={!data.canManage} value={form.address} onChange={e=>setForm({...form,address:e.target.value})}/></label><label><input type="checkbox" disabled={!data.canManage} checked={form.active} onChange={e=>setForm({...form,active:e.target.checked})}/> Активний</label>{data.canManage&&<div><button className="primary" disabled={busy}>{form.id?"Записати":"Створити"}</button><button type="button" disabled={busy} onClick={reset}>Новий</button></div>}</div></form>
+      </section>
+    </div>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/inventory/page.tsx
+++ b/app/staff/inventory/page.tsx
@@ -5,13 +5,14 @@ import StaffWorkspaceShell from "../workspace-shell";
 
 type Staff = { email:string; displayName:string; role:string };
 type Item = { id:number; sku:string; name:string; category:string; unit:string; minStock:number; active:number; stock:number; expiringStock:number; nextExpiry:string };
-type Lot = { id:number; itemId:number; itemName:string; lotNumber:string; expiresOn:string; supplier:string; stock:number };
+type Supplier = { id:number; code:string; name:string };
+type Lot = { id:number; itemId:number; itemName:string; lotNumber:string; expiresOn:string; supplier:string; supplierCounterpartyId:number|null; stock:number };
 type Movement = { id:number; itemId:number; itemName:string; lotId:number; lotNumber:string; movementType:string; quantityDelta:number; unit:string; reason:string; bookingId:number|null; actorEmail:string; createdAt:string; documentId:number|null };
-type Payload = { items:Item[]; lots:Lot[]; movements:Movement[]; staff:Staff; canManage:boolean; error?:string };
+type Payload = { items:Item[]; lots:Lot[]; movements:Movement[]; counterparties:Supplier[]; staff:Staff; canManage:boolean; error?:string };
 type DocumentState = "draft"|"posted"|"reversed"|"cancelled";
 type DocumentType = "inventory_receipt"|"inventory_writeoff";
 type DocumentSummary = { id:number; documentType:DocumentType; number:string; occurredAt:string; state:DocumentState; comment:string; createdBy:string; createdAt:string; postedBy:string; postedAt:string; lineCount:number; totalQuantity:number };
-type DocumentLine = { id:number; lineNo:number; itemId:number; lotId:number|null; lotNumber:string; expiresOn:string; supplier:string; quantity:number; reason:string; bookingId:number|null };
+type DocumentLine = { id:number; lineNo:number; itemId:number; lotId:number|null; lotNumber:string; expiresOn:string; supplier:string; supplierCounterpartyId:number|null; quantity:number; reason:string; bookingId:number|null };
 type DocumentDetail = { document:DocumentSummary; lines:DocumentLine[] };
 type DocumentsPayload = { documents:DocumentSummary[]; staff:Staff; canManage:boolean; error?:string };
 type Mode = "stock"|"documents"|"movements";
@@ -39,7 +40,7 @@ export default function InventoryPage() {
   const [showOnlyAlert,setShowOnlyAlert] = useState(false);
   const [busy,setBusy] = useState(false);
   const [itemForm,setItemForm] = useState({ name:"", sku:"", category:"contrast", unit:"шт", minStock:"0" });
-  const [receive,setReceive] = useState({ itemId:"", quantity:"", lotNumber:"", expiresOn:"", supplier:"", reason:"Надходження" });
+  const [receive,setReceive] = useState({ itemId:"", quantity:"", lotNumber:"", expiresOn:"", supplierCounterpartyId:"", reason:"Надходження" });
   const [writeoff,setWriteoff] = useState({ lotId:"", quantity:"", reason:"Використано під час дослідження", bookingId:"" });
 
   async function loadInventory() {
@@ -118,9 +119,9 @@ export default function InventoryPage() {
     e.preventDefault();
     const created=await documentAction({
       action:"create",documentType:"inventory_receipt",
-      lines:[{itemId:Number(receive.itemId),quantity:Number(receive.quantity),lotNumber:receive.lotNumber,expiresOn:receive.expiresOn,supplier:receive.supplier,reason:receive.reason}],
+      lines:[{itemId:Number(receive.itemId),quantity:Number(receive.quantity),lotNumber:receive.lotNumber,expiresOn:receive.expiresOn,supplierCounterpartyId:receive.supplierCounterpartyId?Number(receive.supplierCounterpartyId):null,reason:receive.reason}],
     },"Чернетку надходження створено");
-    if(created){setReceive({itemId:receive.itemId,quantity:"",lotNumber:"",expiresOn:"",supplier:"",reason:"Надходження"});setMode("documents");}
+    if(created){setReceive({itemId:receive.itemId,quantity:"",lotNumber:"",expiresOn:"",supplierCounterpartyId:"",reason:"Надходження"});setMode("documents");}
   }
   async function createWriteoffDraft(e:React.FormEvent) {
     e.preventDefault();
@@ -153,7 +154,7 @@ export default function InventoryPage() {
 
         {data.canManage && <section className="inventoryOperations">
           <form onSubmit={createItem}><h3>Нова номенклатура</h3><p className="inventoryFormHint">Довідник матеріалів</p><input required placeholder="Назва матеріалу" value={itemForm.name} onChange={e=>setItemForm({...itemForm,name:e.target.value})}/><input placeholder="Код / SKU" value={itemForm.sku} onChange={e=>setItemForm({...itemForm,sku:e.target.value})}/><select value={itemForm.category} onChange={e=>setItemForm({...itemForm,category:e.target.value})}>{CATEGORY_OPTIONS.map(([v,l])=><option key={v} value={v}>{l}</option>)}</select><div className="inventoryFormRow"><input required placeholder="Одиниця" value={itemForm.unit} onChange={e=>setItemForm({...itemForm,unit:e.target.value})}/><input required type="number" min="0" step="0.01" placeholder="Мін. запас" value={itemForm.minStock} onChange={e=>setItemForm({...itemForm,minStock:e.target.value})}/></div><button disabled={busy}>Записати</button></form>
-          <form onSubmit={createReceiptDraft}><h3>Надходження матеріалів</h3><p className="inventoryFormHint">Створює документ-чернетку. Залишок зміниться лише після «Провести».</p><select required value={receive.itemId} onChange={e=>setReceive({...receive,itemId:e.target.value})}><option value="">Оберіть матеріал</option>{data.items.filter(i=>i.active).map(i=><option key={i.id} value={i.id}>{i.name} · {i.unit}</option>)}</select><div className="inventoryFormRow"><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={receive.quantity} onChange={e=>setReceive({...receive,quantity:e.target.value})}/><input placeholder="№ партії" value={receive.lotNumber} onChange={e=>setReceive({...receive,lotNumber:e.target.value})}/></div><input type="date" value={receive.expiresOn} onChange={e=>setReceive({...receive,expiresOn:e.target.value})}/><input placeholder="Постачальник" value={receive.supplier} onChange={e=>setReceive({...receive,supplier:e.target.value})}/><input placeholder="Примітка" value={receive.reason} onChange={e=>setReceive({...receive,reason:e.target.value})}/><button disabled={busy}>Створити чернетку</button></form>
+          <form onSubmit={createReceiptDraft}><h3>Надходження матеріалів</h3><p className="inventoryFormHint">Створює документ-чернетку. Залишок зміниться лише після «Провести».</p><select required value={receive.itemId} onChange={e=>setReceive({...receive,itemId:e.target.value})}><option value="">Оберіть матеріал</option>{data.items.filter(i=>i.active).map(i=><option key={i.id} value={i.id}>{i.name} · {i.unit}</option>)}</select><div className="inventoryFormRow"><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={receive.quantity} onChange={e=>setReceive({...receive,quantity:e.target.value})}/><input placeholder="№ партії" value={receive.lotNumber} onChange={e=>setReceive({...receive,lotNumber:e.target.value})}/></div><input type="date" value={receive.expiresOn} onChange={e=>setReceive({...receive,expiresOn:e.target.value})}/><select value={receive.supplierCounterpartyId} onChange={e=>setReceive({...receive,supplierCounterpartyId:e.target.value})}><option value="">Без постачальника</option>{data.counterparties.map(c=><option key={c.id} value={c.id}>{c.name}{c.code?` · ${c.code}`:""}</option>)}</select><button type="button" className="inventorySmallBtn" onClick={()=>window.location.assign("/staff/counterparties")}>Контрагенти ↗</button><input placeholder="Примітка" value={receive.reason} onChange={e=>setReceive({...receive,reason:e.target.value})}/><button disabled={busy}>Створити чернетку</button></form>
           <form onSubmit={createWriteoffDraft}><h3>Списання матеріалів</h3><p className="inventoryFormHint">Документ можна перевірити перед проведенням.</p><select required value={writeoff.lotId} onChange={e=>setWriteoff({...writeoff,lotId:e.target.value})}><option value="">Оберіть партію</option>{data.lots.map(l=><option key={l.id} value={l.id}>{l.itemName} · {l.lotNumber || "без №"} · залишок {fmt(l.stock)}</option>)}</select><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={writeoff.quantity} onChange={e=>setWriteoff({...writeoff,quantity:e.target.value})}/><input required placeholder="Причина списання" value={writeoff.reason} onChange={e=>setWriteoff({...writeoff,reason:e.target.value})}/><input type="number" min="1" placeholder="ID дослідження (необов'язково)" value={writeoff.bookingId} onChange={e=>setWriteoff({...writeoff,bookingId:e.target.value})}/><button className="danger" disabled={busy}>Створити чернетку</button></form>
         </section>}
       </>}
@@ -167,7 +168,7 @@ export default function InventoryPage() {
         {selected&&<section className="inventoryDocumentCard">
           <header><div><small>{TYPE_UK[selected.document.documentType]}</small><h2>{selected.document.number}</h2><p>{fmtDate(selected.document.occurredAt)} · {selected.document.createdBy}</p></div><span className={`inventoryDocState ${selected.document.state}`}>{STATE_UK[selected.document.state]}</span></header>
           {selected.document.comment&&<p className="inventoryDocComment">{selected.document.comment}</p>}
-          <div className="inventoryDocLines"><table><thead><tr><th>№</th><th>Матеріал</th><th>Партія</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>{selected.lines.map(line=>{const i=itemMap.get(line.itemId);return <tr key={line.id}><td>{line.lineNo}</td><td><b>{i?.name||`Матеріал #${line.itemId}`}</b><small>{i?.unit||""}</small></td><td>{line.lotNumber||"—"}{line.expiresOn?<small>до {line.expiresOn}</small>:null}</td><td className="num">{fmt(line.quantity)} {i?.unit||""}</td><td>{line.reason}{line.bookingId?<small>дослідження #{line.bookingId}</small>:null}</td></tr>;})}</tbody></table></div>
+          <div className="inventoryDocLines"><table><thead><tr><th>№</th><th>Матеріал</th><th>Партія</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>{selected.lines.map(line=>{const i=itemMap.get(line.itemId);return <tr key={line.id}><td>{line.lineNo}</td><td><b>{i?.name||`Матеріал #${line.itemId}`}</b><small>{i?.unit||""}</small></td><td>{line.lotNumber||"—"}{line.expiresOn?<small>до {line.expiresOn}</small>:null}{line.supplier?<small>постачальник: {line.supplier}</small>:null}</td><td className="num">{fmt(line.quantity)} {i?.unit||""}</td><td>{line.reason}{line.bookingId?<small>дослідження #{line.bookingId}</small>:null}</td></tr>;})}</tbody></table></div>
           <footer>
             {selected.document.state==="draft"&&data.canManage&&<><button className="primary" disabled={busy} onClick={()=>void documentAction({action:"post",documentId:selected.document.id},"Документ проведено")}>Провести</button><button disabled={busy} onClick={()=>void documentAction({action:"cancel",documentId:selected.document.id},"Чернетку скасовано")}>Скасувати</button></>}
             <button onClick={()=>window.open(`/staff/inventory/print?id=${selected.document.id}`,"_blank","noopener,noreferrer")}>Друк</button>

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import CommandPalette from "./command-palette";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "finance" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks" | "inventory";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "finance" | "counterparties" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks" | "inventory";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -16,16 +16,10 @@ type StaffWorkspaceShellProps = {
   children: ReactNode;
 };
 
-// Бічна панель: угорі «Огляд» — найчастіші екрани реєстратури; нижче
-// «Модулі» — робочі напрями, згруповані за призначенням. Кожен модуль
-// веде на головну сторінку напряму й розгортається у підпункти-екрани.
 type NavChild = { label:string; href:string };
 type NavLink = { label:string; href:string; section:WorkspaceSection; icon:string };
-// section — головний розділ модуля; sections — усі розділи, що його підсвічують.
 type NavModule = { label:string; href:string; sections:WorkspaceSection[]; icon:string; items:NavChild[] };
 
-// Меню за процесом роботи, а не за модулями системи: як думає відділення —
-// Прийом → Розклад → Дошка → Завдання → Опис → Видача. Пульт зверху як загальний огляд дня.
 const processRail: NavLink[] = [
   { label:"Пульт", href:"/staff/dashboard", section:"dashboard", icon:"🏠" },
   { label:"Прийом", href:"/staff/intake", section:"intake", icon:"📥" },
@@ -36,7 +30,6 @@ const processRail: NavLink[] = [
   { label:"Видача", href:"/staff/studies", section:"studies", icon:"✅" },
 ];
 
-// Модулі — усе, що поза щоденним потоком: довідники, фінанси, адміністрування.
 const systemModules: NavModule[] = [
   { label:"Пацієнти", href:"/staff/patients", sections:["patients","chat"], icon:"👥", items:[
     { label:"Картки пацієнтів", href:"/staff/patients" },
@@ -55,8 +48,9 @@ const systemModules: NavModule[] = [
   { label:"Склад", href:"/staff/inventory", sections:["inventory"], icon:"▣", items:[
     { label:"Витратні матеріали", href:"/staff/inventory" },
   ]},
-  { label:"Фінанси і звіти", href:"/staff/finance", sections:["finance","reports","tariffs"], icon:"💳", items:[
+  { label:"Фінанси і звіти", href:"/staff/finance", sections:["finance","counterparties","reports","tariffs"], icon:"💳", items:[
     { label:"Фінансові документи", href:"/staff/finance" },
+    { label:"Контрагенти", href:"/staff/counterparties" },
     { label:"Звіти відділення", href:"/staff/reports" },
     { label:"Тарифи", href:"/staff/tariffs" },
   ]},
@@ -131,9 +125,7 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
-  // Робочі екрани лікаря працюють на всю ширину (Variant B), тому заголовок
-  // сторінки теж розтягуємо, щоб він не «висів» вужчою колонкою над контентом.
-  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board" || active === "tasks" || active === "inventory" || active === "finance";
+  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board" || active === "tasks" || active === "inventory" || active === "finance" || active === "counterparties";
   return <div className={`workspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
     <aside className="workspaceSidebar">
@@ -155,8 +147,6 @@ export default function StaffWorkspaceShell({
         <p>Модулі</p>
         {systemModules.map((item)=>{
           const isActive = item.sections.includes(active);
-          // Акордеон: типово розгорнутий лише модуль поточного розділу, решта
-          // згорнуті в один рядок. Користувач може розгортати вручну.
           const isOpen = openModules[item.href] ?? isActive;
           return <div className="workspaceModuleGroup" key={item.href}>
             <div className="workspaceModuleRow">
@@ -225,14 +215,14 @@ export default function StaffWorkspaceShell({
       <main className="workspacePage">
         <header className="workspacePageHead">
           <div>
-            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "finance" ? "Фінанси":active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "equipment" ? "Обладнання":active === "services" ? "Послуги кабінетів":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "board" ? "Дошка досліджень":active === "tasks" ? "Завдання":active === "inventory" ? "Склад":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Публічний сайт":active === "schedule" ? "Графік кабінетів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "structure" ? "Структура відділення":active === "audit" ? "Журнал дій":active === "intake" ? "Дошка прийому":"Робочий кабінет"}</p>
+            <p className="workspaceBreadcrumb">RadiologyOS <span>/</span> {active === "finance" ? "Фінанси":active === "counterparties" ? "Контрагенти":active === "reports" ? "Аналітика":active === "protocols" ? "Протоколи":active === "patients" ? "CRM":active === "imaging" ? "DICOM / PACS":active === "equipment" ? "Обладнання":active === "services" ? "Послуги кабінетів":active === "dashboard" ? "Пульт":active === "studies" ? "Дослідження":active === "appointments" ? "Календар записів":active === "board" ? "Дошка досліджень":active === "tasks" ? "Завдання":active === "inventory" ? "Склад":active === "whatsapp" ? "WhatsApp":active === "chat" ? "Чат з пацієнтами":active === "site" ? "Публічний сайт":active === "schedule" ? "Графік кабінетів":active === "tariffs" ? "Тарифи":active === "settings" ? "Налаштування":active === "organization" ? "Організація":active === "structure" ? "Структура відділення":active === "audit" ? "Журнал дій":active === "intake" ? "Дошка прийому":"Робочий кабінет"}</p>
             <h1>{title}</h1>
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
             {active === "reports"
               ? <Link href="/staff">До черги заявок</Link>
-              : active === "protocols" || active === "patients" || active === "imaging" || active === "equipment" || active === "services" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "board" || active === "tasks" || active === "inventory" || active === "finance" || active === "whatsapp" || active === "chat" || active === "schedule" || active === "structure" || active === "audit" || active === "intake"
+              : active === "protocols" || active === "patients" || active === "imaging" || active === "equipment" || active === "services" || active === "dashboard" || active === "settings" || active === "tariffs" || active === "studies" || active === "organization" || active === "appointments" || active === "board" || active === "tasks" || active === "inventory" || active === "finance" || active === "counterparties" || active === "whatsapp" || active === "chat" || active === "schedule" || active === "structure" || active === "audit" || active === "intake"
               ? <><Link href="/staff">До черги заявок</Link><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>
               : <><a href="#bookings">Відкрити заявки</a><Link className="primary" href="/staff/reports">Перейти до звітів</Link></>}
           </div>

--- a/docs/bas-counterparties.md
+++ b/docs/bas-counterparties.md
@@ -1,0 +1,30 @@
+# BAS Counterparties and supplier references
+
+`counterparty` is a real tenant-scoped reference in the RadiologyOS business core. The first consumer is warehouse receipt (`inventory_receipt`).
+
+## Identity and snapshot
+
+A new receipt can point to `counterparties.id` through `supplier_counterparty_id`. The document line also stores the supplier name in the existing `supplier` field as the historical snapshot selected at document creation.
+
+This separation is deliberate:
+
+- `supplier_counterparty_id` answers **which counterparty** the document refers to;
+- `supplier` answers **what supplier name was recorded on this document**;
+- renaming or deactivating the directory entry never rewrites a posted receipt, lot or printed form;
+- legacy free-text supplier values remain valid with a null reference; they are never guessed/backfilled into counterparties.
+
+## Supplier rules
+
+- references are tenant scoped;
+- only active `supplier` / `both` counterparties may be selected for a new receipt;
+- a prepared draft may still be posted if the counterparty is later renamed/deactivated because the document already owns its snapshot;
+- a payer-only counterparty cannot be used as a warehouse supplier;
+- referenced counterparties are retired with `active=0`, not deleted from historical evidence.
+
+## Printed forms
+
+The existing inventory print engine renders the line-level `supplier` snapshot into the immutable `printed_form_snapshots` payload. Reprinting a posted receipt therefore reproduces the historical supplier name even after the master-data record changes.
+
+## Boundary
+
+This is operational master data, not tax/accounting automation. Counterparty balances, purchase invoices, VAT and statutory accounting are outside this slice.

--- a/drizzle/0077_counterparties_suppliers.sql
+++ b/drizzle/0077_counterparties_suppliers.sql
@@ -1,0 +1,131 @@
+-- BAS reference layer: tenant-scoped counterparties become the canonical identity for suppliers.
+-- Existing free-text supplier values remain untouched as historical snapshots; no heuristic backfill.
+CREATE TABLE IF NOT EXISTS `counterparties` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `code` text DEFAULT '' NOT NULL,
+  `name` text NOT NULL,
+  `kind` text DEFAULT 'supplier' NOT NULL CHECK (`kind` IN ('supplier','payer','both','other')),
+  `tax_id` text DEFAULT '' NOT NULL,
+  `phone` text DEFAULT '' NOT NULL,
+  `email` text DEFAULT '' NOT NULL,
+  `address` text DEFAULT '' NOT NULL,
+  `active` integer DEFAULT 1 NOT NULL CHECK (`active` IN (0,1)),
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `counterparties_org_id_idx`
+  ON `counterparties` (`organization_id`,`id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `counterparties_org_code_idx`
+  ON `counterparties` (`organization_id`,`code`) WHERE `code` <> '';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `counterparties_org_kind_active_idx`
+  ON `counterparties` (`organization_id`,`kind`,`active`,`name`);
+--> statement-breakpoint
+
+ALTER TABLE `inventory_document_lines` ADD COLUMN `supplier_counterparty_id` integer;
+--> statement-breakpoint
+ALTER TABLE `inventory_lots` ADD COLUMN `supplier_counterparty_id` integer;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `inventory_document_lines_supplier_idx`
+  ON `inventory_document_lines` (`organization_id`,`supplier_counterparty_id`,`document_id`)
+  WHERE `supplier_counterparty_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `inventory_lots_supplier_idx`
+  ON `inventory_lots` (`organization_id`,`supplier_counterparty_id`,`id`)
+  WHERE `supplier_counterparty_id` IS NOT NULL;
+--> statement-breakpoint
+
+-- Organization is permanent reference identity. Business fields can be edited while the reference exists.
+CREATE TRIGGER IF NOT EXISTS `counterparty_identity_immutable`
+BEFORE UPDATE OF `organization_id` ON `counterparties`
+WHEN NEW.organization_id <> OLD.organization_id
+BEGIN SELECT RAISE(ABORT,'counterparty_tenant_immutable'); END;
+--> statement-breakpoint
+
+-- New receipt links must resolve to one active supplier/both reference in the same tenant.
+-- The free-text supplier field is an explicit selection-time snapshot and must equal the reference name.
+CREATE TRIGGER IF NOT EXISTS `inventory_line_supplier_reference_insert`
+BEFORE INSERT ON `inventory_document_lines`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_supplier_tenant_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.active=1 AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_not_active_supplier') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.name=NEW.supplier
+  ) THEN RAISE(ABORT,'counterparty_supplier_snapshot_mismatch') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `inventory_line_supplier_reference_update`
+BEFORE UPDATE OF `organization_id`,`supplier_counterparty_id`,`supplier` ON `inventory_document_lines`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_supplier_tenant_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.active=1 AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_not_active_supplier') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.name=NEW.supplier
+  ) THEN RAISE(ABORT,'counterparty_supplier_snapshot_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- A posted receipt creates the lot later. It keeps the receipt's supplier snapshot even if the
+-- reference was renamed or deactivated between draft creation and posting, but may never cross tenant/type.
+CREATE TRIGGER IF NOT EXISTS `inventory_lot_supplier_reference_insert`
+BEFORE INSERT ON `inventory_lots`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_lot_supplier_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `inventory_lot_supplier_reference_update`
+BEFORE UPDATE OF `organization_id`,`supplier_counterparty_id`,`supplier` ON `inventory_lots`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM inventory_movements m
+    WHERE m.organization_id=OLD.organization_id AND m.lot_id=OLD.id
+  ) THEN RAISE(ABORT,'inventory_lot_supplier_immutable') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_lot_supplier_invalid') END;
+END;
+--> statement-breakpoint
+
+-- Referenced master data is retired through active=0, never deleted out from under historical documents.
+CREATE TRIGGER IF NOT EXISTS `counterparty_no_delete_when_referenced`
+BEFORE DELETE ON `counterparties`
+WHEN EXISTS (
+  SELECT 1 FROM inventory_document_lines l
+  WHERE l.organization_id=OLD.organization_id AND l.supplier_counterparty_id=OLD.id
+) OR EXISTS (
+  SELECT 1 FROM inventory_lots l
+  WHERE l.organization_id=OLD.organization_id AND l.supplier_counterparty_id=OLD.id
+)
+BEGIN SELECT RAISE(ABORT,'counterparty_in_use'); END;

--- a/drizzle/0078_historical_supplier_trace.sql
+++ b/drizzle/0078_historical_supplier_trace.sql
@@ -1,0 +1,124 @@
+-- A write-off inherits supplier traceability from the historical lot. It must not revalidate
+-- that old supplier snapshot against current counterparty master data after rename/deactivation.
+DROP TRIGGER IF EXISTS `inventory_line_supplier_reference_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `inventory_line_supplier_reference_update`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `inventory_lot_supplier_reference_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `inventory_lot_supplier_reference_update`;
+--> statement-breakpoint
+
+CREATE TRIGGER `inventory_line_supplier_reference_insert`
+BEFORE INSERT ON `inventory_document_lines`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  -- A new receipt selects current active supplier master data and freezes its name snapshot.
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_supplier_tenant_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.active=1 AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_not_active_supplier') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id AND c.name=NEW.supplier
+  ) THEN RAISE(ABORT,'counterparty_supplier_snapshot_mismatch') END;
+
+  -- A write-off copies the exact supplier identity + snapshot from the selected historical lot.
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_writeoff'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM inventory_lots l
+    WHERE l.id=NEW.lot_id AND l.organization_id=NEW.organization_id
+      AND l.supplier_counterparty_id=NEW.supplier_counterparty_id AND l.supplier=NEW.supplier
+  ) THEN RAISE(ABORT,'inventory_writeoff_supplier_trace_mismatch') END;
+
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type IN ('inventory_receipt','inventory_writeoff')
+  ) THEN RAISE(ABORT,'counterparty_supplier_document_type_invalid') END;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `inventory_line_supplier_reference_update`
+BEFORE UPDATE OF `organization_id`,`document_id`,`lot_id`,`supplier_counterparty_id`,`supplier` ON `inventory_document_lines`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_supplier_tenant_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.active=1 AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_not_active_supplier') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id AND c.name=NEW.supplier
+  ) THEN RAISE(ABORT,'counterparty_supplier_snapshot_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_writeoff'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM inventory_lots l
+    WHERE l.id=NEW.lot_id AND l.organization_id=NEW.organization_id
+      AND l.supplier_counterparty_id=NEW.supplier_counterparty_id AND l.supplier=NEW.supplier
+  ) THEN RAISE(ABORT,'inventory_writeoff_supplier_trace_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type IN ('inventory_receipt','inventory_writeoff')
+  ) THEN RAISE(ABORT,'counterparty_supplier_document_type_invalid') END;
+END;
+--> statement-breakpoint
+
+-- Lot creation happens after the receipt line already validated the current supplier reference.
+-- At posting time only tenant identity remains authoritative; later master-data state is irrelevant.
+CREATE TRIGGER `inventory_lot_supplier_reference_insert`
+BEFORE INSERT ON `inventory_lots`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_lot_supplier_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_lot_supplier_reference_update`
+BEFORE UPDATE OF `organization_id`,`supplier_counterparty_id`,`supplier` ON `inventory_lots`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM inventory_movements m
+    WHERE m.organization_id=OLD.organization_id AND m.lot_id=OLD.id
+  ) THEN RAISE(ABORT,'inventory_lot_supplier_immutable') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_lot_supplier_invalid') END;
+END;

--- a/lib/counterparties.ts
+++ b/lib/counterparties.ts
@@ -1,0 +1,88 @@
+export type CounterpartyKind="supplier"|"payer"|"both"|"other";
+
+export type CounterpartyRow={
+  id:number;organizationId:number;code:string;name:string;kind:CounterpartyKind;
+  taxId:string;phone:string;email:string;address:string;active:number;createdAt:string;updatedAt:string;
+};
+
+const KINDS=new Set<CounterpartyKind>(["supplier","payer","both","other"]);
+
+function text(value:unknown,max:number){return String(value??"").trim().slice(0,max);}
+function bool(value:unknown){return value===false||value===0||value==="0"?0:1;}
+export function isCounterpartyKind(value:unknown):value is CounterpartyKind{return KINDS.has(String(value) as CounterpartyKind);}
+
+const SELECT=`SELECT id,organization_id AS organizationId,code,name,kind,tax_id AS taxId,phone,email,address,
+                     active,created_at AS createdAt,updated_at AS updatedAt FROM counterparties`;
+
+export async function getCounterparty(db:D1Database,organizationId:number,id:number){
+  return db.prepare(`${SELECT} WHERE organization_id=? AND id=? LIMIT 1`)
+    .bind(organizationId,id).first<CounterpartyRow>();
+}
+
+export async function listCounterparties(
+  db:D1Database,
+  organizationId:number,
+  input:{kind?:CounterpartyKind|"supplier_or_both";active?:boolean;query?:string;limit?:number}={},
+){
+  const where=["organization_id=?"];const args:Array<string|number>=[organizationId];
+  if(input.kind==="supplier_or_both") where.push("kind IN ('supplier','both')");
+  else if(input.kind){where.push("kind=?");args.push(input.kind);}
+  if(input.active!==undefined){where.push("active=?");args.push(input.active?1:0);}
+  const q=text(input.query,100).toLowerCase();
+  if(q){where.push("(lower(name) LIKE ? OR lower(code) LIKE ? OR lower(tax_id) LIKE ?)");const like=`%${q}%`;args.push(like,like,like);}
+  const limit=Math.max(1,Math.min(500,Math.trunc(input.limit||250)));
+  const rows=await db.prepare(`${SELECT} WHERE ${where.join(" AND ")} ORDER BY active DESC,name,id LIMIT ${limit}`)
+    .bind(...args).all<CounterpartyRow>();
+  return rows.results;
+}
+
+export function normalizeCounterpartyInput(input:Record<string,unknown>){
+  const name=text(input.name,180);
+  const code=text(input.code,80);
+  const kind=isCounterpartyKind(input.kind)?input.kind:"supplier";
+  const taxId=text(input.taxId,40);
+  const phone=text(input.phone,40);
+  const email=text(input.email,160).toLowerCase();
+  const address=text(input.address,300);
+  const active=input.active===undefined?1:bool(input.active);
+  if(!name) throw new Error("counterparty_name_required");
+  if(email&&!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error("counterparty_email_invalid");
+  return {name,code,kind,taxId,phone,email,address,active};
+}
+
+export async function createCounterparty(db:D1Database,input:{organizationId:number;values:Record<string,unknown>}){
+  const value=normalizeCounterpartyInput(input.values);
+  const result=await db.prepare(
+    `INSERT INTO counterparties (organization_id,code,name,kind,tax_id,phone,email,address,active)
+     VALUES (?,?,?,?,?,?,?,?,?)`
+  ).bind(input.organizationId,value.code,value.name,value.kind,value.taxId,value.phone,value.email,value.address,value.active).run();
+  const id=Number(result.meta.last_row_id||0);
+  if(!id) throw new Error("counterparty_create_failed");
+  return getCounterparty(db,input.organizationId,id);
+}
+
+export async function updateCounterparty(db:D1Database,input:{organizationId:number;id:number;values:Record<string,unknown>}){
+  const current=await getCounterparty(db,input.organizationId,input.id);
+  if(!current)return null;
+  const value=normalizeCounterpartyInput({
+    name:input.values.name===undefined?current.name:input.values.name,
+    code:input.values.code===undefined?current.code:input.values.code,
+    kind:input.values.kind===undefined?current.kind:input.values.kind,
+    taxId:input.values.taxId===undefined?current.taxId:input.values.taxId,
+    phone:input.values.phone===undefined?current.phone:input.values.phone,
+    email:input.values.email===undefined?current.email:input.values.email,
+    address:input.values.address===undefined?current.address:input.values.address,
+    active:input.values.active===undefined?!!current.active:input.values.active,
+  });
+  await db.prepare(
+    `UPDATE counterparties SET code=?,name=?,kind=?,tax_id=?,phone=?,email=?,address=?,active=?,updated_at=CURRENT_TIMESTAMP
+     WHERE organization_id=? AND id=?`
+  ).bind(value.code,value.name,value.kind,value.taxId,value.phone,value.email,value.address,value.active,input.organizationId,input.id).run();
+  return getCounterparty(db,input.organizationId,input.id);
+}
+
+export async function getActiveSupplierCounterparty(db:D1Database,organizationId:number,id:number){
+  return db.prepare(
+    `${SELECT} WHERE organization_id=? AND id=? AND active=1 AND kind IN ('supplier','both') LIMIT 1`
+  ).bind(organizationId,id).first<CounterpartyRow>();
+}

--- a/lib/inventory-documents.ts
+++ b/lib/inventory-documents.ts
@@ -1,4 +1,5 @@
 import type { DocumentState } from "./business-core";
+import { getActiveSupplierCounterparty } from "./counterparties";
 
 export type InventoryDocumentType = "inventory_receipt" | "inventory_writeoff";
 
@@ -9,6 +10,7 @@ export type InventoryDocumentLineInput = {
   lotNumber?: string;
   expiresOn?: string;
   supplier?: string;
+  supplierCounterpartyId?: number | null;
   reason?: string;
   bookingId?: number | null;
 };
@@ -37,6 +39,7 @@ export type InventoryDocumentLineRow = {
   lotNumber:string;
   expiresOn:string;
   supplier:string;
+  supplierCounterpartyId:number|null;
   quantity:number;
   reason:string;
   bookingId:number|null;
@@ -75,12 +78,13 @@ async function item(db:D1Database,organizationId:number,itemId:number) {
 async function lot(db:D1Database,organizationId:number,lotId:number) {
   return db.prepare(
     `SELECT l.id,l.item_id AS itemId,l.lot_number AS lotNumber,l.expires_on AS expiresOn,l.supplier,
-            i.name,i.unit,i.active
+            l.supplier_counterparty_id AS supplierCounterpartyId,i.name,i.unit,i.active
      FROM inventory_lots l
      JOIN inventory_items i ON i.id=l.item_id AND i.organization_id=l.organization_id
      WHERE l.organization_id=? AND l.id=? LIMIT 1`
   ).bind(organizationId,lotId).first<{
-    id:number;itemId:number;lotNumber:string;expiresOn:string;supplier:string;name:string;unit:string;active:number;
+    id:number;itemId:number;lotNumber:string;expiresOn:string;supplier:string;supplierCounterpartyId:number|null;
+    name:string;unit:string;active:number;
   }>();
 }
 
@@ -105,7 +109,7 @@ export async function getInventoryDocument(db:D1Database,organizationId:number,d
   const lines = await db.prepare(
     `SELECT id,organization_id AS organizationId,document_id AS documentId,line_no AS lineNo,
             item_id AS itemId,lot_id AS lotId,lot_number AS lotNumber,expires_on AS expiresOn,
-            supplier,quantity,reason,booking_id AS bookingId
+            supplier,supplier_counterparty_id AS supplierCounterpartyId,quantity,reason,booking_id AS bookingId
      FROM inventory_document_lines
      WHERE organization_id=? AND document_id=? ORDER BY line_no,id`
   ).bind(organizationId,documentId).all<InventoryDocumentLineRow>();
@@ -140,7 +144,8 @@ export async function createInventoryDocument(
   }
 
   const normalized:Array<Required<Pick<InventoryDocumentLineInput,"quantity">> & {
-    itemId:number;lotId:number|null;lotNumber:string;expiresOn:string;supplier:string;reason:string;bookingId:number|null;
+    itemId:number;lotId:number|null;lotNumber:string;expiresOn:string;supplier:string;supplierCounterpartyId:number|null;
+    reason:string;bookingId:number|null;
   }> = [];
 
   for (const source of input.lines) {
@@ -153,9 +158,16 @@ export async function createInventoryDocument(
       if (!found || !found.active) throw new Error("inventory_document_item_not_found");
       const expiresOn = text(source.expiresOn,10);
       if (expiresOn && !DATE_RE.test(expiresOn)) throw new Error("inventory_document_invalid_expiry");
+      const supplierCounterpartyId=intOrNull(source.supplierCounterpartyId);
+      let supplier=text(source.supplier,180);
+      if (supplierCounterpartyId) {
+        const counterparty=await getActiveSupplierCounterparty(db,input.organizationId,supplierCounterpartyId);
+        if (!counterparty) throw new Error("inventory_document_supplier_not_found");
+        supplier=counterparty.name;
+      }
       normalized.push({
-        itemId,lotId:null,quantity:qty,lotNumber:text(source.lotNumber,100),expiresOn,
-        supplier:text(source.supplier,180),reason:text(source.reason,500) || "Надходження",bookingId:null,
+        itemId,lotId:null,quantity:qty,lotNumber:text(source.lotNumber,100),expiresOn,supplier,supplierCounterpartyId,
+        reason:text(source.reason,500) || "Надходження",bookingId:null,
       });
     } else {
       const lotId = intOrNull(source.lotId);
@@ -168,7 +180,7 @@ export async function createInventoryDocument(
       if (!reason) throw new Error("inventory_document_reason_required");
       normalized.push({
         itemId:found.itemId,lotId,quantity:qty,lotNumber:found.lotNumber,expiresOn:found.expiresOn,
-        supplier:found.supplier,reason,bookingId,
+        supplier:found.supplier,supplierCounterpartyId:found.supplierCounterpartyId,reason,bookingId,
       });
     }
   }
@@ -188,11 +200,11 @@ export async function createInventoryDocument(
   try {
     await db.batch(normalized.map((line,index)=>db.prepare(
       `INSERT INTO inventory_document_lines
-        (organization_id,document_id,line_no,item_id,lot_id,lot_number,expires_on,supplier,quantity,reason,booking_id)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?)`
+        (organization_id,document_id,line_no,item_id,lot_id,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason,booking_id)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`
     ).bind(
       input.organizationId,documentId,index+1,line.itemId,line.lotId,line.lotNumber,line.expiresOn,
-      line.supplier,line.quantity,line.reason,line.bookingId,
+      line.supplier,line.supplierCounterpartyId,line.quantity,line.reason,line.bookingId,
     )));
   } catch (error) {
     await db.prepare("DELETE FROM business_documents WHERE organization_id=? AND id=? AND state='draft'")
@@ -285,9 +297,9 @@ export async function postInventoryDocument(
     for (const line of lines) {
       if (line.lotId) continue;
       const lotResult = await db.prepare(
-        `INSERT INTO inventory_lots (organization_id,item_id,lot_number,expires_on,supplier)
-         VALUES (?,?,?,?,?)`
-      ).bind(input.organizationId,line.itemId,line.lotNumber,line.expiresOn,line.supplier).run();
+        `INSERT INTO inventory_lots (organization_id,item_id,lot_number,expires_on,supplier,supplier_counterparty_id)
+         VALUES (?,?,?,?,?,?)`
+      ).bind(input.organizationId,line.itemId,line.lotNumber,line.expiresOn,line.supplier,line.supplierCounterpartyId).run();
       const lotId = Number(lotResult.meta.last_row_id || 0);
       if (!lotId) {
         await cleanupUnpostedReceiptLots(db,input.organizationId,input.documentId,createdReceiptLots);

--- a/tests/counterparties-inventory.behavior.test.mjs
+++ b/tests/counterparties-inventory.behavior.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function createCounterparty(db,cookie,body){
+  const response=await callWorker(jsonRequest("/api/staff/counterparties",body,{headers:{cookie}}),db);
+  const payload=await response.json();
+  return {response,payload};
+}
+
+async function seedItem(db,organizationId=1,name="Контраст тестовий"){
+  const result=await db.prepare(
+    "INSERT INTO inventory_items (organization_id,sku,name,category,unit,min_stock) VALUES (?,?,?,'contrast','фл',0)"
+  ).bind(organizationId,`SKU-${organizationId}-${Math.random()}`,name).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function createReceipt(db,cookie,itemId,line={}){
+  const response=await callWorker(jsonRequest("/api/staff/inventory/documents",{
+    action:"create",documentType:"inventory_receipt",
+    lines:[{itemId,quantity:2,lotNumber:"LOT-C",reason:"Надходження",...line}],
+  },{headers:{cookie}}),db);
+  const payload=await response.json();
+  return {response,payload};
+}
+
+async function postDocument(db,cookie,documentId){
+  return callWorker(jsonRequest("/api/staff/inventory/documents",{action:"post",documentId},{headers:{cookie}}),db);
+}
+
+async function printDocument(db,cookie,documentId){
+  const response=await callWorker(jsonRequest("/api/staff/inventory/documents/print",{documentId},{headers:{cookie}}),db);
+  return {response,payload:await response.json()};
+}
+
+test("counterparty directory is tenant scoped and supplier filter does not leak payer-only rows",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Counterparty Org 2','counterparty-org-2',1)");
+    const admin1=await seedStaffSession(db,{email:"counterparty-admin1@example.com",role:"admin",organizationId:1});
+    const admin2=await seedStaffSession(db,{email:"counterparty-admin2@example.com",role:"admin",organizationId:2});
+    const supplier=await createCounterparty(db,admin1,{name:"ТОВ Постачальник 1",code:"SUP-1",kind:"supplier",taxId:"12345678"});
+    assert.equal(supplier.response.status,201);
+    const payer=await createCounterparty(db,admin1,{name:"ТОВ Платник 1",code:"PAY-1",kind:"payer"});
+    assert.equal(payer.response.status,201);
+    const foreign=await createCounterparty(db,admin2,{name:"ТОВ Постачальник 2",code:"SUP-2",kind:"supplier"});
+    assert.equal(foreign.response.status,201);
+
+    const list=await callWorker(new Request("http://localhost/api/staff/counterparties?kind=supplier&active=1",{headers:{cookie:admin1}}),db);
+    assert.equal(list.status,200);
+    const body=await list.json();
+    assert.deepEqual(body.counterparties.map(row=>row.name),["ТОВ Постачальник 1"]);
+    assert.ok(body.counterparties.every(row=>row.organizationId===1));
+
+    const clinician=await seedStaffSession(db,{email:"counterparty-doctor@example.com",role:"radiologist",organizationId:1});
+    const denied=await callWorker(new Request("http://localhost/api/staff/counterparties",{headers:{cookie:clinician}}),db);
+    assert.equal(denied.status,403);
+  });
+});
+
+test("receipt stores supplier reference plus immutable snapshot and historical reprint survives rename",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"supplier-receipt@example.com",role:"admin",organizationId:1});
+    const itemId=await seedItem(db);
+    const createdSupplier=await createCounterparty(db,cookie,{name:"ТОВ Медпостач",code:"MED-1",kind:"supplier"});
+    const supplierId=createdSupplier.payload.counterparty.id;
+
+    const draft=await createReceipt(db,cookie,itemId,{supplierCounterpartyId:supplierId});
+    assert.equal(draft.response.status,201);
+    assert.equal(draft.payload.lines[0].supplierCounterpartyId,supplierId);
+    assert.equal(draft.payload.lines[0].supplier,"ТОВ Медпостач");
+
+    const posted=await postDocument(db,cookie,draft.payload.document.id);
+    assert.equal(posted.status,200);
+    const lot=raw.prepare(
+      "SELECT supplier,supplier_counterparty_id AS supplierCounterpartyId FROM inventory_lots WHERE organization_id=1 AND id=?"
+    ).get(draft.payload.lines[0].lotId||raw.prepare("SELECT lot_id AS lotId FROM inventory_document_lines WHERE document_id=?").get(draft.payload.document.id).lotId);
+    assert.equal(lot.supplier,"ТОВ Медпостач");
+    assert.equal(lot.supplierCounterpartyId,supplierId);
+
+    const firstPrint=await printDocument(db,cookie,draft.payload.document.id);
+    assert.equal(firstPrint.response.status,201);
+    assert.equal(firstPrint.payload.payload.lines[0].supplier,"ТОВ Медпостач");
+
+    const rename=await callWorker(jsonRequest("/api/staff/counterparties",{
+      id:supplierId,name:"ТОВ Медпостач НОВА НАЗВА",
+    },{method:"PATCH",headers:{cookie}}),db);
+    assert.equal(rename.status,200);
+    assert.equal(raw.prepare("SELECT supplier FROM inventory_document_lines WHERE document_id=?").get(draft.payload.document.id).supplier,"ТОВ Медпостач");
+
+    const reprint=await printDocument(db,cookie,draft.payload.document.id);
+    assert.equal(reprint.response.status,200);
+    assert.equal(reprint.payload.snapshot.id,firstPrint.payload.snapshot.id);
+    assert.equal(reprint.payload.payload.lines[0].supplier,"ТОВ Медпостач");
+    assert.throws(()=>raw.prepare("DELETE FROM counterparties WHERE organization_id=1 AND id=?").run(supplierId),/counterparty_in_use/);
+  });
+});
+
+test("D1 rejects cross-tenant and payer-only supplier references",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Supplier Org 2','supplier-org-2',1)");
+    const itemId=await seedItem(db,1);
+    const cross=raw.prepare("INSERT INTO counterparties (organization_id,name,kind) VALUES (2,'Foreign Supplier','supplier')").run();
+    const payer=raw.prepare("INSERT INTO counterparties (organization_id,name,kind) VALUES (1,'Local Payer','payer')").run();
+    const doc=raw.prepare(
+      "INSERT INTO business_documents (organization_id,document_type,number,state,created_by) VALUES (1,'inventory_receipt','НД-REF-GUARD','draft','test@example.com')"
+    ).run();
+    const insert=(supplierId,supplier)=>raw.prepare(
+      `INSERT INTO inventory_document_lines
+       (organization_id,document_id,line_no,item_id,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason)
+       VALUES (1,?,1,?,'LOT','','',?,1,'test')`
+    ).run(Number(doc.lastInsertRowid),itemId,supplierId);
+    assert.throws(()=>insert(Number(cross.lastInsertRowid),"Foreign Supplier"),/counterparty_supplier_tenant_mismatch/);
+    assert.throws(()=>insert(Number(payer.lastInsertRowid),"Local Payer"),/counterparty_not_active_supplier/);
+  });
+});
+
+test("inactive supplier cannot be selected for a new receipt but existing reference stays historical",async()=>{
+  await withD1(async(db)=>{
+    const cookie=await seedStaffSession(db,{email:"supplier-inactive@example.com",role:"admin",organizationId:1});
+    const itemId=await seedItem(db);
+    const created=await createCounterparty(db,cookie,{name:"ТОВ Тимчасовий",kind:"supplier"});
+    const supplierId=created.payload.counterparty.id;
+    const disable=await callWorker(jsonRequest("/api/staff/counterparties",{id:supplierId,active:false},{method:"PATCH",headers:{cookie}}),db);
+    assert.equal(disable.status,200);
+    const receipt=await createReceipt(db,cookie,itemId,{supplierCounterpartyId:supplierId});
+    assert.equal(receipt.response.status,404);
+    assert.match(receipt.payload.error,/Постачальника не знайдено/);
+  });
+});
+
+test("legacy free-text supplier remains compatible without inventing a counterparty link",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"supplier-legacy@example.com",role:"admin",organizationId:1});
+    const itemId=await seedItem(db);
+    const draft=await createReceipt(db,cookie,itemId,{supplier:"Legacy Supplier Ltd"});
+    assert.equal(draft.response.status,201);
+    assert.equal(draft.payload.lines[0].supplier,"Legacy Supplier Ltd");
+    assert.equal(draft.payload.lines[0].supplierCounterpartyId,null);
+    const post=await postDocument(db,cookie,draft.payload.document.id);
+    assert.equal(post.status,200);
+    const lot=raw.prepare("SELECT supplier,supplier_counterparty_id AS supplierCounterpartyId FROM inventory_lots WHERE supplier='Legacy Supplier Ltd' LIMIT 1").get();
+    assert.equal(lot.supplier,"Legacy Supplier Ltd");
+    assert.equal(lot.supplierCounterpartyId,null);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM counterparties").get().n,0);
+  });
+});

--- a/tests/counterparty-historical-writeoff.behavior.test.mjs
+++ b/tests/counterparty-historical-writeoff.behavior.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+test("historical lot remains writable after its supplier master data changes",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"supplier-history@example.com",role:"admin",organizationId:1});
+    const item=await db.prepare(
+      "INSERT INTO inventory_items (organization_id,sku,name,category,unit,min_stock) VALUES (1,'HIST-SKU','Historical contrast','contrast','фл',0)"
+    ).run();
+    const itemId=Number(item.meta.last_row_id);
+
+    const supplierResponse=await callWorker(jsonRequest("/api/staff/counterparties",{
+      name:"ТОВ Історичний постачальник",code:"HIST-SUP",kind:"supplier",
+    },{headers:{cookie}}),db);
+    assert.equal(supplierResponse.status,201);
+    const supplier=(await supplierResponse.json()).counterparty;
+
+    const receiptResponse=await callWorker(jsonRequest("/api/staff/inventory/documents",{
+      action:"create",documentType:"inventory_receipt",
+      lines:[{itemId,quantity:5,lotNumber:"HIST-LOT",supplierCounterpartyId:supplier.id,reason:"Надходження"}],
+    },{headers:{cookie}}),db);
+    assert.equal(receiptResponse.status,201);
+    const receipt=await receiptResponse.json();
+    const postReceipt=await callWorker(jsonRequest("/api/staff/inventory/documents",{
+      action:"post",documentId:receipt.document.id,
+    },{headers:{cookie}}),db);
+    assert.equal(postReceipt.status,200);
+    const receiptLine=raw.prepare(
+      "SELECT lot_id AS lotId,supplier,supplier_counterparty_id AS supplierCounterpartyId FROM inventory_document_lines WHERE document_id=? LIMIT 1"
+    ).get(receipt.document.id);
+    assert.equal(receiptLine.supplier,"ТОВ Історичний постачальник");
+
+    const changeMaster=await callWorker(jsonRequest("/api/staff/counterparties",{
+      id:supplier.id,name:"ТОВ Нова назва",kind:"payer",active:false,
+    },{method:"PATCH",headers:{cookie}}),db);
+    assert.equal(changeMaster.status,200);
+
+    const writeoffResponse=await callWorker(jsonRequest("/api/staff/inventory/documents",{
+      action:"create",documentType:"inventory_writeoff",
+      lines:[{lotId:receiptLine.lotId,quantity:2,reason:"Використано після зміни довідника"}],
+    },{headers:{cookie}}),db);
+    assert.equal(writeoffResponse.status,201);
+    const writeoff=await writeoffResponse.json();
+    assert.equal(writeoff.lines[0].supplier,"ТОВ Історичний постачальник");
+    assert.equal(writeoff.lines[0].supplierCounterpartyId,supplier.id);
+    const postWriteoff=await callWorker(jsonRequest("/api/staff/inventory/documents",{
+      action:"post",documentId:writeoff.document.id,
+    },{headers:{cookie}}),db);
+    assert.equal(postWriteoff.status,200);
+    assert.equal(raw.prepare(
+      "SELECT COALESCE(SUM(quantity_delta),0) AS stock FROM inventory_movements WHERE organization_id=1 AND lot_id=?"
+    ).get(receiptLine.lotId).stock,3);
+
+    const forgedDoc=raw.prepare(
+      "INSERT INTO business_documents (organization_id,document_type,number,state,created_by) VALUES (1,'inventory_writeoff','СП-FORGED-SUP','draft','test@example.com')"
+    ).run();
+    const other=raw.prepare("INSERT INTO counterparties (organization_id,name,kind) VALUES (1,'Other Supplier','supplier')").run();
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO inventory_document_lines
+       (organization_id,document_id,line_no,item_id,lot_id,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason)
+       VALUES (1,?,1,?,?,'HIST-LOT','','Other Supplier',?,1,'forged')`
+    ).run(Number(forgedDoc.lastInsertRowid),itemId,receiptLine.lotId,Number(other.lastInsertRowid)),/inventory_writeoff_supplier_trace_mismatch/);
+  });
+});


### PR DESCRIPTION
## Goal
Make `counterparty` a real BAS-style reference and replace free-text supplier identity in new warehouse receipts with a tenant-scoped directory reference while preserving historical supplier snapshots.

## Implemented
- tenant-scoped `counterparties` directory with supplier/payer/both/other kinds
- `/staff/counterparties` reference list/editor
- supplier selection in new inventory receipts uses `supplier_counterparty_id`
- receipt line keeps the supplier name as an immutable historical snapshot
- posted lot carries both supplier reference and snapshot
- legacy free-text suppliers remain compatible with a null reference; no heuristic backfill
- active supplier/both validation for new receipt selection
- cross-tenant and payer-only supplier links rejected in D1
- referenced counterparties are retired with `active=0`, not deleted out from under history
- existing inventory printed-form snapshot automatically preserves the receipt-time supplier name

## Verification targets
- tenant isolation and role scope
- supplier filter excludes payer-only rows
- receipt stores exact supplier ID + snapshot
- rename after posting does not rewrite document, lot, or historical reprint
- cross-tenant and payer-only D1 rejection
- inactive supplier cannot be newly selected
- legacy free-text path remains compatible

## Boundary
Operational master data only; no VAT/statutory accounting or production deploy.