### PR TITLE
Add BAS inventory transfers between warehouses

### DIFF
--- a/app/api/staff/inventory/transfers/route.ts
+++ b/app/api/staff/inventory/transfers/route.ts
@@ -1,0 +1,94 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import {
+  cancelInventoryTransfer,
+  createInventoryTransfer,
+  getInventoryTransfer,
+  listInventoryTransfers,
+  postInventoryTransfer,
+  type InventoryTransferLineInput,
+} from "../../../../../lib/inventory-transfers";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+const MANAGER_ROLES=new Set(["admin","radiographer"]);
+function canManage(role:string){return MANAGER_ROLES.has(role);}
+function int(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
+function clean(value:unknown,max:number){return String(value??"").trim().slice(0,max);}
+
+function mapCreateError(error:unknown){
+  const code=String(error instanceof Error?error.message:error);
+  if(code.includes("lines_required"))return[400,"Додайте хоча б один рядок переміщення"] as const;
+  if(code.includes("invalid_quantity"))return[400,"Кількість має бути більшою за нуль"] as const;
+  if(code.includes("warehouse_required"))return[400,"Вкажіть склад-відправник і склад-одержувач"] as const;
+  if(code.includes("same_warehouse"))return[400,"Склад-відправник і склад-одержувач мають відрізнятися"] as const;
+  if(code.includes("warehouse_not_found"))return[404,"Склад не знайдено або він неактивний"] as const;
+  if(code.includes("lot_required"))return[400,"Вкажіть партію для переміщення"] as const;
+  if(code.includes("lot_not_found"))return[404,"Партію не знайдено або матеріал неактивний"] as const;
+  return null;
+}
+
+export async function GET(request:Request){
+  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const url=new URL(request.url);const id=int(url.searchParams.get("id"));
+  if(id){
+    const detail=await getInventoryTransfer(db,ctx.organizationId,id);
+    if(!detail)return Response.json({error:"Документ переміщення не знайдено"},{status:404});
+    return Response.json({...detail,staff:ctx.member,canManage:canManage(ctx.role)});
+  }
+  const documents=await listInventoryTransfers(db,ctx.organizationId);
+  return Response.json({documents,staff:ctx.member,canManage:canManage(ctx.role)});
+}
+
+export async function POST(request:Request){
+  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canManage(ctx.role))return Response.json({error:"Переміщення запасів можуть змінювати адміністратор або рентгенолаборант"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;const action=clean(body.action,30);
+
+  if(action==="create"){
+    const lines=Array.isArray(body.lines)?body.lines as InventoryTransferLineInput[]:[];
+    try{
+      const created=await createInventoryTransfer(db,{
+        organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+        occurredAt:clean(body.occurredAt,32)||undefined,comment:clean(body.comment,500),lines,
+      });
+      if(!created)return Response.json({error:"Не вдалося створити документ переміщення"},{status:500});
+      await audit(db,{
+        organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+        action:"inventory_transfer_created",resource:"business_document",targetId:created.document.id,
+        details:{lineCount:created.lines.length},
+      });
+      return Response.json(created,{status:201});
+    }catch(error){
+      const mapped=mapCreateError(error);if(mapped)return Response.json({error:mapped[1]},{status:mapped[0]});
+      throw error;
+    }
+  }
+
+  const documentId=int(body.documentId);if(!documentId)return Response.json({error:"Некоректний документ"},{status:400});
+  if(action==="post"){
+    const result=await postInventoryTransfer(db,{organizationId:ctx.organizationId,documentId,actorEmail:ctx.member.email});
+    if(!result.ok)return Response.json({error:result.error},{status:result.status});
+    await audit(db,{
+      organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+      action:result.idempotent?"inventory_transfer_post_replayed":"inventory_transfer_posted",
+      resource:"business_document",targetId:documentId,details:{idempotent:result.idempotent},
+    });
+    return Response.json(result.document);
+  }
+  if(action==="cancel"){
+    const ok=await cancelInventoryTransfer(db,ctx.organizationId,documentId);
+    if(!ok){
+      const current=await getInventoryTransfer(db,ctx.organizationId,documentId);
+      if(!current)return Response.json({error:"Документ переміщення не знайдено"},{status:404});
+      return Response.json({error:"Скасувати можна лише чернетку"},{status:409});
+    }
+    await audit(db,{
+      organizationId:ctx.organizationId,actorEmail:ctx.member.email,
+      action:"inventory_transfer_cancelled",resource:"business_document",targetId:documentId,
+    });
+    return Response.json({ok:true});
+  }
+  return Response.json({error:"Невідома дія з документом переміщення"},{status:400});
+}

--- a/app/staff/inventory/transfers/page.tsx
+++ b/app/staff/inventory/transfers/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback,useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type Warehouse={id:number;code:string;name:string;active:number;isDefault:number};
+type Balance={warehouseId:number;warehouseCode:string;warehouseName:string;lotId:number;itemId:number;itemName:string;lotNumber:string;stock:number};
+type Staff={email:string;displayName:string;role:string};
+type TransferDoc={id:number;number:string;occurredAt:string;state:string;comment:string;lineCount:number;totalQuantity:number};
+type TransferLine={id:number;itemName:string;unit:string;lotId:number;lotNumber:string;quantity:number;reason:string;sourceWarehouseName:string;destinationWarehouseName:string};
+type Detail={document:TransferDoc;lines:TransferLine[]};
+
+type InventoryPayload={warehouses:Warehouse[];warehouseBalances:Balance[];staff:Staff;canManage:boolean;error?:string};
+type TransferPayload={documents:TransferDoc[];staff:Staff;canManage:boolean;error?:string};
+
+function stateLabel(state:string){return state==="draft"?"Чернетка":state==="posted"?"Проведено":state==="cancelled"?"Скасовано":state==="reversed"?"Сторновано":state;}
+
+export default function InventoryTransfersPage(){
+  const [inventory,setInventory]=useState<InventoryPayload|null>(null);
+  const [documents,setDocuments]=useState<TransferDoc[]>([]);
+  const [selected,setSelected]=useState<Detail|null>(null);
+  const [sourceWarehouseId,setSourceWarehouseId]=useState(0);
+  const [destinationWarehouseId,setDestinationWarehouseId]=useState(0);
+  const [lotId,setLotId]=useState(0);
+  const [quantity,setQuantity]=useState(1);
+  const [reason,setReason]=useState("Переміщення між складами");
+  const [comment,setComment]=useState("");
+  const [error,setError]=useState("");
+  const [notice,setNotice]=useState("");
+  const [busy,setBusy]=useState(false);
+
+  const load=useCallback(async()=>{
+    const [invRes,docRes]=await Promise.all([
+      fetch("/api/staff/inventory",{cache:"no-store"}),
+      fetch("/api/staff/inventory/transfers",{cache:"no-store"}),
+    ]);
+    const inv=await invRes.json().catch(()=>({})) as InventoryPayload;
+    const docs=await docRes.json().catch(()=>({})) as TransferPayload;
+    if(!invRes.ok)throw new Error(inv.error||"Не вдалося завантажити складські залишки");
+    if(!docRes.ok)throw new Error(docs.error||"Не вдалося завантажити переміщення");
+    setInventory(inv);setDocuments(docs.documents||[]);setError("");
+    const active=inv.warehouses.filter(w=>w.active);
+    const main=active.find(w=>w.isDefault)||active[0];
+    if(main)setSourceWarehouseId(current=>current||main.id);
+  },[]);
+
+  useEffect(()=>{const timer=window.setTimeout(()=>void load().catch(e=>setError(e instanceof Error?e.message:"Помилка")),0);return()=>window.clearTimeout(timer);},[load]);
+
+  const activeWarehouses=useMemo(()=>inventory?.warehouses.filter(w=>w.active)||[],[inventory]);
+  const sourceBalances=useMemo(()=>{
+    const rows=(inventory?.warehouseBalances||[]).filter(row=>row.warehouseId===sourceWarehouseId&&Number(row.stock)>0.000001);
+    return rows.sort((a,b)=>`${a.itemName} ${a.lotNumber}`.localeCompare(`${b.itemName} ${b.lotNumber}`,"uk"));
+  },[inventory,sourceWarehouseId]);
+  const selectedBalance=sourceBalances.find(row=>row.lotId===lotId)||null;
+
+  useEffect(()=>{
+    if(sourceBalances.length===0){setLotId(0);return;}
+    if(!sourceBalances.some(row=>row.lotId===lotId))setLotId(sourceBalances[0].lotId);
+  },[sourceBalances,lotId]);
+  useEffect(()=>{
+    if(destinationWarehouseId===sourceWarehouseId)setDestinationWarehouseId(0);
+  },[sourceWarehouseId,destinationWarehouseId]);
+
+  async function openDocument(id:number){
+    const response=await fetch(`/api/staff/inventory/transfers?id=${id}`,{cache:"no-store"});
+    const payload=await response.json().catch(()=>({})) as Detail&{error?:string};
+    if(!response.ok){setNotice(`⚠ ${payload.error||"Не вдалося відкрити документ"}`);return;}
+    setSelected(payload);setNotice("");
+  }
+
+  async function create(event:React.FormEvent){
+    event.preventDefault();if(!inventory?.canManage||!lotId||!sourceWarehouseId||!destinationWarehouseId)return;
+    setBusy(true);setNotice("");
+    try{
+      const response=await fetch("/api/staff/inventory/transfers",{
+        method:"POST",headers:{"content-type":"application/json"},
+        body:JSON.stringify({action:"create",comment,lines:[{lotId,sourceWarehouseId,destinationWarehouseId,quantity,reason}]}),
+      });
+      const payload=await response.json().catch(()=>({})) as Detail&{error?:string};
+      if(!response.ok){setNotice(`⚠ ${payload.error||"Не вдалося створити переміщення"}`);return;}
+      setSelected(payload);setNotice(`✓ Створено чернетку ${payload.document.number}`);setComment("");
+      await load();
+    }finally{setBusy(false);}
+  }
+
+  async function action(kind:"post"|"cancel"){
+    if(!selected)return;setBusy(true);setNotice("");
+    try{
+      const response=await fetch("/api/staff/inventory/transfers",{
+        method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({action:kind,documentId:selected.document.id}),
+      });
+      const payload=await response.json().catch(()=>({})) as {error?:string};
+      if(!response.ok){setNotice(`⚠ ${payload.error||"Операцію не виконано"}`);return;}
+      setNotice(kind==="post"?"✓ Переміщення проведено":"✓ Чернетку скасовано");
+      await load();await openDocument(selected.document.id);
+    }finally{setBusy(false);}
+  }
+
+  return <StaffWorkspaceShell active="inventory" title="Переміщення запасів" description="BAS-документ: списання зі складу-відправника і одночасне оприбуткування тієї самої партії на склад-одержувач." staffName={inventory?.staff.displayName||inventory?.staff.email} staffRole={inventory?.staff.role}>
+    {error&&<p className="financeError">{error}</p>}
+    {!inventory&&!error&&<p className="financeLoading">Завантаження…</p>}
+    {inventory&&<div className="inventoryDocumentsLayout">
+      <section className="financeJournal">
+        <header className="financeToolbar"><div className="financeTabs"><button type="button" onClick={()=>window.location.assign("/staff/inventory")}>← Складський облік</button><button type="button" onClick={()=>window.location.assign("/staff/warehouses")}>Склади</button></div><button type="button" onClick={()=>void load()}>Оновити</button></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Документ</th><th>Дата</th><th>Стан</th><th>Рядків</th><th>Кількість</th><th/></tr></thead><tbody>
+          {documents.map(row=><tr key={row.id}><td><b>{row.number}</b><small>{row.comment||"Переміщення між складами"}</small></td><td>{new Date(row.occurredAt).toLocaleString("uk-UA")}</td><td><span className={`financeState state-${row.state}`}>{stateLabel(row.state)}</span></td><td>{row.lineCount}</td><td>{row.totalQuantity}</td><td><button type="button" onClick={()=>void openDocument(row.id)}>Відкрити</button></td></tr>)}
+          {documents.length===0&&<tr><td colSpan={6}>Переміщень ще немає.</td></tr>}
+        </tbody></table></div>
+      </section>
+
+      <section className="inventoryDocumentCard">
+        <header><div><small>Новий документ</small><h2>Переміщення запасів</h2><p>Залишок перевіряється тільки на складі-відправнику. Склад-одержувач не створює нову партію — переноситься той самий lot.</p></div></header>
+        {notice&&<p className={notice.startsWith("⚠")?"financeError":"notice"}>{notice}</p>}
+        <form className="inventoryOperations" onSubmit={create}><div>
+          <label>Склад-відправник<select value={sourceWarehouseId} onChange={e=>setSourceWarehouseId(Number(e.target.value))}>{activeWarehouses.map(w=><option key={w.id} value={w.id}>{w.name} {w.code?`(${w.code})`:""}</option>)}</select></label>
+          <label>Партія<select value={lotId} onChange={e=>setLotId(Number(e.target.value))}><option value={0}>Оберіть партію…</option>{sourceBalances.map(row=><option key={`${row.warehouseId}-${row.lotId}`} value={row.lotId}>{row.itemName} · {row.lotNumber||`lot #${row.lotId}`} · залишок {row.stock}</option>)}</select></label>
+          <label>Склад-одержувач<select value={destinationWarehouseId} onChange={e=>setDestinationWarehouseId(Number(e.target.value))}><option value={0}>Оберіть склад…</option>{activeWarehouses.filter(w=>w.id!==sourceWarehouseId).map(w=><option key={w.id} value={w.id}>{w.name} {w.code?`(${w.code})`:""}</option>)}</select></label>
+          <label>Кількість<input type="number" min="0.000001" step="any" required value={quantity} onChange={e=>setQuantity(Number(e.target.value))}/>{selectedBalance&&<small>Доступно: {selectedBalance.stock}</small>}</label>
+          <label>Підстава<input value={reason} onChange={e=>setReason(e.target.value)} maxLength={500}/></label>
+          <label>Коментар<input value={comment} onChange={e=>setComment(e.target.value)} maxLength={500}/></label>
+          {inventory.canManage&&<button className="primary" disabled={busy||!lotId||!destinationWarehouseId||quantity<=0}>Створити чернетку</button>}
+        </div></form>
+
+        {selected&&<div className="inventoryOperations"><h3>{selected.document.number} · {stateLabel(selected.document.state)}</h3>
+          {selected.lines.map(line=><p key={line.id}><b>{line.itemName}</b> · партія {line.lotNumber||line.lotId} · {line.quantity} {line.unit}<br/><small>{line.sourceWarehouseName} → {line.destinationWarehouseName} · {line.reason}</small></p>)}
+          {inventory.canManage&&selected.document.state==="draft"&&<div><button className="primary" disabled={busy} type="button" onClick={()=>void action("post")}>Провести</button><button disabled={busy} type="button" onClick={()=>void action("cancel")}>Скасувати чернетку</button></div>}
+        </div>}
+      </section>
+    </div>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/inventory/transfers/page.tsx
+++ b/app/staff/inventory/transfers/page.tsx
@@ -51,15 +51,15 @@ export default function InventoryTransfersPage(){
     const rows=(inventory?.warehouseBalances||[]).filter(row=>row.warehouseId===sourceWarehouseId&&Number(row.stock)>0.000001);
     return rows.sort((a,b)=>`${a.itemName} ${a.lotNumber}`.localeCompare(`${b.itemName} ${b.lotNumber}`,"uk"));
   },[inventory,sourceWarehouseId]);
-  const selectedBalance=sourceBalances.find(row=>row.lotId===lotId)||null;
+  const effectiveLotId=sourceBalances.some(row=>row.lotId===lotId)?lotId:(sourceBalances[0]?.lotId||0);
+  const effectiveDestinationWarehouseId=destinationWarehouseId===sourceWarehouseId?0:destinationWarehouseId;
+  const selectedBalance=sourceBalances.find(row=>row.lotId===effectiveLotId)||null;
 
-  useEffect(()=>{
-    if(sourceBalances.length===0){setLotId(0);return;}
-    if(!sourceBalances.some(row=>row.lotId===lotId))setLotId(sourceBalances[0].lotId);
-  },[sourceBalances,lotId]);
-  useEffect(()=>{
-    if(destinationWarehouseId===sourceWarehouseId)setDestinationWarehouseId(0);
-  },[sourceWarehouseId,destinationWarehouseId]);
+  function changeSource(next:number){
+    setSourceWarehouseId(next);
+    setLotId(0);
+    if(destinationWarehouseId===next)setDestinationWarehouseId(0);
+  }
 
   async function openDocument(id:number){
     const response=await fetch(`/api/staff/inventory/transfers?id=${id}`,{cache:"no-store"});
@@ -69,12 +69,15 @@ export default function InventoryTransfersPage(){
   }
 
   async function create(event:React.FormEvent){
-    event.preventDefault();if(!inventory?.canManage||!lotId||!sourceWarehouseId||!destinationWarehouseId)return;
+    event.preventDefault();
+    if(!inventory?.canManage||!effectiveLotId||!sourceWarehouseId||!effectiveDestinationWarehouseId)return;
     setBusy(true);setNotice("");
     try{
       const response=await fetch("/api/staff/inventory/transfers",{
         method:"POST",headers:{"content-type":"application/json"},
-        body:JSON.stringify({action:"create",comment,lines:[{lotId,sourceWarehouseId,destinationWarehouseId,quantity,reason}]}),
+        body:JSON.stringify({action:"create",comment,lines:[{
+          lotId:effectiveLotId,sourceWarehouseId,destinationWarehouseId:effectiveDestinationWarehouseId,quantity,reason,
+        }]}),
       });
       const payload=await response.json().catch(()=>({})) as Detail&{error?:string};
       if(!response.ok){setNotice(`⚠ ${payload.error||"Не вдалося створити переміщення"}`);return;}
@@ -112,13 +115,13 @@ export default function InventoryTransfersPage(){
         <header><div><small>Новий документ</small><h2>Переміщення запасів</h2><p>Залишок перевіряється тільки на складі-відправнику. Склад-одержувач не створює нову партію — переноситься той самий lot.</p></div></header>
         {notice&&<p className={notice.startsWith("⚠")?"financeError":"notice"}>{notice}</p>}
         <form className="inventoryOperations" onSubmit={create}><div>
-          <label>Склад-відправник<select value={sourceWarehouseId} onChange={e=>setSourceWarehouseId(Number(e.target.value))}>{activeWarehouses.map(w=><option key={w.id} value={w.id}>{w.name} {w.code?`(${w.code})`:""}</option>)}</select></label>
-          <label>Партія<select value={lotId} onChange={e=>setLotId(Number(e.target.value))}><option value={0}>Оберіть партію…</option>{sourceBalances.map(row=><option key={`${row.warehouseId}-${row.lotId}`} value={row.lotId}>{row.itemName} · {row.lotNumber||`lot #${row.lotId}`} · залишок {row.stock}</option>)}</select></label>
-          <label>Склад-одержувач<select value={destinationWarehouseId} onChange={e=>setDestinationWarehouseId(Number(e.target.value))}><option value={0}>Оберіть склад…</option>{activeWarehouses.filter(w=>w.id!==sourceWarehouseId).map(w=><option key={w.id} value={w.id}>{w.name} {w.code?`(${w.code})`:""}</option>)}</select></label>
+          <label>Склад-відправник<select value={sourceWarehouseId} onChange={e=>changeSource(Number(e.target.value))}>{activeWarehouses.map(w=><option key={w.id} value={w.id}>{w.name} {w.code?`(${w.code})`:""}</option>)}</select></label>
+          <label>Партія<select value={effectiveLotId} onChange={e=>setLotId(Number(e.target.value))}><option value={0}>Оберіть партію…</option>{sourceBalances.map(row=><option key={`${row.warehouseId}-${row.lotId}`} value={row.lotId}>{row.itemName} · {row.lotNumber||`lot #${row.lotId}`} · залишок {row.stock}</option>)}</select></label>
+          <label>Склад-одержувач<select value={effectiveDestinationWarehouseId} onChange={e=>setDestinationWarehouseId(Number(e.target.value))}><option value={0}>Оберіть склад…</option>{activeWarehouses.filter(w=>w.id!==sourceWarehouseId).map(w=><option key={w.id} value={w.id}>{w.name} {w.code?`(${w.code})`:""}</option>)}</select></label>
           <label>Кількість<input type="number" min="0.000001" step="any" required value={quantity} onChange={e=>setQuantity(Number(e.target.value))}/>{selectedBalance&&<small>Доступно: {selectedBalance.stock}</small>}</label>
           <label>Підстава<input value={reason} onChange={e=>setReason(e.target.value)} maxLength={500}/></label>
           <label>Коментар<input value={comment} onChange={e=>setComment(e.target.value)} maxLength={500}/></label>
-          {inventory.canManage&&<button className="primary" disabled={busy||!lotId||!destinationWarehouseId||quantity<=0}>Створити чернетку</button>}
+          {inventory.canManage&&<button className="primary" disabled={busy||!effectiveLotId||!effectiveDestinationWarehouseId||quantity<=0}>Створити чернетку</button>}
         </div></form>
 
         {selected&&<div className="inventoryOperations"><h3>{selected.document.number} · {stateLabel(selected.document.state)}</h3>

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -47,6 +47,7 @@ const systemModules: NavModule[] = [
   ]},
   { label:"Склад", href:"/staff/inventory", sections:["inventory"], icon:"▣", items:[
     { label:"Витратні матеріали", href:"/staff/inventory" },
+    { label:"Переміщення запасів", href:"/staff/inventory/transfers" },
     { label:"Склади", href:"/staff/warehouses" },
   ]},
   { label:"Фінанси і звіти", href:"/staff/finance", sections:["finance","counterparties","reports","tariffs"], icon:"💳", items:[

--- a/drizzle/0082_inventory_transfers.sql
+++ b/drizzle/0082_inventory_transfers.sql
@@ -61,6 +61,16 @@ WHEN NOT EXISTS (
   AND (NEW.destination_warehouse_id IS NOT NULL OR NEW.destination_warehouse_code<>'' OR NEW.destination_warehouse_name<>'')
 BEGIN SELECT RAISE(ABORT,'inventory_destination_not_allowed'); END;
 --> statement-breakpoint
+CREATE TRIGGER `inventory_nontransfer_destination_update`
+BEFORE UPDATE OF `organization_id`,`document_id`,`destination_warehouse_id`,`destination_warehouse_code`,`destination_warehouse_name`
+ON `inventory_document_lines`
+WHEN NOT EXISTS (
+  SELECT 1 FROM business_documents d
+  WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_transfer'
+)
+  AND (NEW.destination_warehouse_id IS NOT NULL OR NEW.destination_warehouse_code<>'' OR NEW.destination_warehouse_name<>'')
+BEGIN SELECT RAISE(ABORT,'inventory_destination_not_allowed'); END;
+--> statement-breakpoint
 
 -- Receipt/writeoff have one movement per document line; transfer intentionally has transfer_out + transfer_in.
 DROP INDEX IF EXISTS `inventory_movements_document_line_idx`;

--- a/drizzle/0082_inventory_transfers.sql
+++ b/drizzle/0082_inventory_transfers.sql
@@ -1,0 +1,146 @@
+-- BAS-style warehouse transfer: one posted document line produces two immutable register facts.
+-- warehouse_* is the frozen source snapshot; destination_warehouse_* is the frozen destination snapshot.
+ALTER TABLE `inventory_document_lines` ADD COLUMN `destination_warehouse_id` integer;
+--> statement-breakpoint
+ALTER TABLE `inventory_document_lines` ADD COLUMN `destination_warehouse_code` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `inventory_document_lines` ADD COLUMN `destination_warehouse_name` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `inventory_lines_destination_warehouse_idx`
+  ON `inventory_document_lines` (`organization_id`,`destination_warehouse_id`,`document_id`,`line_no`)
+  WHERE `destination_warehouse_id` IS NOT NULL;
+--> statement-breakpoint
+
+-- A transfer line must have a second active warehouse in the same tenant, distinct from the source.
+CREATE TRIGGER `inventory_transfer_destination_insert`
+BEFORE INSERT ON `inventory_document_lines`
+WHEN EXISTS (
+  SELECT 1 FROM business_documents d
+  WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_transfer'
+)
+BEGIN
+  SELECT CASE WHEN NEW.destination_warehouse_id IS NULL
+    THEN RAISE(ABORT,'inventory_transfer_destination_required') END;
+  SELECT CASE WHEN NEW.destination_warehouse_id=NEW.warehouse_id
+    THEN RAISE(ABORT,'inventory_transfer_same_warehouse') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.destination_warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.destination_warehouse_code AND w.name=NEW.destination_warehouse_name
+  ) THEN RAISE(ABORT,'inventory_transfer_destination_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_transfer_destination_update`
+BEFORE UPDATE OF `organization_id`,`document_id`,`warehouse_id`,`destination_warehouse_id`,`destination_warehouse_code`,`destination_warehouse_name`
+ON `inventory_document_lines`
+WHEN EXISTS (
+  SELECT 1 FROM business_documents d
+  WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_transfer'
+)
+BEGIN
+  SELECT CASE WHEN NEW.destination_warehouse_id IS NULL
+    THEN RAISE(ABORT,'inventory_transfer_destination_required') END;
+  SELECT CASE WHEN NEW.destination_warehouse_id=NEW.warehouse_id
+    THEN RAISE(ABORT,'inventory_transfer_same_warehouse') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.destination_warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.destination_warehouse_code AND w.name=NEW.destination_warehouse_name
+  ) THEN RAISE(ABORT,'inventory_transfer_destination_invalid') END;
+END;
+--> statement-breakpoint
+
+-- Non-transfer documents may not smuggle a destination dimension into the register contract.
+CREATE TRIGGER `inventory_nontransfer_destination_insert`
+BEFORE INSERT ON `inventory_document_lines`
+WHEN NOT EXISTS (
+  SELECT 1 FROM business_documents d
+  WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_transfer'
+)
+  AND (NEW.destination_warehouse_id IS NOT NULL OR NEW.destination_warehouse_code<>'' OR NEW.destination_warehouse_name<>'')
+BEGIN SELECT RAISE(ABORT,'inventory_destination_not_allowed'); END;
+--> statement-breakpoint
+
+-- Receipt/writeoff have one movement per document line; transfer intentionally has transfer_out + transfer_in.
+DROP INDEX IF EXISTS `inventory_movements_document_line_idx`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `inventory_movements_document_line_type_idx`
+  ON `inventory_movements` (`organization_id`,`document_line_id`,`movement_type`)
+  WHERE `document_line_id` IS NOT NULL;
+--> statement-breakpoint
+
+-- The source bucket may never go negative for either an ordinary write-off or a transfer-out.
+DROP TRIGGER IF EXISTS `inventory_writeoff_nonnegative_stock`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_writeoff_nonnegative_stock`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.movement_type IN ('writeoff','transfer_out')
+BEGIN
+  SELECT CASE WHEN (
+    COALESCE((
+      SELECT SUM(quantity_delta) FROM inventory_movements
+      WHERE organization_id=NEW.organization_id AND lot_id=NEW.lot_id
+        AND warehouse_id IS NEW.warehouse_id
+    ),0)+NEW.quantity_delta
+  ) < -0.000001 THEN RAISE(ABORT,'inventory_negative_stock') END;
+END;
+--> statement-breakpoint
+
+-- Exact registrar contract, now including the paired source/destination movements of a transfer.
+DROP TRIGGER IF EXISTS `inventory_movement_document_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_movement_document_integrity`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.document_id IS NOT NULL OR NEW.document_line_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.document_id IS NULL OR NEW.document_line_id IS NULL
+    THEN RAISE(ABORT,'inventory_document_link_incomplete') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM business_documents d
+    JOIN inventory_document_lines l
+      ON l.document_id=d.id AND l.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND l.id=NEW.document_line_id AND l.item_id=NEW.item_id AND l.lot_id=NEW.lot_id
+      AND COALESCE(l.booking_id,0)=COALESCE(NEW.booking_id,0) AND l.reason=NEW.reason
+      AND (
+        (d.document_type='inventory_receipt' AND NEW.movement_type='receipt'
+          AND l.warehouse_id=NEW.warehouse_id
+          AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta-l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_writeoff' AND NEW.movement_type='writeoff'
+          AND l.warehouse_id=NEW.warehouse_id
+          AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta+l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_transfer' AND NEW.movement_type='transfer_out'
+          AND l.warehouse_id=NEW.warehouse_id
+          AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta+l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_transfer' AND NEW.movement_type='transfer_in'
+          AND l.destination_warehouse_id=NEW.warehouse_id
+          AND l.destination_warehouse_code=NEW.warehouse_code AND l.destination_warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta-l.quantity)<0.000001)
+      )
+  ) THEN RAISE(ABORT,'inventory_document_link_invalid') END;
+END;
+--> statement-breakpoint
+
+-- Printed transfer forms, when added, must point to the exact posted transfer document.
+DROP TRIGGER IF EXISTS `printed_inventory_snapshot_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `printed_inventory_snapshot_integrity`
+BEFORE INSERT ON `printed_form_snapshots`
+WHEN NEW.form_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id
+      AND d.organization_id=NEW.organization_id
+      AND d.document_type=NEW.form_type
+      AND d.state=NEW.document_state
+  ) THEN RAISE(ABORT,'printed_form_document_mismatch') END;
+END;

--- a/drizzle/0082_inventory_transfers.sql
+++ b/drizzle/0082_inventory_transfers.sql
@@ -97,6 +97,15 @@ CREATE UNIQUE INDEX `inventory_movements_document_line_type_idx`
   WHERE `document_line_id` IS NOT NULL;
 --> statement-breakpoint
 
+-- Transfers did not exist before 0082, so there is no legacy compatibility reason to allow an
+-- unregistered transfer movement. Every transfer fact must belong to an exact BAS document line.
+CREATE TRIGGER `inventory_transfer_movement_requires_registrar`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.movement_type IN ('transfer_out','transfer_in')
+  AND (NEW.document_id IS NULL OR NEW.document_line_id IS NULL)
+BEGIN SELECT RAISE(ABORT,'inventory_transfer_registrar_required'); END;
+--> statement-breakpoint
+
 -- The source bucket may never go negative for either an ordinary write-off or a transfer-out.
 DROP TRIGGER IF EXISTS `inventory_writeoff_nonnegative_stock`;
 --> statement-breakpoint

--- a/drizzle/0082_inventory_transfers.sql
+++ b/drizzle/0082_inventory_transfers.sql
@@ -12,6 +12,23 @@ CREATE INDEX IF NOT EXISTS `inventory_lines_destination_warehouse_idx`
   WHERE `destination_warehouse_id` IS NOT NULL;
 --> statement-breakpoint
 
+-- Extend the warehouse reference guard from 0081: a destination warehouse used by a transfer draft
+-- is already business data and cannot disappear before the document is posted/cancelled.
+DROP TRIGGER IF EXISTS `warehouse_referenced_no_delete`;
+--> statement-breakpoint
+CREATE TRIGGER `warehouse_referenced_no_delete`
+BEFORE DELETE ON `warehouses`
+WHEN EXISTS (
+  SELECT 1 FROM inventory_document_lines l
+  WHERE l.organization_id=OLD.organization_id
+    AND (l.warehouse_id=OLD.id OR l.destination_warehouse_id=OLD.id)
+) OR EXISTS (
+  SELECT 1 FROM inventory_movements m
+  WHERE m.organization_id=OLD.organization_id AND m.warehouse_id=OLD.id
+)
+BEGIN SELECT RAISE(ABORT,'warehouse_in_use'); END;
+--> statement-breakpoint
+
 -- A transfer line must have a second active warehouse in the same tenant, distinct from the source.
 CREATE TRIGGER `inventory_transfer_destination_insert`
 BEFORE INSERT ON `inventory_document_lines`

--- a/lib/inventory-transfers.ts
+++ b/lib/inventory-transfers.ts
@@ -1,0 +1,213 @@
+import { resolveWarehouse } from "./warehouses";
+
+export type InventoryTransferLineInput={
+  lotId:number;
+  sourceWarehouseId:number;
+  destinationWarehouseId:number;
+  quantity:number;
+  reason?:string;
+};
+
+type TransferDocumentRow={
+  id:number;organizationId:number;documentType:"inventory_transfer";number:string;occurredAt:string;
+  state:"draft"|"posted"|"reversed"|"cancelled";comment:string;createdBy:string;createdAt:string;
+  postedBy:string;postedAt:string;
+};
+
+export type InventoryTransferLineRow={
+  id:number;organizationId:number;documentId:number;lineNo:number;itemId:number;itemName:string;unit:string;
+  lotId:number;lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;
+  sourceWarehouseId:number;sourceWarehouseCode:string;sourceWarehouseName:string;
+  destinationWarehouseId:number;destinationWarehouseCode:string;destinationWarehouseName:string;
+};
+
+function text(value:unknown,max:number){return String(value??"").trim().slice(0,max);}
+function positiveInt(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
+function positiveNumber(value:unknown){const n=Number(value);return Number.isFinite(n)&&n>0?n:null;}
+
+async function lotForOrg(db:D1Database,organizationId:number,lotId:number){
+  return db.prepare(
+    `SELECT l.id,l.item_id AS itemId,l.lot_number AS lotNumber,l.expires_on AS expiresOn,l.supplier,
+            l.supplier_counterparty_id AS supplierCounterpartyId,i.name AS itemName,i.unit,i.active
+     FROM inventory_lots l
+     JOIN inventory_items i ON i.id=l.item_id AND i.organization_id=l.organization_id
+     WHERE l.organization_id=? AND l.id=? LIMIT 1`
+  ).bind(organizationId,lotId).first<{
+    id:number;itemId:number;lotNumber:string;expiresOn:string;supplier:string;supplierCounterpartyId:number|null;
+    itemName:string;unit:string;active:number;
+  }>();
+}
+
+export async function getInventoryTransfer(db:D1Database,organizationId:number,documentId:number){
+  const document=await db.prepare(
+    `SELECT id,organization_id AS organizationId,document_type AS documentType,number,
+            occurred_at AS occurredAt,state,comment,created_by AS createdBy,created_at AS createdAt,
+            posted_by AS postedBy,posted_at AS postedAt
+     FROM business_documents
+     WHERE organization_id=? AND id=? AND document_type='inventory_transfer' LIMIT 1`
+  ).bind(organizationId,documentId).first<TransferDocumentRow>();
+  if(!document)return null;
+  const lines=await db.prepare(
+    `SELECT l.id,l.organization_id AS organizationId,l.document_id AS documentId,l.line_no AS lineNo,
+            l.item_id AS itemId,i.name AS itemName,i.unit,l.lot_id AS lotId,l.lot_number AS lotNumber,
+            l.expires_on AS expiresOn,l.supplier,l.quantity,l.reason,
+            l.warehouse_id AS sourceWarehouseId,l.warehouse_code AS sourceWarehouseCode,l.warehouse_name AS sourceWarehouseName,
+            l.destination_warehouse_id AS destinationWarehouseId,
+            l.destination_warehouse_code AS destinationWarehouseCode,l.destination_warehouse_name AS destinationWarehouseName
+     FROM inventory_document_lines l
+     JOIN inventory_items i ON i.id=l.item_id AND i.organization_id=l.organization_id
+     WHERE l.organization_id=? AND l.document_id=? ORDER BY l.line_no,l.id`
+  ).bind(organizationId,documentId).all<InventoryTransferLineRow>();
+  return{document,lines:lines.results};
+}
+
+export async function listInventoryTransfers(db:D1Database,organizationId:number,limit=150){
+  const safeLimit=Math.max(1,Math.min(300,Math.trunc(limit)));
+  const rows=await db.prepare(
+    `SELECT d.id,d.organization_id AS organizationId,d.document_type AS documentType,d.number,
+            d.occurred_at AS occurredAt,d.state,d.comment,d.created_by AS createdBy,d.created_at AS createdAt,
+            d.posted_by AS postedBy,d.posted_at AS postedAt,COUNT(l.id) AS lineCount,COALESCE(SUM(l.quantity),0) AS totalQuantity
+     FROM business_documents d
+     LEFT JOIN inventory_document_lines l ON l.organization_id=d.organization_id AND l.document_id=d.id
+     WHERE d.organization_id=? AND d.document_type='inventory_transfer'
+     GROUP BY d.id ORDER BY d.occurred_at DESC,d.id DESC LIMIT ${safeLimit}`
+  ).bind(organizationId).all<TransferDocumentRow&{lineCount:number;totalQuantity:number}>();
+  return rows.results;
+}
+
+export async function createInventoryTransfer(db:D1Database,input:{
+  organizationId:number;actorEmail:string;occurredAt?:string;comment?:string;lines:InventoryTransferLineInput[];
+}){
+  if(!Array.isArray(input.lines)||input.lines.length<1||input.lines.length>100)throw new Error("inventory_transfer_lines_required");
+  const normalized:Array<{
+    itemId:number;lotId:number;lotNumber:string;expiresOn:string;supplier:string;supplierCounterpartyId:number|null;
+    quantity:number;reason:string;sourceWarehouseId:number;sourceWarehouseCode:string;sourceWarehouseName:string;
+    destinationWarehouseId:number;destinationWarehouseCode:string;destinationWarehouseName:string;
+  }>=[];
+
+  for(const source of input.lines){
+    const lotId=positiveInt(source.lotId);if(!lotId)throw new Error("inventory_transfer_lot_required");
+    const qty=positiveNumber(source.quantity);if(!qty)throw new Error("inventory_transfer_invalid_quantity");
+    const sourceWarehouseId=positiveInt(source.sourceWarehouseId);
+    const destinationWarehouseId=positiveInt(source.destinationWarehouseId);
+    if(!sourceWarehouseId||!destinationWarehouseId)throw new Error("inventory_transfer_warehouse_required");
+    if(sourceWarehouseId===destinationWarehouseId)throw new Error("inventory_transfer_same_warehouse");
+    const [from,to,lot]=await Promise.all([
+      resolveWarehouse(db,{organizationId:input.organizationId,warehouseId:sourceWarehouseId}),
+      resolveWarehouse(db,{organizationId:input.organizationId,warehouseId:destinationWarehouseId}),
+      lotForOrg(db,input.organizationId,lotId),
+    ]);
+    if(!lot||!lot.active)throw new Error("inventory_transfer_lot_not_found");
+    normalized.push({
+      itemId:lot.itemId,lotId:lot.id,lotNumber:lot.lotNumber,expiresOn:lot.expiresOn,supplier:lot.supplier,
+      supplierCounterpartyId:lot.supplierCounterpartyId,quantity:qty,
+      reason:text(source.reason,500)||"Переміщення між складами",
+      sourceWarehouseId:from.id,sourceWarehouseCode:from.code,sourceWarehouseName:from.name,
+      destinationWarehouseId:to.id,destinationWarehouseCode:to.code,destinationWarehouseName:to.name,
+    });
+  }
+
+  const occurredAt=text(input.occurredAt,32)||new Date().toISOString();
+  const comment=text(input.comment,500);
+  const created=await db.prepare(
+    `INSERT INTO business_documents (organization_id,document_type,number,occurred_at,state,comment,created_by)
+     VALUES (?,'inventory_transfer','',?,'draft',?,?)`
+  ).bind(input.organizationId,occurredAt,comment,input.actorEmail).run();
+  const documentId=Number(created.meta.last_row_id||0);if(!documentId)throw new Error("inventory_transfer_create_failed");
+  await db.prepare("UPDATE business_documents SET number=? WHERE organization_id=? AND id=? AND state='draft'")
+    .bind(`ПМ-${String(documentId).padStart(6,"0")}`,input.organizationId,documentId).run();
+  try{
+    await db.batch(normalized.map((line,index)=>db.prepare(
+      `INSERT INTO inventory_document_lines
+        (organization_id,document_id,line_no,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
+         destination_warehouse_id,destination_warehouse_code,destination_warehouse_name,
+         lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason,booking_id)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,NULL)`
+    ).bind(
+      input.organizationId,documentId,index+1,line.itemId,line.lotId,
+      line.sourceWarehouseId,line.sourceWarehouseCode,line.sourceWarehouseName,
+      line.destinationWarehouseId,line.destinationWarehouseCode,line.destinationWarehouseName,
+      line.lotNumber,line.expiresOn,line.supplier,line.supplierCounterpartyId,line.quantity,line.reason,
+    )));
+  }catch(error){
+    await db.prepare("DELETE FROM business_documents WHERE organization_id=? AND id=? AND state='draft'")
+      .bind(input.organizationId,documentId).run().catch(()=>{});
+    throw error;
+  }
+  return getInventoryTransfer(db,input.organizationId,documentId);
+}
+
+export async function cancelInventoryTransfer(db:D1Database,organizationId:number,documentId:number){
+  const result=await db.prepare(
+    `UPDATE business_documents SET state='cancelled'
+     WHERE organization_id=? AND id=? AND document_type='inventory_transfer' AND state='draft'`
+  ).bind(organizationId,documentId).run();
+  return Number(result.meta.changes||0)===1;
+}
+
+export async function postInventoryTransfer(db:D1Database,input:{organizationId:number;documentId:number;actorEmail:string}){
+  const current=await getInventoryTransfer(db,input.organizationId,input.documentId);
+  if(!current)return{ok:false as const,status:404,error:"Документ переміщення не знайдено"};
+  if(current.document.state==="posted")return{ok:true as const,idempotent:true,document:current};
+  if(current.document.state!=="draft")return{ok:false as const,status:409,error:"Провести можна лише чернетку"};
+  if(current.lines.length<1)return{ok:false as const,status:409,error:"У документі немає рядків"};
+
+  const required=new Map<string,{warehouseId:number;lotId:number;quantity:number}>();
+  for(const line of current.lines){
+    if(line.sourceWarehouseId===line.destinationWarehouseId)return{ok:false as const,status:409,error:"Склад-відправник і склад-одержувач мають відрізнятися"};
+    const key=`${line.sourceWarehouseId}:${line.lotId}`;
+    const prior=required.get(key);
+    required.set(key,{warehouseId:line.sourceWarehouseId,lotId:line.lotId,quantity:(prior?.quantity||0)+Number(line.quantity)});
+  }
+  for(const value of required.values()){
+    const balance=await db.prepare(
+      `SELECT COALESCE(SUM(quantity_delta),0) AS stock FROM inventory_movements
+       WHERE organization_id=? AND warehouse_id=? AND lot_id=?`
+    ).bind(input.organizationId,value.warehouseId,value.lotId).first<{stock:number}>();
+    if(Number(balance?.stock||0)+0.000001<value.quantity){
+      return{ok:false as const,status:409,error:"Недостатній залишок у партії на складі-відправнику"};
+    }
+  }
+
+  const postedAt=new Date().toISOString();
+  const statements:D1PreparedStatement[]=[
+    db.prepare(
+      `UPDATE business_documents SET state='posted',posted_by=?,posted_at=?
+       WHERE organization_id=? AND id=? AND document_type='inventory_transfer' AND state='draft'`
+    ).bind(input.actorEmail,postedAt,input.organizationId,input.documentId),
+  ];
+  for(const line of current.lines){
+    statements.push(db.prepare(
+      `INSERT INTO inventory_movements
+        (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,
+         reason,booking_id,actor_email,document_id,document_line_id)
+       VALUES (?,?,?,?,?,?, 'transfer_out', ?,?,NULL,?,?,?)`
+    ).bind(
+      input.organizationId,line.itemId,line.lotId,line.sourceWarehouseId,line.sourceWarehouseCode,line.sourceWarehouseName,
+      -Number(line.quantity),line.reason,input.actorEmail,input.documentId,line.id,
+    ));
+    statements.push(db.prepare(
+      `INSERT INTO inventory_movements
+        (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,
+         reason,booking_id,actor_email,document_id,document_line_id)
+       VALUES (?,?,?,?,?,?, 'transfer_in', ?,?,NULL,?,?,?)`
+    ).bind(
+      input.organizationId,line.itemId,line.lotId,line.destinationWarehouseId,line.destinationWarehouseCode,line.destinationWarehouseName,
+      Number(line.quantity),line.reason,input.actorEmail,input.documentId,line.id,
+    ));
+  }
+  try{
+    await db.batch(statements);
+  }catch(error){
+    const message=String(error).toLowerCase();
+    if(message.includes("unique")){
+      const again=await getInventoryTransfer(db,input.organizationId,input.documentId);
+      if(again?.document.state==="posted")return{ok:true as const,idempotent:true,document:again};
+    }
+    if(message.includes("inventory_negative_stock")){
+      return{ok:false as const,status:409,error:"Недостатній залишок у партії на складі-відправнику"};
+    }
+    throw error;
+  }
+  return{ok:true as const,idempotent:false,document:await getInventoryTransfer(db,input.organizationId,input.documentId)};
+}

--- a/tests/inventory-transfers.behavior.test.mjs
+++ b/tests/inventory-transfers.behavior.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function post(db,cookie,url,body){return callWorker(jsonRequest(url,body,{headers:{cookie}}),db);}
+async function warehouse(db,cookie,body){return post(db,cookie,"/api/staff/warehouses",body);}
+async function inventory(db,cookie,body){return post(db,cookie,"/api/staff/inventory",body);}
+async function transfer(db,cookie,body){return post(db,cookie,"/api/staff/inventory/transfers",body);}
+
+async function seedStock(db,raw,cookie,quantity=5){
+  const itemRes=await inventory(db,cookie,{action:"create_item",name:"Transfer contrast",sku:"TR-CON",category:"contrast",unit:"фл",minStock:0});
+  assert.equal(itemRes.status,201);const {id:itemId}=await itemRes.json();
+  const receipt=await inventory(db,cookie,{action:"receive",itemId,quantity,lotNumber:"TR-LOT"});
+  assert.equal(receipt.status,201);const body=await receipt.json();
+  const lotId=body.lotId;
+  const main=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1").get();
+  return{itemId,lotId,main};
+}
+
+test("posted transfer moves the same lot atomically between warehouse buckets",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"transfer@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await seedStock(db,raw,cookie,5);
+    const destinationRes=await warehouse(db,cookie,{code:"CT",name:"Склад КТ",active:true});
+    assert.equal(destinationRes.status,201);const {warehouse:destination}=await destinationRes.json();
+
+    const created=await transfer(db,cookie,{action:"create",comment:"До КТ",lines:[{
+      lotId,sourceWarehouseId:main.id,destinationWarehouseId:destination.id,quantity:3,reason:"Поповнення КТ",
+    }]});
+    assert.equal(created.status,201);const draft=await created.json();
+    assert.equal(draft.document.documentType,"inventory_transfer");
+    assert.equal(draft.document.state,"draft");
+    assert.equal(draft.lines[0].sourceWarehouseCode,"MAIN");
+    assert.equal(draft.lines[0].destinationWarehouseCode,"CT");
+
+    const posted=await transfer(db,cookie,{action:"post",documentId:draft.document.id});
+    assert.equal(posted.status,200);const postedBody=await posted.json();
+    assert.equal(postedBody.document.state,"posted");
+
+    const movements=raw.prepare(
+      "SELECT movement_type,warehouse_id,quantity_delta,document_line_id FROM inventory_movements WHERE organization_id=1 AND document_id=? ORDER BY id"
+    ).all(draft.document.id);
+    assert.equal(movements.length,2);
+    assert.deepEqual(movements.map(row=>row.movement_type),["transfer_out","transfer_in"]);
+    assert.equal(movements[0].warehouse_id,main.id);assert.equal(movements[0].quantity_delta,-3);
+    assert.equal(movements[1].warehouse_id,destination.id);assert.equal(movements[1].quantity_delta,3);
+    assert.equal(movements[0].document_line_id,movements[1].document_line_id);
+
+    const sourceStock=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND warehouse_id=? AND lot_id=?").get(main.id,lotId).stock;
+    const destinationStock=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND warehouse_id=? AND lot_id=?").get(destination.id,lotId).stock;
+    assert.equal(sourceStock,2);assert.equal(destinationStock,3);
+
+    const replay=await transfer(db,cookie,{action:"post",documentId:draft.document.id});
+    assert.equal(replay.status,200);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS count FROM inventory_movements WHERE document_id=?").get(draft.document.id).count,2);
+  });
+});
+
+test("transfer cannot borrow stock from another warehouse or use the same warehouse",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"transfer-guard@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await seedStock(db,raw,cookie,2);
+    const destinationRes=await warehouse(db,cookie,{code:"XR",name:"Рентген-склад",active:true});
+    const {warehouse:destination}=await destinationRes.json();
+
+    const same=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:main.id,quantity:1}]});
+    assert.equal(same.status,400);assert.match((await same.json()).error,/відрізнятися/i);
+
+    const first=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:destination.id,quantity:2}]});
+    const firstBody=await first.json();assert.equal((await transfer(db,cookie,{action:"post",documentId:firstBody.document.id})).status,200);
+
+    // All stock is now in XR. A new transfer that still names MAIN as source must fail even though
+    // the tenant owns two units of the same lot in another warehouse.
+    const wrongSource=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:destination.id,quantity:1}]});
+    const wrongBody=await wrongSource.json();const denied=await transfer(db,cookie,{action:"post",documentId:wrongBody.document.id});
+    assert.equal(denied.status,409);assert.match((await denied.json()).error,/складі-відправнику/i);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS count FROM inventory_movements WHERE document_id=?").get(wrongBody.document.id).count,0);
+  });
+});
+
+test("transfer enforces tenant ownership and exact destination snapshot in D1",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Other Org','other-org',1)");
+    const cookie=await seedStaffSession(db,{email:"transfer-tenant@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await seedStock(db,raw,cookie,2);
+    const foreign=raw.prepare("SELECT id FROM warehouses WHERE organization_id=2 AND is_default=1").get();
+    const denied=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:foreign.id,quantity:1}]});
+    assert.equal(denied.status,404);
+
+    const destinationRes=await warehouse(db,cookie,{code:"SAFE",name:"Безпечний склад",active:true});
+    const {warehouse:destination}=await destinationRes.json();
+    const created=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:destination.id,quantity:1}]});
+    const body=await created.json();const line=body.lines[0];
+    assert.throws(()=>raw.prepare(
+      "UPDATE inventory_document_lines SET destination_warehouse_code='TAMPER' WHERE id=?"
+    ).run(line.id),/inventory_transfer_destination_invalid/);
+
+    assert.equal((await transfer(db,cookie,{action:"post",documentId:body.document.id})).status,200);
+    const out=raw.prepare("SELECT * FROM inventory_movements WHERE document_id=? AND movement_type='transfer_out'").get(body.document.id);
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO inventory_movements
+       (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,document_id,document_line_id)
+       VALUES (1,?,?,?,?,?,'transfer_in',1,?,?,?,?)`
+    ).run(out.item_id,out.lot_id,main.id,main.code,main.name,line.reason,"tamper",body.document.id,line.id),/inventory_document_link_invalid/);
+  });
+});

--- a/tests/inventory-transfers.behavior.test.mjs
+++ b/tests/inventory-transfers.behavior.test.mjs
@@ -5,6 +5,7 @@ import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs
 async function post(db,cookie,url,body){return callWorker(jsonRequest(url,body,{headers:{cookie}}),db);}
 async function warehouse(db,cookie,body){return post(db,cookie,"/api/staff/warehouses",body);}
 async function inventory(db,cookie,body){return post(db,cookie,"/api/staff/inventory",body);}
+async function document(db,cookie,body){return post(db,cookie,"/api/staff/inventory/documents",body);}
 async function transfer(db,cookie,body){return post(db,cookie,"/api/staff/inventory/transfers",body);}
 
 async function seedStock(db,raw,cookie,quantity=5){
@@ -82,7 +83,7 @@ test("transfer enforces tenant ownership and exact destination snapshot in D1",a
   await withD1(async(db,raw)=>{
     raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Other Org','other-org',1)");
     const cookie=await seedStaffSession(db,{email:"transfer-tenant@example.com",role:"admin",organizationId:1});
-    const {lotId,main}=await seedStock(db,raw,cookie,2);
+    const {itemId,lotId,main}=await seedStock(db,raw,cookie,2);
     const foreign=raw.prepare("SELECT id FROM warehouses WHERE organization_id=2 AND is_default=1").get();
     const denied=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:foreign.id,quantity:1}]});
     assert.equal(denied.status,404);
@@ -99,6 +100,17 @@ test("transfer enforces tenant ownership and exact destination snapshot in D1",a
     assert.throws(()=>raw.prepare(
       "UPDATE inventory_document_lines SET destination_warehouse_code='TAMPER' WHERE id=?"
     ).run(line.id),/inventory_transfer_destination_invalid/);
+
+    // Receipt/writeoff lines may never acquire a destination dimension and masquerade as transfers.
+    const receiptDraftRes=await document(db,cookie,{action:"create",documentType:"inventory_receipt",lines:[{
+      itemId,warehouseId:main.id,quantity:1,lotNumber:"NO-DEST",
+    }]});
+    assert.equal(receiptDraftRes.status,201);const receiptDraft=await receiptDraftRes.json();
+    assert.throws(()=>raw.prepare(
+      `UPDATE inventory_document_lines
+       SET destination_warehouse_id=?,destination_warehouse_code=?,destination_warehouse_name=?
+       WHERE id=?`
+    ).run(destination.id,destination.code,destination.name,receiptDraft.lines[0].id),/inventory_destination_not_allowed/);
 
     assert.equal((await transfer(db,cookie,{action:"post",documentId:body.document.id})).status,200);
     const out=raw.prepare("SELECT * FROM inventory_movements WHERE document_id=? AND movement_type='transfer_out'").get(body.document.id);

--- a/tests/inventory-transfers.behavior.test.mjs
+++ b/tests/inventory-transfers.behavior.test.mjs
@@ -90,6 +90,14 @@ test("transfer enforces tenant ownership and exact destination snapshot in D1",a
 
     const destinationRes=await warehouse(db,cookie,{code:"SAFE",name:"Безпечний склад",active:true});
     const {warehouse:destination}=await destinationRes.json();
+
+    // New transfer movement types cannot exist outside an exact BAS document registrar.
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO inventory_movements
+       (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email)
+       VALUES (1,?,?,?,?,?,'transfer_in',1,'unregistered','tamper')`
+    ).run(itemId,lotId,destination.id,destination.code,destination.name),/inventory_transfer_registrar_required/);
+
     const created=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:destination.id,quantity:1}]});
     const body=await created.json();const line=body.lines[0];
 

--- a/tests/inventory-transfers.behavior.test.mjs
+++ b/tests/inventory-transfers.behavior.test.mjs
@@ -91,6 +91,11 @@ test("transfer enforces tenant ownership and exact destination snapshot in D1",a
     const {warehouse:destination}=await destinationRes.json();
     const created=await transfer(db,cookie,{action:"create",lines:[{lotId,sourceWarehouseId:main.id,destinationWarehouseId:destination.id,quantity:1}]});
     const body=await created.json();const line=body.lines[0];
+
+    // Destination is already part of an immutable business fact while the document is a draft.
+    assert.throws(()=>raw.prepare(
+      "DELETE FROM warehouses WHERE organization_id=1 AND id=?"
+    ).run(destination.id),/warehouse_in_use/);
     assert.throws(()=>raw.prepare(
       "UPDATE inventory_document_lines SET destination_warehouse_code='TAMPER' WHERE id=?"
     ).run(line.id),/inventory_transfer_destination_invalid/);


### PR DESCRIPTION
## Scope
- add BAS-style `inventory_transfer` registrar on top of the existing business document core
- freeze source and destination warehouse id/code/name snapshots on each transfer line
- post paired immutable `transfer_out` / `transfer_in` register movements for the same lot
- enforce source warehouse + lot non-negative stock atomically in D1
- prevent same-warehouse transfers, cross-tenant warehouses, destination snapshot tampering, duplicate posting, and unregistered transfer movements
- protect destination warehouses referenced by transfer drafts from deletion
- prevent receipt/writeoff rows from acquiring a transfer destination dimension
- add staff transfer API, transfer journal/card UI, and warehouse-navigation entry
- add behavioral coverage for atomic movement, replay safety, warehouse isolation, tenant isolation, D1 registrar integrity, and destination reference integrity

## Safety contract
- transfer never creates a new lot; the exact same `lot_id` moves between warehouse buckets
- another warehouse's balance cannot cover the source warehouse
- every `transfer_out` / `transfer_in` must belong to an exact BAS document line
- one transfer line intentionally owns two movement facts; receipt/writeoff remain one movement per line/type
- posted register facts remain append-only
- no production deploy in this PR

## Verification
Exact head `6eed16dd148e347d917ec653511129c043c08b2e`:
- CI #1096 — success
- CodeQL #1011 — success
- lint — success
- typecheck — success
- build — success
- behavioral/migration tests — success
- production release gate — success