### PR TITLE
Add atomic BAS inventory transfers between warehouses

### DIFF
--- a/app/api/staff/inventory/documents/print/route.ts
+++ b/app/api/staff/inventory/documents/print/route.ts
@@ -60,6 +60,7 @@ async function renderPayload(db:D1Database,organizationId:number,documentId:numb
       postedBy:detail.document.postedBy,
       postedAt:detail.document.postedAt,
     },
+    transfer:detail.transfer,
     lines:lines.results,
   };
 }

--- a/app/api/staff/inventory/documents/route.ts
+++ b/app/api/staff/inventory/documents/route.ts
@@ -26,11 +26,13 @@ function mapCreateError(error:unknown) {
   if (code.includes("lines_required")) return [400,"Додайте хоча б один рядок документа"] as const;
   if (code.includes("invalid_quantity")) return [400,"Кількість має бути більшою за нуль"] as const;
   if (code.includes("warehouse_not_found")) return [404,"Склад не знайдено або він неактивний"] as const;
+  if (code.includes("transfer_warehouse_required")) return [400,"Для переміщення вкажіть склад-відправник і склад-одержувач"] as const;
+  if (code.includes("transfer_same_warehouse")) return [400,"Склад-відправник і склад-одержувач мають бути різними"] as const;
   if (code.includes("item_required")) return [400,"Для надходження вкажіть матеріал"] as const;
   if (code.includes("item_not_found")) return [404,"Матеріал не знайдено або він неактивний"] as const;
   if (code.includes("invalid_expiry")) return [400,"Некоректний термін придатності"] as const;
   if (code.includes("supplier_not_found")) return [404,"Постачальника не знайдено, він неактивний або не є постачальником"] as const;
-  if (code.includes("lot_required")) return [400,"Для списання вкажіть партію"] as const;
+  if (code.includes("lot_required")) return [400,"Для списання або переміщення вкажіть партію"] as const;
   if (code.includes("lot_not_found")) return [404,"Партію не знайдено або матеріал неактивний"] as const;
   if (code.includes("booking_not_found")) return [400,"Дослідження не належить до цієї організації"] as const;
   if (code.includes("reason_required")) return [400,"Вкажіть причину списання"] as const;
@@ -72,13 +74,19 @@ export async function POST(request:Request) {
         type:body.documentType,
         occurredAt:clean(body.occurredAt,32) || undefined,
         comment:clean(body.comment,500),
+        sourceWarehouseId:int(body.sourceWarehouseId),
+        destinationWarehouseId:int(body.destinationWarehouseId),
         lines,
       });
       if (!created) return Response.json({ error:"Не вдалося створити документ" },{status:500});
       await audit(db,{
         organizationId:ctx.organizationId,actorEmail:ctx.member.email,
         action:"inventory_document_created",resource:"business_document",targetId:created.document.id,
-        details:{ type:created.document.documentType, lineCount:created.lines.length },
+        details:{
+          type:created.document.documentType,lineCount:created.lines.length,
+          sourceWarehouseId:created.transfer?.sourceWarehouseId ?? null,
+          destinationWarehouseId:created.transfer?.destinationWarehouseId ?? null,
+        },
       });
       return Response.json(created,{status:201});
     } catch (error) {

--- a/app/staff/inventory/print/page.tsx
+++ b/app/staff/inventory/print/page.tsx
@@ -3,11 +3,12 @@
 import { useEffect,useState } from "react";
 
 type PrintLine={lineNo:number;itemId:number;itemName:string;unit:string;warehouseId?:number;warehouseCode?:string;warehouseName?:string;lotNumber:string;expiresOn:string;supplier:string;quantity:number;reason:string;bookingId:number|null};
-type PrintPayload={templateVersion:number;formType:"inventory_receipt"|"inventory_writeoff";organization:{name:string};document:{id:number;number:string;documentType:string;occurredAt:string;state:string;comment:string;createdBy:string;createdAt:string;postedBy:string;postedAt:string};lines:PrintLine[]};
+type Transfer={sourceWarehouseId:number;sourceWarehouseCode:string;sourceWarehouseName:string;destinationWarehouseId:number;destinationWarehouseCode:string;destinationWarehouseName:string};
+type PrintPayload={templateVersion:number;formType:"inventory_receipt"|"inventory_writeoff"|"inventory_transfer";organization:{name:string};document:{id:number;number:string;documentType:string;occurredAt:string;state:string;comment:string;createdBy:string;createdAt:string;postedBy:string;postedAt:string};transfer:Transfer|null;lines:PrintLine[]};
 type Snapshot={id:number;documentId:number;formType:string;templateVersion:number;generatedBy:string;generatedAt:string;storageKey:string;sha256:string};
 type ResponsePayload={snapshot:Snapshot;payload:PrintPayload;error?:string};
 
-const TYPE_UK={inventory_receipt:"Надходження матеріалів",inventory_writeoff:"Списання матеріалів"} as const;
+const TYPE_UK={inventory_receipt:"Надходження матеріалів",inventory_writeoff:"Списання матеріалів",inventory_transfer:"Переміщення між складами"} as const;
 const STATE_UK:Record<string,string>={draft:"ЧЕРНЕТКА",posted:"Проведено",reversed:"Сторновано",cancelled:"Скасовано"};
 function fmt(n:number){return Number(n||0).toLocaleString("uk-UA",{maximumFractionDigits:2});}
 function fmtDate(v:string){const d=new Date(v);return Number.isNaN(d.getTime())?v:d.toLocaleString("uk-UA",{dateStyle:"medium",timeStyle:"short"});}
@@ -35,6 +36,7 @@ export default function InventoryPrintPage(){
   if(!data)return <main className="inventoryPrintPage"><div className="inventoryPrintSheet"><p>Формування друкованої форми…</p></div></main>;
   const {payload,snapshot}=data;
   const isDraft=payload.document.state==="draft";
+  const isTransfer=payload.formType==="inventory_transfer";
   return <main className="inventoryPrintPage">
     <div className="inventoryPrintToolbar"><button onClick={()=>window.close()}>Закрити</button><button onClick={()=>window.print()}>Друкувати / PDF</button></div>
     <article className="inventoryPrintSheet">
@@ -44,9 +46,13 @@ export default function InventoryPrintPage(){
         <div><span>Створив</span><b>{payload.document.createdBy}</b></div><div><span>Стан</span><b>{STATE_UK[payload.document.state]||payload.document.state}</b></div>
         {payload.document.postedBy&&<><div><span>Провів</span><b>{payload.document.postedBy}</b></div><div><span>Проведено</span><b>{fmtDate(payload.document.postedAt)}</b></div></>}
       </section>
+      {isTransfer&&payload.transfer&&<section className="inventoryPrintMeta">
+        <div><span>Зі складу</span><b>{payload.transfer.sourceWarehouseName}</b><small>{payload.transfer.sourceWarehouseCode||"без коду"}</small></div>
+        <div><span>На склад</span><b>{payload.transfer.destinationWarehouseName}</b><small>{payload.transfer.destinationWarehouseCode||"без коду"}</small></div>
+      </section>}
       {payload.document.comment&&<p><b>Примітка:</b> {payload.document.comment}</p>}
-      <table><thead><tr><th>№</th><th>Склад</th><th>Матеріал</th><th>Партія / термін</th><th>Постачальник</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>
-        {payload.lines.map(l=><tr key={l.lineNo}><td>{l.lineNo}</td><td><b>{l.warehouseName||"—"}</b>{l.warehouseCode?<><br/><small>{l.warehouseCode}</small></>:null}</td><td><b>{l.itemName}</b></td><td>{l.lotNumber||"—"}{l.expiresOn?<><br/><small>до {l.expiresOn}</small></>:null}</td><td>{l.supplier||"—"}</td><td className="num">{fmt(l.quantity)} {l.unit}</td><td>{l.reason||"—"}{l.bookingId?<><br/><small>дослідження #{l.bookingId}</small></>:null}</td></tr>)}
+      <table><thead><tr><th>№</th>{!isTransfer&&<th>Склад</th>}<th>Матеріал</th><th>Партія / термін</th><th>Постачальник</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>
+        {payload.lines.map(l=><tr key={l.lineNo}><td>{l.lineNo}</td>{!isTransfer&&<td><b>{l.warehouseName||"—"}</b>{l.warehouseCode?<><br/><small>{l.warehouseCode}</small></>:null}</td>}<td><b>{l.itemName}</b></td><td>{l.lotNumber||"—"}{l.expiresOn?<><br/><small>до {l.expiresOn}</small></>:null}</td><td>{l.supplier||"—"}</td><td className="num">{fmt(l.quantity)} {l.unit}</td><td>{l.reason||"—"}{l.bookingId?<><br/><small>дослідження #{l.bookingId}</small></>:null}</td></tr>)}
       </tbody></table>
       <section className="inventoryPrintFooter"><div><span>Відповідальний</span><div className="inventoryPrintSignature"/></div><div><span>Підпис</span><div className="inventoryPrintSignature"/></div></section>
       <p className="inventoryPrintVersion">Форма v{snapshot.templateVersion} · snapshot #{snapshot.id} · SHA-256 {snapshot.sha256.slice(0,12)}…</p>

--- a/drizzle/0082_inventory_transfer.sql
+++ b/drizzle/0082_inventory_transfer.sql
@@ -1,0 +1,322 @@
+-- BAS-style warehouse transfer: one posted document moves the same lot quantity from one
+-- warehouse bucket to another without changing organization-wide stock.
+CREATE TABLE IF NOT EXISTS `inventory_transfer_details` (
+  `organization_id` integer NOT NULL,
+  `document_id` integer PRIMARY KEY NOT NULL,
+  `source_warehouse_id` integer NOT NULL,
+  `source_warehouse_code` text DEFAULT '' NOT NULL,
+  `source_warehouse_name` text NOT NULL,
+  `destination_warehouse_id` integer NOT NULL,
+  `destination_warehouse_code` text DEFAULT '' NOT NULL,
+  `destination_warehouse_name` text NOT NULL,
+  FOREIGN KEY (`document_id`,`organization_id`) REFERENCES `business_documents`(`id`,`organization_id`),
+  FOREIGN KEY (`source_warehouse_id`) REFERENCES `warehouses`(`id`),
+  FOREIGN KEY (`destination_warehouse_id`) REFERENCES `warehouses`(`id`),
+  CHECK (`source_warehouse_id` <> `destination_warehouse_id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `inventory_transfer_details_org_doc_idx`
+  ON `inventory_transfer_details` (`organization_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `inventory_transfer_details_source_idx`
+  ON `inventory_transfer_details` (`organization_id`,`source_warehouse_id`,`document_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `inventory_transfer_details_destination_idx`
+  ON `inventory_transfer_details` (`organization_id`,`destination_warehouse_id`,`document_id`);
+--> statement-breakpoint
+
+-- A transfer header is a frozen tenant-scoped snapshot while its registrar is a draft.
+CREATE TRIGGER `inventory_transfer_details_integrity_insert`
+BEFORE INSERT ON `inventory_transfer_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type='inventory_transfer' AND d.state='draft'
+  ) THEN RAISE(ABORT,'inventory_transfer_document_invalid') END;
+  SELECT CASE WHEN NEW.source_warehouse_id=NEW.destination_warehouse_id
+    THEN RAISE(ABORT,'inventory_transfer_same_warehouse') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.source_warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.source_warehouse_code AND w.name=NEW.source_warehouse_name
+  ) THEN RAISE(ABORT,'inventory_transfer_source_invalid') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.destination_warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.destination_warehouse_code AND w.name=NEW.destination_warehouse_name
+  ) THEN RAISE(ABORT,'inventory_transfer_destination_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_transfer_details_integrity_update`
+BEFORE UPDATE ON `inventory_transfer_details`
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id
+      AND d.document_type='inventory_transfer' AND d.state='draft'
+  ) THEN RAISE(ABORT,'inventory_transfer_immutable') END;
+  SELECT CASE WHEN NEW.organization_id<>OLD.organization_id OR NEW.document_id<>OLD.document_id
+    THEN RAISE(ABORT,'inventory_transfer_identity_immutable') END;
+  SELECT CASE WHEN NEW.source_warehouse_id=NEW.destination_warehouse_id
+    THEN RAISE(ABORT,'inventory_transfer_same_warehouse') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.source_warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.source_warehouse_code AND w.name=NEW.source_warehouse_name
+  ) THEN RAISE(ABORT,'inventory_transfer_source_invalid') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM warehouses w
+    WHERE w.id=NEW.destination_warehouse_id AND w.organization_id=NEW.organization_id AND w.active=1
+      AND w.code=NEW.destination_warehouse_code AND w.name=NEW.destination_warehouse_name
+  ) THEN RAISE(ABORT,'inventory_transfer_destination_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_transfer_details_no_delete_posted`
+BEFORE DELETE ON `inventory_transfer_details`
+WHEN NOT EXISTS (
+  SELECT 1 FROM business_documents d
+  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+)
+BEGIN SELECT RAISE(ABORT,'inventory_transfer_immutable'); END;
+--> statement-breakpoint
+
+-- A warehouse referenced only by a draft transfer header is still in use. Recreate the guard from
+-- 0081 with transfer details included.
+DROP TRIGGER IF EXISTS `warehouse_referenced_no_delete`;
+--> statement-breakpoint
+CREATE TRIGGER `warehouse_referenced_no_delete`
+BEFORE DELETE ON `warehouses`
+WHEN EXISTS (
+  SELECT 1 FROM inventory_document_lines l
+  WHERE l.organization_id=OLD.organization_id AND l.warehouse_id=OLD.id
+) OR EXISTS (
+  SELECT 1 FROM inventory_movements m
+  WHERE m.organization_id=OLD.organization_id AND m.warehouse_id=OLD.id
+) OR EXISTS (
+  SELECT 1 FROM inventory_transfer_details t
+  WHERE t.organization_id=OLD.organization_id
+    AND (t.source_warehouse_id=OLD.id OR t.destination_warehouse_id=OLD.id)
+)
+BEGIN SELECT RAISE(ABORT,'warehouse_in_use'); END;
+--> statement-breakpoint
+
+-- A transfer line inherits traceability from the selected historical lot exactly like a write-off.
+-- Recreate the supplier guards from 0078 so inventory_transfer is a valid historical-lot document.
+DROP TRIGGER IF EXISTS `inventory_line_supplier_reference_insert`;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS `inventory_line_supplier_reference_update`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_line_supplier_reference_insert`
+BEFORE INSERT ON `inventory_document_lines`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_supplier_tenant_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.active=1 AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_not_active_supplier') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id AND c.name=NEW.supplier
+  ) THEN RAISE(ABORT,'counterparty_supplier_snapshot_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type IN ('inventory_writeoff','inventory_transfer')
+  ) AND NOT EXISTS (
+    SELECT 1 FROM inventory_lots l
+    WHERE l.id=NEW.lot_id AND l.organization_id=NEW.organization_id
+      AND l.supplier_counterparty_id=NEW.supplier_counterparty_id AND l.supplier=NEW.supplier
+  ) THEN RAISE(ABORT,'inventory_writeoff_supplier_trace_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')
+  ) THEN RAISE(ABORT,'counterparty_supplier_document_type_invalid') END;
+END;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_line_supplier_reference_update`
+BEFORE UPDATE OF `organization_id`,`document_id`,`lot_id`,`supplier_counterparty_id`,`supplier` ON `inventory_document_lines`
+WHEN NEW.supplier_counterparty_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+  ) THEN RAISE(ABORT,'counterparty_supplier_tenant_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id
+      AND c.active=1 AND c.kind IN ('supplier','both')
+  ) THEN RAISE(ABORT,'counterparty_not_active_supplier') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.document_type='inventory_receipt'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM counterparties c
+    WHERE c.id=NEW.supplier_counterparty_id AND c.organization_id=NEW.organization_id AND c.name=NEW.supplier
+  ) THEN RAISE(ABORT,'counterparty_supplier_snapshot_mismatch') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type IN ('inventory_writeoff','inventory_transfer')
+  ) AND NOT EXISTS (
+    SELECT 1 FROM inventory_lots l
+    WHERE l.id=NEW.lot_id AND l.organization_id=NEW.organization_id
+      AND l.supplier_counterparty_id=NEW.supplier_counterparty_id AND l.supplier=NEW.supplier
+  ) THEN RAISE(ABORT,'inventory_writeoff_supplier_trace_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM business_documents d
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+      AND d.document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')
+  ) THEN RAISE(ABORT,'counterparty_supplier_document_type_invalid') END;
+END;
+--> statement-breakpoint
+
+-- One receipt/writeoff line still has one registrar movement. A transfer line has exactly one
+-- transfer_out and one transfer_in; uniqueness is therefore line+movement type.
+DROP INDEX IF EXISTS `inventory_movements_document_line_idx`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `inventory_movements_document_line_type_idx`
+  ON `inventory_movements` (`organization_id`,`document_line_id`,`movement_type`)
+  WHERE `document_line_id` IS NOT NULL;
+--> statement-breakpoint
+
+-- A negative transfer is subject to the same atomic stock invariant as a write-off, scoped to
+-- source warehouse + lot. The paired transfer_in is positive and cannot make stock negative.
+DROP TRIGGER IF EXISTS `inventory_writeoff_nonnegative_stock`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_writeoff_nonnegative_stock`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.movement_type IN ('writeoff','transfer_out')
+BEGIN
+  SELECT CASE WHEN (
+    COALESCE((
+      SELECT SUM(quantity_delta) FROM inventory_movements
+      WHERE organization_id=NEW.organization_id AND lot_id=NEW.lot_id
+        AND warehouse_id IS NEW.warehouse_id
+    ),0)+NEW.quantity_delta
+  ) < -0.000001 THEN RAISE(ABORT,'inventory_negative_stock') END;
+END;
+--> statement-breakpoint
+
+-- Exact registrar contract for all warehouse documents, including both transfer directions.
+DROP TRIGGER IF EXISTS `inventory_movement_document_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `inventory_movement_document_integrity`
+BEFORE INSERT ON `inventory_movements`
+WHEN NEW.document_id IS NOT NULL OR NEW.document_line_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.document_id IS NULL OR NEW.document_line_id IS NULL
+    THEN RAISE(ABORT,'inventory_document_link_incomplete') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM business_documents d
+    JOIN inventory_document_lines l
+      ON l.document_id=d.id AND l.organization_id=d.organization_id
+    LEFT JOIN inventory_transfer_details t
+      ON t.document_id=d.id AND t.organization_id=d.organization_id
+    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+      AND l.id=NEW.document_line_id AND l.item_id=NEW.item_id AND l.lot_id=NEW.lot_id
+      AND COALESCE(l.booking_id,0)=COALESCE(NEW.booking_id,0) AND l.reason=NEW.reason
+      AND (
+        (d.document_type='inventory_receipt' AND NEW.movement_type='receipt'
+          AND l.warehouse_id=NEW.warehouse_id
+          AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta-l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_writeoff' AND NEW.movement_type='writeoff'
+          AND l.warehouse_id=NEW.warehouse_id
+          AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta+l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_transfer' AND NEW.movement_type='transfer_out'
+          AND t.source_warehouse_id=l.warehouse_id
+          AND t.source_warehouse_code=l.warehouse_code AND t.source_warehouse_name=l.warehouse_name
+          AND l.warehouse_id=NEW.warehouse_id
+          AND l.warehouse_code=NEW.warehouse_code AND l.warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta+l.quantity)<0.000001)
+        OR
+        (d.document_type='inventory_transfer' AND NEW.movement_type='transfer_in'
+          AND t.source_warehouse_id=l.warehouse_id
+          AND t.source_warehouse_code=l.warehouse_code AND t.source_warehouse_name=l.warehouse_name
+          AND t.destination_warehouse_id=NEW.warehouse_id
+          AND t.destination_warehouse_code=NEW.warehouse_code
+          AND t.destination_warehouse_name=NEW.warehouse_name
+          AND ABS(NEW.quantity_delta-l.quantity)<0.000001)
+      )
+  ) THEN RAISE(ABORT,'inventory_document_link_invalid') END;
+END;
+--> statement-breakpoint
+
+-- A transfer cannot transition to posted unless its full header/line snapshot is coherent.
+CREATE TRIGGER `inventory_transfer_post_requirements`
+BEFORE UPDATE OF `state` ON `business_documents`
+WHEN OLD.document_type='inventory_transfer' AND OLD.state='draft' AND NEW.state='posted'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM inventory_transfer_details t
+    WHERE t.document_id=OLD.id AND t.organization_id=OLD.organization_id
+      AND t.source_warehouse_id<>t.destination_warehouse_id
+  ) THEN RAISE(ABORT,'inventory_transfer_details_required') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM inventory_document_lines l
+    WHERE l.document_id=OLD.id AND l.organization_id=OLD.organization_id
+  ) THEN RAISE(ABORT,'inventory_transfer_lines_required') END;
+  SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM inventory_document_lines l
+    JOIN inventory_transfer_details t
+      ON t.document_id=l.document_id AND t.organization_id=l.organization_id
+    WHERE l.document_id=OLD.id AND l.organization_id=OLD.organization_id
+      AND (l.lot_id IS NULL
+        OR l.warehouse_id<>t.source_warehouse_id
+        OR l.warehouse_code<>t.source_warehouse_code
+        OR l.warehouse_name<>t.source_warehouse_name)
+  ) THEN RAISE(ABORT,'inventory_transfer_source_snapshot_mismatch') END;
+END;
+--> statement-breakpoint
+
+-- Posting itself is the registrar engine: direct D1 state changes cannot create a half-transfer.
+-- If any source bucket would become negative, inventory_negative_stock aborts the whole UPDATE and
+-- therefore both movement directions and the posted state roll back atomically.
+CREATE TRIGGER `inventory_transfer_post_movements`
+AFTER UPDATE OF `state` ON `business_documents`
+WHEN OLD.document_type='inventory_transfer' AND OLD.state='draft' AND NEW.state='posted'
+BEGIN
+  INSERT INTO inventory_movements
+    (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
+     movement_type,quantity_delta,reason,booking_id,actor_email,document_id,document_line_id,created_at)
+  SELECT l.organization_id,l.item_id,l.lot_id,l.warehouse_id,l.warehouse_code,l.warehouse_name,
+         'transfer_out',-l.quantity,l.reason,l.booking_id,NEW.posted_by,NEW.id,l.id,NEW.posted_at
+  FROM inventory_document_lines l
+  WHERE l.organization_id=NEW.organization_id AND l.document_id=NEW.id;
+
+  INSERT INTO inventory_movements
+    (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
+     movement_type,quantity_delta,reason,booking_id,actor_email,document_id,document_line_id,created_at)
+  SELECT l.organization_id,l.item_id,l.lot_id,t.destination_warehouse_id,t.destination_warehouse_code,t.destination_warehouse_name,
+         'transfer_in',l.quantity,l.reason,l.booking_id,NEW.posted_by,NEW.id,l.id,NEW.posted_at
+  FROM inventory_document_lines l
+  JOIN inventory_transfer_details t
+    ON t.document_id=l.document_id AND t.organization_id=l.organization_id
+  WHERE l.organization_id=NEW.organization_id AND l.document_id=NEW.id;
+END;

--- a/drizzle/0083_inventory_transfer_print_integrity.sql
+++ b/drizzle/0083_inventory_transfer_print_integrity.sql
@@ -1,0 +1,16 @@
+-- Transfer printed forms are evidence under the same exact document tenant/type/state contract as
+-- receipt and write-off forms.
+DROP TRIGGER IF EXISTS `printed_inventory_snapshot_integrity`;
+--> statement-breakpoint
+CREATE TRIGGER `printed_inventory_snapshot_integrity`
+BEFORE INSERT ON `printed_form_snapshots`
+WHEN NEW.form_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM `business_documents` d
+    WHERE d.id=NEW.document_id
+      AND d.organization_id=NEW.organization_id
+      AND d.document_type=NEW.form_type
+      AND d.state=NEW.document_state
+  ) THEN RAISE(ABORT,'printed_form_document_mismatch') END;
+END;

--- a/lib/inventory-documents.ts
+++ b/lib/inventory-documents.ts
@@ -2,7 +2,7 @@ import type { DocumentState } from "./business-core";
 import { getActiveSupplierCounterparty } from "./counterparties";
 import { resolveWarehouse } from "./warehouses";
 
-export type InventoryDocumentType = "inventory_receipt" | "inventory_writeoff";
+export type InventoryDocumentType = "inventory_receipt" | "inventory_writeoff" | "inventory_transfer";
 
 export type InventoryDocumentLineInput = {
   itemId?: number;
@@ -50,6 +50,17 @@ export type InventoryDocumentLineRow = {
   bookingId:number|null;
 };
 
+export type InventoryTransferDetailsRow = {
+  organizationId:number;
+  documentId:number;
+  sourceWarehouseId:number;
+  sourceWarehouseCode:string;
+  sourceWarehouseName:string;
+  destinationWarehouseId:number;
+  destinationWarehouseCode:string;
+  destinationWarehouseName:string;
+};
+
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function text(value:unknown,max:number) {
@@ -67,11 +78,13 @@ function intOrNull(value:unknown) {
 }
 
 function prefix(type:InventoryDocumentType) {
-  return type === "inventory_receipt" ? "НД" : "СП";
+  if (type === "inventory_receipt") return "НД";
+  if (type === "inventory_writeoff") return "СП";
+  return "ПМ";
 }
 
 export function isInventoryDocumentType(value:unknown): value is InventoryDocumentType {
-  return value === "inventory_receipt" || value === "inventory_writeoff";
+  return value === "inventory_receipt" || value === "inventory_writeoff" || value === "inventory_transfer";
 }
 
 async function item(db:D1Database,organizationId:number,itemId:number) {
@@ -100,6 +113,18 @@ async function bookingExists(db:D1Database,organizationId:number,bookingId:numbe
   ).bind(organizationId,bookingId).first<{ok:number}>());
 }
 
+async function getTransferDetails(db:D1Database,organizationId:number,documentId:number) {
+  return db.prepare(
+    `SELECT organization_id AS organizationId,document_id AS documentId,
+            source_warehouse_id AS sourceWarehouseId,source_warehouse_code AS sourceWarehouseCode,
+            source_warehouse_name AS sourceWarehouseName,
+            destination_warehouse_id AS destinationWarehouseId,
+            destination_warehouse_code AS destinationWarehouseCode,
+            destination_warehouse_name AS destinationWarehouseName
+     FROM inventory_transfer_details WHERE organization_id=? AND document_id=? LIMIT 1`
+  ).bind(organizationId,documentId).first<InventoryTransferDetailsRow>();
+}
+
 export async function getInventoryDocument(db:D1Database,organizationId:number,documentId:number) {
   const document = await db.prepare(
     `SELECT id,organization_id AS organizationId,document_type AS documentType,number,
@@ -107,7 +132,7 @@ export async function getInventoryDocument(db:D1Database,organizationId:number,d
             posted_by AS postedBy,posted_at AS postedAt
      FROM business_documents
      WHERE organization_id=? AND id=?
-       AND document_type IN ('inventory_receipt','inventory_writeoff')
+       AND document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')
      LIMIT 1`
   ).bind(organizationId,documentId).first<InventoryDocumentRow>();
   if (!document) return null;
@@ -120,7 +145,10 @@ export async function getInventoryDocument(db:D1Database,organizationId:number,d
      FROM inventory_document_lines
      WHERE organization_id=? AND document_id=? ORDER BY line_no,id`
   ).bind(organizationId,documentId).all<InventoryDocumentLineRow>();
-  return { document, lines:lines.results };
+  const transfer = document.documentType === "inventory_transfer"
+    ? await getTransferDetails(db,organizationId,documentId)
+    : null;
+  return { document, lines:lines.results, transfer };
 }
 
 export async function listInventoryDocuments(db:D1Database,organizationId:number,limit=150) {
@@ -129,25 +157,42 @@ export async function listInventoryDocuments(db:D1Database,organizationId:number
     `SELECT d.id,d.organization_id AS organizationId,d.document_type AS documentType,d.number,
             d.occurred_at AS occurredAt,d.state,d.comment,d.created_by AS createdBy,
             d.created_at AS createdAt,d.posted_by AS postedBy,d.posted_at AS postedAt,
-            COUNT(l.id) AS lineCount,COALESCE(SUM(l.quantity),0) AS totalQuantity
+            COUNT(l.id) AS lineCount,COALESCE(SUM(l.quantity),0) AS totalQuantity,
+            MAX(t.source_warehouse_name) AS transferSourceWarehouseName,
+            MAX(t.destination_warehouse_name) AS transferDestinationWarehouseName
      FROM business_documents d
      LEFT JOIN inventory_document_lines l
        ON l.organization_id=d.organization_id AND l.document_id=d.id
-     WHERE d.organization_id=? AND d.document_type IN ('inventory_receipt','inventory_writeoff')
+     LEFT JOIN inventory_transfer_details t
+       ON t.organization_id=d.organization_id AND t.document_id=d.id
+     WHERE d.organization_id=? AND d.document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')
      GROUP BY d.id
      ORDER BY d.occurred_at DESC,d.id DESC LIMIT ${safeLimit}`
-  ).bind(organizationId).all<InventoryDocumentRow & {lineCount:number;totalQuantity:number}>();
+  ).bind(organizationId).all<InventoryDocumentRow & {
+    lineCount:number;totalQuantity:number;transferSourceWarehouseName:string|null;transferDestinationWarehouseName:string|null;
+  }>();
   return rows.results;
 }
 
 export async function createInventoryDocument(
   db:D1Database,
-  input:{organizationId:number;actorEmail:string;type:InventoryDocumentType;occurredAt?:string;comment?:string;lines:InventoryDocumentLineInput[]},
+  input:{
+    organizationId:number;actorEmail:string;type:InventoryDocumentType;occurredAt?:string;comment?:string;
+    sourceWarehouseId?:number|null;destinationWarehouseId?:number|null;lines:InventoryDocumentLineInput[];
+  },
 ) {
   const occurredAt = text(input.occurredAt,32) || new Date().toISOString();
   const comment = text(input.comment,500);
   if (!Array.isArray(input.lines) || input.lines.length < 1 || input.lines.length > 100) {
     throw new Error("inventory_document_lines_required");
+  }
+
+  const transferWarehouses = input.type === "inventory_transfer" ? {
+    source:await resolveWarehouse(db,{organizationId:input.organizationId,warehouseId:intOrNull(input.sourceWarehouseId)}),
+    destination:await resolveWarehouse(db,{organizationId:input.organizationId,warehouseId:intOrNull(input.destinationWarehouseId)}),
+  } : null;
+  if (transferWarehouses && transferWarehouses.source.id === transferWarehouses.destination.id) {
+    throw new Error("inventory_transfer_same_warehouse");
   }
 
   const normalized:Array<Required<Pick<InventoryDocumentLineInput,"quantity">> & {
@@ -159,7 +204,7 @@ export async function createInventoryDocument(
   for (const source of input.lines) {
     const qty = quantity(source.quantity);
     if (!qty) throw new Error("inventory_document_invalid_quantity");
-    const warehouse=await resolveWarehouse(db,{
+    const warehouse = transferWarehouses?.source ?? await resolveWarehouse(db,{
       organizationId:input.organizationId,
       warehouseId:intOrNull(source.warehouseId),
     });
@@ -187,9 +232,9 @@ export async function createInventoryDocument(
       if (!lotId) throw new Error("inventory_document_lot_required");
       const found = await lot(db,input.organizationId,lotId);
       if (!found || !found.active) throw new Error("inventory_document_lot_not_found");
-      const bookingId = intOrNull(source.bookingId);
+      const bookingId = input.type === "inventory_transfer" ? null : intOrNull(source.bookingId);
       if (!(await bookingExists(db,input.organizationId,bookingId))) throw new Error("inventory_document_booking_not_found");
-      const reason = text(source.reason,500);
+      const reason = text(source.reason,500) || (input.type === "inventory_transfer" ? "Переміщення між складами" : "");
       if (!reason) throw new Error("inventory_document_reason_required");
       normalized.push({
         itemId:found.itemId,lotId,warehouseId:warehouse.id,warehouseCode:warehouse.code,warehouseName:warehouse.name,
@@ -212,7 +257,20 @@ export async function createInventoryDocument(
   ).bind(number,input.organizationId,documentId).run();
 
   try {
-    await db.batch(normalized.map((line,index)=>db.prepare(
+    const statements:D1PreparedStatement[] = [];
+    if (transferWarehouses) {
+      statements.push(db.prepare(
+        `INSERT INTO inventory_transfer_details
+          (organization_id,document_id,source_warehouse_id,source_warehouse_code,source_warehouse_name,
+           destination_warehouse_id,destination_warehouse_code,destination_warehouse_name)
+         VALUES (?,?,?,?,?,?,?,?)`
+      ).bind(
+        input.organizationId,documentId,
+        transferWarehouses.source.id,transferWarehouses.source.code,transferWarehouses.source.name,
+        transferWarehouses.destination.id,transferWarehouses.destination.code,transferWarehouses.destination.name,
+      ));
+    }
+    statements.push(...normalized.map((line,index)=>db.prepare(
       `INSERT INTO inventory_document_lines
         (organization_id,document_id,line_no,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
          lot_number,expires_on,supplier,supplier_counterparty_id,quantity,reason,booking_id)
@@ -221,7 +279,10 @@ export async function createInventoryDocument(
       input.organizationId,documentId,index+1,line.itemId,line.lotId,line.warehouseId,line.warehouseCode,line.warehouseName,
       line.lotNumber,line.expiresOn,line.supplier,line.supplierCounterpartyId,line.quantity,line.reason,line.bookingId,
     )));
+    await db.batch(statements);
   } catch (error) {
+    await db.prepare("DELETE FROM inventory_transfer_details WHERE organization_id=? AND document_id=?")
+      .bind(input.organizationId,documentId).run().catch(()=>{});
     await db.prepare("DELETE FROM business_documents WHERE organization_id=? AND id=? AND state='draft'")
       .bind(input.organizationId,documentId).run().catch(()=>{});
     throw error;
@@ -234,7 +295,7 @@ export async function cancelInventoryDocument(db:D1Database,organizationId:numbe
   const result = await db.prepare(
     `UPDATE business_documents SET state='cancelled'
      WHERE organization_id=? AND id=? AND state='draft'
-       AND document_type IN ('inventory_receipt','inventory_writeoff')`
+       AND document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer')`
   ).bind(organizationId,documentId).run();
   return Number(result.meta.changes || 0) === 1;
 }
@@ -288,11 +349,14 @@ export async function postInventoryDocument(
   if (current.document.state === "posted") return { ok:true as const,idempotent:true,document:current };
   if (current.document.state !== "draft") return { ok:false as const,status:409,error:"Провести можна лише чернетку" };
   if (current.lines.length < 1) return { ok:false as const,status:409,error:"У документі немає рядків" };
+  if (current.document.documentType === "inventory_transfer" && !current.transfer) {
+    return { ok:false as const,status:409,error:"У переміщенні не вказані склади" };
+  }
 
-  if (current.document.documentType === "inventory_writeoff") {
+  if (current.document.documentType === "inventory_writeoff" || current.document.documentType === "inventory_transfer") {
     const required = new Map<string,{warehouseId:number;lotId:number;quantity:number}>();
     for (const line of current.lines) {
-      if (!line.lotId) return { ok:false as const,status:409,error:"У списанні не вказана партія" };
+      if (!line.lotId) return { ok:false as const,status:409,error:"У документі не вказана партія" };
       const key=`${line.warehouseId}:${line.lotId}`;
       const prior=required.get(key);
       required.set(key,{warehouseId:line.warehouseId,lotId:line.lotId,quantity:(prior?.quantity||0)+Number(line.quantity)});
@@ -332,12 +396,14 @@ export async function postInventoryDocument(
   }
 
   const postedAt = new Date().toISOString();
-  const statements = [
+  const statements:D1PreparedStatement[] = [
     db.prepare(
       `UPDATE business_documents SET state='posted',posted_by=?,posted_at=?
        WHERE organization_id=? AND id=? AND state='draft'`
     ).bind(input.actorEmail,postedAt,input.organizationId,input.documentId),
-    ...lines.map((line)=>db.prepare(
+  ];
+  if (current.document.documentType !== "inventory_transfer") {
+    statements.push(...lines.map((line)=>db.prepare(
       `INSERT INTO inventory_movements
         (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
          movement_type,quantity_delta,reason,booking_id,actor_email,document_id,document_line_id)
@@ -347,8 +413,8 @@ export async function postInventoryDocument(
       current.document.documentType === "inventory_receipt" ? "receipt" : "writeoff",
       current.document.documentType === "inventory_receipt" ? Number(line.quantity) : -Number(line.quantity),
       line.reason,line.bookingId,input.actorEmail,input.documentId,line.id,
-    )),
-  ];
+    )));
+  }
 
   try {
     await db.batch(statements);

--- a/tests/inventory-transfer-print.behavior.test.mjs
+++ b/tests/inventory-transfer-print.behavior.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function inventory(db,cookie,body){return callWorker(jsonRequest("/api/staff/inventory",body,{headers:{cookie}}),db);}
+async function document(db,cookie,body){return callWorker(jsonRequest("/api/staff/inventory/documents",body,{headers:{cookie}}),db);}
+async function warehouse(db,cookie,body){return callWorker(jsonRequest("/api/staff/warehouses",body,{headers:{cookie}}),db);}
+async function printDocument(db,cookie,documentId){return callWorker(jsonRequest("/api/staff/inventory/documents/print",{documentId},{headers:{cookie}}),db);}
+
+test("posted transfer print freezes both warehouse snapshots and reprints the canonical evidence",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"transfer-print@example.com",role:"admin",organizationId:1});
+    const source=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1").get();
+    const destinationRes=await warehouse(db,cookie,{code:"PRINT-DST",name:"Склад друку transfer",active:true});
+    const {warehouse:destination}=await destinationRes.json();
+    const itemRes=await inventory(db,cookie,{action:"create_item",name:"Print transfer item",sku:"PRINT-TR",category:"other",unit:"шт",minStock:0});
+    const {id:itemId}=await itemRes.json();
+    const receipt=await inventory(db,cookie,{action:"receive",itemId,warehouseId:source.id,quantity:3,lotNumber:"PRINT-LOT"});
+    const {lotId}=await receipt.json();
+    const draftRes=await document(db,cookie,{
+      action:"create",documentType:"inventory_transfer",sourceWarehouseId:source.id,destinationWarehouseId:destination.id,
+      lines:[{lotId,quantity:1,reason:"Для друку"}],
+    });
+    const draft=await draftRes.json();
+    assert.equal((await document(db,cookie,{action:"post",documentId:draft.document.id})).status,200);
+
+    const first=await printDocument(db,cookie,draft.document.id);
+    assert.equal(first.status,201);
+    const firstBody=await first.json();
+    assert.equal(firstBody.snapshot.formType,"inventory_transfer");
+    assert.equal(firstBody.payload.transfer.sourceWarehouseName,source.name);
+    assert.equal(firstBody.payload.transfer.destinationWarehouseName,"Склад друку transfer");
+    assert.equal(firstBody.payload.lines[0].lotNumber,"PRINT-LOT");
+
+    raw.prepare("UPDATE warehouses SET name='Source renamed',code='SRC-NEW' WHERE id=?").run(source.id);
+    raw.prepare("UPDATE warehouses SET name='Destination renamed',code='DST-NEW' WHERE id=?").run(destination.id);
+
+    const again=await printDocument(db,cookie,draft.document.id);
+    assert.equal(again.status,200);
+    const secondBody=await again.json();
+    assert.equal(secondBody.snapshot.id,firstBody.snapshot.id);
+    assert.equal(secondBody.snapshot.sha256,firstBody.snapshot.sha256);
+    assert.equal(secondBody.payload.transfer.sourceWarehouseName,source.name);
+    assert.equal(secondBody.payload.transfer.destinationWarehouseName,"Склад друку transfer");
+
+    assert.throws(()=>raw.prepare("UPDATE printed_form_snapshots SET generated_by='tamper' WHERE id=?").run(firstBody.snapshot.id),/printed_form_snapshot_immutable/);
+  });
+});

--- a/tests/inventory-transfer.behavior.test.mjs
+++ b/tests/inventory-transfer.behavior.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function inventory(db,cookie,body){return callWorker(jsonRequest("/api/staff/inventory",body,{headers:{cookie}}),db);}
+async function document(db,cookie,body){return callWorker(jsonRequest("/api/staff/inventory/documents",body,{headers:{cookie}}),db);}
+async function warehouse(db,cookie,body){return callWorker(jsonRequest("/api/staff/warehouses",body,{headers:{cookie}}),db);}
+
+async function setupStock(db,raw,cookie,quantity=10){
+  const itemRes=await inventory(db,cookie,{action:"create_item",name:"Transfer contrast",sku:`TR-${Date.now()}-${Math.random()}`,category:"contrast",unit:"фл",minStock:0});
+  assert.equal(itemRes.status,201);
+  const {id:itemId}=await itemRes.json();
+  const main=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1").get();
+  const receipt=await inventory(db,cookie,{action:"receive",itemId,warehouseId:main.id,quantity,lotNumber:"TR-LOT"});
+  assert.equal(receipt.status,200);
+  const {lotId}=await receipt.json();
+  return {itemId,lotId,main};
+}
+
+test("posted transfer moves the same lot between warehouses and keeps organization total unchanged",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"transfer@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await setupStock(db,raw,cookie,10);
+    const destinationRes=await warehouse(db,cookie,{code:"CT-TR",name:"Склад КТ transfer",active:true});
+    assert.equal(destinationRes.status,201);
+    const {warehouse:destination}=await destinationRes.json();
+
+    const draftRes=await document(db,cookie,{
+      action:"create",documentType:"inventory_transfer",
+      sourceWarehouseId:main.id,destinationWarehouseId:destination.id,
+      lines:[{lotId,quantity:4,reason:"Переміщення до КТ"}],
+    });
+    assert.equal(draftRes.status,201);
+    const draft=await draftRes.json();
+    assert.equal(draft.document.documentType,"inventory_transfer");
+    assert.match(draft.document.number,/^ПМ-\d{6}$/);
+    assert.equal(draft.transfer.sourceWarehouseId,main.id);
+    assert.equal(draft.transfer.destinationWarehouseId,destination.id);
+    assert.equal(draft.lines[0].warehouseId,main.id,"line snapshot is the source warehouse");
+
+    const posted=await document(db,cookie,{action:"post",documentId:draft.document.id});
+    assert.equal(posted.status,200);
+    const movements=raw.prepare(
+      `SELECT movement_type,warehouse_id,quantity_delta,lot_id,warehouse_code,warehouse_name
+       FROM inventory_movements WHERE organization_id=1 AND document_id=? ORDER BY id`
+    ).all(draft.document.id);
+    assert.equal(movements.length,2);
+    assert.deepEqual(movements.map(row=>row.movement_type),["transfer_out","transfer_in"]);
+    assert.equal(movements[0].warehouse_id,main.id);assert.equal(movements[0].quantity_delta,-4);
+    assert.equal(movements[1].warehouse_id,destination.id);assert.equal(movements[1].quantity_delta,4);
+    assert.equal(movements[0].lot_id,lotId);assert.equal(movements[1].lot_id,lotId);
+
+    const sourceStock=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND warehouse_id=? AND lot_id=?").get(main.id,lotId).stock;
+    const destinationStock=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND warehouse_id=? AND lot_id=?").get(destination.id,lotId).stock;
+    const total=raw.prepare("SELECT SUM(quantity_delta) AS stock FROM inventory_movements WHERE organization_id=1 AND lot_id=?").get(lotId).stock;
+    assert.equal(sourceStock,6);assert.equal(destinationStock,4);assert.equal(total,10);
+
+    const replay=await document(db,cookie,{action:"post",documentId:draft.document.id});
+    assert.equal(replay.status,200);
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM inventory_movements WHERE document_id=?").get(draft.document.id).n,2);
+  });
+});
+
+test("insufficient source stock aborts both transfer directions and leaves document draft",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"transfer-negative@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await setupStock(db,raw,cookie,2);
+    const destinationRes=await warehouse(db,cookie,{code:"XR-NEG",name:"Склад XR negative",active:true});
+    const {warehouse:destination}=await destinationRes.json();
+    const draftRes=await document(db,cookie,{
+      action:"create",documentType:"inventory_transfer",sourceWarehouseId:main.id,destinationWarehouseId:destination.id,
+      lines:[{lotId,quantity:3}],
+    });
+    const draft=await draftRes.json();
+
+    const post=await document(db,cookie,{action:"post",documentId:draft.document.id});
+    assert.equal(post.status,409);
+    assert.match((await post.json()).error,/Недостатній залишок/);
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(draft.document.id).state,"draft");
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM inventory_movements WHERE document_id=?").get(draft.document.id).n,0);
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET state='posted',posted_by='forged',posted_at='2026-08-16T20:00:00Z' WHERE id=?"
+    ).run(draft.document.id),/inventory_negative_stock/);
+    assert.equal(raw.prepare("SELECT state FROM business_documents WHERE id=?").get(draft.document.id).state,"draft");
+    assert.equal(raw.prepare("SELECT COUNT(*) AS n FROM inventory_movements WHERE document_id=?").get(draft.document.id).n,0);
+  });
+});
+
+test("transfer rejects same-warehouse and foreign-tenant destinations",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Transfer Org 2','transfer-org-2',1)");
+    const cookie=await seedStaffSession(db,{email:"transfer-tenant@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await setupStock(db,raw,cookie,5);
+    const foreign=raw.prepare("SELECT id FROM warehouses WHERE organization_id=2 AND is_default=1").get();
+
+    const same=await document(db,cookie,{
+      action:"create",documentType:"inventory_transfer",sourceWarehouseId:main.id,destinationWarehouseId:main.id,
+      lines:[{lotId,quantity:1}],
+    });
+    assert.equal(same.status,400);
+
+    const crossTenant=await document(db,cookie,{
+      action:"create",documentType:"inventory_transfer",sourceWarehouseId:main.id,destinationWarehouseId:foreign.id,
+      lines:[{lotId,quantity:1}],
+    });
+    assert.equal(crossTenant.status,404);
+  });
+});
+
+test("posted transfer keeps frozen source and destination snapshots after master-data rename",async()=>{
+  await withD1(async(db,raw)=>{
+    const cookie=await seedStaffSession(db,{email:"transfer-snapshot@example.com",role:"admin",organizationId:1});
+    const {lotId,main}=await setupStock(db,raw,cookie,5);
+    const destinationRes=await warehouse(db,cookie,{code:"DST",name:"Склад призначення",active:true});
+    const {warehouse:destination}=await destinationRes.json();
+    const draftRes=await document(db,cookie,{
+      action:"create",documentType:"inventory_transfer",sourceWarehouseId:main.id,destinationWarehouseId:destination.id,
+      lines:[{lotId,quantity:2}],
+    });
+    const draft=await draftRes.json();
+    assert.equal((await document(db,cookie,{action:"post",documentId:draft.document.id})).status,200);
+
+    raw.prepare("UPDATE warehouses SET code='MAIN-NEW',name='Головний склад новий' WHERE id=?").run(main.id);
+    raw.prepare("UPDATE warehouses SET code='DST-NEW',name='Склад призначення новий' WHERE id=?").run(destination.id);
+
+    const details=raw.prepare(
+      `SELECT source_warehouse_code,source_warehouse_name,destination_warehouse_code,destination_warehouse_name
+       FROM inventory_transfer_details WHERE document_id=?`
+    ).get(draft.document.id);
+    assert.deepEqual({...details},{
+      source_warehouse_code:main.code,source_warehouse_name:main.name,
+      destination_warehouse_code:"DST",destination_warehouse_name:"Склад призначення",
+    });
+    const movements=raw.prepare("SELECT movement_type,warehouse_code,warehouse_name FROM inventory_movements WHERE document_id=? ORDER BY id").all(draft.document.id);
+    assert.equal(movements[0].warehouse_code,main.code);assert.equal(movements[0].warehouse_name,main.name);
+    assert.equal(movements[1].warehouse_code,"DST");assert.equal(movements[1].warehouse_name,"Склад призначення");
+  });
+});

--- a/tests/inventory-transfer.behavior.test.mjs
+++ b/tests/inventory-transfer.behavior.test.mjs
@@ -12,7 +12,7 @@ async function setupStock(db,raw,cookie,quantity=10){
   const {id:itemId}=await itemRes.json();
   const main=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1").get();
   const receipt=await inventory(db,cookie,{action:"receive",itemId,warehouseId:main.id,quantity,lotNumber:"TR-LOT"});
-  assert.equal(receipt.status,200);
+  assert.equal(receipt.status,201);
   const {lotId}=await receipt.json();
   return {itemId,lotId,main};
 }


### PR DESCRIPTION
## Scope
- add `inventory_transfer` as a first-class warehouse document
- freeze source and destination warehouse snapshots in `inventory_transfer_details`
- reuse the same lot identity across both warehouse buckets
- post exactly one `transfer_out` and one `transfer_in` movement per document line
- keep organization-wide stock unchanged while moving stock between warehouses
- expose transfer creation/posting through the existing inventory documents API

## Safety contract
- source and destination must be different active warehouses in the same tenant
- source stock is checked per warehouse + lot
- D1 itself generates both transfer movements on `draft -> posted`; direct SQL cannot create a half-transfer
- `inventory_negative_stock` aborts the whole post atomically
- exact registrar validates lot/item/quantity/source/destination snapshots
- posted transfer snapshots remain historical after warehouse rename/deactivation
- no production deploy in this PR

## Status
Draft while UI, printed form, report/journal integration and exact-head CI/CodeQL are completed.