### PR TITLE
Add BAS warehouses and stock-location dimension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,23 @@ jobs:
         run: npm run build
 
       - name: Tests
-        run: node --experimental-strip-types --test tests/*.test.mjs
+        shell: bash
+        run: |
+          set +e
+          node --experimental-strip-types --test tests/*.test.mjs 2>&1 | tee test-output.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "### Behavioral test failure"
+              echo
+              echo '```text'
+              tail -n 160 test-output.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            details=$(tail -n 120 test-output.log | tr '\n' ' ' | sed 's/%/%25/g; s/\r/%0D/g')
+            echo "::error title=Behavioral tests failed::$details"
+            exit "$status"
+          fi
 
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,18 @@ jobs:
           node --experimental-strip-types --test tests/*.test.mjs 2>&1 | tee test-output.log
           status=${PIPESTATUS[0]}
           if [ "$status" -ne 0 ]; then
+            failure_context=$(grep -n -B 20 -A 45 "not ok " test-output.log || true)
+            if [ -z "$failure_context" ]; then
+              failure_context=$(tail -n 160 test-output.log)
+            fi
             {
               echo "### Behavioral test failure"
               echo
               echo '```text'
-              tail -n 160 test-output.log
+              printf '%s\n' "$failure_context"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            details=$(tail -n 120 test-output.log | tr '\n' ' ' | sed 's/%/%25/g; s/\r/%0D/g')
+            details=$(printf '%s\n' "$failure_context" | tail -n 260 | tr '\n' ' ' | sed 's/%/%25/g; s/\r/%0D/g')
             echo "::error title=Behavioral tests failed::$details"
             exit "$status"
           fi

--- a/app/api/staff/inventory/documents/print/route.ts
+++ b/app/api/staff/inventory/documents/print/route.ts
@@ -96,22 +96,23 @@ export async function POST(request:Request) {
   const formType=detail.document.documentType;
   const documentState=detail.document.state;
 
-  // Once a document leaves draft, its first generated form for this template/state becomes the
-  // canonical reprint. Warehouse/item master-data edits never rewrite the frozen payload.
+  // Once a document leaves draft, its earliest snapshot for that document/type/state is the
+  // canonical reprint across template upgrades. A later template may enrich first-time prints,
+  // but it must never silently replace what was already printed for the posted document.
   if(documentState!=="draft") {
     const existing=await db.prepare(
       `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
               document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
               generated_at AS generatedAt,storage_key AS storageKey,sha256
        FROM printed_form_snapshots
-       WHERE organization_id=? AND document_id=? AND form_type=? AND template_version=? AND document_state=?
+       WHERE organization_id=? AND document_id=? AND form_type=? AND document_state=?
        ORDER BY id ASC LIMIT 1`
-    ).bind(ctx.organizationId,documentId,formType,TEMPLATE_VERSION,documentState).first<SnapshotRow>();
+    ).bind(ctx.organizationId,documentId,formType,documentState).first<SnapshotRow>();
     if(existing) {
       await audit(db,{
         organizationId:ctx.organizationId,actorEmail:ctx.member.email,
         action:"printed_form_reprinted",resource:"business_document",targetId:documentId,
-        details:{formType,templateVersion:TEMPLATE_VERSION,snapshotId:existing.id},
+        details:{formType,templateVersion:existing.templateVersion,snapshotId:existing.id},
       });
       return Response.json({snapshot:publicSnapshot(existing),payload:JSON.parse(existing.payloadJson)});
     }

--- a/app/api/staff/inventory/documents/print/route.ts
+++ b/app/api/staff/inventory/documents/print/route.ts
@@ -3,7 +3,7 @@ import { dbBinding } from "../../../../../../lib/db";
 import { getInventoryDocument } from "../../../../../../lib/inventory-documents";
 import { requireOrgContext } from "../../../../../../lib/tenant";
 
-const TEMPLATE_VERSION = 1;
+const TEMPLATE_VERSION = 2;
 
 type SnapshotRow={
   id:number;documentId:number;formType:string;templateVersion:number;documentState:string;
@@ -34,14 +34,15 @@ async function renderPayload(db:D1Database,organizationId:number,documentId:numb
     .bind(organizationId).first<{name:string}>();
   const lines=await db.prepare(
     `SELECT l.line_no AS lineNo,l.item_id AS itemId,i.name AS itemName,i.unit,
+            l.warehouse_id AS warehouseId,l.warehouse_code AS warehouseCode,l.warehouse_name AS warehouseName,
             l.lot_number AS lotNumber,l.expires_on AS expiresOn,l.supplier,l.quantity,l.reason,
             l.booking_id AS bookingId
      FROM inventory_document_lines l
      JOIN inventory_items i ON i.id=l.item_id AND i.organization_id=l.organization_id
      WHERE l.organization_id=? AND l.document_id=? ORDER BY l.line_no,l.id`
   ).bind(organizationId,documentId).all<{
-    lineNo:number;itemId:number;itemName:string;unit:string;lotNumber:string;expiresOn:string;
-    supplier:string;quantity:number;reason:string;bookingId:number|null;
+    lineNo:number;itemId:number;itemName:string;unit:string;warehouseId:number;warehouseCode:string;warehouseName:string;
+    lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;bookingId:number|null;
   }>();
   return {
     templateVersion:TEMPLATE_VERSION,
@@ -95,9 +96,8 @@ export async function POST(request:Request) {
   const formType=detail.document.documentType;
   const documentState=detail.document.state;
 
-  // Once a document leaves draft, its first generated form for that immutable state becomes the
-  // canonical reprint. Later master-data edits (for example a renamed inventory item) must not
-  // silently rewrite what was printed for the posted document.
+  // Once a document leaves draft, its first generated form for this template/state becomes the
+  // canonical reprint. Warehouse/item master-data edits never rewrite the frozen payload.
   if(documentState!=="draft") {
     const existing=await db.prepare(
       `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,

--- a/app/api/staff/inventory/documents/route.ts
+++ b/app/api/staff/inventory/documents/route.ts
@@ -25,6 +25,7 @@ function mapCreateError(error:unknown) {
   const code = String(error instanceof Error ? error.message : error);
   if (code.includes("lines_required")) return [400,"Додайте хоча б один рядок документа"] as const;
   if (code.includes("invalid_quantity")) return [400,"Кількість має бути більшою за нуль"] as const;
+  if (code.includes("warehouse_not_found")) return [404,"Склад не знайдено або він неактивний"] as const;
   if (code.includes("item_required")) return [400,"Для надходження вкажіть матеріал"] as const;
   if (code.includes("item_not_found")) return [404,"Матеріал не знайдено або він неактивний"] as const;
   if (code.includes("invalid_expiry")) return [400,"Некоректний термін придатності"] as const;

--- a/app/api/staff/inventory/route.ts
+++ b/app/api/staff/inventory/route.ts
@@ -6,6 +6,7 @@ import {
   postInventoryDocument,
 } from "../../../../lib/inventory-documents";
 import { requireOrgContext } from "../../../../lib/tenant";
+import { listWarehouses } from "../../../../lib/warehouses";
 
 const CATEGORIES = new Set(["contrast","catheter","syringe","infusion","ppe","film","paper","disinfectant","other"]);
 const MANAGER_ROLES = new Set(["admin","radiographer"]);
@@ -19,10 +20,11 @@ type LotRow = {
   supplierCounterpartyId:number|null; stock:number;
 };
 type MovementRow = {
-  id:number; itemId:number; itemName:string; lotId:number; lotNumber:string; movementType:string;
-  quantityDelta:number; unit:string; reason:string; bookingId:number|null; actorEmail:string; createdAt:string;
-  documentId:number|null;
+  id:number; itemId:number; itemName:string; lotId:number; lotNumber:string; warehouseId:number|null;
+  warehouseCode:string;warehouseName:string;movementType:string;quantityDelta:number;unit:string;reason:string;
+  bookingId:number|null;actorEmail:string;createdAt:string;documentId:number|null;
 };
+type WarehouseBalanceRow={warehouseId:number;warehouseCode:string;warehouseName:string;lotId:number;itemId:number;itemName:string;lotNumber:string;stock:number};
 type SupplierRow={id:number;code:string;name:string};
 
 function cleanText(value:unknown,max:number) { return String(value || "").trim().slice(0,max); }
@@ -34,6 +36,7 @@ function nonNegativeNumber(value:unknown) {
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? n : null;
 }
+function positiveInt(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
 function canManage(role:string) { return MANAGER_ROLES.has(role); }
 
 async function itemForOrg(db:D1Database,organizationId:number,itemId:number) {
@@ -44,6 +47,7 @@ async function itemForOrg(db:D1Database,organizationId:number,itemId:number) {
 function inventoryDocumentError(error:unknown) {
   const code = String(error instanceof Error ? error.message : error);
   if (code.includes("invalid_expiry")) return Response.json({ error:"Некоректний термін придатності" },{status:400});
+  if (code.includes("warehouse_not_found")) return Response.json({ error:"Склад не знайдено або він неактивний" },{status:404});
   if (code.includes("item_not_found")) return Response.json({ error:"Матеріал не знайдено або він неактивний" },{status:404});
   if (code.includes("supplier_not_found")) return Response.json({ error:"Постачальника не знайдено, він неактивний або не є постачальником" },{status:404});
   if (code.includes("lot_not_found")) return Response.json({ error:"Партію не знайдено" },{status:404});
@@ -84,9 +88,23 @@ export async function GET(request:Request) {
      ORDER BY CASE WHEN l.expires_on = '' THEN 1 ELSE 0 END, l.expires_on, i.name`
   ).bind(ctx.organizationId).all<LotRow>();
 
+  const warehouseBalances=await db.prepare(
+    `SELECT m.warehouse_id AS warehouseId,m.warehouse_code AS warehouseCode,m.warehouse_name AS warehouseName,
+            m.lot_id AS lotId,m.item_id AS itemId,i.name AS itemName,l.lot_number AS lotNumber,
+            COALESCE(SUM(m.quantity_delta),0) AS stock
+     FROM inventory_movements m
+     JOIN inventory_items i ON i.id=m.item_id AND i.organization_id=m.organization_id
+     JOIN inventory_lots l ON l.id=m.lot_id AND l.organization_id=m.organization_id
+     WHERE m.organization_id=? AND m.warehouse_id IS NOT NULL
+     GROUP BY m.warehouse_id,m.lot_id,m.item_id
+     HAVING stock>0.000001
+     ORDER BY m.warehouse_name,i.name,l.lot_number,m.warehouse_id,m.lot_id`
+  ).bind(ctx.organizationId).all<WarehouseBalanceRow>();
+
   const movements = await db.prepare(
     `SELECT m.id, m.item_id AS itemId, i.name AS itemName, m.lot_id AS lotId,
-            l.lot_number AS lotNumber, m.movement_type AS movementType,
+            l.lot_number AS lotNumber,m.warehouse_id AS warehouseId,m.warehouse_code AS warehouseCode,
+            m.warehouse_name AS warehouseName,m.movement_type AS movementType,
             m.quantity_delta AS quantityDelta, i.unit, m.reason, m.booking_id AS bookingId,
             m.actor_email AS actorEmail, m.created_at AS createdAt,m.document_id AS documentId
      FROM inventory_movements m
@@ -100,8 +118,9 @@ export async function GET(request:Request) {
     `SELECT id,code,name FROM counterparties
      WHERE organization_id=? AND active=1 AND kind IN ('supplier','both') ORDER BY name,id LIMIT 500`
   ).bind(ctx.organizationId).all<SupplierRow>();
+  const warehouses=await listWarehouses(db,ctx.organizationId);
 
-  return Response.json({ items:items.results, lots:lots.results, movements:movements.results, counterparties:counterparties.results, staff:ctx.member, canManage:canManage(ctx.role) });
+  return Response.json({ items:items.results, lots:lots.results, warehouseBalances:warehouseBalances.results, warehouses, movements:movements.results, counterparties:counterparties.results, staff:ctx.member, canManage:canManage(ctx.role) });
 }
 
 export async function POST(request:Request) {
@@ -135,8 +154,8 @@ export async function POST(request:Request) {
     }
   }
 
-  // Compatibility actions: old callers still work, but every NEW movement is now registered by
-  // a BAS-style document and posting engine. Legacy free-text supplier remains accepted here.
+  // Compatibility actions: old callers still work. warehouseId is optional and resolves to the
+  // active default warehouse; new callers may select an explicit warehouse.
   if (action === "receive") {
     const itemId = Number(body.itemId);
     const quantity = positiveNumber(body.quantity);
@@ -147,7 +166,7 @@ export async function POST(request:Request) {
         actorEmail:ctx.member.email,
         type:"inventory_receipt",
         lines:[{
-          itemId,quantity,
+          itemId,warehouseId:positiveInt(body.warehouseId),quantity,
           lotNumber:cleanText(body.lotNumber,100),
           expiresOn:cleanText(body.expiresOn,10),
           supplier:cleanText(body.supplier,180),
@@ -162,7 +181,7 @@ export async function POST(request:Request) {
         return Response.json({error:posted.error},{status:posted.status});
       }
       const lotId = posted.document?.lines[0]?.lotId || 0;
-      await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"inventory_received", resource:"inventory", targetId:itemId, details:{ documentId:created.document.id, lotId, quantity, hasExpiry:!!cleanText(body.expiresOn,10) } });
+      await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"inventory_received", resource:"inventory", targetId:itemId, details:{ documentId:created.document.id, lotId, quantity, warehouseId:posted.document?.lines[0]?.warehouseId || null, hasExpiry:!!cleanText(body.expiresOn,10) } });
       return Response.json({ ok:true,lotId,documentId:created.document.id }, { status:201 });
     } catch (error) {
       const mapped = inventoryDocumentError(error);
@@ -183,7 +202,7 @@ export async function POST(request:Request) {
         organizationId:ctx.organizationId,
         actorEmail:ctx.member.email,
         type:"inventory_writeoff",
-        lines:[{lotId,quantity,reason,bookingId}],
+        lines:[{lotId,warehouseId:positiveInt(body.warehouseId),quantity,reason,bookingId}],
       });
       if (!created) return Response.json({ error:"Не вдалося створити документ списання" },{status:500});
       const posted = await postInventoryDocument(db,{organizationId:ctx.organizationId,documentId:created.document.id,actorEmail:ctx.member.email});
@@ -192,7 +211,7 @@ export async function POST(request:Request) {
         return Response.json({error:posted.error},{status:posted.status});
       }
       const itemId = posted.document?.lines[0]?.itemId || 0;
-      await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"inventory_written_off", resource:"inventory", targetId:itemId, details:{ documentId:created.document.id, lotId, quantity, linkedBooking:!!bookingId } });
+      await audit(db,{ organizationId:ctx.organizationId, actorEmail:ctx.member.email, action:"inventory_written_off", resource:"inventory", targetId:itemId, details:{ documentId:created.document.id, lotId, quantity, warehouseId:posted.document?.lines[0]?.warehouseId || null, linkedBooking:!!bookingId } });
       return Response.json({ ok:true,documentId:created.document.id });
     } catch (error) {
       const mapped = inventoryDocumentError(error);

--- a/app/api/staff/inventory/route.ts
+++ b/app/api/staff/inventory/route.ts
@@ -89,16 +89,17 @@ export async function GET(request:Request) {
   ).bind(ctx.organizationId).all<LotRow>();
 
   const warehouseBalances=await db.prepare(
-    `SELECT m.warehouse_id AS warehouseId,m.warehouse_code AS warehouseCode,m.warehouse_name AS warehouseName,
+    `SELECT w.id AS warehouseId,w.code AS warehouseCode,w.name AS warehouseName,
             m.lot_id AS lotId,m.item_id AS itemId,i.name AS itemName,l.lot_number AS lotNumber,
             COALESCE(SUM(m.quantity_delta),0) AS stock
      FROM inventory_movements m
+     JOIN warehouses w ON w.id=m.warehouse_id AND w.organization_id=m.organization_id
      JOIN inventory_items i ON i.id=m.item_id AND i.organization_id=m.organization_id
      JOIN inventory_lots l ON l.id=m.lot_id AND l.organization_id=m.organization_id
      WHERE m.organization_id=? AND m.warehouse_id IS NOT NULL
-     GROUP BY m.warehouse_id,m.lot_id,m.item_id
+     GROUP BY w.id,w.code,w.name,m.lot_id,m.item_id
      HAVING stock>0.000001
-     ORDER BY m.warehouse_name,i.name,l.lot_number,m.warehouse_id,m.lot_id`
+     ORDER BY w.name,i.name,l.lot_number,w.id,m.lot_id`
   ).bind(ctx.organizationId).all<WarehouseBalanceRow>();
 
   const movements = await db.prepare(

--- a/app/api/staff/warehouses/route.ts
+++ b/app/api/staff/warehouses/route.ts
@@ -1,0 +1,48 @@
+import { audit } from "../../../../lib/audit";
+import { dbBinding } from "../../../../lib/db";
+import { createWarehouse,listWarehouses,updateWarehouse } from "../../../../lib/warehouses";
+import { requireOrgContext } from "../../../../lib/tenant";
+
+function id(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
+function mapError(error:unknown){
+  const code=String(error instanceof Error?error.message:error).toLowerCase();
+  if(code.includes("warehouse_name_required"))return Response.json({error:"Вкажіть назву складу"},{status:400});
+  if(code.includes("warehouse_default_must_be_active"))return Response.json({error:"Основний склад має бути активним"},{status:409});
+  if(code.includes("warehouse_default_replacement_required"))return Response.json({error:"Спочатку створіть інший активний склад і зробіть його основним"},{status:409});
+  if(code.includes("unique"))return Response.json({error:"Такий код складу вже існує"},{status:409});
+  return null;
+}
+async function context(request:Request){
+  const db=dbBinding();if(!db)return {response:Response.json({error:"База тимчасово недоступна"},{status:503})} as const;
+  const ctx=await requireOrgContext(request,db);if(!ctx)return {response:Response.json({error:"Доступ лише для персоналу"},{status:403})} as const;
+  return {db,ctx} as const;
+}
+export async function GET(request:Request){
+  const auth=await context(request);if("response" in auth)return auth.response;const {db,ctx}=auth;
+  const activeParam=new URL(request.url).searchParams.get("active");const active=activeParam==="1"?true:activeParam==="0"?false:undefined;
+  const warehouses=await listWarehouses(db,ctx.organizationId,{active});
+  return Response.json({warehouses,staff:ctx.member,canEdit:ctx.role==="admin"});
+}
+export async function POST(request:Request){
+  const auth=await context(request);if("response" in auth)return auth.response;const {db,ctx}=auth;
+  if(ctx.role!=="admin")return Response.json({error:"Довідник складів може змінювати лише адміністратор"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  try{
+    const warehouse=await createWarehouse(db,{organizationId:ctx.organizationId,values:body});
+    if(!warehouse)return Response.json({error:"Не вдалося створити склад"},{status:500});
+    await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"warehouse_created",resource:"warehouse",targetId:warehouse.id,details:{active:!!warehouse.active,isDefault:!!warehouse.isDefault,hasCode:!!warehouse.code}});
+    return Response.json({warehouse},{status:201});
+  }catch(error){const mapped=mapError(error);if(mapped)return mapped;throw error;}
+}
+export async function PATCH(request:Request){
+  const auth=await context(request);if("response" in auth)return auth.response;const {db,ctx}=auth;
+  if(ctx.role!=="admin")return Response.json({error:"Довідник складів може змінювати лише адміністратор"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;const warehouseId=id(body.id);
+  if(!warehouseId)return Response.json({error:"Некоректний склад"},{status:400});
+  try{
+    const warehouse=await updateWarehouse(db,{organizationId:ctx.organizationId,id:warehouseId,values:body});
+    if(!warehouse)return Response.json({error:"Склад не знайдено"},{status:404});
+    await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"warehouse_updated",resource:"warehouse",targetId:warehouse.id,details:{active:!!warehouse.active,isDefault:!!warehouse.isDefault,hasCode:!!warehouse.code}});
+    return Response.json({warehouse});
+  }catch(error){const mapped=mapError(error);if(mapped)return mapped;throw error;}
+}

--- a/app/staff/inventory/page.tsx
+++ b/app/staff/inventory/page.tsx
@@ -6,13 +6,15 @@ import StaffWorkspaceShell from "../workspace-shell";
 type Staff = { email:string; displayName:string; role:string };
 type Item = { id:number; sku:string; name:string; category:string; unit:string; minStock:number; active:number; stock:number; expiringStock:number; nextExpiry:string };
 type Supplier = { id:number; code:string; name:string };
+type Warehouse = { id:number; code:string; name:string; active:number; isDefault:number };
 type Lot = { id:number; itemId:number; itemName:string; lotNumber:string; expiresOn:string; supplier:string; supplierCounterpartyId:number|null; stock:number };
-type Movement = { id:number; itemId:number; itemName:string; lotId:number; lotNumber:string; movementType:string; quantityDelta:number; unit:string; reason:string; bookingId:number|null; actorEmail:string; createdAt:string; documentId:number|null };
-type Payload = { items:Item[]; lots:Lot[]; movements:Movement[]; counterparties:Supplier[]; staff:Staff; canManage:boolean; error?:string };
+type WarehouseBalance = { warehouseId:number; warehouseCode:string; warehouseName:string; lotId:number; itemId:number; itemName:string; lotNumber:string; stock:number };
+type Movement = { id:number; itemId:number; itemName:string; lotId:number; lotNumber:string; warehouseId:number|null; warehouseCode:string; warehouseName:string; movementType:string; quantityDelta:number; unit:string; reason:string; bookingId:number|null; actorEmail:string; createdAt:string; documentId:number|null };
+type Payload = { items:Item[]; lots:Lot[]; warehouseBalances:WarehouseBalance[]; warehouses:Warehouse[]; movements:Movement[]; counterparties:Supplier[]; staff:Staff; canManage:boolean; error?:string };
 type DocumentState = "draft"|"posted"|"reversed"|"cancelled";
 type DocumentType = "inventory_receipt"|"inventory_writeoff";
 type DocumentSummary = { id:number; documentType:DocumentType; number:string; occurredAt:string; state:DocumentState; comment:string; createdBy:string; createdAt:string; postedBy:string; postedAt:string; lineCount:number; totalQuantity:number };
-type DocumentLine = { id:number; lineNo:number; itemId:number; lotId:number|null; lotNumber:string; expiresOn:string; supplier:string; supplierCounterpartyId:number|null; quantity:number; reason:string; bookingId:number|null };
+type DocumentLine = { id:number; lineNo:number; itemId:number; lotId:number|null; warehouseId:number; warehouseCode:string; warehouseName:string; lotNumber:string; expiresOn:string; supplier:string; supplierCounterpartyId:number|null; quantity:number; reason:string; bookingId:number|null };
 type DocumentDetail = { document:DocumentSummary; lines:DocumentLine[] };
 type DocumentsPayload = { documents:DocumentSummary[]; staff:Staff; canManage:boolean; error?:string };
 type Mode = "stock"|"documents"|"movements";
@@ -40,14 +42,19 @@ export default function InventoryPage() {
   const [showOnlyAlert,setShowOnlyAlert] = useState(false);
   const [busy,setBusy] = useState(false);
   const [itemForm,setItemForm] = useState({ name:"", sku:"", category:"contrast", unit:"шт", minStock:"0" });
-  const [receive,setReceive] = useState({ itemId:"", quantity:"", lotNumber:"", expiresOn:"", supplierCounterpartyId:"", reason:"Надходження" });
-  const [writeoff,setWriteoff] = useState({ lotId:"", quantity:"", reason:"Використано під час дослідження", bookingId:"" });
+  const [receive,setReceive] = useState({ warehouseId:"", itemId:"", quantity:"", lotNumber:"", expiresOn:"", supplierCounterpartyId:"", reason:"Надходження" });
+  const [writeoff,setWriteoff] = useState({ warehouseId:"", lotId:"", quantity:"", reason:"Використано під час дослідження", bookingId:"" });
 
   async function loadInventory() {
     const res = await fetch("/api/staff/inventory", { cache:"no-store" });
     const payload = await res.json().catch(()=>({})) as Payload;
     if (!res.ok || !payload.staff) throw new Error(payload.error || "Не вдалося завантажити склад");
     setData(payload);
+    const defaultWarehouse=payload.warehouses?.find(w=>w.active&&w.isDefault) || payload.warehouses?.find(w=>w.active);
+    if(defaultWarehouse){
+      setReceive(current=>current.warehouseId?current:{...current,warehouseId:String(defaultWarehouse.id)});
+      setWriteoff(current=>current.warehouseId?current:{...current,warehouseId:String(defaultWarehouse.id)});
+    }
   }
   async function loadDocuments() {
     const res=await fetch("/api/staff/inventory/documents",{cache:"no-store"});
@@ -72,6 +79,10 @@ export default function InventoryPage() {
   },[data,query,category,showOnlyAlert]);
 
   const itemMap=useMemo(()=>new Map((data?.items||[]).map(i=>[i.id,i])),[data]);
+  const writeoffLots=useMemo(()=>{
+    const warehouseId=Number(writeoff.warehouseId);
+    return (data?.warehouseBalances||[]).filter(row=>row.warehouseId===warehouseId&&row.stock>0.000001);
+  },[data,writeoff.warehouseId]);
   const metrics = useMemo(() => {
     const all=(data?.items || []).filter(i=>i.active);
     return { active:all.length, low:all.filter(i=>i.stock <= i.minStock).length, expiring:all.filter(i=>i.expiringStock > 0).length, empty:all.filter(i=>i.stock <= 0).length };
@@ -119,20 +130,20 @@ export default function InventoryPage() {
     e.preventDefault();
     const created=await documentAction({
       action:"create",documentType:"inventory_receipt",
-      lines:[{itemId:Number(receive.itemId),quantity:Number(receive.quantity),lotNumber:receive.lotNumber,expiresOn:receive.expiresOn,supplierCounterpartyId:receive.supplierCounterpartyId?Number(receive.supplierCounterpartyId):null,reason:receive.reason}],
+      lines:[{warehouseId:Number(receive.warehouseId),itemId:Number(receive.itemId),quantity:Number(receive.quantity),lotNumber:receive.lotNumber,expiresOn:receive.expiresOn,supplierCounterpartyId:receive.supplierCounterpartyId?Number(receive.supplierCounterpartyId):null,reason:receive.reason}],
     },"Чернетку надходження створено");
-    if(created){setReceive({itemId:receive.itemId,quantity:"",lotNumber:"",expiresOn:"",supplierCounterpartyId:"",reason:"Надходження"});setMode("documents");}
+    if(created){setReceive({...receive,quantity:"",lotNumber:"",expiresOn:"",supplierCounterpartyId:"",reason:"Надходження"});setMode("documents");}
   }
   async function createWriteoffDraft(e:React.FormEvent) {
     e.preventDefault();
     const created=await documentAction({
       action:"create",documentType:"inventory_writeoff",
-      lines:[{lotId:Number(writeoff.lotId),quantity:Number(writeoff.quantity),reason:writeoff.reason,bookingId:writeoff.bookingId?Number(writeoff.bookingId):null}],
+      lines:[{warehouseId:Number(writeoff.warehouseId),lotId:Number(writeoff.lotId),quantity:Number(writeoff.quantity),reason:writeoff.reason,bookingId:writeoff.bookingId?Number(writeoff.bookingId):null}],
     },"Чернетку списання створено");
-    if(created){setWriteoff({lotId:writeoff.lotId,quantity:"",reason:"Використано під час дослідження",bookingId:""});setMode("documents");}
+    if(created){setWriteoff({...writeoff,lotId:"",quantity:"",reason:"Використано під час дослідження",bookingId:""});setMode("documents");}
   }
 
-  return <StaffWorkspaceShell active="inventory" title="Склад" description="BAS-подібний облік матеріалів: номенклатура, документи, проведення, регістр рухів і друковані форми." staffName={data?.staff.displayName || data?.staff.email} staffRole={data?.staff.role}>
+  return <StaffWorkspaceShell active="inventory" title="Склад" description="BAS-подібний облік матеріалів: номенклатура, склади, документи, проведення, регістр рухів і друковані форми." staffName={data?.staff.displayName || data?.staff.email} staffRole={data?.staff.role}>
     {!loaded ? <p className="notice">Завантаження складу…</p> : error ? <p className="notice error">{error}</p> : data && <>
       {toast && <p className={`inventoryToast${toast.startsWith("⚠")?" warn":""}`} role="status" onClick={()=>setToast("")}>{toast}</p>}
       <section className="inventoryKpi" aria-label="Стан складу"><div><b>{metrics.active}</b><span>позицій активно</span></div><div className={metrics.low?"warn":""}><b>{metrics.low}</b><span>нижче мінімуму</span></div><div className={metrics.expiring?"warn":""}><b>{metrics.expiring}</b><span>термін ≤ 30 днів</span></div><div className={metrics.empty?"danger":""}><b>{metrics.empty}</b><span>немає залишку</span></div></section>
@@ -140,6 +151,7 @@ export default function InventoryPage() {
         <button className={mode==="stock"?"active":""} onClick={()=>setMode("stock")}>Залишки</button>
         <button className={mode==="documents"?"active":""} onClick={()=>setMode("documents")}>Документи <span className="inventoryTabCount">{documents.length}</span></button>
         <button className={mode==="movements"?"active":""} onClick={()=>setMode("movements")}>Рухи</button>
+        <button onClick={()=>window.location.assign("/staff/warehouses")}>Склади</button>
       </div>
 
       {mode === "stock" && <>
@@ -149,13 +161,13 @@ export default function InventoryPage() {
             {items.map(i=>{ const low=i.stock<=i.minStock; const exp=i.expiringStock>0; return <tr key={i.id} className={`${!i.active?"inactive ":""}${low?"low":""}`}><td><b>{i.name}</b><small>{i.sku || "без коду"} · {i.unit}</small></td><td>{CATEGORY_UK[i.category] || i.category}</td><td className="num"><strong>{fmt(i.stock)}</strong> {i.unit}</td><td className="num">{fmt(i.minStock)}</td><td>{i.nextExpiry || "—"}{exp?<small className="expiryWarn"> ≤ 30 днів</small>:null}</td><td><span className={`inventoryState ${i.stock<=0?"empty":low?"low":"ok"}`}>{i.stock<=0?"Немає":low?"Поповнити":"Достатньо"}</span></td></tr>;})}
             {items.length===0 && <tr><td colSpan={6} className="emptyCell">Немає позицій за фільтром.</td></tr>}
           </tbody></table></div></section>
-          <aside className="inventorySide"><section><div className="inventorySectionHead"><h2>Партії в наявності</h2><span>{data.lots.length}</span></div><ul className="inventoryLots">{data.lots.map(l=><li key={l.id}><div><b>{l.itemName}</b><small>Партія {l.lotNumber || "—"}{l.supplier?` · ${l.supplier}`:""}</small></div><span><b>{fmt(l.stock)}</b><small>{l.expiresOn?`до ${l.expiresOn}`:"без терміну"}</small></span></li>)}{data.lots.length===0 && <li className="inventoryEmpty">Партій із залишком немає.</li>}</ul></section></aside>
+          <aside className="inventorySide"><section><div className="inventorySectionHead"><h2>Залишки по складах</h2><span>{data.warehouseBalances.length}</span></div><ul className="inventoryLots">{data.warehouseBalances.map(l=><li key={`${l.warehouseId}-${l.lotId}`}><div><b>{l.itemName}</b><small>{l.warehouseName} · партія {l.lotNumber || "—"}</small></div><span><b>{fmt(l.stock)}</b></span></li>)}{data.warehouseBalances.length===0 && <li className="inventoryEmpty">Залишків немає.</li>}</ul></section></aside>
         </div>
 
         {data.canManage && <section className="inventoryOperations">
           <form onSubmit={createItem}><h3>Нова номенклатура</h3><p className="inventoryFormHint">Довідник матеріалів</p><input required placeholder="Назва матеріалу" value={itemForm.name} onChange={e=>setItemForm({...itemForm,name:e.target.value})}/><input placeholder="Код / SKU" value={itemForm.sku} onChange={e=>setItemForm({...itemForm,sku:e.target.value})}/><select value={itemForm.category} onChange={e=>setItemForm({...itemForm,category:e.target.value})}>{CATEGORY_OPTIONS.map(([v,l])=><option key={v} value={v}>{l}</option>)}</select><div className="inventoryFormRow"><input required placeholder="Одиниця" value={itemForm.unit} onChange={e=>setItemForm({...itemForm,unit:e.target.value})}/><input required type="number" min="0" step="0.01" placeholder="Мін. запас" value={itemForm.minStock} onChange={e=>setItemForm({...itemForm,minStock:e.target.value})}/></div><button disabled={busy}>Записати</button></form>
-          <form onSubmit={createReceiptDraft}><h3>Надходження матеріалів</h3><p className="inventoryFormHint">Створює документ-чернетку. Залишок зміниться лише після «Провести».</p><select required value={receive.itemId} onChange={e=>setReceive({...receive,itemId:e.target.value})}><option value="">Оберіть матеріал</option>{data.items.filter(i=>i.active).map(i=><option key={i.id} value={i.id}>{i.name} · {i.unit}</option>)}</select><div className="inventoryFormRow"><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={receive.quantity} onChange={e=>setReceive({...receive,quantity:e.target.value})}/><input placeholder="№ партії" value={receive.lotNumber} onChange={e=>setReceive({...receive,lotNumber:e.target.value})}/></div><input type="date" value={receive.expiresOn} onChange={e=>setReceive({...receive,expiresOn:e.target.value})}/><select value={receive.supplierCounterpartyId} onChange={e=>setReceive({...receive,supplierCounterpartyId:e.target.value})}><option value="">Без постачальника</option>{data.counterparties.map(c=><option key={c.id} value={c.id}>{c.name}{c.code?` · ${c.code}`:""}</option>)}</select><button type="button" className="inventorySmallBtn" onClick={()=>window.location.assign("/staff/counterparties")}>Контрагенти ↗</button><input placeholder="Примітка" value={receive.reason} onChange={e=>setReceive({...receive,reason:e.target.value})}/><button disabled={busy}>Створити чернетку</button></form>
-          <form onSubmit={createWriteoffDraft}><h3>Списання матеріалів</h3><p className="inventoryFormHint">Документ можна перевірити перед проведенням.</p><select required value={writeoff.lotId} onChange={e=>setWriteoff({...writeoff,lotId:e.target.value})}><option value="">Оберіть партію</option>{data.lots.map(l=><option key={l.id} value={l.id}>{l.itemName} · {l.lotNumber || "без №"} · залишок {fmt(l.stock)}</option>)}</select><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={writeoff.quantity} onChange={e=>setWriteoff({...writeoff,quantity:e.target.value})}/><input required placeholder="Причина списання" value={writeoff.reason} onChange={e=>setWriteoff({...writeoff,reason:e.target.value})}/><input type="number" min="1" placeholder="ID дослідження (необов'язково)" value={writeoff.bookingId} onChange={e=>setWriteoff({...writeoff,bookingId:e.target.value})}/><button className="danger" disabled={busy}>Створити чернетку</button></form>
+          <form onSubmit={createReceiptDraft}><h3>Надходження матеріалів</h3><p className="inventoryFormHint">Створює документ-чернетку. Залишок зміниться лише після «Провести».</p><select required value={receive.warehouseId} onChange={e=>setReceive({...receive,warehouseId:e.target.value})}><option value="">Оберіть склад</option>{data.warehouses.filter(w=>w.active).map(w=><option key={w.id} value={w.id}>{w.name}{w.code?` · ${w.code}`:""}{w.isDefault?" · основний":""}</option>)}</select><select required value={receive.itemId} onChange={e=>setReceive({...receive,itemId:e.target.value})}><option value="">Оберіть матеріал</option>{data.items.filter(i=>i.active).map(i=><option key={i.id} value={i.id}>{i.name} · {i.unit}</option>)}</select><div className="inventoryFormRow"><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={receive.quantity} onChange={e=>setReceive({...receive,quantity:e.target.value})}/><input placeholder="№ партії" value={receive.lotNumber} onChange={e=>setReceive({...receive,lotNumber:e.target.value})}/></div><input type="date" value={receive.expiresOn} onChange={e=>setReceive({...receive,expiresOn:e.target.value})}/><select value={receive.supplierCounterpartyId} onChange={e=>setReceive({...receive,supplierCounterpartyId:e.target.value})}><option value="">Без постачальника</option>{data.counterparties.map(c=><option key={c.id} value={c.id}>{c.name}{c.code?` · ${c.code}`:""}</option>)}</select><button type="button" className="inventorySmallBtn" onClick={()=>window.location.assign("/staff/counterparties")}>Контрагенти ↗</button><input placeholder="Примітка" value={receive.reason} onChange={e=>setReceive({...receive,reason:e.target.value})}/><button disabled={busy}>Створити чернетку</button></form>
+          <form onSubmit={createWriteoffDraft}><h3>Списання матеріалів</h3><p className="inventoryFormHint">Партії показані лише з залишком на вибраному складі.</p><select required value={writeoff.warehouseId} onChange={e=>setWriteoff({...writeoff,warehouseId:e.target.value,lotId:""})}><option value="">Оберіть склад</option>{data.warehouses.filter(w=>w.active).map(w=><option key={w.id} value={w.id}>{w.name}{w.code?` · ${w.code}`:""}{w.isDefault?" · основний":""}</option>)}</select><select required value={writeoff.lotId} onChange={e=>setWriteoff({...writeoff,lotId:e.target.value})}><option value="">Оберіть партію</option>{writeoffLots.map(l=><option key={`${l.warehouseId}-${l.lotId}`} value={l.lotId}>{l.itemName} · {l.lotNumber || "без №"} · залишок {fmt(l.stock)}</option>)}</select><input required type="number" min="0.01" step="0.01" placeholder="Кількість" value={writeoff.quantity} onChange={e=>setWriteoff({...writeoff,quantity:e.target.value})}/><input required placeholder="Причина списання" value={writeoff.reason} onChange={e=>setWriteoff({...writeoff,reason:e.target.value})}/><input type="number" min="1" placeholder="ID дослідження (необов'язково)" value={writeoff.bookingId} onChange={e=>setWriteoff({...writeoff,bookingId:e.target.value})}/><button className="danger" disabled={busy}>Створити чернетку</button></form>
         </section>}
       </>}
 
@@ -168,7 +180,7 @@ export default function InventoryPage() {
         {selected&&<section className="inventoryDocumentCard">
           <header><div><small>{TYPE_UK[selected.document.documentType]}</small><h2>{selected.document.number}</h2><p>{fmtDate(selected.document.occurredAt)} · {selected.document.createdBy}</p></div><span className={`inventoryDocState ${selected.document.state}`}>{STATE_UK[selected.document.state]}</span></header>
           {selected.document.comment&&<p className="inventoryDocComment">{selected.document.comment}</p>}
-          <div className="inventoryDocLines"><table><thead><tr><th>№</th><th>Матеріал</th><th>Партія</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>{selected.lines.map(line=>{const i=itemMap.get(line.itemId);return <tr key={line.id}><td>{line.lineNo}</td><td><b>{i?.name||`Матеріал #${line.itemId}`}</b><small>{i?.unit||""}</small></td><td>{line.lotNumber||"—"}{line.expiresOn?<small>до {line.expiresOn}</small>:null}{line.supplier?<small>постачальник: {line.supplier}</small>:null}</td><td className="num">{fmt(line.quantity)} {i?.unit||""}</td><td>{line.reason}{line.bookingId?<small>дослідження #{line.bookingId}</small>:null}</td></tr>;})}</tbody></table></div>
+          <div className="inventoryDocLines"><table><thead><tr><th>№</th><th>Склад</th><th>Матеріал</th><th>Партія</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>{selected.lines.map(line=>{const i=itemMap.get(line.itemId);return <tr key={line.id}><td>{line.lineNo}</td><td><b>{line.warehouseName}</b><small>{line.warehouseCode||`#${line.warehouseId}`}</small></td><td><b>{i?.name||`Матеріал #${line.itemId}`}</b><small>{i?.unit||""}</small></td><td>{line.lotNumber||"—"}{line.expiresOn?<small>до {line.expiresOn}</small>:null}{line.supplier?<small>постачальник: {line.supplier}</small>:null}</td><td className="num">{fmt(line.quantity)} {i?.unit||""}</td><td>{line.reason}{line.bookingId?<small>дослідження #{line.bookingId}</small>:null}</td></tr>;})}</tbody></table></div>
           <footer>
             {selected.document.state==="draft"&&data.canManage&&<><button className="primary" disabled={busy} onClick={()=>void documentAction({action:"post",documentId:selected.document.id},"Документ проведено")}>Провести</button><button disabled={busy} onClick={()=>void documentAction({action:"cancel",documentId:selected.document.id},"Чернетку скасовано")}>Скасувати</button></>}
             <button onClick={()=>window.open(`/staff/inventory/print?id=${selected.document.id}`,"_blank","noopener,noreferrer")}>Друк</button>
@@ -177,7 +189,7 @@ export default function InventoryPage() {
         </section>}
       </div>}
 
-      {mode === "movements" && <section className="inventoryMainTable movements"><div className="inventorySectionHead"><h2>Регістр рухів запасів</h2><span>останні {data.movements.length}</span></div><div className="inventoryTableWrap"><table><thead><tr><th>Дата</th><th>Матеріал / партія</th><th>Операція</th><th>Кількість</th><th>Документ</th><th>Причина</th><th>Хто</th></tr></thead><tbody>{data.movements.map(m=><tr key={m.id}><td>{m.createdAt}</td><td><b>{m.itemName}</b><small>{m.lotNumber || "без №"}</small></td><td>{m.movementType==="receipt"?"Надходження":"Списання"}</td><td className={`num ${m.quantityDelta<0?"negative":"positive"}`}>{m.quantityDelta>0?"+":""}{fmt(m.quantityDelta)} {m.unit}</td><td>{m.documentId?<button className="inventoryDocLink" onClick={()=>void openDocument(m.documentId!)}>#{m.documentId}</button>:<span className="legacyMovement">Legacy</span>}</td><td>{m.reason}{m.bookingId?<small>дослідження #{m.bookingId}</small>:null}</td><td>{m.actorEmail}</td></tr>)}</tbody></table></div></section>}
+      {mode === "movements" && <section className="inventoryMainTable movements"><div className="inventorySectionHead"><h2>Регістр рухів запасів</h2><span>останні {data.movements.length}</span></div><div className="inventoryTableWrap"><table><thead><tr><th>Дата</th><th>Склад</th><th>Матеріал / партія</th><th>Операція</th><th>Кількість</th><th>Документ</th><th>Причина</th><th>Хто</th></tr></thead><tbody>{data.movements.map(m=><tr key={m.id}><td>{m.createdAt}</td><td>{m.warehouseName||"Legacy"}<small>{m.warehouseCode}</small></td><td><b>{m.itemName}</b><small>{m.lotNumber || "без №"}</small></td><td>{m.movementType==="receipt"?"Надходження":"Списання"}</td><td className={`num ${m.quantityDelta<0?"negative":"positive"}`}>{m.quantityDelta>0?"+":""}{fmt(m.quantityDelta)} {m.unit}</td><td>{m.documentId?<button className="inventoryDocLink" onClick={()=>void openDocument(m.documentId!)}>#{m.documentId}</button>:<span className="legacyMovement">Legacy</span>}</td><td>{m.reason}{m.bookingId?<small>дослідження #{m.bookingId}</small>:null}</td><td>{m.actorEmail}</td></tr>)}</tbody></table></div></section>}
     </>}
   </StaffWorkspaceShell>;
 }

--- a/app/staff/inventory/print/page.tsx
+++ b/app/staff/inventory/print/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect,useState } from "react";
 
-type PrintLine={lineNo:number;itemId:number;itemName:string;unit:string;lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;bookingId:number|null};
+type PrintLine={lineNo:number;itemId:number;itemName:string;unit:string;warehouseId:number;warehouseCode:string;warehouseName:string;lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;bookingId:number|null};
 type PrintPayload={templateVersion:number;formType:"inventory_receipt"|"inventory_writeoff";organization:{name:string};document:{id:number;number:string;documentType:string;occurredAt:string;state:string;comment:string;createdBy:string;createdAt:string;postedBy:string;postedAt:string};lines:PrintLine[]};
 type Snapshot={id:number;documentId:number;formType:string;templateVersion:number;generatedBy:string;generatedAt:string;storageKey:string;sha256:string};
 type ResponsePayload={snapshot:Snapshot;payload:PrintPayload;error?:string};
@@ -45,8 +45,8 @@ export default function InventoryPrintPage(){
         {payload.document.postedBy&&<><div><span>Провів</span><b>{payload.document.postedBy}</b></div><div><span>Проведено</span><b>{fmtDate(payload.document.postedAt)}</b></div></>}
       </section>
       {payload.document.comment&&<p><b>Примітка:</b> {payload.document.comment}</p>}
-      <table><thead><tr><th>№</th><th>Матеріал</th><th>Партія / термін</th><th>Постачальник</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>
-        {payload.lines.map(l=><tr key={l.lineNo}><td>{l.lineNo}</td><td><b>{l.itemName}</b></td><td>{l.lotNumber||"—"}{l.expiresOn?<><br/><small>до {l.expiresOn}</small></>:null}</td><td>{l.supplier||"—"}</td><td className="num">{fmt(l.quantity)} {l.unit}</td><td>{l.reason||"—"}{l.bookingId?<><br/><small>дослідження #{l.bookingId}</small></>:null}</td></tr>)}
+      <table><thead><tr><th>№</th><th>Склад</th><th>Матеріал</th><th>Партія / термін</th><th>Постачальник</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>
+        {payload.lines.map(l=><tr key={l.lineNo}><td>{l.lineNo}</td><td><b>{l.warehouseName}</b>{l.warehouseCode?<><br/><small>{l.warehouseCode}</small></>:null}</td><td><b>{l.itemName}</b></td><td>{l.lotNumber||"—"}{l.expiresOn?<><br/><small>до {l.expiresOn}</small></>:null}</td><td>{l.supplier||"—"}</td><td className="num">{fmt(l.quantity)} {l.unit}</td><td>{l.reason||"—"}{l.bookingId?<><br/><small>дослідження #{l.bookingId}</small></>:null}</td></tr>)}
       </tbody></table>
       <section className="inventoryPrintFooter"><div><span>Відповідальний</span><div className="inventoryPrintSignature"/></div><div><span>Підпис</span><div className="inventoryPrintSignature"/></div></section>
       <p className="inventoryPrintVersion">Форма v{snapshot.templateVersion} · snapshot #{snapshot.id} · SHA-256 {snapshot.sha256.slice(0,12)}…</p>

--- a/app/staff/inventory/print/page.tsx
+++ b/app/staff/inventory/print/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect,useState } from "react";
 
-type PrintLine={lineNo:number;itemId:number;itemName:string;unit:string;warehouseId:number;warehouseCode:string;warehouseName:string;lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;bookingId:number|null};
+type PrintLine={lineNo:number;itemId:number;itemName:string;unit:string;warehouseId?:number;warehouseCode?:string;warehouseName?:string;lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;bookingId:number|null};
 type PrintPayload={templateVersion:number;formType:"inventory_receipt"|"inventory_writeoff";organization:{name:string};document:{id:number;number:string;documentType:string;occurredAt:string;state:string;comment:string;createdBy:string;createdAt:string;postedBy:string;postedAt:string};lines:PrintLine[]};
 type Snapshot={id:number;documentId:number;formType:string;templateVersion:number;generatedBy:string;generatedAt:string;storageKey:string;sha256:string};
 type ResponsePayload={snapshot:Snapshot;payload:PrintPayload;error?:string};
@@ -46,7 +46,7 @@ export default function InventoryPrintPage(){
       </section>
       {payload.document.comment&&<p><b>Примітка:</b> {payload.document.comment}</p>}
       <table><thead><tr><th>№</th><th>Склад</th><th>Матеріал</th><th>Партія / термін</th><th>Постачальник</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>
-        {payload.lines.map(l=><tr key={l.lineNo}><td>{l.lineNo}</td><td><b>{l.warehouseName}</b>{l.warehouseCode?<><br/><small>{l.warehouseCode}</small></>:null}</td><td><b>{l.itemName}</b></td><td>{l.lotNumber||"—"}{l.expiresOn?<><br/><small>до {l.expiresOn}</small></>:null}</td><td>{l.supplier||"—"}</td><td className="num">{fmt(l.quantity)} {l.unit}</td><td>{l.reason||"—"}{l.bookingId?<><br/><small>дослідження #{l.bookingId}</small></>:null}</td></tr>)}
+        {payload.lines.map(l=><tr key={l.lineNo}><td>{l.lineNo}</td><td><b>{l.warehouseName||"—"}</b>{l.warehouseCode?<><br/><small>{l.warehouseCode}</small></>:null}</td><td><b>{l.itemName}</b></td><td>{l.lotNumber||"—"}{l.expiresOn?<><br/><small>до {l.expiresOn}</small></>:null}</td><td>{l.supplier||"—"}</td><td className="num">{fmt(l.quantity)} {l.unit}</td><td>{l.reason||"—"}{l.bookingId?<><br/><small>дослідження #{l.bookingId}</small></>:null}</td></tr>)}
       </tbody></table>
       <section className="inventoryPrintFooter"><div><span>Відповідальний</span><div className="inventoryPrintSignature"/></div><div><span>Підпис</span><div className="inventoryPrintSignature"/></div></section>
       <p className="inventoryPrintVersion">Форма v{snapshot.templateVersion} · snapshot #{snapshot.id} · SHA-256 {snapshot.sha256.slice(0,12)}…</p>

--- a/app/staff/reports/registers/page.tsx
+++ b/app/staff/reports/registers/page.tsx
@@ -17,6 +17,7 @@ type Report={
     equipment:Array<{equipmentId:string;loadedMinutes:number;reversedMinutes:number;netMinutes:number}>;
     staff:Array<{memberEmail:string;staffRole:string;performed:number;reversed:number;net:number}>;
     inventory:Array<{itemId:number;sku:string;name:string;unit:string;opening:number;incoming:number;outgoing:number;closing:number}>;
+    inventoryByWarehouse:Array<{warehouseId:number;warehouseCode:string;warehouseName:string;itemId:number;sku:string;name:string;unit:string;opening:number;incoming:number;outgoing:number;closing:number}>;
   };
   error?:string;
 };
@@ -115,10 +116,18 @@ export default function RegisterTurnoverPage(){
       </section>
 
       <section className="financeJournal">
-        <header className="financeToolbar"><div><b>Склад: обороти і залишки</b><small>Залишок рахується з `inventory_movements`, а не з поля “поточна кількість”.</small></div></header>
+        <header className="financeToolbar"><div><b>Склад: обороти і залишки</b><small>Загальний баланс організації з `inventory_movements`, незалежно від місця зберігання.</small></div></header>
         <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Матеріал</th><th>Од.</th><th className="num">На початок</th><th className="num">Надійшло</th><th className="num">Вибуло</th><th className="num">На кінець</th></tr></thead><tbody>
           {data.breakdowns.inventory.map(row=><tr key={row.itemId}><td><b>{row.name}</b><small>{row.sku||`#${row.itemId}`}</small></td><td>{row.unit}</td><td className="num">{number(row.opening)}</td><td className="num positive">{number(row.incoming)}</td><td className="num negative">{number(row.outgoing)}</td><td className="num"><b>{number(row.closing)}</b></td></tr>)}
           {data.breakdowns.inventory.length===0&&<tr><td colSpan={6}>Складських рухів і залишків немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>Склад: по місцях зберігання</b><small>Історичний розріз використовує snapshot складу з кожного immutable руху.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Склад</th><th>Матеріал</th><th>Од.</th><th className="num">На початок</th><th className="num">Надійшло</th><th className="num">Вибуло</th><th className="num">На кінець</th></tr></thead><tbody>
+          {data.breakdowns.inventoryByWarehouse.map(row=><tr key={`${row.warehouseId}-${row.warehouseCode}-${row.itemId}`}><td><b>{row.warehouseName}</b><small>{row.warehouseCode||`#${row.warehouseId}`}</small></td><td><b>{row.name}</b><small>{row.sku||`#${row.itemId}`}</small></td><td>{row.unit}</td><td className="num">{number(row.opening)}</td><td className="num positive">{number(row.incoming)}</td><td className="num negative">{number(row.outgoing)}</td><td className="num"><b>{number(row.closing)}</b></td></tr>)}
+          {data.breakdowns.inventoryByWarehouse.length===0&&<tr><td colSpan={7}>Складських рухів із прив’язкою до місця зберігання немає.</td></tr>}
         </tbody></table></div>
       </section>
     </>}

--- a/app/staff/warehouses/page.tsx
+++ b/app/staff/warehouses/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useCallback,useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+
+type Warehouse={id:number;code:string;name:string;active:number;isDefault:number;createdAt:string;updatedAt:string};
+type Staff={email:string;displayName:string;role:string};
+type Payload={warehouses:Warehouse[];staff:Staff;canEdit:boolean;error?:string};
+type Form={id:number|null;code:string;name:string;active:boolean;isDefault:boolean};
+const EMPTY:Form={id:null,code:"",name:"",active:true,isDefault:false};
+
+export default function WarehousesPage(){
+  const [data,setData]=useState<Payload|null>(null);const [form,setForm]=useState<Form>(EMPTY);const [query,setQuery]=useState("");const [error,setError]=useState("");const [notice,setNotice]=useState("");const [busy,setBusy]=useState(false);
+  const load=useCallback(async()=>{const response=await fetch("/api/staff/warehouses",{cache:"no-store"});const payload=await response.json().catch(()=>({})) as Payload;if(!response.ok)throw new Error(payload.error||"Не вдалося завантажити склади");setData(payload);setError("");},[]);
+  useEffect(()=>{const timer=window.setTimeout(()=>void load().catch(e=>setError(e instanceof Error?e.message:"Помилка")),0);return()=>window.clearTimeout(timer);},[load]);
+  const rows=useMemo(()=>{const q=query.trim().toLowerCase();return(data?.warehouses||[]).filter(row=>!q||`${row.name} ${row.code}`.toLowerCase().includes(q));},[data,query]);
+  function edit(row:Warehouse){setForm({id:row.id,code:row.code,name:row.name,active:!!row.active,isDefault:!!row.isDefault});setNotice("");}
+  function reset(){setForm(EMPTY);setNotice("");}
+  async function save(event:React.FormEvent){event.preventDefault();if(!data?.canEdit)return;setBusy(true);setNotice("");try{const response=await fetch("/api/staff/warehouses",{method:form.id?"PATCH":"POST",headers:{"content-type":"application/json"},body:JSON.stringify(form)});const payload=await response.json().catch(()=>({})) as {error?:string;warehouse?:Warehouse};if(!response.ok){setNotice(`⚠ ${payload.error||"Не вдалося зберегти"}`);return;}setNotice(`✓ ${form.id?"Склад оновлено":"Склад створено"}`);await load();if(payload.warehouse)edit(payload.warehouse);}finally{setBusy(false);}}
+  return <StaffWorkspaceShell active="inventory" title="Склади" description="BAS-довідник місць зберігання. Залишки й складські документи ведуться по конкретному складу." staffName={data?.staff.displayName||data?.staff.email} staffRole={data?.staff.role}>
+    {error&&<p className="financeError">{error}</p>}{!data&&!error&&<p className="financeLoading">Завантаження…</p>}
+    {data&&<div className="inventoryDocumentsLayout"><section className="financeJournal"><header className="financeToolbar"><div className="financeTabs"><button type="button" onClick={()=>window.location.assign("/staff/inventory")}>← Складський облік</button></div><input type="search" value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пошук: назва або код…"/><button type="button" onClick={()=>void load()}>Оновити</button></header><div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Склад</th><th>Код</th><th>Основний</th><th>Стан</th><th/></tr></thead><tbody>{rows.map(row=><tr key={row.id}><td><b>{row.name}</b><small>ID {row.id}</small></td><td>{row.code||"—"}</td><td>{row.isDefault?<b>Так</b>:"—"}</td><td><span className={`financeState ${row.active?"state-posted":"state-cancelled"}`}>{row.active?"Активний":"Неактивний"}</span></td><td><button type="button" onClick={()=>edit(row)}>Відкрити</button></td></tr>)}{rows.length===0&&<tr><td colSpan={5}>Складів за відбором немає.</td></tr>}</tbody></table></div></section>
+      <section className="inventoryDocumentCard"><header><div><small>Довідник</small><h2>{form.id?`Склад #${form.id}`:"Новий склад"}</h2><p>{data.canEdit?"Назву й код можна змінити; проведені документи зберігають власний історичний snapshot.":"Режим перегляду; змінює лише адміністратор."}</p></div></header>{notice&&<p className={notice.startsWith("⚠")?"financeError":"notice"}>{notice}</p>}
+        <form className="inventoryOperations" onSubmit={save}><div><label>Назва<input required disabled={!data.canEdit} value={form.name} onChange={e=>setForm({...form,name:e.target.value})}/></label><label>Код<input disabled={!data.canEdit} value={form.code} onChange={e=>setForm({...form,code:e.target.value})}/></label><label><input type="checkbox" disabled={!data.canEdit} checked={form.active} onChange={e=>setForm({...form,active:e.target.checked})}/> Активний</label><label><input type="checkbox" disabled={!data.canEdit} checked={form.isDefault} onChange={e=>setForm({...form,isDefault:e.target.checked,active:e.target.checked?true:form.active})}/> Основний склад</label>{data.canEdit&&<div><button className="primary" disabled={busy}>{form.id?"Записати":"Створити"}</button><button type="button" disabled={busy} onClick={reset}>Новий</button></div>}</div></form>
+      </section></div>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -47,6 +47,7 @@ const systemModules: NavModule[] = [
   ]},
   { label:"Склад", href:"/staff/inventory", sections:["inventory"], icon:"▣", items:[
     { label:"Витратні матеріали", href:"/staff/inventory" },
+    { label:"Склади", href:"/staff/warehouses" },
   ]},
   { label:"Фінанси і звіти", href:"/staff/finance", sections:["finance","counterparties","reports","tariffs"], icon:"💳", items:[
     { label:"Фінансові документи", href:"/staff/finance" },

--- a/docs/bas-warehouses.md
+++ b/docs/bas-warehouses.md
@@ -1,0 +1,44 @@
+# BAS warehouses / stock locations
+
+RadiologyOS treats a warehouse as a tenant-scoped master-data reference and as an explicit dimension of the inventory register.
+
+## Core rule
+
+A lot/batch is not owned by one warehouse. The same lot may have stock in several warehouses. Stock truth is therefore calculated by:
+
+`organization + warehouse + item + lot`
+
+Receipt and write-off documents freeze the selected warehouse identity (`warehouse_id`) plus its human-readable code/name snapshot. Posted register movements copy the exact same warehouse identity and snapshot.
+
+## Default warehouse and migration
+
+Migration `0081_warehouses.sql` creates one active default warehouse (`MAIN`, `Основний склад`) for every existing organization and automatically seeds it for newly created organizations.
+
+Pre-0081 inventory rows are assigned to this default warehouse. This is deterministic, not heuristic: the previous schema could represent only one implicit stock location for the whole organization, so there is no alternative historical location to infer.
+
+New document lines must always reference an active warehouse. API callers that omit `warehouseId` resolve to the active default warehouse, which preserves compatibility with existing receipt/write-off callers.
+
+## Posting invariants
+
+- receipt creates a positive movement in the selected warehouse;
+- write-off creates a negative movement in the selected warehouse;
+- another warehouse's stock can never satisfy a write-off;
+- the D1 non-negative-stock trigger evaluates `warehouse + lot` atomically;
+- linked movements must match the posted document line exactly, including warehouse id/code/name;
+- movements remain append-only and are never rewritten after posting.
+
+## Master-data lifecycle
+
+Warehouses are tenant scoped. Only administrators change the directory; staff may read it for inventory work.
+
+A warehouse can be renamed or deactivated, but posted documents/movements keep the historical warehouse snapshot. Referenced warehouses cannot be physically deleted. One active default warehouse is maintained by the application-level directory workflow.
+
+## Printed forms
+
+Inventory printed-form template version 2 includes the frozen warehouse id/code/name from the document line. Reprinting a posted document reuses the canonical immutable snapshot for that template/state, so later warehouse renames do not alter the historical form.
+
+## Deliberately out of scope
+
+`inventory_transfer` is not enabled in this block. The schema is prepared for it conceptually: a future transfer document will post a negative movement from one warehouse and a positive movement into another rather than changing a lot's identity.
+
+Production deployment is not part of this PR.

--- a/drizzle/0081_warehouses.sql
+++ b/drizzle/0081_warehouses.sql
@@ -1,0 +1,188 @@
+-- BAS reference: warehouses become an explicit stock-register dimension.
+-- The pre-0081 model represented exactly one implicit storage location per organization, so
+-- historical rows are deterministically mapped to the seeded MAIN warehouse (not guessed).
+CREATE TABLE IF NOT EXISTS `warehouses` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `code` text DEFAULT '' NOT NULL,
+  `name` text NOT NULL,
+  `active` integer DEFAULT 1 NOT NULL CHECK (`active` IN (0,1)),
+  `is_default` integer DEFAULT 0 NOT NULL CHECK (`is_default` IN (0,1)),
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `warehouses_org_id_idx`
+  ON `warehouses` (`organization_id`,`id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `warehouses_org_code_idx`
+  ON `warehouses` (`organization_id`,`code`) WHERE `code` <> '';
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `warehouses_one_default_idx`
+  ON `warehouses` (`organization_id`) WHERE `is_default`=1;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `warehouses_org_active_name_idx`
+  ON `warehouses` (`organization_id`,`active`,`name`,`id`);
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO `warehouses` (`organization_id`,`code`,`name`,`active`,`is_default`)
+SELECT id,'MAIN','Основний склад',1,1 FROM organizations;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `organization_seed_default_warehouse`
+AFTER INSERT ON `organizations`
+BEGIN
+  INSERT OR IGNORE INTO warehouses (organization_id,code,name,active,is_default)
+    VALUES (NEW.id,'MAIN','Основний склад',1,1);
+END;
+--> statement-breakpoint
+
+ALTER TABLE `inventory_document_lines` ADD COLUMN `warehouse_id` integer;
+--> statement-breakpoint
+ALTER TABLE `inventory_document_lines` ADD COLUMN `warehouse_code` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `inventory_document_lines` ADD COLUMN `warehouse_name` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `inventory_movements` ADD COLUMN `warehouse_id` integer;
+--> statement-breakpoint
+ALTER TABLE `inventory_movements` ADD COLUMN `warehouse_code` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `inventory_movements` ADD COLUMN `warehouse_name` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+
+-- Before this migration an organization had one and only one representable warehouse. Preserve
+-- those facts by assigning every historical stock row to that organization's seeded MAIN warehouse.
+UPDATE inventory_document_lines
+SET warehouse_id=(SELECT w.id FROM warehouses w WHERE w.organization_id=inventory_document_lines.organization_id AND w.is_default=1 LIMIT 1),
+    warehouse_code=(SELECT w.code FROM warehouses w WHERE w.organization_id=inventory_document_lines.organization_id AND w.is_default=1 LIMIT 1),
+    warehouse_name=(SELECT w.name FROM warehouses w WHERE w.organization_id=inventory_document_lines.organization_id AND w.is_default=1 LIMIT 1)
+WHERE warehouse_id IS NULL;
+--> statement-breakpoint
+UPDATE inventory_movements
+SET warehouse_id=(SELECT w.id FROM warehouses w WHERE w.organization_id=inventory_movements.organization_id AND w.is_default=1 LIMIT 1),
+    warehouse_code=(SELECT w.code FROM warehouses w WHERE w.organization_id=inventory_movements.organization_id AND w.is_default=1 LIMIT 1),
+    warehouse_name=(SELECT w.name FROM warehouses w WHERE w.organization_id=inventory_movements.organization_id AND w.is_default=1 LIMIT 1)
+WHERE warehouse_id IS NULL;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `inventory_lines_warehouse_idx`
+  ON `inventory_document_lines` (`organization_id`,`warehouse_id`,`document_id`,`line_no`)
+  WHERE `warehouse_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `inventory_movements_warehouse_item_idx`
+  ON `inventory_movements` (`organization_id`,`warehouse_id`,`item_id`,`id` DESC)
+  WHERE `warehouse_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `inventory_movements_warehouse_lot_idx`
+  ON `inventory_movements` (`organization_id`,`warehouse_id`,`lot_id`,`id` DESC)
+  WHERE `warehouse_id` IS NOT NULL;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS `warehouse_default_must_be_active_insert`
+BEFORE INSERT ON `warehouses`
+WHEN NEW.is_default=1 AND NEW.active<>1
+BEGIN SELECT RAISE(ABORT,'warehouse_default_must_be_active'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `warehouse_default_must_be_active_update`
+BEFORE UPDATE OF `active`,`is_default` ON `warehouses`
+WHEN NEW.is_default=1 AND NEW.active<>1
+BEGIN SELECT RAISE(ABORT,'warehouse_default_must_be_active'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `warehouse_tenant_immutable`
+BEFORE UPDATE OF `organization_id` ON `warehouses`
+WHEN NEW.organization_id<>OLD.organization_id
+BEGIN SELECT RAISE(ABORT,'warehouse_tenant_immutable'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `warehouse_referenced_no_delete`
+BEFORE DELETE ON `warehouses`
+WHEN EXISTS (
+  SELECT 1 FROM inventory_document_lines l
+  WHERE l.organization_id=OLD.organization_id AND l.warehouse_id=OLD.id
+) OR EXISTS (
+  SELECT 1 FROM inventory_movements m
+  WHERE m.organization_id=OLD.organization_id AND m.warehouse_id=OLD.id
+)
+BEGIN SELECT RAISE(ABORT,'warehouse_in_use'); END;
+--> statement-breakpoint
+
+-- New document rows select current active warehouse master data and freeze name/code snapshots.
+CREATE TRIGGER IF NOT EXISTS `inventory_line_warehouse_reference_insert`
+BEFORE INSERT ON `inventory_document_lines`
+BEGIN
+  SELECT CASE WHEN NEW.warehouse_id IS NULL
+    THEN RAISE(ABORT,'inventory_warehouse_required') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.warehouse_id AND w.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'inventory_warehouse_tenant_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.warehouse_code AND w.name=NEW.warehouse_name
+  ) THEN RAISE(ABORT,'inventory_warehouse_snapshot_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `inventory_line_warehouse_reference_update`
+BEFORE UPDATE OF `organization_id`,`warehouse_id`,`warehouse_code`,`warehouse_name` ON `inventory_document_lines`
+BEGIN
+  SELECT CASE WHEN NEW.warehouse_id IS NULL
+    THEN RAISE(ABORT,'inventory_warehouse_required') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.warehouse_id AND w.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'inventory_warehouse_tenant_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.warehouse_code AND w.name=NEW.warehouse_name
+  ) THEN RAISE(ABORT,'inventory_warehouse_snapshot_invalid') END;
+END;
+--> statement-breakpoint
+
+-- Stock may never become negative inside one warehouse+lot bucket. Another warehouse's balance
+-- cannot satisfy a write-off here.
+DROP TRIGGER IF EXISTS `inventory_writeoff_nonnegative_stock`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_writeoff_nonnegative_stock`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.movement_type='writeoff'
+BEGIN
+  SELECT CASE WHEN (
+    COALESCE((
+      SELECT SUM(quantity_delta) FROM inventory_movements
+      WHERE organization_id=NEW.organization_id AND lot_id=NEW.lot_id
+        AND warehouse_id IS NEW.warehouse_id
+    ),0)+NEW.quantity_delta
+  ) < -0.000001 THEN RAISE(ABORT,'inventory_negative_stock') END;
+END;
+--> statement-breakpoint
+
+-- Extend the exact registrar contract: warehouse identity and historical snapshot are now part of
+-- the immutable movement fact alongside item/lot/quantity/reason/booking.
+DROP TRIGGER IF EXISTS `inventory_movement_document_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_movement_document_integrity`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.document_id IS NOT NULL OR NEW.document_line_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.document_id IS NULL OR NEW.document_line_id IS NULL
+    THEN RAISE(ABORT,'inventory_document_link_incomplete') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM business_documents d
+    JOIN inventory_document_lines l
+      ON l.document_id=d.id AND l.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND l.id=NEW.document_line_id AND l.item_id=NEW.item_id AND l.lot_id=NEW.lot_id
+      AND COALESCE(l.booking_id,0)=COALESCE(NEW.booking_id,0) AND l.reason=NEW.reason
+      AND l.warehouse_id=NEW.warehouse_id
+      AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+      AND (
+        (d.document_type='inventory_receipt' AND NEW.movement_type='receipt'
+          AND ABS(NEW.quantity_delta-l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_writeoff' AND NEW.movement_type='writeoff'
+          AND ABS(NEW.quantity_delta+l.quantity)<0.000001)
+      )
+  ) THEN RAISE(ABORT,'inventory_document_link_invalid') END;
+END;

--- a/lib/inventory-documents.ts
+++ b/lib/inventory-documents.ts
@@ -1,11 +1,13 @@
 import type { DocumentState } from "./business-core";
 import { getActiveSupplierCounterparty } from "./counterparties";
+import { resolveWarehouse } from "./warehouses";
 
 export type InventoryDocumentType = "inventory_receipt" | "inventory_writeoff";
 
 export type InventoryDocumentLineInput = {
   itemId?: number;
   lotId?: number;
+  warehouseId?: number | null;
   quantity: number;
   lotNumber?: string;
   expiresOn?: string;
@@ -36,6 +38,9 @@ export type InventoryDocumentLineRow = {
   lineNo:number;
   itemId:number;
   lotId:number|null;
+  warehouseId:number;
+  warehouseCode:string;
+  warehouseName:string;
   lotNumber:string;
   expiresOn:string;
   supplier:string;
@@ -108,7 +113,9 @@ export async function getInventoryDocument(db:D1Database,organizationId:number,d
   if (!document) return null;
   const lines = await db.prepare(
     `SELECT id,organization_id AS organizationId,document_id AS documentId,line_no AS lineNo,
-            item_id AS itemId,lot_id AS lotId,lot_number AS lotNumber,expires_on AS expiresOn,
+            item_id AS itemId,lot_id AS lotId,warehouse_id AS warehouseId,
+            warehouse_code AS warehouseCode,warehouse_name AS warehouseName,
+            lot_number AS lotNumber,expires_on AS expiresOn,
             supplier,supplier_counterparty_id AS supplierCounterpartyId,quantity,reason,booking_id AS bookingId
      FROM inventory_document_lines
      WHERE organization_id=? AND document_id=? ORDER BY line_no,id`
@@ -144,13 +151,18 @@ export async function createInventoryDocument(
   }
 
   const normalized:Array<Required<Pick<InventoryDocumentLineInput,"quantity">> & {
-    itemId:number;lotId:number|null;lotNumber:string;expiresOn:string;supplier:string;supplierCounterpartyId:number|null;
+    itemId:number;lotId:number|null;warehouseId:number;warehouseCode:string;warehouseName:string;
+    lotNumber:string;expiresOn:string;supplier:string;supplierCounterpartyId:number|null;
     reason:string;bookingId:number|null;
   }> = [];
 
   for (const source of input.lines) {
     const qty = quantity(source.quantity);
     if (!qty) throw new Error("inventory_document_invalid_quantity");
+    const warehouse=await resolveWarehouse(db,{
+      organizationId:input.organizationId,
+      warehouseId:intOrNull(source.warehouseId),
+    });
     if (input.type === "inventory_receipt") {
       const itemId = intOrNull(source.itemId);
       if (!itemId) throw new Error("inventory_document_item_required");
@@ -166,7 +178,8 @@ export async function createInventoryDocument(
         supplier=counterparty.name;
       }
       normalized.push({
-        itemId,lotId:null,quantity:qty,lotNumber:text(source.lotNumber,100),expiresOn,supplier,supplierCounterpartyId,
+        itemId,lotId:null,warehouseId:warehouse.id,warehouseCode:warehouse.code,warehouseName:warehouse.name,
+        quantity:qty,lotNumber:text(source.lotNumber,100),expiresOn,supplier,supplierCounterpartyId,
         reason:text(source.reason,500) || "Надходження",bookingId:null,
       });
     } else {
@@ -179,7 +192,8 @@ export async function createInventoryDocument(
       const reason = text(source.reason,500);
       if (!reason) throw new Error("inventory_document_reason_required");
       normalized.push({
-        itemId:found.itemId,lotId,quantity:qty,lotNumber:found.lotNumber,expiresOn:found.expiresOn,
+        itemId:found.itemId,lotId,warehouseId:warehouse.id,warehouseCode:warehouse.code,warehouseName:warehouse.name,
+        quantity:qty,lotNumber:found.lotNumber,expiresOn:found.expiresOn,
         supplier:found.supplier,supplierCounterpartyId:found.supplierCounterpartyId,reason,bookingId,
       });
     }
@@ -200,11 +214,12 @@ export async function createInventoryDocument(
   try {
     await db.batch(normalized.map((line,index)=>db.prepare(
       `INSERT INTO inventory_document_lines
-        (organization_id,document_id,line_no,item_id,lot_id,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason,booking_id)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`
+        (organization_id,document_id,line_no,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
+         lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason,booking_id)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
     ).bind(
-      input.organizationId,documentId,index+1,line.itemId,line.lotId,line.lotNumber,line.expiresOn,
-      line.supplier,line.supplierCounterpartyId,line.quantity,line.reason,line.bookingId,
+      input.organizationId,documentId,index+1,line.itemId,line.lotId,line.warehouseId,line.warehouseCode,line.warehouseName,
+      line.lotNumber,line.expiresOn,line.supplier,line.supplierCounterpartyId,line.quantity,line.reason,line.bookingId,
     )));
   } catch (error) {
     await db.prepare("DELETE FROM business_documents WHERE organization_id=? AND id=? AND state='draft'")
@@ -275,18 +290,20 @@ export async function postInventoryDocument(
   if (current.lines.length < 1) return { ok:false as const,status:409,error:"У документі немає рядків" };
 
   if (current.document.documentType === "inventory_writeoff") {
-    const requiredByLot = new Map<number,number>();
+    const required = new Map<string,{warehouseId:number;lotId:number;quantity:number}>();
     for (const line of current.lines) {
       if (!line.lotId) return { ok:false as const,status:409,error:"У списанні не вказана партія" };
-      requiredByLot.set(line.lotId,(requiredByLot.get(line.lotId) || 0) + Number(line.quantity));
+      const key=`${line.warehouseId}:${line.lotId}`;
+      const prior=required.get(key);
+      required.set(key,{warehouseId:line.warehouseId,lotId:line.lotId,quantity:(prior?.quantity||0)+Number(line.quantity)});
     }
-    for (const [lotId,required] of requiredByLot) {
+    for (const value of required.values()) {
       const balance = await db.prepare(
         `SELECT COALESCE(SUM(quantity_delta),0) AS stock
-         FROM inventory_movements WHERE organization_id=? AND lot_id=?`
-      ).bind(input.organizationId,lotId).first<{stock:number}>();
-      if (Number(balance?.stock || 0) + 0.000001 < required) {
-        return { ok:false as const,status:409,error:"Недостатній залишок у партії для проведення документа" };
+         FROM inventory_movements WHERE organization_id=? AND warehouse_id=? AND lot_id=?`
+      ).bind(input.organizationId,value.warehouseId,value.lotId).first<{stock:number}>();
+      if (Number(balance?.stock || 0) + 0.000001 < value.quantity) {
+        return { ok:false as const,status:409,error:"Недостатній залишок у партії на вибраному складі" };
       }
     }
   }
@@ -322,10 +339,11 @@ export async function postInventoryDocument(
     ).bind(input.actorEmail,postedAt,input.organizationId,input.documentId),
     ...lines.map((line)=>db.prepare(
       `INSERT INTO inventory_movements
-        (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,booking_id,actor_email,document_id,document_line_id)
-       VALUES (?,?,?,?,?,?,?,?,?,?)`
+        (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
+         movement_type,quantity_delta,reason,booking_id,actor_email,document_id,document_line_id)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
     ).bind(
-      input.organizationId,line.itemId,line.lotId,
+      input.organizationId,line.itemId,line.lotId,line.warehouseId,line.warehouseCode,line.warehouseName,
       current.document.documentType === "inventory_receipt" ? "receipt" : "writeoff",
       current.document.documentType === "inventory_receipt" ? Number(line.quantity) : -Number(line.quantity),
       line.reason,line.bookingId,input.actorEmail,input.documentId,line.id,
@@ -342,7 +360,7 @@ export async function postInventoryDocument(
     }
     await cleanupUnpostedReceiptLots(db,input.organizationId,input.documentId,createdReceiptLots);
     if (message.includes("inventory_negative_stock")) {
-      return { ok:false as const,status:409,error:"Недостатній залишок у партії для проведення документа" };
+      return { ok:false as const,status:409,error:"Недостатній залишок у партії на вибраному складі" };
     }
     throw error;
   }

--- a/lib/register-turnover-report.ts
+++ b/lib/register-turnover-report.ts
@@ -88,6 +88,26 @@ async function inventoryBalances(db:D1Database,organizationId:number,period:Regi
   return rows.results;
 }
 
+async function inventoryBalancesByWarehouse(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT m.warehouse_id AS warehouseId,m.warehouse_code AS warehouseCode,m.warehouse_name AS warehouseName,
+       i.id AS itemId,i.sku,i.name,i.unit,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10)<? THEN m.quantity_delta ELSE 0 END),0) AS opening,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10) BETWEEN ? AND ? AND m.quantity_delta>0 THEN m.quantity_delta ELSE 0 END),0) AS incoming,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10) BETWEEN ? AND ? AND m.quantity_delta<0 THEN -m.quantity_delta ELSE 0 END),0) AS outgoing,
+       COALESCE(SUM(CASE WHEN substr(m.created_at,1,10)<=? THEN m.quantity_delta ELSE 0 END),0) AS closing
+     FROM inventory_movements m
+     JOIN inventory_items i ON i.organization_id=m.organization_id AND i.id=m.item_id
+     WHERE m.organization_id=? AND m.warehouse_id IS NOT NULL AND substr(m.created_at,1,10)<=?
+     GROUP BY m.warehouse_id,m.warehouse_code,m.warehouse_name,i.id,i.sku,i.name,i.unit
+     HAVING opening<>0 OR incoming<>0 OR outgoing<>0 OR closing<>0
+     ORDER BY m.warehouse_name,i.name,m.warehouse_id,i.id LIMIT 500`
+  ).bind(
+    period.from,period.from,period.to,period.from,period.to,period.to,organizationId,period.to,
+  ).all();
+  return rows.results;
+}
+
 async function revenueByService(db:D1Database,organizationId:number,period:RegisterPeriod) {
   const rows=await db.prepare(
     `SELECT service_code AS serviceCode,
@@ -141,7 +161,7 @@ async function staffByMember(db:D1Database,organizationId:number,period:Register
 }
 
 export async function buildRegisterTurnoverReport(db:D1Database,organizationId:number,period:RegisterPeriod) {
-  const [revenue,cash,settlements,services,equipment,staff,inventory,revenueServices,cashMethods,equipmentRows,staffRows]=await Promise.all([
+  const [revenue,cash,settlements,services,equipment,staff,inventory,inventoryByWarehouse,revenueServices,cashMethods,equipmentRows,staffRows]=await Promise.all([
     deltaTurnover(db,"revenue_movements","amount_delta",organizationId,period),
     deltaTurnover(db,"cash_movements","amount_delta",organizationId,period),
     settlementTurnover(db,organizationId,period),
@@ -149,6 +169,7 @@ export async function buildRegisterTurnoverReport(db:D1Database,organizationId:n
     deltaTurnover(db,"equipment_load_movements","minutes_delta",organizationId,period),
     deltaTurnover(db,"staff_output_movements","units_delta",organizationId,period),
     inventoryBalances(db,organizationId,period),
+    inventoryBalancesByWarehouse(db,organizationId,period),
     revenueByService(db,organizationId,period),
     cashByMethod(db,organizationId,period),
     equipmentByUnit(db,organizationId,period),
@@ -158,6 +179,6 @@ export async function buildRegisterTurnoverReport(db:D1Database,organizationId:n
     period,
     generatedAt:new Date().toISOString(),
     registers:{revenue,cash,settlements,services,equipment,staff},
-    breakdowns:{revenueByService:revenueServices,cashByMethod:cashMethods,equipment:equipmentRows,staff:staffRows,inventory},
+    breakdowns:{revenueByService:revenueServices,cashByMethod:cashMethods,equipment:equipmentRows,staff:staffRows,inventory,inventoryByWarehouse},
   };
 }

--- a/lib/warehouses.ts
+++ b/lib/warehouses.ts
@@ -1,0 +1,82 @@
+export type WarehouseRow={
+  id:number;organizationId:number;code:string;name:string;active:number;isDefault:number;createdAt:string;updatedAt:string;
+};
+
+const SELECT=`SELECT id,organization_id AS organizationId,code,name,active,is_default AS isDefault,
+                     created_at AS createdAt,updated_at AS updatedAt FROM warehouses`;
+
+function text(value:unknown,max:number){return String(value??"").trim().slice(0,max);}
+function flag(value:unknown){return value===false||value===0||value==="0"?0:1;}
+
+export async function getWarehouse(db:D1Database,organizationId:number,id:number){
+  return db.prepare(`${SELECT} WHERE organization_id=? AND id=? LIMIT 1`).bind(organizationId,id).first<WarehouseRow>();
+}
+
+export async function listWarehouses(db:D1Database,organizationId:number,input:{active?:boolean}={}){
+  const where=["organization_id=?"];const args:Array<number>=[organizationId];
+  if(input.active!==undefined){where.push("active=?");args.push(input.active?1:0);}
+  const rows=await db.prepare(`${SELECT} WHERE ${where.join(" AND ")} ORDER BY active DESC,is_default DESC,name,id`)
+    .bind(...args).all<WarehouseRow>();
+  return rows.results;
+}
+
+export function normalizeWarehouseInput(input:Record<string,unknown>){
+  const name=text(input.name,180);if(!name)throw new Error("warehouse_name_required");
+  const code=text(input.code,80);const active=input.active===undefined?1:flag(input.active);
+  const isDefault=input.isDefault===undefined?0:flag(input.isDefault);
+  if(isDefault&&!active)throw new Error("warehouse_default_must_be_active");
+  return{name,code,active,isDefault};
+}
+
+async function applyDefault(db:D1Database,organizationId:number,id:number){
+  await db.batch([
+    db.prepare(`UPDATE warehouses SET is_default=0,updated_at=CURRENT_TIMESTAMP
+                WHERE organization_id=? AND id<>? AND is_default=1`).bind(organizationId,id),
+    db.prepare(`UPDATE warehouses SET is_default=1,active=1,updated_at=CURRENT_TIMESTAMP
+                WHERE organization_id=? AND id=?`).bind(organizationId,id),
+  ]);
+}
+
+export async function createWarehouse(db:D1Database,input:{organizationId:number;values:Record<string,unknown>}){
+  const v=normalizeWarehouseInput(input.values);
+  const result=await db.prepare(`INSERT INTO warehouses (organization_id,code,name,active,is_default)
+                                 VALUES (?,?,?,?,0)`).bind(input.organizationId,v.code,v.name,v.active).run();
+  const id=Number(result.meta.last_row_id||0);if(!id)throw new Error("warehouse_create_failed");
+  if(v.isDefault)await applyDefault(db,input.organizationId,id);
+  return getWarehouse(db,input.organizationId,id);
+}
+
+export async function updateWarehouse(db:D1Database,input:{organizationId:number;id:number;values:Record<string,unknown>}){
+  const current=await getWarehouse(db,input.organizationId,input.id);if(!current)return null;
+  const v=normalizeWarehouseInput({
+    name:input.values.name===undefined?current.name:input.values.name,
+    code:input.values.code===undefined?current.code:input.values.code,
+    active:input.values.active===undefined?!!current.active:input.values.active,
+    isDefault:input.values.isDefault===undefined?!!current.isDefault:input.values.isDefault,
+  });
+  if(current.isDefault&&(!v.active||!v.isDefault)){
+    const replacement=await db.prepare(`SELECT id FROM warehouses
+      WHERE organization_id=? AND id<>? AND active=1 ORDER BY is_default DESC,id LIMIT 1`)
+      .bind(input.organizationId,input.id).first<{id:number}>();
+    if(!replacement)throw new Error("warehouse_default_replacement_required");
+    await applyDefault(db,input.organizationId,replacement.id);
+  }
+  await db.prepare(`UPDATE warehouses SET code=?,name=?,active=?,is_default=0,updated_at=CURRENT_TIMESTAMP
+                    WHERE organization_id=? AND id=?`)
+    .bind(v.code,v.name,v.active,input.organizationId,input.id).run();
+  if(v.isDefault)await applyDefault(db,input.organizationId,input.id);
+  return getWarehouse(db,input.organizationId,input.id);
+}
+
+export async function resolveWarehouse(db:D1Database,input:{organizationId:number;warehouseId?:number|null}){
+  if(input.warehouseId){
+    const row=await db.prepare(`${SELECT} WHERE organization_id=? AND id=? AND active=1 LIMIT 1`)
+      .bind(input.organizationId,input.warehouseId).first<WarehouseRow>();
+    if(!row)throw new Error("inventory_document_warehouse_not_found");
+    return row;
+  }
+  const row=await db.prepare(`${SELECT} WHERE organization_id=? AND active=1 ORDER BY is_default DESC,id LIMIT 1`)
+    .bind(input.organizationId).first<WarehouseRow>();
+  if(!row)throw new Error("inventory_document_warehouse_not_found");
+  return row;
+}

--- a/tests/counterparties-inventory.behavior.test.mjs
+++ b/tests/counterparties-inventory.behavior.test.mjs
@@ -101,16 +101,17 @@ test("D1 rejects cross-tenant and payer-only supplier references",async()=>{
     const itemId=await seedItem(db,1);
     const cross=raw.prepare("INSERT INTO counterparties (organization_id,name,kind) VALUES (2,'Foreign Supplier','supplier')").run();
     const payer=raw.prepare("INSERT INTO counterparties (organization_id,name,kind) VALUES (1,'Local Payer','payer')").run();
+    const warehouse=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1 LIMIT 1").get();
     const doc=raw.prepare(
       "INSERT INTO business_documents (organization_id,document_type,number,state,created_by) VALUES (1,'inventory_receipt','НД-REF-GUARD','draft','test@example.com')"
     ).run();
-    const insert=(supplierId,supplier)=>raw.prepare(
+    const insert=(supplierId)=>raw.prepare(
       `INSERT INTO inventory_document_lines
-       (organization_id,document_id,line_no,item_id,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason)
-       VALUES (1,?,1,?,'LOT','','',?,1,'test')`
-    ).run(Number(doc.lastInsertRowid),itemId,supplierId);
-    assert.throws(()=>insert(Number(cross.lastInsertRowid),"Foreign Supplier"),/counterparty_supplier_tenant_mismatch/);
-    assert.throws(()=>insert(Number(payer.lastInsertRowid),"Local Payer"),/counterparty_not_active_supplier/);
+       (organization_id,document_id,line_no,item_id,warehouse_id,warehouse_code,warehouse_name,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason)
+       VALUES (1,?,1,?,?,?,?, 'LOT','', '',?,1,'test')`
+    ).run(Number(doc.lastInsertRowid),itemId,warehouse.id,warehouse.code,warehouse.name,supplierId);
+    assert.throws(()=>insert(Number(cross.lastInsertRowid)),/counterparty_supplier_tenant_mismatch/);
+    assert.throws(()=>insert(Number(payer.lastInsertRowid)),/counterparty_not_active_supplier/);
   });
 });
 

--- a/tests/counterparty-historical-writeoff.behavior.test.mjs
+++ b/tests/counterparty-historical-writeoff.behavior.test.mjs
@@ -56,10 +56,11 @@ test("historical lot remains writable after its supplier master data changes",as
       "INSERT INTO business_documents (organization_id,document_type,number,state,created_by) VALUES (1,'inventory_writeoff','СП-FORGED-SUP','draft','test@example.com')"
     ).run();
     const other=raw.prepare("INSERT INTO counterparties (organization_id,name,kind) VALUES (1,'Other Supplier','supplier')").run();
+    const warehouse=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1 LIMIT 1").get();
     assert.throws(()=>raw.prepare(
       `INSERT INTO inventory_document_lines
-       (organization_id,document_id,line_no,item_id,lot_id,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason)
-       VALUES (1,?,1,?,?,'HIST-LOT','','Other Supplier',?,1,'forged')`
-    ).run(Number(forgedDoc.lastInsertRowid),itemId,receiptLine.lotId,Number(other.lastInsertRowid)),/inventory_writeoff_supplier_trace_mismatch/);
+       (organization_id,document_id,line_no,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason)
+       VALUES (1,?,1,?,?,?,?,?,'HIST-LOT','','Other Supplier',?,1,'forged')`
+    ).run(Number(forgedDoc.lastInsertRowid),itemId,receiptLine.lotId,warehouse.id,warehouse.code,warehouse.name,Number(other.lastInsertRowid)),/inventory_writeoff_supplier_trace_mismatch/);
   });
 });

--- a/tests/inventory-d1-migration.test.mjs
+++ b/tests/inventory-d1-migration.test.mjs
@@ -14,19 +14,24 @@ test("new inventory write-off is document-posted and D1 prevents negative stock 
   const route = await read("app/api/staff/inventory/route.ts");
   const engine = await read("lib/inventory-documents.ts");
   const hardening = await read("drizzle/0062_inventory_document_integrity_hardening.sql");
+  const warehouseHardening = await read("drizzle/0081_warehouses.sql");
 
   // Compatibility callers no longer write the register directly; they create and post a registrar.
   assert.match(route, /createInventoryDocument/);
   assert.match(route, /postInventoryDocument/);
   assert.doesNotMatch(route, /INSERT INTO inventory_movements[\s\S]*SELECT \?,\?,\?,'writeoff'/);
 
-  // Application-level precheck gives a friendly 409 in the normal path.
+  // Application-level precheck gives a friendly 409 in the normal path and scopes stock to the selected warehouse.
   assert.match(engine, /SELECT COALESCE\(SUM\(quantity_delta\),0\) AS stock/);
-  assert.match(engine, /Недостатній залишок у партії для проведення документа/);
+  assert.match(engine, /warehouse_id=\? AND lot_id=\?/);
+  assert.match(engine, /Недостатній залишок у партії на вибраному складі/);
 
-  // D1 is the final authority and closes concurrent write-off races.
-  assert.match(hardening, /CREATE TRIGGER IF NOT EXISTS `inventory_writeoff_nonnegative_stock`/);
-  assert.match(hardening, /RAISE\(ABORT,'inventory_negative_stock'\)/);
+  // D1 remains the final authority. 0062 established append-only movements; 0081 replaces the
+  // non-negative trigger with the stronger warehouse+lot bucket so another warehouse cannot cover a write-off.
   assert.match(hardening, /CREATE TRIGGER IF NOT EXISTS `inventory_movements_no_update`/);
   assert.match(hardening, /CREATE TRIGGER IF NOT EXISTS `inventory_movements_no_delete`/);
+  assert.match(warehouseHardening, /DROP TRIGGER IF EXISTS `inventory_writeoff_nonnegative_stock`/);
+  assert.match(warehouseHardening, /CREATE TRIGGER `inventory_writeoff_nonnegative_stock`/);
+  assert.match(warehouseHardening, /warehouse_id IS NEW\.warehouse_id/);
+  assert.match(warehouseHardening, /RAISE\(ABORT,'inventory_negative_stock'\)/);
 });

--- a/tests/inventory-documents-security.behavior.test.mjs
+++ b/tests/inventory-documents-security.behavior.test.mjs
@@ -58,21 +58,26 @@ test("D1 rejects movement quantity/type mismatches and atomically prevents negat
       action:"create",documentType:"inventory_writeoff",lines:[{lotId,quantity:2,reason:"Race protected"}],
     });
     const writeoff=await writeoffRes.json();
+    const line=writeoff.lines[0];
     raw.prepare(
       "UPDATE business_documents SET state='posted',posted_by='test',posted_at=CURRENT_TIMESTAMP WHERE id=? AND organization_id=1"
     ).run(writeoff.document.id);
 
+    // Supply the exact warehouse identity/snapshot so this assertion reaches the intended
+    // movement-type registrar check rather than failing earlier on the warehouse dimension.
     assert.throws(()=>raw.prepare(
       `INSERT INTO inventory_movements
-       (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,actor_email,document_id,document_line_id)
-       VALUES (1,?,?,'receipt',2,'Race protected','test',?,?)`
-    ).run(itemId,lotId,writeoff.document.id,writeoff.lines[0].id),/inventory_document_link_invalid/);
+       (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,document_id,document_line_id)
+       VALUES (1,?,?,?,?,?,'receipt',2,'Race protected','test',?,?)`
+    ).run(itemId,lotId,line.warehouseId,line.warehouseCode,line.warehouseName,writeoff.document.id,line.id),/inventory_document_link_invalid/);
 
+    // With every registrar field valid, an oversized write-off must reach the atomic
+    // warehouse+lot non-negative stock guard and be rejected there.
     assert.throws(()=>raw.prepare(
       `INSERT INTO inventory_movements
-       (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,actor_email,document_id,document_line_id)
-       VALUES (1,?,?,'writeoff',-2,'Race protected','test',?,?)`
-    ).run(itemId,lotId,writeoff.document.id,writeoff.lines[0].id),/inventory_negative_stock/);
+       (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,document_id,document_line_id)
+       VALUES (1,?,?,?,?,?,'writeoff',-2,'Race protected','test',?,?)`
+    ).run(itemId,lotId,line.warehouseId,line.warehouseCode,line.warehouseName,writeoff.document.id,line.id),/inventory_negative_stock/);
 
     const balance=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND lot_id=?").get(lotId);
     assert.equal(balance.stock,1);

--- a/tests/inventory-printed-forms.behavior.test.mjs
+++ b/tests/inventory-printed-forms.behavior.test.mjs
@@ -20,12 +20,15 @@ test("posted inventory form is snapshotted and exact reprint survives master-dat
     const first=await printDocument(db,cookie,documentId);
     assert.equal(first.status,201);
     const form1=await first.json();
-    assert.equal(form1.snapshot.templateVersion,1);
+    assert.equal(form1.snapshot.templateVersion,2);
     assert.equal(form1.snapshot.documentState,"posted");
     assert.equal(form1.snapshot.sha256.length,64);
     assert.equal(form1.payload.lines[0].itemName,"Контраст оригінальний");
+    assert.equal(form1.payload.lines[0].warehouseCode,"MAIN");
+    assert.equal(form1.payload.lines[0].warehouseName,"Основний склад");
 
     await db.prepare("UPDATE inventory_items SET name='Контраст перейменований' WHERE organization_id=1 AND id=?").bind(itemId).run();
+    await db.prepare("UPDATE warehouses SET name='Головний склад',code='MAIN-RENAMED' WHERE organization_id=1 AND is_default=1").run();
 
     const again=await printDocument(db,cookie,documentId);
     assert.equal(again.status,200);
@@ -33,6 +36,8 @@ test("posted inventory form is snapshotted and exact reprint survives master-dat
     assert.equal(form2.snapshot.id,form1.snapshot.id,"posted reprint must reuse canonical snapshot");
     assert.equal(form2.snapshot.sha256,form1.snapshot.sha256);
     assert.equal(form2.payload.lines[0].itemName,"Контраст оригінальний","historical print must not silently use renamed master data");
+    assert.equal(form2.payload.lines[0].warehouseCode,"MAIN");
+    assert.equal(form2.payload.lines[0].warehouseName,"Основний склад","historical print must keep warehouse snapshot");
 
     assert.throws(()=>raw.prepare("UPDATE printed_form_snapshots SET generated_by='tamper@example.com' WHERE id=?").run(form1.snapshot.id),/printed_form_snapshot_immutable/);
     assert.throws(()=>raw.prepare("DELETE FROM printed_form_snapshots WHERE id=?").run(form1.snapshot.id),/printed_form_snapshot_immutable/);

--- a/tests/inventory-printed-forms.behavior.test.mjs
+++ b/tests/inventory-printed-forms.behavior.test.mjs
@@ -44,6 +44,30 @@ test("posted inventory form is snapshotted and exact reprint survives master-dat
   });
 });
 
+test("posted reprint preserves an older canonical snapshot across template upgrades",async()=>{
+  await withD1(async(db)=>{
+    const cookie=await seedStaffSession(db,{email:"printer-upgrade@example.com",role:"admin",organizationId:1});
+    const itemRes=await postInventory(db,cookie,{action:"create_item",name:"Legacy print item",sku:"PRINT-V1",category:"other",unit:"шт",minStock:0});
+    const {id:itemId}=await itemRes.json();
+    const receipt=await postInventory(db,cookie,{action:"receive",itemId,quantity:1,lotNumber:"V1"});
+    const {documentId}=await receipt.json();
+    const legacyPayload={templateVersion:1,formType:"inventory_receipt",organization:{name:"Legacy Org"},document:{id:documentId,state:"posted"},lines:[{lineNo:1,itemName:"Назва з форми v1"}]};
+    const legacy=await db.prepare(
+      `INSERT INTO printed_form_snapshots
+       (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,sha256)
+       VALUES (1,?,'inventory_receipt',1,'posted',?,'legacy-printer','legacy-v1-hash')`
+    ).bind(documentId,JSON.stringify(legacyPayload)).run();
+
+    const reprint=await printDocument(db,cookie,documentId);
+    assert.equal(reprint.status,200);
+    const body=await reprint.json();
+    assert.equal(body.snapshot.id,Number(legacy.meta.last_row_id));
+    assert.equal(body.snapshot.templateVersion,1);
+    assert.equal(body.snapshot.sha256,"legacy-v1-hash");
+    assert.equal(body.payload.lines[0].itemName,"Назва з форми v1");
+  });
+});
+
 test("printed form snapshots are tenant scoped",async()=>{
   await withD1(async(db,raw)=>{
     raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Org 2','org-2',1)");

--- a/tests/register-turnover-report.behavior.test.mjs
+++ b/tests/register-turnover-report.behavior.test.mjs
@@ -62,6 +62,10 @@ async function seedInventory(db,organizationId=1) {
      VALUES (?,?,'TURN-LOT','2027-12-31','Test Supplier')`
   ).bind(organizationId,itemId).run();
   const lotId=Number(lotResult.meta.last_row_id);
+  const warehouse=await db.prepare(
+    `SELECT id,code,name FROM warehouses WHERE organization_id=? AND is_default=1 LIMIT 1`
+  ).bind(organizationId).first();
+  assert.ok(warehouse?.id,"default warehouse must exist");
   for(const movement of [
     {date:"2026-07-31 09:00:00",delta:10,type:"receipt"},
     {date:"2026-08-05 09:00:00",delta:5,type:"receipt"},
@@ -69,11 +73,11 @@ async function seedInventory(db,organizationId=1) {
   ]){
     await db.prepare(
       `INSERT INTO inventory_movements
-       (organization_id,item_id,lot_id,movement_type,quantity_delta,reason,actor_email,created_at)
-       VALUES (?,?,?,?,?,'turnover test','turnover@example.com',?)`
-    ).bind(organizationId,itemId,lotId,movement.type,movement.delta,movement.date).run();
+       (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,created_at)
+       VALUES (?,?,?,?,?,?,?,?,'turnover test','turnover@example.com',?)`
+    ).bind(organizationId,itemId,lotId,warehouse.id,warehouse.code,warehouse.name,movement.type,movement.delta,movement.date).run();
   }
-  return itemId;
+  return {itemId,warehouse};
 }
 
 test("register report derives opening, period turnovers and closing balances from immutable movements",async()=>{
@@ -95,7 +99,7 @@ test("register report derives opening, period turnovers and closing balances fro
 
     // Military service has operational movements but no revenue/settlement charge.
     await seedCompleted(db,{code:"RD-TURN-MIL",amount:5000,category:"military",performedAt:"2026-08-12T12:00:00",duration:20,regions:1});
-    const itemId=await seedInventory(db);
+    const {itemId,warehouse}=await seedInventory(db);
 
     const response=await report(db,admin);
     assert.equal(response.status,200);
@@ -143,6 +147,15 @@ test("register report derives opening, period turnovers and closing balances fro
     assert.equal(stock.incoming,5);
     assert.equal(stock.outgoing,3);
     assert.equal(stock.closing,12);
+
+    const warehouseStock=body.breakdowns.inventoryByWarehouse.find(row=>row.itemId===itemId&&row.warehouseId===warehouse.id);
+    assert.ok(warehouseStock);
+    assert.equal(warehouseStock.warehouseCode,"MAIN");
+    assert.equal(warehouseStock.warehouseName,"Основний склад");
+    assert.equal(warehouseStock.opening,10);
+    assert.equal(warehouseStock.incoming,5);
+    assert.equal(warehouseStock.outgoing,3);
+    assert.equal(warehouseStock.closing,12);
   });
 });
 

--- a/tests/warehouses.behavior.test.mjs
+++ b/tests/warehouses.behavior.test.mjs
@@ -68,12 +68,12 @@ test("warehouse tenant and frozen snapshot are enforced",async()=>{
     assert.equal((await document(db,org1,{action:"post",documentId:body.document.id})).status,200);
     const line=raw.prepare("SELECT warehouse_id,warehouse_code,warehouse_name FROM inventory_document_lines WHERE document_id=?").get(body.document.id);
     const movement=raw.prepare("SELECT warehouse_id,warehouse_code,warehouse_name FROM inventory_movements WHERE document_id=?").get(body.document.id);
-    assert.deepEqual(line,{warehouse_id:second.id,warehouse_code:"XR",warehouse_name:"Рентген-склад"});
-    assert.deepEqual(movement,{warehouse_id:second.id,warehouse_code:"XR",warehouse_name:"Рентген-склад"});
+    assert.deepEqual({...line},{warehouse_id:second.id,warehouse_code:"XR",warehouse_name:"Рентген-склад"});
+    assert.deepEqual({...movement},{warehouse_id:second.id,warehouse_code:"XR",warehouse_name:"Рентген-склад"});
 
     const renamed=await saveWarehouse(db,org1,{id:second.id,name:"Склад рентгенографії",code:"XR2",active:true,isDefault:false},"PATCH");
     assert.equal(renamed.status,200);
     const after=raw.prepare("SELECT warehouse_code,warehouse_name FROM inventory_movements WHERE document_id=?").get(body.document.id);
-    assert.deepEqual(after,{warehouse_code:"XR",warehouse_name:"Рентген-склад"},"posted register snapshot must not follow master-data rename");
+    assert.deepEqual({...after},{warehouse_code:"XR",warehouse_name:"Рентген-склад"},"posted register snapshot must not follow master-data rename");
   });
 });

--- a/tests/warehouses.behavior.test.mjs
+++ b/tests/warehouses.behavior.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function warehouses(db,cookie){return callWorker(new Request("http://localhost/api/staff/warehouses",{headers:{cookie}}),db);}
+async function saveWarehouse(db,cookie,body,method="POST"){
+  return callWorker(jsonRequest("/api/staff/warehouses",body,{method,headers:{cookie}}),db);
+}
+async function inventory(db,cookie,body){return callWorker(jsonRequest("/api/staff/inventory",body,{headers:{cookie}}),db);}
+async function document(db,cookie,body){return callWorker(jsonRequest("/api/staff/inventory/documents",body,{headers:{cookie}}),db);}
+
+test("every organization has exactly one active default warehouse",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"warehouse-default@example.com",role:"admin",organizationId:1});
+    const response=await warehouses(db,cookie);assert.equal(response.status,200);
+    const payload=await response.json();
+    assert.equal(payload.warehouses.filter(w=>w.isDefault).length,1);
+    assert.equal(payload.warehouses.find(w=>w.isDefault).code,"MAIN");
+
+    raw.exec("INSERT INTO organizations (id,name,slug,active) VALUES (22,'Warehouse Org','warehouse-org',1)");
+    const row=raw.prepare("SELECT code,name,active,is_default FROM warehouses WHERE organization_id=22").get();
+    assert.equal(row.code,"MAIN");assert.equal(row.name,"Основний склад");assert.equal(row.active,1);assert.equal(row.is_default,1);
+  });
+});
+
+test("writeoff cannot consume another warehouse balance for the same lot",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"warehouse-split@example.com",role:"admin",organizationId:1});
+    const createdWarehouse=await saveWarehouse(db,cookie,{code:"CT",name:"Склад КТ",active:true});
+    assert.equal(createdWarehouse.status,201);const {warehouse:ct}=await createdWarehouse.json();
+    const main=raw.prepare("SELECT id FROM warehouses WHERE organization_id=1 AND is_default=1").get();
+
+    const itemRes=await inventory(db,cookie,{action:"create_item",name:"Контраст складський",sku:"WH-CT",category:"contrast",unit:"фл",minStock:0});
+    const {id:itemId}=await itemRes.json();
+    const receipt=await document(db,cookie,{action:"create",documentType:"inventory_receipt",lines:[{itemId,warehouseId:ct.id,quantity:5,lotNumber:"WH-SAME"}]});
+    assert.equal(receipt.status,201);const receiptBody=await receipt.json();
+    assert.equal((await document(db,cookie,{action:"post",documentId:receiptBody.document.id})).status,200);
+    const lotId=raw.prepare("SELECT lot_id AS lotId FROM inventory_document_lines WHERE document_id=?").get(receiptBody.document.id).lotId;
+
+    const wrong=await document(db,cookie,{action:"create",documentType:"inventory_writeoff",lines:[{lotId,warehouseId:main.id,quantity:1,reason:"Не той склад"}]});
+    assert.equal(wrong.status,201);const wrongBody=await wrong.json();
+    const wrongPost=await document(db,cookie,{action:"post",documentId:wrongBody.document.id});
+    assert.equal(wrongPost.status,409);
+    assert.match((await wrongPost.json()).error,/вибраному складі/i);
+
+    const right=await document(db,cookie,{action:"create",documentType:"inventory_writeoff",lines:[{lotId,warehouseId:ct.id,quantity:2,reason:"Використано"}]});
+    const rightBody=await right.json();assert.equal((await document(db,cookie,{action:"post",documentId:rightBody.document.id})).status,200);
+    const ctStock=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND warehouse_id=? AND lot_id=?").get(ct.id,lotId).stock;
+    const mainStock=raw.prepare("SELECT COALESCE(SUM(quantity_delta),0) AS stock FROM inventory_movements WHERE organization_id=1 AND warehouse_id=? AND lot_id=?").get(main.id,lotId).stock;
+    assert.equal(ctStock,3);assert.equal(mainStock,0);
+  });
+});
+
+test("warehouse tenant and frozen snapshot are enforced",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Org 2','org-2',1)");
+    const org1=await seedStaffSession(db,{email:"warehouse-org1@example.com",role:"admin",organizationId:1});
+    const foreign=raw.prepare("SELECT id FROM warehouses WHERE organization_id=2 AND is_default=1").get();
+    const itemRes=await inventory(db,org1,{action:"create_item",name:"Папір WH",sku:"WH-P",category:"paper",unit:"пач",minStock:0});
+    const {id:itemId}=await itemRes.json();
+    const denied=await document(db,org1,{action:"create",documentType:"inventory_receipt",lines:[{itemId,warehouseId:foreign.id,quantity:1,lotNumber:"FOREIGN"}]});
+    assert.equal(denied.status,404);
+
+    const secondRes=await saveWarehouse(db,org1,{code:"XR",name:"Рентген-склад",active:true});const {warehouse:second}=await secondRes.json();
+    const receipt=await document(db,org1,{action:"create",documentType:"inventory_receipt",lines:[{itemId,warehouseId:second.id,quantity:2,lotNumber:"SNAP"}]});
+    const body=await receipt.json();
+    assert.throws(()=>raw.prepare("UPDATE inventory_document_lines SET warehouse_id=?,warehouse_code='MAIN',warehouse_name='Основний склад' WHERE id=?").run(foreign.id,body.lines[0].id),/inventory_warehouse_tenant_mismatch/);
+    assert.equal((await document(db,org1,{action:"post",documentId:body.document.id})).status,200);
+    const line=raw.prepare("SELECT warehouse_id,warehouse_code,warehouse_name FROM inventory_document_lines WHERE document_id=?").get(body.document.id);
+    const movement=raw.prepare("SELECT warehouse_id,warehouse_code,warehouse_name FROM inventory_movements WHERE document_id=?").get(body.document.id);
+    assert.deepEqual(line,{warehouse_id:second.id,warehouse_code:"XR",warehouse_name:"Рентген-склад"});
+    assert.deepEqual(movement,{warehouse_id:second.id,warehouse_code:"XR",warehouse_name:"Рентген-склад"});
+
+    const renamed=await saveWarehouse(db,org1,{id:second.id,name:"Склад рентгенографії",code:"XR2",active:true,isDefault:false},"PATCH");
+    assert.equal(renamed.status,200);
+    const after=raw.prepare("SELECT warehouse_code,warehouse_name FROM inventory_movements WHERE document_id=?").get(body.document.id);
+    assert.deepEqual(after,{warehouse_code:"XR",warehouse_name:"Рентген-склад"},"posted register snapshot must not follow master-data rename");
+  });
+});


### PR DESCRIPTION
## Scope
- add tenant-scoped BAS warehouse directory with one deterministic default warehouse per organization
- migrate the previously implicit single-location inventory history to that default warehouse
- freeze warehouse id/code/name snapshots in inventory document lines and register movements
- bind receipt/writeoff posting to a concrete warehouse
- enforce non-negative stock per warehouse + lot, not across the whole tenant
- add tenant-scoped warehouse API and first-class staff UI
- add warehouse selector to receipt/writeoff flows, warehouse balances and report breakdown
- bump new inventory printed forms to template v2 while preserving the earliest canonical snapshot for exact historical reprint
- improve CI failure diagnostics so behavioral `not ok` context is surfaced in check annotations

## Safety contract
- warehouse is a register dimension, not a property of the lot; the same lot can exist in multiple warehouses
- historical pre-0081 rows map to `Основний склад` because the old model could represent only that one implicit location
- posted movement and printed-form snapshots remain immutable after warehouse rename/deactivation
- write-off stock is checked atomically inside the selected warehouse + lot bucket
- movement registrar requires exact warehouse id/code/name snapshot from the posted document line
- warehouse edits are admin-only and all access is tenant-scoped
- no production deploy in this PR

## Verification
Exact head: `a25469bbfa7053b30f1d098c3e547bfc1a137f27`
- CI #1080 — success
- behavioral tests — success
- production release gate — success
- CodeQL #995 — success
- manual security review — tenant isolation, cross-warehouse stock isolation, exact registrar snapshot, append-only movements, immutable historical print/reprint checked

Ready to merge.