### PR TITLE
Use D1 file-import path for production migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Apply D1 migrations
-        run: npx wrangler d1 migrations apply radiologyos --remote --config wrangler.cloudflare.toml
+        run: bash scripts/apply-d1-migrations-remote.sh radiologyos wrangler.cloudflare.toml drizzle
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/scripts/apply-d1-migrations-remote.sh
+++ b/scripts/apply-d1-migrations-remote.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATABASE="${1:-radiologyos}"
+CONFIG="${2:-wrangler.cloudflare.toml}"
+MIGRATIONS_DIR="${3:-drizzle}"
+
+if [[ ! -d "${MIGRATIONS_DIR}" ]]; then
+  echo "D1 migration directory not found: ${MIGRATIONS_DIR}" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+run_json() {
+  local output="$1"
+  shift
+  npx wrangler d1 execute "${DATABASE}" --remote --config "${CONFIG}" --json "$@" > "${output}"
+}
+
+# Keep the migration registry identical to Wrangler's built-in D1 migration table.
+run_json "${TMP_DIR}/init.json" --command "CREATE TABLE IF NOT EXISTS d1_migrations(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT UNIQUE,
+  applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);"
+
+read_applied() {
+  run_json "${TMP_DIR}/applied.json" --command "SELECT name FROM d1_migrations ORDER BY id;"
+  node - "${TMP_DIR}/applied.json" "${TMP_DIR}/applied.txt" <<'NODE'
+const fs = require("node:fs");
+const [input, output] = process.argv.slice(2);
+const payload = JSON.parse(fs.readFileSync(input, "utf8"));
+const rows = payload?.[0]?.results ?? [];
+const names = rows.map((row) => String(row.name ?? "")).filter(Boolean);
+fs.writeFileSync(output, names.join("\n") + (names.length ? "\n" : ""));
+NODE
+}
+
+read_applied
+mapfile -t MIGRATIONS < <(find "${MIGRATIONS_DIR}" -maxdepth 1 -type f -name '*.sql' -printf '%f\n' | LC_ALL=C sort)
+
+for name in "${MIGRATIONS[@]}"; do
+  if [[ ! "${name}" =~ ^[0-9]+_[A-Za-z0-9._-]+\.sql$ ]]; then
+    echo "Unsafe D1 migration filename: ${name}" >&2
+    exit 1
+  fi
+  if grep -Fqx -- "${name}" "${TMP_DIR}/applied.txt"; then
+    continue
+  fi
+
+  echo "Applying D1 migration via file import: ${name}"
+  IMPORT_FILE="${TMP_DIR}/${name}"
+  cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"
+  printf "\nINSERT INTO d1_migrations (name) VALUES ('%s');\n" "${name}" >> "${IMPORT_FILE}"
+
+  # --file uses Wrangler's remote D1 import path rather than the /query path used
+  # by `d1 migrations apply`. The migration and registry insert are submitted in
+  # the same SQL file, so a failed import cannot mark an unapplied migration done.
+  npx wrangler d1 execute "${DATABASE}" --remote --config "${CONFIG}" --file "${IMPORT_FILE}"
+
+  VERIFY_SQL="SELECT COUNT(*) AS applied FROM d1_migrations WHERE name='${name}';"
+  run_json "${TMP_DIR}/verify.json" --command "${VERIFY_SQL}"
+  node - "${TMP_DIR}/verify.json" "${name}" <<'NODE'
+const fs = require("node:fs");
+const [input, name] = process.argv.slice(2);
+const payload = JSON.parse(fs.readFileSync(input, "utf8"));
+const count = Number(payload?.[0]?.results?.[0]?.applied ?? 0);
+if (count !== 1) {
+  console.error(`D1 migration registry verification failed for ${name}`);
+  process.exit(1);
+}
+NODE
+  printf '%s\n' "${name}" >> "${TMP_DIR}/applied.txt"
+done
+
+read_applied
+node - "${MIGRATIONS_DIR}" "${TMP_DIR}/applied.txt" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const [dir, appliedFile] = process.argv.slice(2);
+const local = fs.readdirSync(dir).filter((name) => name.endsWith(".sql")).sort();
+const applied = new Set(fs.readFileSync(appliedFile, "utf8").split(/\r?\n/).filter(Boolean));
+const missing = local.filter((name) => !applied.has(name));
+if (missing.length) {
+  console.error(`D1 migration verification failed; still unapplied: ${missing.join(", ")}`);
+  process.exit(1);
+}
+console.log(`D1 migrations verified: ${local.length} local migration(s) are recorded as applied.`);
+NODE

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -29,7 +29,7 @@ echo "[2/5] Recording the current D1 recovery bookmark…"
 npx wrangler d1 time-travel info radiologyos --config "${CONFIG}"
 
 echo "[3/5] Applying D1 migrations to the remote database…"
-npx wrangler d1 migrations apply radiologyos --remote --config "${CONFIG}"
+bash scripts/apply-d1-migrations-remote.sh radiologyos "${CONFIG}" drizzle
 
 echo "[4/5] Verifying a secure active administrator credential…"
 ADMIN_GUARD_SQL=$(cat <<'SQL'

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
 test("local deploy uses valid remote D1 command contracts", async () => {
-  const script = await read("scripts/deploy-cloudflare.sh");
+  const [script, migrationScript] = await Promise.all([
+    read("scripts/deploy-cloudflare.sh"),
+    read("scripts/apply-d1-migrations-remote.sh"),
+  ]);
 
   assert.match(
     script,
@@ -20,9 +24,41 @@ test("local deploy uses valid remote D1 command contracts", async () => {
   );
   assert.match(
     script,
-    /wrangler d1 migrations apply radiologyos --remote --config \"\$\{CONFIG\}\"/,
-    "Migration application must remain explicitly remote",
+    /bash scripts\/apply-d1-migrations-remote\.sh radiologyos \"\$\{CONFIG\}\" drizzle/,
+    "Local deploy must use the shared remote D1 migration executor",
   );
+  assert.match(
+    migrationScript,
+    /wrangler d1 execute \"\$\{DATABASE\}\" --remote --config \"\$\{CONFIG\}\" --file \"\$\{IMPORT_FILE\}\"/,
+    "Remote migrations must use Wrangler's file-import execution path",
+  );
+  assert.doesNotMatch(
+    `${script}\n${migrationScript}`,
+    /wrangler d1 migrations apply/,
+    "Deployment must not return to the remote /query migration path that fails on valid trigger bodies",
+  );
+});
+
+test("remote D1 migration executor keeps migration tracking in the imported SQL file", async () => {
+  const script = await read("scripts/apply-d1-migrations-remote.sh");
+  const copySql = script.indexOf('cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"');
+  const tracking = script.indexOf("INSERT INTO d1_migrations (name) VALUES ('%s');");
+  const executeFile = script.indexOf('--file "${IMPORT_FILE}"');
+  const verifyRegistry = script.indexOf("SELECT COUNT(*) AS applied FROM d1_migrations WHERE name='${name}';");
+
+  assert.notEqual(copySql, -1, "migration SQL must be copied unchanged into the import file");
+  assert.notEqual(tracking, -1, "migration registry insert must be appended to the import file");
+  assert.notEqual(executeFile, -1, "the combined SQL file must be sent through --file");
+  assert.notEqual(verifyRegistry, -1, "the registry must be verified after each imported migration");
+  assert.ok(copySql < tracking && tracking < executeFile && executeFile < verifyRegistry);
+  assert.match(script, /Unsafe D1 migration filename/);
+  assert.match(script, /still unapplied/);
+});
+
+test("remote D1 migration executor has valid bash syntax", () => {
+  const path = fileURLToPath(new URL("../scripts/apply-d1-migrations-remote.sh", import.meta.url));
+  const result = spawnSync("bash", ["-n", path], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
 });
 
 test("deployment paths preserve runtime Worker vars", async () => {
@@ -65,6 +101,10 @@ test("GitHub production workflow uses the same Time Travel command contract", as
   const workflow = await read(".github/workflows/deploy.yml");
   assert.match(workflow, /wrangler d1 time-travel info radiologyos --config wrangler\.cloudflare\.toml/);
   assert.doesNotMatch(workflow, /wrangler d1 time-travel info[^\n]*--remote/);
+  assert.match(
+    workflow,
+    /bash scripts\/apply-d1-migrations-remote\.sh radiologyos wrangler\.cloudflare\.toml drizzle/,
+  );
 });
 
 test("production deploy paths reject placeholder or malformed administrator hashes", async () => {

--- a/tests/drizzle-generation-guard.test.mjs
+++ b/tests/drizzle-generation-guard.test.mjs
@@ -32,7 +32,22 @@ test("db:generate fails closed while Drizzle metadata trails committed SQL migra
 });
 
 test("production deploy applies committed SQL migrations directly instead of generating schema", async () => {
-  const deploy = await read("scripts/deploy-cloudflare.sh");
-  assert.match(deploy, /wrangler d1 migrations apply radiologyos --remote/);
-  assert.doesNotMatch(deploy, /db:generate|drizzle-kit generate/);
+  const [deploy, migrationExecutor] = await Promise.all([
+    read("scripts/deploy-cloudflare.sh"),
+    read("scripts/apply-d1-migrations-remote.sh"),
+  ]);
+  assert.match(
+    deploy,
+    /bash scripts\/apply-d1-migrations-remote\.sh radiologyos \"\$\{CONFIG\}\" drizzle/,
+  );
+  assert.match(
+    migrationExecutor,
+    /cat \"\$\{MIGRATIONS_DIR\}\/\$\{name\}\" > \"\$\{IMPORT_FILE\}\"/,
+    "the executor must import committed migration SQL files directly",
+  );
+  assert.match(
+    migrationExecutor,
+    /wrangler d1 execute \"\$\{DATABASE\}\" --remote --config \"\$\{CONFIG\}\" --file \"\$\{IMPORT_FILE\}\"/,
+  );
+  assert.doesNotMatch(`${deploy}\n${migrationExecutor}`, /db:generate|drizzle-kit generate/);
 });


### PR DESCRIPTION
Production deploys #137 and #138 failed safely before Worker deployment because Wrangler `d1 migrations apply` sends a whole migration through the remote `/query` path and D1 returned `SQLITE_ERROR 7500: incomplete input` on migration 0059. Later pending migrations contain the same valid multi-statement trigger pattern, so rewriting one migration would not be a durable fix.

This PR keeps every migration SQL file and every database guard unchanged. It adds a shared remote migration executor that:
- initializes the standard `d1_migrations` registry schema if needed;
- reads already-applied migration names;
- sends each pending `drizzle/*.sql` through Wrangler `d1 execute --file` (the remote file-import path);
- appends that migration's `d1_migrations` insert to the same uploaded SQL file;
- verifies the registry after every migration and again at the end;
- rejects unsafe migration filenames.

Both GitHub production deployment and the local production deploy script use the same executor. Production-gate tests assert the file-import path, atomic tracking placement, final verification, and shell syntax.

No application code changes. No migration skipped. No tenant/inventory/finance guard weakened.