### PR TITLE
Harden Patient Order cancellation lifecycle

### DIFF
--- a/app/api/booking-status/route.ts
+++ b/app/api/booking-status/route.ts
@@ -2,6 +2,7 @@ import {
   normalizeBookingCode,
   requirePatientSession,
 } from "../../../lib/patient-auth";
+import { patientOrderCancellationBlocker } from "../../../lib/patient-orders";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { stateLabel } from "../../../lib/study-state";
 import { dbBinding } from "../../../lib/db";
@@ -54,6 +55,15 @@ export async function PATCH(request: Request) {
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
   if (!["new", "confirmed", "rescheduled"].includes(booking.status)) {
     return Response.json({ error: "Цю заявку вже не можна скасувати онлайн" }, { status: 409 });
+  }
+  const blocker=await patientOrderCancellationBlocker(db,session.organizationId,booking.id);
+  if(blocker){
+    const error=blocker==="payment_refund_required"
+      ?"За заявкою вже є оплата. Для скасування зверніться до реєстратури щодо повернення коштів."
+      :blocker==="service_storno_required"
+        ?"Послугу вже проведено. Для скасування зверніться до реєстратури."
+        :"Скасування тимчасово недоступне через незавершений пов’язаний документ. Зверніться до реєстратури.";
+    return Response.json({error},{status:409});
   }
   await db.batch([
     db.prepare("UPDATE bookings SET status = 'cancelled' WHERE id = ? AND organization_id = ?").bind(booking.id, session.organizationId),

--- a/drizzle/0083_patient_order_lifecycle.sql
+++ b/drizzle/0083_patient_order_lifecycle.sql
@@ -1,0 +1,141 @@
+-- Patient Order lifecycle: booking cancellation must respect immutable economic facts.
+-- Draft orders close together with their booking. Posted orders remain historical roots;
+-- payments/services must be corrected through refund/storno before the booking may be cancelled.
+
+-- One deterministic booking-cancel guard. It applies to legacy bookings too for active economic facts,
+-- while Patient Order-specific draft descendants are checked only when an order exists.
+CREATE TRIGGER IF NOT EXISTS `booking_cancel_economic_facts_guard`
+BEFORE UPDATE OF `status` ON `bookings`
+WHEN OLD.status <> 'cancelled' AND NEW.status = 'cancelled'
+BEGIN
+  SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM `payment_transactions` p
+    WHERE p.organization_id=OLD.organization_id AND p.booking_id=OLD.id AND p.status='paid'
+  ) THEN RAISE(ABORT,'booking_cancel_payment_refund_required') END;
+
+  SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM `service_delivery_details` s
+    JOIN `business_documents` d
+      ON d.id=s.document_id AND d.organization_id=s.organization_id
+    WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id
+      AND d.document_type='service_delivery' AND d.state='posted'
+  ) THEN RAISE(ABORT,'booking_cancel_service_storno_required') END;
+
+  SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM `patient_order_details` o
+    JOIN `business_documents` child
+      ON child.organization_id=o.organization_id AND child.basis_document_id=o.document_id
+    WHERE o.organization_id=OLD.organization_id AND o.booking_id=OLD.id
+      AND child.state='draft'
+      AND child.document_type IN ('payment','service_delivery')
+  ) THEN RAISE(ABORT,'booking_cancel_downstream_draft_exists') END;
+END;
+--> statement-breakpoint
+
+-- Closing an operational booking closes only its still-draft commercial root.
+-- A posted Patient Order is evidence and is intentionally preserved as posted.
+CREATE TRIGGER IF NOT EXISTS `booking_cancel_closes_draft_patient_order`
+AFTER UPDATE OF `status` ON `bookings`
+WHEN OLD.status <> 'cancelled' AND NEW.status = 'cancelled'
+BEGIN
+  UPDATE `business_documents`
+  SET state='cancelled'
+  WHERE organization_id=NEW.organization_id
+    AND document_type='patient_order'
+    AND state='draft'
+    AND id=(
+      SELECT o.document_id
+      FROM `patient_order_details` o
+      WHERE o.organization_id=NEW.organization_id AND o.booking_id=NEW.id
+      LIMIT 1
+    );
+END;
+--> statement-breakpoint
+
+-- The commercial root cannot be cancelled independently from the operational booking.
+CREATE TRIGGER IF NOT EXISTS `patient_order_cancel_requires_booking_cancelled`
+BEFORE UPDATE OF `state` ON `business_documents`
+WHEN OLD.document_type='patient_order' AND OLD.state='draft' AND NEW.state='cancelled'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM `patient_order_details` o
+    JOIN `bookings` b ON b.id=o.booking_id AND b.organization_id=o.organization_id
+    WHERE o.document_id=OLD.id AND o.organization_id=OLD.organization_id
+      AND b.status='cancelled'
+  ) THEN RAISE(ABORT,'patient_order_cancel_requires_booking_cancelled') END;
+END;
+--> statement-breakpoint
+
+-- A cancelled business document may never become a new document basis. This prevents a cancelled
+-- Patient Order from later acquiring a payment/service-delivery through a stale UI or direct SQL.
+CREATE TRIGGER IF NOT EXISTS `business_document_cancelled_basis_insert`
+BEFORE INSERT ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM `business_documents` src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.state='cancelled'
+  )
+BEGIN SELECT RAISE(ABORT,'business_document_basis_cancelled'); END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `business_document_cancelled_basis_update`
+BEFORE UPDATE OF `basis_document_id`,`organization_id` ON `business_documents`
+WHEN NEW.basis_document_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM `business_documents` src
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.state='cancelled'
+  )
+BEGIN SELECT RAISE(ABORT,'business_document_basis_cancelled'); END;
+--> statement-breakpoint
+
+-- A reversed service source remains immutable after storno, except for the final operational
+-- completed -> cancelled transition once the cancellation guard confirms that no live economic fact remains.
+DROP TRIGGER IF EXISTS `booking_reversed_service_snapshot_immutable`;
+--> statement-breakpoint
+CREATE TRIGGER `booking_reversed_service_snapshot_immutable`
+BEFORE UPDATE OF
+  `patient_id`,`patient_category`,`service`,`service_code`,`equipment_id`,`duration_minutes`,
+  `anatomical_regions_count`,`performed_at`,`assigned_radiologist_email`,`assigned_radiographer_email`,
+  `payment_amount`,`status`
+ON `bookings`
+WHEN EXISTS (
+  SELECT 1
+  FROM `service_delivery_details` s
+  JOIN `business_documents` d ON d.id=s.document_id AND d.organization_id=s.organization_id
+  WHERE s.organization_id=OLD.organization_id AND s.booking_id=OLD.id
+    AND d.document_type='service_delivery' AND d.state='reversed'
+)
+AND (
+  NEW.organization_id IS NOT OLD.organization_id
+  OR NEW.patient_id IS NOT OLD.patient_id
+  OR NEW.patient_category IS NOT OLD.patient_category
+  OR NEW.service IS NOT OLD.service
+  OR NEW.service_code IS NOT OLD.service_code
+  OR NEW.equipment_id IS NOT OLD.equipment_id
+  OR NEW.duration_minutes IS NOT OLD.duration_minutes
+  OR NEW.anatomical_regions_count IS NOT OLD.anatomical_regions_count
+  OR NEW.performed_at IS NOT OLD.performed_at
+  OR NEW.assigned_radiologist_email IS NOT OLD.assigned_radiologist_email
+  OR NEW.assigned_radiographer_email IS NOT OLD.assigned_radiographer_email
+  OR NEW.payment_amount IS NOT OLD.payment_amount
+  OR NEW.status IS NOT OLD.status
+)
+AND NOT (
+  OLD.status='completed' AND NEW.status='cancelled'
+  AND NEW.organization_id IS OLD.organization_id
+  AND NEW.patient_id IS OLD.patient_id
+  AND NEW.patient_category IS OLD.patient_category
+  AND NEW.service IS OLD.service
+  AND NEW.service_code IS OLD.service_code
+  AND NEW.equipment_id IS OLD.equipment_id
+  AND NEW.duration_minutes IS OLD.duration_minutes
+  AND NEW.anatomical_regions_count IS OLD.anatomical_regions_count
+  AND NEW.performed_at IS OLD.performed_at
+  AND NEW.assigned_radiologist_email IS OLD.assigned_radiologist_email
+  AND NEW.assigned_radiographer_email IS OLD.assigned_radiographer_email
+  AND NEW.payment_amount IS OLD.payment_amount
+)
+BEGIN SELECT RAISE(ABORT,'service_delivery_booking_immutable'); END;

--- a/drizzle/0083_patient_order_lifecycle.sql
+++ b/drizzle/0083_patient_order_lifecycle.sql
@@ -70,14 +70,15 @@ BEGIN
 END;
 --> statement-breakpoint
 
--- A cancelled business document may never become a new document basis. This prevents a cancelled
--- Patient Order from later acquiring a payment/service-delivery through a stale UI or direct SQL.
+-- A cancelled Patient Order may never become a new document basis. This prevents a stale UI or
+-- direct SQL from attaching payment/service-delivery facts after the operational cancellation.
 CREATE TRIGGER IF NOT EXISTS `business_document_cancelled_basis_insert`
 BEFORE INSERT ON `business_documents`
 WHEN NEW.basis_document_id IS NOT NULL
   AND EXISTS (
     SELECT 1 FROM `business_documents` src
-    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.state='cancelled'
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type='patient_order' AND src.state='cancelled'
   )
 BEGIN SELECT RAISE(ABORT,'business_document_basis_cancelled'); END;
 --> statement-breakpoint
@@ -86,7 +87,8 @@ BEFORE UPDATE OF `basis_document_id`,`organization_id` ON `business_documents`
 WHEN NEW.basis_document_id IS NOT NULL
   AND EXISTS (
     SELECT 1 FROM `business_documents` src
-    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id AND src.state='cancelled'
+    WHERE src.id=NEW.basis_document_id AND src.organization_id=NEW.organization_id
+      AND src.document_type='patient_order' AND src.state='cancelled'
   )
 BEGIN SELECT RAISE(ABORT,'business_document_basis_cancelled'); END;
 --> statement-breakpoint

--- a/lib/patient-orders.ts
+++ b/lib/patient-orders.ts
@@ -4,6 +4,11 @@ export type PatientOrderRow={
   durationMinutes:number;priceAmount:number;chargeAmount:number;currency:string;
 };
 
+export type PatientOrderCancellationBlocker=
+  |"payment_refund_required"
+  |"service_storno_required"
+  |"downstream_draft_exists";
+
 export async function getPatientOrderForBooking(
   db:D1Database,
   organizationId:number,
@@ -21,6 +26,41 @@ export async function getPatientOrderForBooking(
      LIMIT 1`
   ).bind(organizationId,bookingId).first<PatientOrderRow>();
   return row||null;
+}
+
+export async function patientOrderCancellationBlocker(
+  db:D1Database,
+  organizationId:number,
+  bookingId:number,
+):Promise<PatientOrderCancellationBlocker|null>{
+  const paid=await db.prepare(
+    `SELECT 1 AS found FROM payment_transactions
+     WHERE organization_id=? AND booking_id=? AND status='paid' LIMIT 1`
+  ).bind(organizationId,bookingId).first();
+  if(paid)return "payment_refund_required";
+
+  const delivered=await db.prepare(
+    `SELECT 1 AS found
+     FROM service_delivery_details s
+     JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+     WHERE s.organization_id=? AND s.booking_id=?
+       AND d.document_type='service_delivery' AND d.state='posted'
+     LIMIT 1`
+  ).bind(organizationId,bookingId).first();
+  if(delivered)return "service_storno_required";
+
+  const draft=await db.prepare(
+    `SELECT 1 AS found
+     FROM patient_order_details o
+     JOIN business_documents child
+       ON child.organization_id=o.organization_id AND child.basis_document_id=o.document_id
+     WHERE o.organization_id=? AND o.booking_id=?
+       AND child.state='draft' AND child.document_type IN ('payment','service_delivery')
+     LIMIT 1`
+  ).bind(organizationId,bookingId).first();
+  if(draft)return "downstream_draft_exists";
+
+  return null;
 }
 
 export async function listPatientOrders(db:D1Database,organizationId:number,limit=250){

--- a/tests/booking-cancel.behavior.test.mjs
+++ b/tests/booking-cancel.behavior.test.mjs
@@ -32,6 +32,13 @@ test("a patient cancels their own active booking; status and event are written",
     assert.equal(res.status, 200);
     const row = await db.prepare("SELECT status FROM bookings WHERE code = ?").bind("RD-OWN0000001").first("status");
     assert.equal(row, "cancelled");
+    const order = await db.prepare(
+      `SELECT d.state FROM patient_order_details o
+       JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+       JOIN bookings b ON b.id=o.booking_id AND b.organization_id=o.organization_id
+       WHERE b.code=? AND o.organization_id=1`
+    ).bind("RD-OWN0000001").first("state");
+    assert.equal(order, "cancelled");
     const ev = await db.prepare("SELECT COUNT(*) AS n FROM booking_events WHERE action = 'cancelled'").first("n");
     assert.equal(ev, 1);
   });
@@ -62,6 +69,31 @@ test("a patient cannot cancel someone else's booking", async () => {
     assert.equal(res.status, 404);
     const row = await db.prepare("SELECT status FROM bookings WHERE code = ?").bind("RD-OTHER00001").first("status");
     assert.equal(row, "new");
+  });
+});
+
+test("a paid booking returns 409 until finance is refunded", async () => {
+  await withD1(async (db) => {
+    await seed(db, { code: "RD-PAIDCANCEL1", phoneNormalized: "380971112233" });
+    const booking = await db.prepare(
+      "SELECT id FROM bookings WHERE organization_id=1 AND code='RD-PAIDCANCEL1'"
+    ).first();
+    await db.prepare(
+      `INSERT INTO payment_transactions
+       (organization_id,booking_id,amount,currency,provider,provider_reference,status,paid_at)
+       VALUES (1,?,1500,'UAH','legacy','cancel-paid','paid',CURRENT_TIMESTAMP)`
+    ).bind(booking.id).run();
+    const cookie = await seedPatientSession(db, "380971112233");
+    const res = await cancel(db, cookie, "RD-PAIDCANCEL1");
+    assert.equal(res.status, 409);
+    const body = await res.json();
+    assert.match(body.error,/оплата|повернення/i);
+    assert.equal(await db.prepare("SELECT status FROM bookings WHERE id=?").bind(booking.id).first("status"),"new");
+    assert.equal(await db.prepare(
+      `SELECT d.state FROM patient_order_details o
+       JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+       WHERE o.organization_id=1 AND o.booking_id=?`
+    ).bind(booking.id).first("state"),"draft");
   });
 });
 

--- a/tests/patient-order-lifecycle.behavior.test.mjs
+++ b/tests/patient-order-lifecycle.behavior.test.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { refundLatestPayment,settleVerifiedProviderPayment } from "../lib/payment-settlement.ts";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db,{
+  organizationId=1,
+  code="RD-LIFECYCLE-001",
+  amount=2600,
+  status="confirmed",
+  desiredTime="10:00",
+}={}){
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,'Lifecycle Patient','+380501112233','380501112233','КТ ОГК','ct-chest','ct',30,
+       '2026-08-25',?,'civilian','pending',?,0,?,2,'lifecycle-doctor@example.com','lifecycle-tech@example.com')`
+  ).bind(organizationId,code,desiredTime,amount,status).run();
+  return Number(result.meta.last_row_id);
+}
+
+function orderFor(raw,organizationId,bookingId){
+  return raw.prepare(
+    `SELECT d.id,d.state,d.number
+     FROM patient_order_details o
+     JOIN business_documents d ON d.id=o.document_id AND d.organization_id=o.organization_id
+     WHERE o.organization_id=? AND o.booking_id=? AND d.document_type='patient_order'`
+  ).get(organizationId,bookingId);
+}
+
+function serviceFor(raw,organizationId,bookingId){
+  return raw.prepare(
+    `SELECT d.id,d.state
+     FROM service_delivery_details s
+     JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+     WHERE s.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery'`
+  ).get(organizationId,bookingId);
+}
+
+async function storno(db,cookie,sourceDocumentId){
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{
+    sourceDocumentId,
+    reason:"Сторно перед фінальним скасуванням заявки",
+  },{headers:{cookie}}),db);
+}
+
+test("cancelling a booking closes its still-draft Patient Order",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db);
+    const order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"draft");
+
+    await db.prepare("UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?")
+      .bind(bookingId).run();
+
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"cancelled");
+    assert.equal(orderFor(raw,1,bookingId).state,"cancelled");
+  });
+});
+
+test("a draft Patient Order cannot be cancelled independently from its booking",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-ROOT"});
+    const order=orderFor(raw,1,bookingId);
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE business_documents SET state='cancelled' WHERE organization_id=1 AND id=?"
+    ).run(order.id),/patient_order_cancel_requires_booking_cancelled/);
+    assert.equal(orderFor(raw,1,bookingId).state,"draft");
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"confirmed");
+  });
+});
+
+test("a paid fact blocks cancellation until refund; posted Patient Order remains historical",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-PAID",amount:2900});
+    await settleVerifiedProviderPayment(db,{
+      organizationId:1,
+      bookingId,
+      provider:"liqpay",
+      providerReference:"lifecycle-paid",
+      amount:2900,
+    });
+    const order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"posted");
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/booking_cancel_payment_refund_required/);
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"confirmed");
+
+    const refunded=await refundLatestPayment(db,{
+      organizationId:1,
+      bookingId,
+      actor:"lifecycle@example.com",
+    });
+    assert.equal(refunded.changed,true);
+    await db.prepare("UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?")
+      .bind(bookingId).run();
+
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"cancelled");
+    assert.equal(orderFor(raw,1,bookingId).state,"posted");
+    assert.equal(raw.prepare(
+      "SELECT status FROM payment_transactions WHERE organization_id=1 AND booking_id=? ORDER BY id DESC LIMIT 1"
+    ).get(bookingId).status,"refunded");
+  });
+});
+
+test("a posted service blocks cancellation until storno, then completed -> cancelled is allowed",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-SERVICE",amount:3100});
+    await db.prepare(
+      "UPDATE bookings SET performed_at='2026-08-25T10:05:00',status='completed' WHERE organization_id=1 AND id=?"
+    ).bind(bookingId).run();
+    const order=orderFor(raw,1,bookingId);
+    const service=serviceFor(raw,1,bookingId);
+    assert.equal(order.state,"posted");
+    assert.equal(service.state,"posted");
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?"
+    ).run(bookingId));
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"completed");
+
+    const cookie=await seedStaffSession(db,{email:"lifecycle-storno@example.com",role:"registrar",organizationId:1});
+    const response=await storno(db,cookie,service.id);
+    assert.equal(response.status,201);
+    assert.equal(serviceFor(raw,1,bookingId).state,"reversed");
+
+    await db.prepare("UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?")
+      .bind(bookingId).run();
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"cancelled");
+    assert.equal(orderFor(raw,1,bookingId).state,"posted");
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET payment_amount=1 WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/service_delivery_booking_immutable/);
+  });
+});
+
+test("a draft downstream business document blocks booking cancellation",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-DRAFT"});
+    const order=orderFor(raw,1,bookingId);
+    raw.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,occurred_at,state,comment,created_by,basis_document_id)
+       VALUES (1,'payment','ОП-DRAFT-CANCEL',CURRENT_TIMESTAMP,'draft','draft child','lifecycle@example.com',?)`
+    ).run(order.id);
+
+    assert.throws(()=>raw.prepare(
+      "UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?"
+    ).run(bookingId),/booking_cancel_downstream_draft_exists/);
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"confirmed");
+    assert.equal(orderFor(raw,1,bookingId).state,"draft");
+  });
+});
+
+test("a cancelled Patient Order cannot become the basis of a new economic document",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-BASIS"});
+    await db.prepare("UPDATE bookings SET status='cancelled' WHERE organization_id=1 AND id=?")
+      .bind(bookingId).run();
+    const order=orderFor(raw,1,bookingId);
+    assert.equal(order.state,"cancelled");
+
+    assert.throws(()=>raw.prepare(
+      `INSERT INTO business_documents
+       (organization_id,document_type,number,occurred_at,state,comment,created_by,basis_document_id)
+       VALUES (1,'payment','ОП-AFTER-CANCEL',CURRENT_TIMESTAMP,'draft','must fail','lifecycle@example.com',?)`
+    ).run(order.id),/business_document_basis_cancelled/);
+  });
+});

--- a/tests/patient-order-lifecycle.behavior.test.mjs
+++ b/tests/patient-order-lifecycle.behavior.test.mjs
@@ -108,6 +108,28 @@ test("a paid fact blocks cancellation until refund; posted Patient Order remains
   });
 });
 
+test("staff gets a readable 409 instead of a D1 error when paid booking cancellation is blocked",async()=>{
+  await withD1(async(db,raw)=>{
+    const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-STAFF",amount:2800});
+    await settleVerifiedProviderPayment(db,{
+      organizationId:1,
+      bookingId,
+      provider:"liqpay",
+      providerReference:"lifecycle-staff",
+      amount:2800,
+    });
+    const cookie=await seedStaffSession(db,{email:"lifecycle-registrar@example.com",role:"registrar",organizationId:1});
+    const response=await callWorker(jsonRequest("/api/staff/bookings",{
+      id:bookingId,status:"cancelled",
+    },{method:"PATCH",headers:{cookie}}),db);
+    assert.equal(response.status,409);
+    const body=await response.json();
+    assert.match(body.error,/повернення оплати/i);
+    assert.equal(raw.prepare("SELECT status FROM bookings WHERE id=?").get(bookingId).status,"confirmed");
+    assert.equal(orderFor(raw,1,bookingId).state,"posted");
+  });
+});
+
 test("a posted service blocks cancellation until storno, then completed -> cancelled is allowed",async()=>{
   await withD1(async(db,raw)=>{
     const bookingId=await seedBooking(db,{code:"RD-LIFECYCLE-SERVICE",amount:3100});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -104,6 +104,20 @@ function unsafeCrossSiteRequest(request: Request): boolean {
   }
 }
 
+function patientOrderLifecycleConflict(error: unknown): string | null {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("booking_cancel_payment_refund_required")) {
+    return "Спочатку оформіть повернення оплати.";
+  }
+  if (message.includes("booking_cancel_service_storno_required")) {
+    return "Послуга вже проведена — спочатку оформіть сторно.";
+  }
+  if (message.includes("booking_cancel_downstream_draft_exists")) {
+    return "Є незавершений пов’язаний документ. Спочатку скасуйте або завершіть його.";
+  }
+  return null;
+}
+
 const worker = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__ = env.DB;
@@ -156,7 +170,13 @@ const worker = {
       }, allowedWidths), request);
     }
 
-    return secure(await handler.fetch(request, env, ctx), request);
+    try {
+      return secure(await handler.fetch(request, env, ctx), request);
+    } catch (error) {
+      const conflict = url.pathname.startsWith("/api/") ? patientOrderLifecycleConflict(error) : null;
+      if (conflict) return secure(Response.json({ error: conflict }, { status: 409 }), request);
+      throw error;
+    }
   },
 
   async scheduled(_event: unknown, env: Env, ctx: ExecutionContext): Promise<void> {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -5,6 +5,9 @@ import { getSetting } from "../lib/settings";
 import { parseSiteContent, SITE_CONTENT_KEY } from "../lib/site-content";
 import { runDueReminders } from "../lib/reminders";
 import { runOperationalTasks } from "../lib/operational-tasks";
+import { patientOrderCancellationBlocker, type PatientOrderCancellationBlocker } from "../lib/patient-orders";
+import { canAccessBooking, canManageBookings } from "../lib/staff-auth";
+import { requireOrgContext } from "../lib/tenant";
 
 interface Env {
   ASSETS: Fetcher;
@@ -104,18 +107,40 @@ function unsafeCrossSiteRequest(request: Request): boolean {
   }
 }
 
+function patientOrderBlockerMessage(blocker: PatientOrderCancellationBlocker): string {
+  if (blocker === "payment_refund_required") return "Спочатку оформіть повернення оплати.";
+  if (blocker === "service_storno_required") return "Послуга вже проведена — спочатку оформіть сторно.";
+  return "Є незавершений пов’язаний документ. Спочатку скасуйте або завершіть його.";
+}
+
 function patientOrderLifecycleConflict(error: unknown): string | null {
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes("booking_cancel_payment_refund_required")) {
-    return "Спочатку оформіть повернення оплати.";
+    return patientOrderBlockerMessage("payment_refund_required");
   }
   if (message.includes("booking_cancel_service_storno_required")) {
-    return "Послуга вже проведена — спочатку оформіть сторно.";
+    return patientOrderBlockerMessage("service_storno_required");
   }
   if (message.includes("booking_cancel_downstream_draft_exists")) {
-    return "Є незавершений пов’язаний документ. Спочатку скасуйте або завершіть його.";
+    return patientOrderBlockerMessage("downstream_draft_exists");
   }
   return null;
+}
+
+async function recoverStaffCancellationConflict(
+  request: Request | null,
+  env: Env,
+  response: Response,
+): Promise<Response | null> {
+  if (!request || response.status !== 500) return null;
+  const body = await request.json().catch(() => ({})) as { id?: unknown; status?: unknown };
+  if (body.status !== "cancelled" || !Number.isInteger(body.id)) return null;
+  const org = await requireOrgContext(request, env.DB);
+  if (!org || !canManageBookings(org.member.role)) return null;
+  const bookingId = Number(body.id);
+  if (!(await canAccessBooking(env.DB, org.member, bookingId, org.organizationId))) return null;
+  const blocker = await patientOrderCancellationBlocker(env.DB, org.organizationId, bookingId);
+  return blocker ? Response.json({ error: patientOrderBlockerMessage(blocker) }, { status: 409 }) : null;
 }
 
 const worker = {
@@ -170,8 +195,13 @@ const worker = {
       }, allowedWidths), request);
     }
 
+    const staffCancellationProbe = request.method === "PATCH" && url.pathname === "/api/staff/bookings"
+      ? request.clone()
+      : null;
     try {
-      return secure(await handler.fetch(request, env, ctx), request);
+      const response = await handler.fetch(request, env, ctx);
+      const recovered = await recoverStaffCancellationConflict(staffCancellationProbe, env, response);
+      return secure(recovered || response, request);
     } catch (error) {
       const conflict = url.pathname.startsWith("/api/") ? patientOrderLifecycleConflict(error) : null;
       if (conflict) return secure(Response.json({ error: conflict }, { status: 409 }), request);


### PR DESCRIPTION
## Summary
- coordinate booking cancellation with the existing Patient Order root
- close only draft Patient Orders when their booking is cancelled
- require refund before cancelling a booking with an active paid transaction
- require service storno before cancelling a completed booking with a posted service-delivery fact
- preserve posted Patient Orders as immutable historical commercial roots after corrections
- prevent new economic documents from using a cancelled Patient Order as basis
- return a readable 409 for blocked patient self-service cancellation
- add behavioral coverage for draft cancel, refund, storno, downstream draft and cancelled-basis guards

## Safety / invariants
- tenant scoped
- D1 is authoritative; API preflight is UX only
- posted payment/service/order facts are not rewritten
- corrections continue through existing refund/storno document paths
- no production deploy