### PR TITLE
ops: one-time production deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to Cloudflare
 
-# Manual trigger only — run it from the Actions tab after the two repository
-# secrets (CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID) are set. The build runs
-# on GitHub's Linux runner, so nothing needs to be built locally.
+# Manual trigger remains the normal deployment path. The temporary push trigger
+# below runs only for an explicitly approved main merge whose commit message
+# contains [deploy-approved]; it will be removed immediately after this rollout.
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +14,9 @@ on:
         options:
           - CANCEL
           - DEPLOY
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -25,7 +28,7 @@ concurrency:
 jobs:
   deploy:
     name: Build and deploy
-    if: ${{ inputs.confirmation == 'DEPLOY' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.confirmation == 'DEPLOY') || (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[deploy-approved]')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     environment: production


### PR DESCRIPTION
One-time production rollout trigger for the already-reviewed current `main`.

- Application code unchanged.
- D1 migration files unchanged.
- Adds a temporary `push` trigger gated by `[deploy-approved]` in the merge commit message.
- After the production workflow succeeds, this trigger will be removed and deploy will return to manual-only.

Target application baseline before this ops-only PR: `39328a420a5d06c8079f539698b3ebadf1d66604`.