### PR TITLE
Fix D1 0059 trigger parsing

### DIFF
--- a/drizzle/0059_business_inventory_documents.sql
+++ b/drizzle/0059_business_inventory_documents.sql
@@ -93,20 +93,22 @@ CREATE INDEX IF NOT EXISTS `printed_form_snapshots_document_idx`
 CREATE TRIGGER IF NOT EXISTS `inventory_document_lines_tenant_insert`
 BEFORE INSERT ON `inventory_document_lines`
 BEGIN
-  SELECT CASE WHEN NOT EXISTS (
-    SELECT 1 FROM `business_documents` d
-    WHERE d.id = NEW.document_id AND d.organization_id = NEW.organization_id
-      AND d.document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count')
-  ) THEN RAISE(ABORT,'inventory_document_tenant_mismatch') END;
-  SELECT CASE WHEN NOT EXISTS (
-    SELECT 1 FROM `inventory_items` i WHERE i.id = NEW.item_id AND i.organization_id = NEW.organization_id
-  ) THEN RAISE(ABORT,'inventory_item_tenant_mismatch') END;
-  SELECT CASE WHEN NEW.lot_id IS NOT NULL AND NOT EXISTS (
-    SELECT 1 FROM `inventory_lots` l WHERE l.id = NEW.lot_id AND l.organization_id = NEW.organization_id AND l.item_id = NEW.item_id
-  ) THEN RAISE(ABORT,'inventory_lot_tenant_mismatch') END;
-  SELECT CASE WHEN NEW.booking_id IS NOT NULL AND NOT EXISTS (
-    SELECT 1 FROM `bookings` b WHERE b.id = NEW.booking_id AND b.organization_id = NEW.organization_id
-  ) THEN RAISE(ABORT,'inventory_booking_tenant_mismatch') END;
+  SELECT CASE
+    WHEN NOT EXISTS (
+      SELECT 1 FROM `business_documents` d
+      WHERE d.id = NEW.document_id AND d.organization_id = NEW.organization_id
+        AND d.document_type IN ('inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count')
+    ) THEN RAISE(ABORT,'inventory_document_tenant_mismatch')
+    WHEN NOT EXISTS (
+      SELECT 1 FROM `inventory_items` i WHERE i.id = NEW.item_id AND i.organization_id = NEW.organization_id
+    ) THEN RAISE(ABORT,'inventory_item_tenant_mismatch')
+    WHEN NEW.lot_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM `inventory_lots` l WHERE l.id = NEW.lot_id AND l.organization_id = NEW.organization_id AND l.item_id = NEW.item_id
+    ) THEN RAISE(ABORT,'inventory_lot_tenant_mismatch')
+    WHEN NEW.booking_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM `bookings` b WHERE b.id = NEW.booking_id AND b.organization_id = NEW.organization_id
+    ) THEN RAISE(ABORT,'inventory_booking_tenant_mismatch')
+  END;
 END;
 --> statement-breakpoint
 
@@ -175,16 +177,19 @@ CREATE TRIGGER IF NOT EXISTS `inventory_movement_document_integrity`
 BEFORE INSERT ON `inventory_movements`
 WHEN NEW.document_id IS NOT NULL OR NEW.document_line_id IS NOT NULL
 BEGIN
-  SELECT CASE WHEN NEW.document_id IS NULL OR NEW.document_line_id IS NULL THEN RAISE(ABORT,'inventory_document_link_incomplete') END;
-  SELECT CASE WHEN NOT EXISTS (
-    SELECT 1
-    FROM `business_documents` d
-    JOIN `inventory_document_lines` l
-      ON l.document_id=d.id AND l.organization_id=d.organization_id
-    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
-      AND l.id=NEW.document_line_id AND l.item_id=NEW.item_id
-      AND (l.lot_id IS NULL OR l.lot_id=NEW.lot_id)
-  ) THEN RAISE(ABORT,'inventory_document_link_invalid') END;
+  SELECT CASE
+    WHEN NEW.document_id IS NULL OR NEW.document_line_id IS NULL
+      THEN RAISE(ABORT,'inventory_document_link_incomplete')
+    WHEN NOT EXISTS (
+      SELECT 1
+      FROM `business_documents` d
+      JOIN `inventory_document_lines` l
+        ON l.document_id=d.id AND l.organization_id=d.organization_id
+      WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id AND d.state='posted'
+        AND l.id=NEW.document_line_id AND l.item_id=NEW.item_id
+        AND (l.lot_id IS NULL OR l.lot_id=NEW.lot_id)
+    ) THEN RAISE(ABORT,'inventory_document_link_invalid')
+  END;
 END;
 --> statement-breakpoint
 

--- a/tests/d1-migration-comment-compat.test.mjs
+++ b/tests/d1-migration-comment-compat.test.mjs
@@ -4,6 +4,15 @@ import { readFile } from "node:fs/promises";
 
 const migration = new URL("../drizzle/0059_business_inventory_documents.sql", import.meta.url);
 
+function triggerBody(sql, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = sql.match(
+    new RegExp(`CREATE TRIGGER IF NOT EXISTS \\`${escaped}\\`[\\s\\S]*?\\nBEGIN\\n([\\s\\S]*?)\\nEND;\\n--> statement-breakpoint`),
+  );
+  assert.ok(match, `trigger ${name} must exist and keep its statement breakpoint`);
+  return match[1];
+}
+
 test("migration 0059 keeps only statement-breakpoint line comments", async () => {
   const sql = await readFile(migration, "utf8");
   const otherComments = sql
@@ -12,4 +21,31 @@ test("migration 0059 keeps only statement-breakpoint line comments", async () =>
     .filter((line) => line.startsWith("--") && line !== "--> statement-breakpoint");
 
   assert.deepEqual(otherComments, []);
+});
+
+test("migration 0059 keeps parser-sensitive inventory guards single-statement", async () => {
+  const sql = await readFile(migration, "utf8");
+  const tenantGuard = triggerBody(sql, "inventory_document_lines_tenant_insert");
+  const movementGuard = triggerBody(sql, "inventory_movement_document_integrity");
+
+  assert.equal((tenantGuard.match(/;/g) ?? []).length, 1);
+  assert.equal((movementGuard.match(/;/g) ?? []).length, 1);
+
+  const tenantErrors = [
+    "inventory_document_tenant_mismatch",
+    "inventory_item_tenant_mismatch",
+    "inventory_lot_tenant_mismatch",
+    "inventory_booking_tenant_mismatch",
+  ];
+  for (const error of tenantErrors) assert.match(tenantGuard, new RegExp(error));
+  for (let i = 1; i < tenantErrors.length; i += 1) {
+    assert.ok(tenantGuard.indexOf(tenantErrors[i - 1]) < tenantGuard.indexOf(tenantErrors[i]));
+  }
+
+  assert.match(movementGuard, /inventory_document_link_incomplete/);
+  assert.match(movementGuard, /inventory_document_link_invalid/);
+  assert.ok(
+    movementGuard.indexOf("inventory_document_link_incomplete") <
+      movementGuard.indexOf("inventory_document_link_invalid"),
+  );
 });


### PR DESCRIPTION
Closed without merge after confirming the same multi-statement trigger pattern exists in later pending migrations (for example 0063). Rewriting 0059 alone would only move the production failure forward. The replacement fix changes the production migration execution path to Wrangler's file-import endpoint while preserving the migration SQL and migration tracking atomically.