### PR TITLE
Separate staff chat history by immutable patient identity

### DIFF
--- a/app/api/staff/chat/route.ts
+++ b/app/api/staff/chat/route.ts
@@ -1,12 +1,11 @@
 // Єдиний контакт-центр пацієнтів. Історія береться з patient_communications
 // незалежно від каналу; ручні відповіді поки відправляються через legacy-global
-// WhatsApp-шлюз org 1. Усі читання та записи tenant-scoped; secondary tenants
-// можуть читати свою історію, але не використовувати глобальний шлюз для reply.
+// WhatsApp-шлюз org 1.
 //
-// A transport thread is still phone-scoped because WhatsApp/SMS physically use
-// that destination. Phone is NOT patient identity: if several exact profiles
-// share a phone, the thread is marked shared and a manual reply fails closed
-// until the caller works from a concrete patient/booking context.
+// КРИТИЧНА ІНВАРІАНТА: phone — лише контакт, а не identity. Exact-діалоги
+// групуються та читаються виключно за immutable patient_id. Старі записи без
+// patient_id залишаються окремими legacy phone-buckets і ніколи автоматично не
+// домішуються до exact-пацієнта, навіть якщо номер збігається.
 
 import { canViewPatientRegistry } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
@@ -17,10 +16,49 @@ import { audit } from "../../../../lib/audit";
 
 const PRIMARY_ORGANIZATION_ID = 1;
 const CHANNELS = new Set(["whatsapp", "telegram", "sms", "email"]);
+const PATIENT_ID = /^[a-f0-9]{32}$/i;
 
 function channelFilter(request: Request): string {
   const value = (new URL(request.url).searchParams.get("channel") || "").trim().toLowerCase();
   return CHANNELS.has(value) ? value : "";
+}
+
+function exactPatientId(value: string | null | undefined): string {
+  const patientId = String(value || "").trim().toLowerCase();
+  return PATIENT_ID.test(patientId) ? patientId : "";
+}
+
+async function resolvePhoneCompatibilityScope(
+  db: D1Database,
+  organizationId: number,
+  phone: string,
+  channel: string,
+): Promise<{ patientId: string; legacyPhone: string; ambiguous: boolean }> {
+  const row = channel
+    ? await db.prepare(
+        `SELECT COUNT(DISTINCT CASE
+                  WHEN patient_id != '' THEN 'patient:' || patient_id
+                  ELSE 'legacy:' || phone_normalized END) AS scopeCount,
+                COALESCE(MAX(CASE WHEN patient_id != '' THEN patient_id ELSE '' END), '') AS patientId,
+                MAX(CASE WHEN patient_id = '' THEN 1 ELSE 0 END) AS hasLegacy
+         FROM patient_communications
+         WHERE organization_id = ? AND phone_normalized = ? AND channel = ?`
+      ).bind(organizationId, phone, channel).first<{ scopeCount:number; patientId:string; hasLegacy:number }>()
+    : await db.prepare(
+        `SELECT COUNT(DISTINCT CASE
+                  WHEN patient_id != '' THEN 'patient:' || patient_id
+                  ELSE 'legacy:' || phone_normalized END) AS scopeCount,
+                COALESCE(MAX(CASE WHEN patient_id != '' THEN patient_id ELSE '' END), '') AS patientId,
+                MAX(CASE WHEN patient_id = '' THEN 1 ELSE 0 END) AS hasLegacy
+         FROM patient_communications
+         WHERE organization_id = ? AND phone_normalized = ?`
+      ).bind(organizationId, phone).first<{ scopeCount:number; patientId:string; hasLegacy:number }>();
+
+  const scopeCount = Number(row?.scopeCount || 0);
+  if (scopeCount > 1) return { patientId:"", legacyPhone:"", ambiguous:true };
+  const patientId = exactPatientId(row?.patientId || "");
+  if (patientId) return { patientId, legacyPhone:"", ambiguous:false };
+  return { patientId:"", legacyPhone:Number(row?.hasLegacy || 0) === 1 ? phone : "", ambiguous:false };
 }
 
 export async function GET(request: Request) {
@@ -30,252 +68,407 @@ export async function GET(request: Request) {
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
   const member = ctx.member;
   const orgId = ctx.organizationId;
-  if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Контакт-центр доступний реєстратору або адміністратору" }, { status: 403 });
+  if (!canViewPatientRegistry(member.role)) {
+    return Response.json({ error: "Контакт-центр доступний реєстратору або адміністратору" }, { status: 403 });
+  }
 
   const url = new URL(request.url);
-  const phone = normalizeUkrainianPhone(url.searchParams.get("phone") || "");
   const channel = channelFilter(request);
+  let patientId = exactPatientId(url.searchParams.get("patientId"));
+  let legacyPhone = normalizeUkrainianPhone(url.searchParams.get("legacyPhone") || "");
+  const compatibilityPhone = normalizeUkrainianPhone(url.searchParams.get("phone") || "");
 
-  if (phone) {
+  // Backward compatibility for old bookmarks/callers: phone-only reads are
+  // accepted only when that phone maps to exactly one communication scope.
+  // Scope ambiguity is global across channels: a channel filter may narrow
+  // messages only after identity has already been resolved safely.
+  if (!patientId && !legacyPhone && compatibilityPhone) {
+    const scope = await resolvePhoneCompatibilityScope(db, orgId, compatibilityPhone, "");
+    if (scope.ambiguous) {
+      return Response.json({
+        error: "Цей номер містить кілька окремих історій. Виберіть конкретного пацієнта або legacy-історію.",
+      }, { status: 409, headers:{ "cache-control":"no-store" } });
+    }
+    patientId = scope.patientId;
+    legacyPhone = scope.legacyPhone;
+  }
+
+  if (patientId || legacyPhone) {
+    if (patientId) {
+      const profile = await db.prepare(
+        `SELECT display_name AS name, phone_normalized AS phone, do_not_contact AS doNotContact
+         FROM patient_profiles
+         WHERE organization_id = ? AND patient_id = ? LIMIT 1`
+      ).bind(orgId, patientId).first<{ name:string; phone:string; doNotContact:number }>();
+
+      if (!profile) {
+        return Response.json({ error:"Діалог пацієнта не знайдено" }, { status:404, headers:{ "cache-control":"no-store" } });
+      }
+
+      const rows = channel
+        ? await db.prepare(
+            `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor,
+                    external_id AS externalId, phone_normalized AS phone, created_at AS createdAt
+             FROM patient_communications
+             WHERE organization_id = ? AND patient_id = ? AND channel = ?
+             ORDER BY created_at ASC, id ASC LIMIT 400`
+          ).bind(orgId, patientId, channel).all()
+        : await db.prepare(
+            `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor,
+                    external_id AS externalId, phone_normalized AS phone, created_at AS createdAt
+             FROM patient_communications
+             WHERE organization_id = ? AND patient_id = ?
+             ORDER BY created_at ASC, id ASC LIMIT 400`
+          ).bind(orgId, patientId).all();
+
+      const issues = await db.prepare(
+        `SELECT n.id, n.channel, n.kind, n.status, n.error, n.created_at AS createdAt, n.booking_id AS bookingId
+         FROM patient_notifications n
+         JOIN bookings b ON b.id = n.booking_id AND b.organization_id = n.organization_id
+         WHERE n.organization_id = ? AND b.patient_id = ? AND n.status = 'failed'
+         ORDER BY n.id DESC LIMIT 30`
+      ).bind(orgId, patientId).all();
+
+      const telegram = await db.prepare(
+        `SELECT 1 AS linked FROM patient_telegram_identities
+         WHERE organization_id = ? AND patient_id = ? AND telegram_chat_id != '' LIMIT 1`
+      ).bind(orgId, patientId).first<{ linked:number }>();
+
+      const shared = profile.phone
+        ? await db.prepare(
+            `SELECT COUNT(*) AS count FROM patient_profiles
+             WHERE organization_id = ? AND phone_normalized = ?`
+          ).bind(orgId, profile.phone).first<{ count:number }>()
+        : null;
+
+      await audit(db, {
+        organizationId: orgId,
+        actorEmail: member.email,
+        action: "contact_center_thread_viewed",
+        resource: "patient_communication",
+        targetId: patientId,
+        details: { channel:channel || "all", identityKind:"patient" },
+      });
+
+      return Response.json({
+        conversationKey:`patient:${patientId}`,
+        identityKind:"patient",
+        patientId,
+        phone:profile.phone,
+        name:profile.name || "",
+        sharedPhone:Number(shared?.count || 0) > 1,
+        messages:rows.results,
+        issues:issues.results,
+        availableReplyChannels:
+          orgId === PRIMARY_ORGANIZATION_ID
+          && !!profile.phone
+          && Number(profile.doNotContact || 0) !== 1
+          && Number(shared?.count || 0) <= 1
+            ? ["whatsapp"] : [],
+        linkedTelegram:Number(telegram?.linked || 0) === 1,
+        staff:member,
+      }, { headers:{ "cache-control":"no-store" } });
+    }
+
     const rows = channel
       ? await db.prepare(
-          `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor, external_id AS externalId, created_at AS createdAt
+          `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor,
+                  external_id AS externalId, phone_normalized AS phone, created_at AS createdAt
            FROM patient_communications
-           WHERE phone_normalized = ? AND organization_id = ? AND channel = ?
+           WHERE organization_id = ? AND patient_id = '' AND phone_normalized = ? AND channel = ?
            ORDER BY created_at ASC, id ASC LIMIT 400`
-        ).bind(phone, orgId, channel).all()
+        ).bind(orgId, legacyPhone, channel).all()
       : await db.prepare(
-          `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor, external_id AS externalId, created_at AS createdAt
+          `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor,
+                  external_id AS externalId, phone_normalized AS phone, created_at AS createdAt
            FROM patient_communications
-           WHERE phone_normalized = ? AND organization_id = ?
+           WHERE organization_id = ? AND patient_id = '' AND phone_normalized = ?
            ORDER BY created_at ASC, id ASC LIMIT 400`
-        ).bind(phone, orgId).all();
+        ).bind(orgId, legacyPhone).all();
 
-    // Keep the identity lookup on two ordinary positional bindings. Reusing
-    // numbered parameters in this scalar-subquery shape is not portable across
-    // D1 and Node's SQLite runtime used by the production test harness.
-    const patient = await db.prepare(
-      `WITH input(phone, org_id) AS (VALUES (?, ?))
+    if (rows.results.length === 0) {
+      return Response.json({ error:"Legacy-діалог не знайдено" }, { status:404, headers:{ "cache-control":"no-store" } });
+    }
+
+    const identity = await db.prepare(
+      `WITH input(org_id, phone) AS (VALUES (?, ?))
        SELECT
          (SELECT COUNT(*) FROM patient_profiles p
-          WHERE p.phone_normalized = i.phone AND p.organization_id = i.org_id) AS profileCount,
-         COALESCE((
-           SELECT MAX(display_name) FROM patient_profiles p
-           WHERE p.phone_normalized = i.phone AND p.organization_id = i.org_id
-           HAVING COUNT(*) = 1
-         ), (
-           SELECT name FROM bookings b
-           WHERE b.phone_normalized = i.phone AND b.organization_id = i.org_id
-             AND NOT EXISTS (
-               SELECT 1 FROM patient_profiles p2
-               WHERE p2.phone_normalized = b.phone_normalized AND p2.organization_id = b.organization_id
-             )
-           ORDER BY b.id DESC LIMIT 1
-         ), '') AS name,
-         CASE WHEN EXISTS (
-           SELECT 1 FROM patient_telegram_identities ti
-           WHERE ti.phone_normalized = i.phone AND ti.organization_id = i.org_id AND ti.telegram_chat_id != ''
-         ) THEN 1 ELSE 0 END AS telegramLinked,
-         CASE WHEN EXISTS (
-           SELECT 1 FROM bookings b
-           WHERE b.organization_id = i.org_id
-             AND b.phone_normalized = i.phone
-             AND b.patient_id != ''
-             AND NOT EXISTS (
-               SELECT 1 FROM patient_profiles p3
-               WHERE p3.organization_id = b.organization_id
-                 AND p3.patient_id = b.patient_id
-                 AND p3.phone_normalized = b.phone_normalized
-             )
-         ) THEN 1 ELSE 0 END AS staleLinkedContact
+          WHERE p.organization_id = i.org_id AND p.phone_normalized = i.phone) AS exactProfileCount,
+         (SELECT COUNT(*) FROM bookings b
+          WHERE b.organization_id = i.org_id AND b.phone_normalized = i.phone AND b.patient_id = '') AS legacyBookingCount,
+         COALESCE((SELECT MAX(name) FROM bookings b
+          WHERE b.organization_id = i.org_id AND b.phone_normalized = i.phone AND b.patient_id = ''
+          HAVING COUNT(*) = 1), '') AS name
        FROM input i`
-    ).bind(phone, orgId).first<{
-      profileCount:number; name:string; telegramLinked:number; staleLinkedContact:number;
-    }>();
+    ).bind(orgId, legacyPhone).first<{ exactProfileCount:number; legacyBookingCount:number; name:string }>();
 
     const issues = await db.prepare(
       `SELECT n.id, n.channel, n.kind, n.status, n.error, n.created_at AS createdAt, n.booking_id AS bookingId
        FROM patient_notifications n
        JOIN bookings b ON b.id = n.booking_id AND b.organization_id = n.organization_id
-       WHERE n.organization_id = ? AND b.phone_normalized = ? AND n.status = 'failed'
+       WHERE n.organization_id = ? AND b.patient_id = '' AND b.phone_normalized = ? AND n.status = 'failed'
        ORDER BY n.id DESC LIMIT 30`
-    ).bind(orgId, phone).all();
+    ).bind(orgId, legacyPhone).all();
+
+    const exactProfileCount = Number(identity?.exactProfileCount || 0);
+    const legacyBookingCount = Number(identity?.legacyBookingCount || 0);
 
     await audit(db, {
-      organizationId: orgId,
-      actorEmail: member.email,
-      action: "contact_center_thread_viewed",
-      resource: "patient_communication",
-      targetId: phone,
-      details: {
-        channel: channel || "all",
-        sharedPhone:Number(patient?.profileCount || 0) > 1,
-        staleLinkedContact:Number(patient?.staleLinkedContact || 0) === 1,
-      },
+      organizationId:orgId,
+      actorEmail:member.email,
+      action:"contact_center_thread_viewed",
+      resource:"patient_communication",
+      targetId:`legacy:${legacyPhone}`,
+      details:{ channel:channel || "all", identityKind:"legacy", exactProfileCount, legacyBookingCount },
     });
 
     return Response.json({
-      phone,
-      name: patient?.name || "",
-      sharedPhone: Number(patient?.profileCount || 0) > 1,
-      staleLinkedContact: Number(patient?.staleLinkedContact || 0) === 1,
-      messages: rows.results,
-      issues: issues.results,
+      conversationKey:`legacy:${legacyPhone}`,
+      identityKind:"legacy",
+      patientId:"",
+      phone:legacyPhone,
+      name:identity?.name || "",
+      sharedPhone:exactProfileCount > 1,
+      messages:rows.results,
+      issues:issues.results,
       availableReplyChannels:
-        orgId === PRIMARY_ORGANIZATION_ID
-        && Number(patient?.profileCount || 0) <= 1
-        && Number(patient?.staleLinkedContact || 0) !== 1
-          ? ["whatsapp"]
-          : [],
-      linkedTelegram: Number(patient?.telegramLinked || 0) === 1,
-      staff: member,
-    }, { headers: { "cache-control":"no-store" } });
+        orgId === PRIMARY_ORGANIZATION_ID && exactProfileCount === 0 && legacyBookingCount === 1
+          ? ["whatsapp"] : [],
+      linkedTelegram:false,
+      legacyAmbiguous:exactProfileCount > 0 || legacyBookingCount !== 1,
+      staff:member,
+    }, { headers:{ "cache-control":"no-store" } });
   }
 
   const conversations = channel
     ? await db.prepare(
-        `SELECT c.phone_normalized AS phone, c.summary AS lastText, c.direction AS lastDirection,
-                c.channel AS lastChannel, c.created_at AS lastAt,
-                CASE WHEN (
-                  SELECT COUNT(*) FROM patient_profiles p0
-                  WHERE p0.phone_normalized = c.phone_normalized AND p0.organization_id = ?1
-                ) = 1 THEN COALESCE((
-                  SELECT MAX(display_name) FROM patient_profiles p
-                  WHERE p.phone_normalized = c.phone_normalized AND p.organization_id = ?1
-                ), '') ELSE '' END AS name,
-                CASE WHEN (
+        `WITH input(org_id, channel) AS (VALUES (?, ?)),
+         latest AS (
+           SELECT CASE WHEN pc.patient_id != '' THEN 'patient:' || pc.patient_id ELSE 'legacy:' || pc.phone_normalized END AS conversationKey,
+                  MAX(pc.id) AS maxId
+           FROM patient_communications pc
+           CROSS JOIN input i
+           WHERE pc.organization_id = i.org_id AND pc.channel = i.channel
+           GROUP BY conversationKey
+         )
+         SELECT latest.conversationKey,
+                CASE WHEN c.patient_id != '' THEN 'patient' ELSE 'legacy' END AS identityKind,
+                c.patient_id AS patientId,
+                CASE WHEN c.patient_id != '' THEN COALESCE((
+                  SELECT p.phone_normalized FROM patient_profiles p
+                  WHERE p.organization_id = i.org_id AND p.patient_id = c.patient_id LIMIT 1
+                ), c.phone_normalized) ELSE c.phone_normalized END AS phone,
+                c.summary AS lastText, c.direction AS lastDirection, c.channel AS lastChannel,
+                c.created_at AS lastAt,
+                CASE WHEN c.patient_id != '' THEN COALESCE((
+                  SELECT p.display_name FROM patient_profiles p
+                  WHERE p.organization_id = i.org_id AND p.patient_id = c.patient_id LIMIT 1
+                ), '')
+                WHEN (SELECT COUNT(*) FROM bookings b
+                      WHERE b.organization_id = i.org_id AND b.patient_id = '' AND b.phone_normalized = c.phone_normalized) = 1
+                THEN COALESCE((SELECT MAX(b2.name) FROM bookings b2
+                               WHERE b2.organization_id = i.org_id AND b2.patient_id = '' AND b2.phone_normalized = c.phone_normalized), '')
+                ELSE '' END AS name,
+                CASE WHEN c.patient_id != '' THEN (
                   SELECT COUNT(*) FROM patient_profiles p3
-                  WHERE p3.phone_normalized = c.phone_normalized AND p3.organization_id = ?1
-                ) > 1 THEN 1 ELSE 0 END AS sharedPhone,
-                (SELECT COUNT(*) FROM patient_notifications n
-                   JOIN bookings b2 ON b2.id = n.booking_id AND b2.organization_id = n.organization_id
-                  WHERE n.organization_id = ?1 AND b2.phone_normalized = c.phone_normalized AND n.status = 'failed') AS issueCount
-         FROM patient_communications c
-         JOIN (SELECT phone_normalized, MAX(id) AS maxId FROM patient_communications
-               WHERE organization_id = ?1 AND channel = ?2 GROUP BY phone_normalized) m
-           ON m.phone_normalized = c.phone_normalized AND m.maxId = c.id
-         WHERE c.organization_id = ?1
-         ORDER BY c.created_at DESC LIMIT 150`
+                  WHERE p3.organization_id = i.org_id AND p3.phone_normalized = COALESCE((
+                    SELECT p4.phone_normalized FROM patient_profiles p4
+                    WHERE p4.organization_id = i.org_id AND p4.patient_id = c.patient_id LIMIT 1
+                  ), c.phone_normalized)
+                ) ELSE (
+                  SELECT COUNT(*) FROM patient_profiles p5
+                  WHERE p5.organization_id = i.org_id AND p5.phone_normalized = c.phone_normalized
+                ) END AS exactProfileCount,
+                CASE WHEN c.patient_id != '' THEN (
+                  SELECT COUNT(*) FROM patient_notifications n
+                  JOIN bookings b3 ON b3.id = n.booking_id AND b3.organization_id = n.organization_id
+                  WHERE n.organization_id = i.org_id AND b3.patient_id = c.patient_id AND n.status = 'failed'
+                ) ELSE (
+                  SELECT COUNT(*) FROM patient_notifications n
+                  JOIN bookings b4 ON b4.id = n.booking_id AND b4.organization_id = n.organization_id
+                  WHERE n.organization_id = i.org_id AND b4.patient_id = '' AND b4.phone_normalized = c.phone_normalized AND n.status = 'failed'
+                ) END AS issueCount
+         FROM latest
+         CROSS JOIN input i
+         JOIN patient_communications c ON c.id = latest.maxId AND c.organization_id = i.org_id
+         ORDER BY c.created_at DESC, c.id DESC LIMIT 150`
       ).bind(orgId, channel).all()
     : await db.prepare(
-        `SELECT c.phone_normalized AS phone, c.summary AS lastText, c.direction AS lastDirection,
-                c.channel AS lastChannel, c.created_at AS lastAt,
-                CASE WHEN (
-                  SELECT COUNT(*) FROM patient_profiles p0
-                  WHERE p0.phone_normalized = c.phone_normalized AND p0.organization_id = ?1
-                ) = 1 THEN COALESCE((
-                  SELECT MAX(display_name) FROM patient_profiles p
-                  WHERE p.phone_normalized = c.phone_normalized AND p.organization_id = ?1
-                ), '') ELSE '' END AS name,
-                CASE WHEN (
+        `WITH input(org_id) AS (VALUES (?)),
+         latest AS (
+           SELECT CASE WHEN pc.patient_id != '' THEN 'patient:' || pc.patient_id ELSE 'legacy:' || pc.phone_normalized END AS conversationKey,
+                  MAX(pc.id) AS maxId
+           FROM patient_communications pc
+           CROSS JOIN input i
+           WHERE pc.organization_id = i.org_id
+           GROUP BY conversationKey
+         )
+         SELECT latest.conversationKey,
+                CASE WHEN c.patient_id != '' THEN 'patient' ELSE 'legacy' END AS identityKind,
+                c.patient_id AS patientId,
+                CASE WHEN c.patient_id != '' THEN COALESCE((
+                  SELECT p.phone_normalized FROM patient_profiles p
+                  WHERE p.organization_id = i.org_id AND p.patient_id = c.patient_id LIMIT 1
+                ), c.phone_normalized) ELSE c.phone_normalized END AS phone,
+                c.summary AS lastText, c.direction AS lastDirection, c.channel AS lastChannel,
+                c.created_at AS lastAt,
+                CASE WHEN c.patient_id != '' THEN COALESCE((
+                  SELECT p.display_name FROM patient_profiles p
+                  WHERE p.organization_id = i.org_id AND p.patient_id = c.patient_id LIMIT 1
+                ), '')
+                WHEN (SELECT COUNT(*) FROM bookings b
+                      WHERE b.organization_id = i.org_id AND b.patient_id = '' AND b.phone_normalized = c.phone_normalized) = 1
+                THEN COALESCE((SELECT MAX(b2.name) FROM bookings b2
+                               WHERE b2.organization_id = i.org_id AND b2.patient_id = '' AND b2.phone_normalized = c.phone_normalized), '')
+                ELSE '' END AS name,
+                CASE WHEN c.patient_id != '' THEN (
                   SELECT COUNT(*) FROM patient_profiles p3
-                  WHERE p3.phone_normalized = c.phone_normalized AND p3.organization_id = ?1
-                ) > 1 THEN 1 ELSE 0 END AS sharedPhone,
-                (SELECT COUNT(*) FROM patient_notifications n
-                   JOIN bookings b2 ON b2.id = n.booking_id AND b2.organization_id = n.organization_id
-                  WHERE n.organization_id = ?1 AND b2.phone_normalized = c.phone_normalized AND n.status = 'failed') AS issueCount
-         FROM patient_communications c
-         JOIN (SELECT phone_normalized, MAX(id) AS maxId FROM patient_communications
-               WHERE organization_id = ?1 GROUP BY phone_normalized) m
-           ON m.phone_normalized = c.phone_normalized AND m.maxId = c.id
-         WHERE c.organization_id = ?1
-         ORDER BY c.created_at DESC LIMIT 150`
+                  WHERE p3.organization_id = i.org_id AND p3.phone_normalized = COALESCE((
+                    SELECT p4.phone_normalized FROM patient_profiles p4
+                    WHERE p4.organization_id = i.org_id AND p4.patient_id = c.patient_id LIMIT 1
+                  ), c.phone_normalized)
+                ) ELSE (
+                  SELECT COUNT(*) FROM patient_profiles p5
+                  WHERE p5.organization_id = i.org_id AND p5.phone_normalized = c.phone_normalized
+                ) END AS exactProfileCount,
+                CASE WHEN c.patient_id != '' THEN (
+                  SELECT COUNT(*) FROM patient_notifications n
+                  JOIN bookings b3 ON b3.id = n.booking_id AND b3.organization_id = n.organization_id
+                  WHERE n.organization_id = i.org_id AND b3.patient_id = c.patient_id AND n.status = 'failed'
+                ) ELSE (
+                  SELECT COUNT(*) FROM patient_notifications n
+                  JOIN bookings b4 ON b4.id = n.booking_id AND b4.organization_id = n.organization_id
+                  WHERE n.organization_id = i.org_id AND b4.patient_id = '' AND b4.phone_normalized = c.phone_normalized AND n.status = 'failed'
+                ) END AS issueCount
+         FROM latest
+         CROSS JOIN input i
+         JOIN patient_communications c ON c.id = latest.maxId AND c.organization_id = i.org_id
+         ORDER BY c.created_at DESC, c.id DESC LIMIT 150`
       ).bind(orgId).all();
 
   const channelStats = await db.prepare(
-    `SELECT channel, COUNT(*) AS count
-     FROM patient_communications
-     WHERE organization_id = ?
-     GROUP BY channel`
+    `SELECT channel, COUNT(*) AS count FROM patient_communications
+     WHERE organization_id = ? GROUP BY channel`
   ).bind(orgId).all();
   const failed = await db.prepare(
     `SELECT COUNT(*) AS count FROM patient_notifications WHERE organization_id = ? AND status = 'failed'`
   ).bind(orgId).first<{ count:number }>();
 
+  const normalizedConversations = (conversations.results as Array<Record<string, unknown>>).map((row) => ({
+    ...row,
+    sharedPhone:Number(row.exactProfileCount || 0) > 1,
+    legacyAmbiguous:row.identityKind === "legacy" && Number(row.exactProfileCount || 0) > 0,
+  }));
+
   return Response.json({
-    conversations: conversations.results,
-    channelStats: channelStats.results,
-    failedDeliveries: Number(failed?.count || 0),
-    activeChannel: channel || "all",
-    staff: member,
-  }, { headers: { "cache-control":"no-store" } });
+    conversations:normalizedConversations,
+    channelStats:channelStats.results,
+    failedDeliveries:Number(failed?.count || 0),
+    activeChannel:channel || "all",
+    staff:member,
+  }, { headers:{ "cache-control":"no-store" } });
 }
 
 export async function POST(request: Request) {
   const db = dbBinding();
-  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
   const ctx = await requireOrgContext(request, db);
-  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  if (!ctx) return Response.json({ error:"Доступ лише для персоналу" }, { status:403 });
   const member = ctx.member;
-  if (!canViewPatientRegistry(member.role)) return Response.json({ error: "Відповідати може реєстратор або адміністратор" }, { status: 403 });
+  if (!canViewPatientRegistry(member.role)) {
+    return Response.json({ error:"Відповідати може реєстратор або адміністратору" }, { status:403 });
+  }
   if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID) {
-    return Response.json({ error: "Вихідний WhatsApp ще не налаштований для цієї організації" }, { status: 403 });
+    return Response.json({ error:"Вихідний WhatsApp ще не налаштований для цієї організації" }, { status:403 });
   }
 
-  const body = await request.json().catch(() => ({})) as { phone?:string; text?:string; channel?:string };
-  const phone = normalizeUkrainianPhone(String(body.phone || ""));
+  const body = await request.json().catch(() => ({})) as {
+    patientId?:string; phone?:string; text?:string; channel?:string; identityKind?:string;
+  };
+  const patientId = exactPatientId(body.patientId);
+  const requestedPhone = normalizeUkrainianPhone(String(body.phone || ""));
   const text = String(body.text || "").trim().slice(0, 2000);
   const channel = String(body.channel || "whatsapp").trim().toLowerCase();
-  if (!phone || !text) return Response.json({ error: "Вкажіть номер і текст повідомлення" }, { status: 400 });
-  if (channel !== "whatsapp") return Response.json({ error: "Ручна відповідь для цього каналу ще не підключена" }, { status: 400 });
+  if (!text) return Response.json({ error:"Вкажіть текст повідомлення" }, { status:400 });
+  if (channel !== "whatsapp") {
+    return Response.json({ error:"Ручна відповідь для цього каналу ще не підключена" }, { status:400 });
+  }
 
-  const identity = await db.prepare(
-    `WITH input(org_id, phone) AS (VALUES (?, ?))
-     SELECT
-       (SELECT COUNT(*) FROM patient_profiles p
-        WHERE p.organization_id = i.org_id AND p.phone_normalized = i.phone) AS profileCount,
-       COALESCE((SELECT MAX(patient_id) FROM patient_profiles p
-        WHERE p.organization_id = i.org_id AND p.phone_normalized = i.phone HAVING COUNT(*) = 1), '') AS patientId,
-       CASE WHEN EXISTS (
-         SELECT 1 FROM bookings b WHERE b.organization_id = i.org_id AND b.phone_normalized = i.phone
-       ) THEN 1 ELSE 0 END AS hasBooking,
-       CASE WHEN EXISTS (
-         SELECT 1 FROM bookings b
-         WHERE b.organization_id = i.org_id
-           AND b.phone_normalized = i.phone
-           AND b.patient_id != ''
-           AND NOT EXISTS (
-             SELECT 1 FROM patient_profiles p
-             WHERE p.organization_id = b.organization_id
-               AND p.patient_id = b.patient_id
-               AND p.phone_normalized = b.phone_normalized
-           )
-       ) THEN 1 ELSE 0 END AS staleLinkedContact
-     FROM input i`
-  ).bind(ctx.organizationId, phone).first<{
-    profileCount:number; patientId:string; hasBooking:number; staleLinkedContact:number;
-  }>();
-  const profileCount = Number(identity?.profileCount || 0);
-  if (Number(identity?.staleLinkedContact || 0) === 1) {
-    return Response.json({
-      error: "Контакт exact-пацієнта змінено після створення запису. Відкрийте актуальну CRM-картку перед відправленням.",
-    }, { status: 409 });
-  }
-  if (profileCount > 1) {
-    return Response.json({
-      error: "Цей номер використовується кількома пацієнтами. Надішліть повідомлення з конкретної картки або заявки.",
-    }, { status: 409 });
-  }
-  if (!profileCount && !Number(identity?.hasBooking || 0)) {
-    return Response.json({ error: "Пацієнта не знайдено в цій організації" }, { status: 404 });
+  let phone = requestedPhone;
+  let storedPatientId = "";
+
+  if (patientId) {
+    const profile = await db.prepare(
+      `SELECT phone_normalized AS phone, do_not_contact AS doNotContact
+       FROM patient_profiles WHERE organization_id = ? AND patient_id = ? LIMIT 1`
+    ).bind(ctx.organizationId, patientId).first<{ phone:string; doNotContact:number }>();
+    if (!profile) return Response.json({ error:"Пацієнта не знайдено в цій організації" }, { status:404 });
+    phone = normalizeUkrainianPhone(profile.phone || "");
+    if (!phone) return Response.json({ error:"У картці пацієнта немає коректного номера" }, { status:409 });
+    if (requestedPhone && requestedPhone !== phone) {
+      return Response.json({ error:"Контакт пацієнта змінився. Оновіть діалог перед відправленням." }, { status:409 });
+    }
+    if (Number(profile.doNotContact || 0) === 1) {
+      return Response.json({ error:"Для пацієнта встановлено заборону на контакт" }, { status:409 });
+    }
+    const shared = await db.prepare(
+      `SELECT COUNT(*) AS count FROM patient_profiles
+       WHERE organization_id = ? AND phone_normalized = ?`
+    ).bind(ctx.organizationId, phone).first<{ count:number }>();
+    if (Number(shared?.count || 0) > 1) {
+      return Response.json({
+        error:"Цей номер є спільним контактом кількох пацієнтів. Ручна відправка медичної інформації заблокована.",
+      }, { status:409 });
+    }
+    storedPatientId = patientId;
+  } else {
+    if (!phone) return Response.json({ error:"Вкажіть номер отримувача" }, { status:400 });
+    const identity = await db.prepare(
+      `WITH input(org_id, phone) AS (VALUES (?, ?))
+       SELECT
+         (SELECT COUNT(*) FROM patient_profiles p
+          WHERE p.organization_id = i.org_id AND p.phone_normalized = i.phone) AS exactProfileCount,
+         (SELECT COUNT(*) FROM bookings b
+          WHERE b.organization_id = i.org_id AND b.phone_normalized = i.phone AND b.patient_id = '') AS legacyBookingCount
+       FROM input i`
+    ).bind(ctx.organizationId, phone).first<{ exactProfileCount:number; legacyBookingCount:number }>();
+    const exactProfileCount = Number(identity?.exactProfileCount || 0);
+    const legacyBookingCount = Number(identity?.legacyBookingCount || 0);
+    if (exactProfileCount > 0) {
+      return Response.json({
+        error:"Цей номер належить exact-профілю. Виберіть конкретного пацієнта перед відправленням.",
+      }, { status:409 });
+    }
+    if (legacyBookingCount === 0) {
+      return Response.json({ error:"Пацієнта не знайдено в цій організації" }, { status:404 });
+    }
+    if (legacyBookingCount !== 1) {
+      return Response.json({
+        error:"Legacy-номер пов'язаний з кількома записами. Спочатку ідентифікуйте пацієнта в CRM.",
+      }, { status:409 });
+    }
   }
 
   const result = await sendWhatsApp(db, phone, text);
-  if (!result.ok) return Response.json({ error: result.error || "Не вдалося надіслати" }, { status: 400 });
+  if (!result.ok) return Response.json({ error:result.error || "Не вдалося надіслати" }, { status:400 });
 
   await db.prepare(
     `INSERT INTO patient_communications
        (organization_id, patient_id, phone_normalized, channel, direction, summary, actor, external_id)
      VALUES (?, ?, ?, 'whatsapp', 'outbound', ?, ?, ?)`
-  ).bind(ctx.organizationId, identity?.patientId || "", phone, text, member.email, result.idMessage || "").run();
+  ).bind(ctx.organizationId, storedPatientId, phone, text, member.email, result.idMessage || "").run();
   await audit(db, {
-    organizationId: ctx.organizationId,
-    actorEmail: member.email,
-    action: "contact_center_message_sent",
-    resource: "patient_communication",
-    targetId: identity?.patientId || phone,
-    details: { channel:"whatsapp", length:text.length, exactPatient:!!identity?.patientId },
+    organizationId:ctx.organizationId,
+    actorEmail:member.email,
+    action:"contact_center_message_sent",
+    resource:"patient_communication",
+    targetId:storedPatientId || `legacy:${phone}`,
+    details:{ channel:"whatsapp", length:text.length, identityKind:storedPatientId ? "patient" : "legacy" },
   });
 
-  return Response.json({ ok:true, message:{ direction:"outbound", channel:"whatsapp", text, actor:member.email, createdAt:new Date().toISOString() } });
+  return Response.json({
+    ok:true,
+    message:{ patientId:storedPatientId, direction:"outbound", channel:"whatsapp", text, actor:member.email, createdAt:new Date().toISOString() },
+  });
 }

--- a/app/staff/chat/page.tsx
+++ b/app/staff/chat/page.tsx
@@ -7,8 +7,10 @@ import { roleLabelUk } from "../../../lib/labels";
 type StaffInfo = { email: string; displayName: string; role: string };
 type Channel = "whatsapp" | "telegram" | "sms" | "email";
 type Conversation = {
+  conversationKey: string; identityKind: "patient" | "legacy"; patientId: string;
   phone: string; name: string; lastText: string; lastDirection: string;
   lastChannel: Channel; lastAt: string; issueCount: number; sharedPhone?: number | boolean;
+  legacyAmbiguous?: boolean;
 };
 type Message = { id?: number; patientId?: string; channel: Channel; direction: string; text: string; actor: string; createdAt: string };
 type DeliveryIssue = { id: number; channel: Channel; kind: string; status: string; error: string; createdAt: string; bookingId: number };
@@ -35,9 +37,10 @@ export default function StaffChatPage() {
   const [failedDeliveries, setFailedDeliveries] = useState(0);
   const [channel, setChannel] = useState("all");
   const [query, setQuery] = useState("");
-  const [active, setActive] = useState<string | null>(null);
+  const [active, setActive] = useState<Conversation | null>(null);
   const [activeName, setActiveName] = useState("");
   const [activeSharedPhone, setActiveSharedPhone] = useState(false);
+  const [activeLegacyAmbiguous, setActiveLegacyAmbiguous] = useState(false);
   const [replyChannels, setReplyChannels] = useState<string[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [issues, setIssues] = useState<DeliveryIssue[]>([]);
@@ -67,25 +70,36 @@ export default function StaffChatPage() {
 
   async function changeChannel(next: string) {
     setChannel(next); setActive(null); setMessages([]); setIssues([]); setLoaded(false);
-    setActiveSharedPhone(false); setReplyChannels([]);
+    setActiveSharedPhone(false); setActiveLegacyAmbiguous(false); setReplyChannels([]);
     await loadConversations(next);
   }
 
-  async function openConversation(phone: string) {
-    setActive(phone); setError(""); setMessages([]); setIssues([]); setDraft(""); setThreadLoading(true);
-    setActiveSharedPhone(false); setReplyChannels([]);
+  async function openConversation(conversation: Conversation) {
+    setActive(conversation); setError(""); setMessages([]); setIssues([]); setDraft(""); setThreadLoading(true);
+    setActiveSharedPhone(false); setActiveLegacyAmbiguous(false); setReplyChannels([]);
     try {
+      const identity = conversation.identityKind === "patient"
+        ? `patientId=${encodeURIComponent(conversation.patientId)}`
+        : `legacyPhone=${encodeURIComponent(conversation.phone)}`;
       const filter = channel === "all" ? "" : `&channel=${encodeURIComponent(channel)}`;
-      const res = await fetch(`/api/staff/chat?phone=${encodeURIComponent(phone)}${filter}`, { cache: "no-store" });
+      const res = await fetch(`/api/staff/chat?${identity}${filter}`, { cache: "no-store" });
       const data = await res.json().catch(() => ({})) as {
-        messages?: Message[]; name?: string; issues?: DeliveryIssue[];
-        sharedPhone?: boolean; availableReplyChannels?: string[];
+        messages?: Message[]; name?: string; phone?: string; issues?: DeliveryIssue[];
+        sharedPhone?: boolean; legacyAmbiguous?: boolean; availableReplyChannels?: string[]; error?: string;
       };
+      if (!res.ok) {
+        setError(data.error || "Не вдалося завантажити діалог");
+        return;
+      }
       setMessages(data.messages || []);
       setIssues(data.issues || []);
       setActiveName(data.name || "");
       setActiveSharedPhone(!!data.sharedPhone);
+      setActiveLegacyAmbiguous(!!data.legacyAmbiguous);
       setReplyChannels(Array.isArray(data.availableReplyChannels) ? data.availableReplyChannels : []);
+      if (data.phone && data.phone !== conversation.phone) {
+        setActive(current => current ? { ...current, phone:data.phone as string } : current);
+      }
     } catch {
       setError("Не вдалося завантажити діалог — перевірте зʼєднання");
     } finally {
@@ -100,7 +114,13 @@ export default function StaffChatPage() {
     const text = draft.trim();
     const res = await fetch("/api/staff/chat", {
       method: "POST", headers: { "content-type": "application/json" },
-      body: JSON.stringify({ phone: active, text, channel: "whatsapp" }),
+      body: JSON.stringify({
+        patientId:active.identityKind === "patient" ? active.patientId : "",
+        identityKind:active.identityKind,
+        phone:active.phone,
+        text,
+        channel:"whatsapp",
+      }),
     });
     const data = await res.json().catch(() => ({})) as { ok?: boolean; message?: Message; error?: string };
     setSending(false);
@@ -117,13 +137,13 @@ export default function StaffChatPage() {
   }, [conversations, query]);
 
   const stat = (name: string) => Number(channelStats.find(s => s.channel === name)?.count || 0);
-  const canReplyWhatsApp = !!active && replyChannels.includes("whatsapp") && !activeSharedPhone;
+  const canReplyWhatsApp = !!active && replyChannels.includes("whatsapp") && !activeSharedPhone && !activeLegacyAmbiguous;
 
   const body = forbidden
     ? <p className="notice error" role="alert">Контакт-центр доступний реєстратору або адміністратору.</p>
     : <div className="contactCenter">
         <section className="contactKpis" aria-label="Комунікації за каналами">
-          <article><small>Діалоги</small><b>{conversations.length}</b><span>у поточному фільтрі</span></article>
+          <article><small>Діалоги</small><b>{conversations.length}</b><span>окремі identity-scopes</span></article>
           <article><small>WhatsApp</small><b>{stat("whatsapp")}</b><span>подій у журналі</span></article>
           <article><small>Telegram</small><b>{stat("telegram")}</b><span>подій у журналі</span></article>
           <article className={failedDeliveries ? "warn" : ""}><small>Помилки доставки</small><b>{failedDeliveries}</b><span>потребують уваги</span></article>
@@ -145,10 +165,12 @@ export default function StaffChatPage() {
             {!loaded ? <p className="empty">Завантаження…</p>
               : filtered.length === 0 ? <p className="empty">Немає комунікацій у цьому фільтрі.</p>
                 : filtered.map(c => (
-                  <button key={c.phone} className={`chatListItem${active === c.phone ? " active" : ""}`} onClick={() => void openConversation(c.phone)}>
+                  <button key={c.conversationKey} className={`chatListItem${active?.conversationKey === c.conversationKey ? " active" : ""}`} onClick={() => void openConversation(c)}>
                     <span className={`channelDot ${c.lastChannel}`} aria-hidden="true" />
                     <b>{c.name || displayPhone(c.phone)}</b>
-                    {c.sharedPhone ? <small>Спільний номер · виберіть конкретну картку для відповіді</small> : <small>{c.lastDirection === "inbound" ? "" : "Вихідне · "}{c.lastText}</small>}
+                    {c.identityKind === "legacy"
+                      ? <small>Непривʼязана legacy-історія · {c.lastText}</small>
+                      : <small>{c.lastDirection === "inbound" ? "" : "Вихідне · "}{c.lastText}</small>}
                     <span className="chatListMeta">{CHANNEL_LABEL[c.lastChannel] || c.lastChannel} · {shortTime(c.lastAt)}</span>
                     {Number(c.issueCount || 0) > 0 && <span className="issueBadge">{c.issueCount}</span>}
                   </button>
@@ -156,15 +178,22 @@ export default function StaffChatPage() {
           </aside>
 
           <section className="chatThread">
-            {!active ? <div className="chatEmpty"><span className="contactEmptyIcon" aria-hidden="true" /><p>Оберіть діалог зліва</p><small>Історія WhatsApp, Telegram, SMS та e-mail в одному місці.</small></div>
+            {!active ? <div className="chatEmpty"><span className="contactEmptyIcon" aria-hidden="true" /><p>Оберіть діалог зліва</p><small>Exact-пацієнти розділені за patient_id; legacy-події не домішуються автоматично.</small></div>
               : <>
                   <header className="chatThreadHead">
-                    <div><b>{activeName || displayPhone(active)}</b><small>{displayPhone(active)}{activeSharedPhone ? " · спільний номер" : ""}</small></div>
-                    <span className="contactReplyHint">{canReplyWhatsApp ? "Відповідь: WhatsApp" : activeSharedPhone ? "Відповідь заблокована: неоднозначна особа" : "Вихідний канал недоступний"}</span>
+                    <div>
+                      <b>{activeName || displayPhone(active.phone)}</b>
+                      <small>{displayPhone(active.phone)}{active.identityKind === "legacy" ? " · legacy / неідентифіковано" : activeSharedPhone ? " · спільний контакт" : ""}</small>
+                    </div>
+                    <span className="contactReplyHint">{canReplyWhatsApp ? "Відповідь: WhatsApp" : activeLegacyAmbiguous ? "Відповідь заблокована: потрібна ідентифікація" : activeSharedPhone ? "Відповідь заблокована: спільний контакт" : "Вихідний канал недоступний"}</span>
                   </header>
-                  {activeSharedPhone && <div className="deliveryIssues" role="status">
-                    <b>Один номер використовують кілька пацієнтів</b>
-                    <span>Щоб не надіслати медичну інформацію не тій особі, відкрийте конкретну CRM-картку або заявку.</span>
+                  {active.identityKind === "legacy" && <div className="deliveryIssues" role="status">
+                    <b>Legacy-історія не є карткою пацієнта</b>
+                    <span>Повідомлення без patient_id зберігаються окремо й не приєднуються до exact-профілю за номером телефону.</span>
+                  </div>}
+                  {activeLegacyAmbiguous && <div className="deliveryIssues" role="status">
+                    <b>Відповідь заблокована</b>
+                    <span>Спочатку ідентифікуйте пацієнта в CRM, щоб не надіслати медичну інформацію не тій особі.</span>
                   </div>}
                   {issues.length > 0 && <div className="deliveryIssues" role="status">
                     <b>Не доставлено: {issues.length}</b>
@@ -182,7 +211,7 @@ export default function StaffChatPage() {
                   </div>
                   {error && <p className="notice error" role="alert">{error}</p>}
                   <form className="chatReply" onSubmit={reply}>
-                    <input value={draft} onChange={e => setDraft(e.target.value)} disabled={!canReplyWhatsApp} placeholder={activeSharedPhone ? "Оберіть конкретну картку пацієнта для відповіді" : "Відповідь пацієнту у WhatsApp…"} />
+                    <input value={draft} onChange={e => setDraft(e.target.value)} disabled={!canReplyWhatsApp} placeholder={activeLegacyAmbiguous ? "Спочатку ідентифікуйте пацієнта" : activeSharedPhone ? "Спільний контакт: ручна відповідь заблокована" : "Відповідь пацієнту у WhatsApp…"} />
                     <button type="submit" disabled={sending || !draft.trim() || !canReplyWhatsApp}>{sending ? "…" : "Надіслати"}</button>
                   </form>
                 </>}

--- a/tests/contact-center.behavior.test.mjs
+++ b/tests/contact-center.behavior.test.mjs
@@ -41,17 +41,18 @@ test("contact-center communication history stays tenant scoped across channels",
   assert.deepEqual(telegramOnly.map((row) => row.summary), ["Org1 Telegram"]);
 });
 
-test("contact-center route derives tenant, preserves exact ids, and fails closed on ambiguous or stale replies", async () => {
+test("contact-center route derives tenant, preserves exact ids, and fails closed on ambiguous compatibility reads", async () => {
   const route = await read("app/api/staff/chat/route.ts");
   assert.match(route, /requireOrgContext\(request, db\)/);
   assert.match(route, /patient_communications[\s\S]*organization_id = \?/);
   assert.match(route, /patient_id AS patientId/);
-  assert.match(route, /profileCount/);
-  assert.match(route, /if \(profileCount > 1\)/);
-  assert.match(route, /staleLinkedContact/);
-  assert.match(route, /p\.patient_id = b\.patient_id/);
-  assert.match(route, /p\.phone_normalized = b\.phone_normalized/);
-  assert.match(route, /Number\(identity\?\.staleLinkedContact \|\| 0\) === 1/);
+  assert.match(route, /resolvePhoneCompatibilityScope/);
+  assert.match(route, /if \(scope\.ambiguous\)/);
+  assert.match(route, /WHERE organization_id = \? AND patient_id = \? LIMIT 1/);
+  assert.match(route, /if \(!profile\)[\s\S]*status:404/);
+  assert.match(route, /exactProfileCount/);
+  assert.match(route, /legacyBookingCount/);
+  assert.match(route, /requestedPhone && requestedPhone !== phone/);
   assert.match(route, /availableReplyChannels/);
   assert.match(route, /contact_center_thread_viewed/);
   assert.match(route, /contact_center_message_sent/);
@@ -59,7 +60,7 @@ test("contact-center route derives tenant, preserves exact ids, and fails closed
   assert.match(route, /\(organization_id, patient_id, phone_normalized, channel/);
 });
 
-test("contact-center UI exposes channels, delivery issues, and shared-phone ambiguity", async () => {
+test("contact-center UI exposes identity scopes, channels, delivery issues, and reply ambiguity", async () => {
   const [page, globals, styles] = await Promise.all([
     read("app/staff/chat/page.tsx"),
     read("app/globals.css"),
@@ -68,10 +69,13 @@ test("contact-center UI exposes channels, delivery issues, and shared-phone ambi
   assert.match(page, /title="Контакт-центр"/);
   for (const channel of ["whatsapp", "telegram", "sms", "email"]) assert.match(page, new RegExp(`"${channel}"`));
   assert.match(page, /Помилки доставки/);
+  assert.match(page, /conversationKey/);
+  assert.match(page, /identityKind/);
   assert.match(page, /sharedPhone/);
-  assert.match(page, /Відповідь заблокована: неоднозначна особа/);
+  assert.match(page, /Відповідь заблокована: потрібна ідентифікація/);
   assert.match(page, /replyChannels\.includes\("whatsapp"\)/);
-  assert.match(page, /Один номер використовують кілька пацієнтів/);
+  assert.match(page, /Legacy-історія не є карткою пацієнта/);
+  assert.match(page, /спільний контакт/);
   assert.match(globals, /18-contact-center\.css/);
   assert.match(styles, /\.contactKpis/);
   assert.match(styles, /\.deliveryIssues/);

--- a/tests/global-messaging-primary-tenant.behavior.test.mjs
+++ b/tests/global-messaging-primary-tenant.behavior.test.mjs
@@ -83,6 +83,11 @@ test("secondary tenant contact-center cannot reply through primary WhatsApp", as
     await addOrganizationTwo(db);
     const phone = "380502223344";
     await addBooking(db, { id:202, organizationId:2, code:"CHAT-ORG2", phone });
+    await db.prepare(
+      `INSERT INTO patient_communications
+        (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
+       VALUES (2, '', ?, 'whatsapp', 'inbound', 'Org2 legacy thread', 'system')`
+    ).bind(phone).run();
     await setGlobal(db, "whatsapp_id_instance", "org1-instance");
     await setGlobal(db, "whatsapp_api_token_instance", "org1-token");
     await setGlobal(db, "whatsapp_enabled", "1");

--- a/tests/staff-chat-patient-identity.behavior.test.mjs
+++ b/tests/staff-chat-patient-identity.behavior.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const PHONE = "380971234567";
+const OTHER_PHONE = "380991112233";
+const PATIENT_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PATIENT_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PATIENT_OTHER_TENANT = "cccccccccccccccccccccccccccccccc";
+
+async function seedProfile(db, organizationId, patientId, name, phone = PHONE) {
+  await db.prepare(
+    `INSERT INTO patient_profiles
+      (patient_id, organization_id, phone_normalized, display_name, updated_by)
+     VALUES (?, ?, ?, ?, 'seed@example.com')`
+  ).bind(patientId, organizationId, phone, name).run();
+}
+
+async function seedCommunication(db, organizationId, patientId, phone, text) {
+  await db.prepare(
+    `INSERT INTO patient_communications
+      (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
+     VALUES (?, ?, ?, 'whatsapp', 'inbound', ?, 'system')`
+  ).bind(organizationId, patientId, phone, text).run();
+}
+
+function staffGet(path, cookie) {
+  return jsonRequest(path, undefined, { method:"GET", headers:{ cookie } });
+}
+
+function staffPost(path, cookie, body) {
+  return jsonRequest(path, body, { method:"POST", headers:{ cookie } });
+}
+
+test("staff chat separates exact patients and legacy history that share one phone", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db, 1, PATIENT_A, "Patient Alpha");
+    await seedProfile(db, 1, PATIENT_B, "Patient Beta");
+    await seedCommunication(db, 1, PATIENT_A, PHONE, "ALPHA_PRIVATE_MESSAGE");
+    await seedCommunication(db, 1, PATIENT_B, PHONE, "BETA_PRIVATE_MESSAGE");
+    await seedCommunication(db, 1, "", PHONE, "LEGACY_UNLINKED_MESSAGE");
+
+    const cookie = await seedStaffSession(db, {
+      email:"registrar@example.com", role:"registrar", displayName:"Registrar", organizationId:1,
+    });
+
+    const list = await callWorker(staffGet("/api/staff/chat", cookie), db);
+    assert.equal(list.status, 200);
+    const listBody = await list.json();
+    assert.equal(listBody.conversations.length, 3);
+    assert.deepEqual(
+      new Set(listBody.conversations.map((row) => row.conversationKey)),
+      new Set([`patient:${PATIENT_A}`, `patient:${PATIENT_B}`, `legacy:${PHONE}`]),
+    );
+
+    const alpha = await callWorker(staffGet(`/api/staff/chat?patientId=${PATIENT_A}`, cookie), db);
+    assert.equal(alpha.status, 200);
+    const alphaText = JSON.stringify(await alpha.json());
+    assert.match(alphaText, /ALPHA_PRIVATE_MESSAGE/);
+    assert.doesNotMatch(alphaText, /BETA_PRIVATE_MESSAGE|LEGACY_UNLINKED_MESSAGE/);
+
+    const beta = await callWorker(staffGet(`/api/staff/chat?patientId=${PATIENT_B}`, cookie), db);
+    assert.equal(beta.status, 200);
+    const betaText = JSON.stringify(await beta.json());
+    assert.match(betaText, /BETA_PRIVATE_MESSAGE/);
+    assert.doesNotMatch(betaText, /ALPHA_PRIVATE_MESSAGE|LEGACY_UNLINKED_MESSAGE/);
+
+    const legacy = await callWorker(staffGet(`/api/staff/chat?legacyPhone=${PHONE}`, cookie), db);
+    assert.equal(legacy.status, 200);
+    const legacyText = JSON.stringify(await legacy.json());
+    assert.match(legacyText, /LEGACY_UNLINKED_MESSAGE/);
+    assert.doesNotMatch(legacyText, /ALPHA_PRIVATE_MESSAGE|BETA_PRIVATE_MESSAGE/);
+  });
+});
+
+test("phone-only staff chat fails closed when a shared contact has multiple identity scopes", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db, 1, PATIENT_A, "Patient Alpha");
+    await seedProfile(db, 1, PATIENT_B, "Patient Beta");
+    await seedCommunication(db, 1, PATIENT_A, PHONE, "ALPHA_SECRET");
+    await seedCommunication(db, 1, PATIENT_B, PHONE, "BETA_SECRET");
+    await seedCommunication(db, 1, "", PHONE, "LEGACY_SECRET");
+
+    const cookie = await seedStaffSession(db, { email:"registrar@example.com", role:"registrar", organizationId:1 });
+    const response = await callWorker(staffGet(`/api/staff/chat?phone=${PHONE}`, cookie), db);
+    assert.equal(response.status, 409);
+    const text = await response.text();
+    assert.doesNotMatch(text, /ALPHA_SECRET|BETA_SECRET|LEGACY_SECRET/);
+  });
+});
+
+test("phone-only compatibility remains ambiguous across channel filters", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db, 1, PATIENT_A, "Patient Alpha");
+    await seedProfile(db, 1, PATIENT_B, "Patient Beta");
+    await seedCommunication(db, 1, PATIENT_A, PHONE, "ALPHA_WHATSAPP_SECRET");
+    await db.prepare(
+      `INSERT INTO patient_communications
+        (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
+       VALUES (1, ?, ?, 'telegram', 'inbound', 'BETA_TELEGRAM_SECRET', 'system')`
+    ).bind(PATIENT_B, PHONE).run();
+
+    const cookie = await seedStaffSession(db, { email:"registrar@example.com", role:"registrar", organizationId:1 });
+    const response = await callWorker(
+      staffGet(`/api/staff/chat?phone=${PHONE}&channel=whatsapp`, cookie),
+      db,
+    );
+    assert.equal(response.status, 409);
+    const text = await response.text();
+    assert.doesNotMatch(text, /ALPHA_WHATSAPP_SECRET|BETA_TELEGRAM_SECRET/);
+  });
+});
+
+test("legacy reply fails closed when the phone belongs to an exact profile", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db, 1, PATIENT_A, "Patient Alpha");
+    await seedCommunication(db, 1, "", PHONE, "OLD_LEGACY_MESSAGE");
+    const cookie = await seedStaffSession(db, { email:"registrar@example.com", role:"registrar", organizationId:1 });
+
+    const response = await callWorker(staffPost("/api/staff/chat", cookie, {
+      phone:PHONE, identityKind:"legacy", text:"Do not send", channel:"whatsapp",
+    }), db);
+    assert.equal(response.status, 409);
+
+    const count = await db.prepare(
+      `SELECT COUNT(*) AS count FROM patient_communications
+       WHERE organization_id = 1 AND direction = 'outbound'`
+    ).first();
+    assert.equal(Number(count?.count || 0), 0);
+  });
+});
+
+test("exact reply rejects a stale client phone before transport and exact lookup stays tenant-scoped", async () => {
+  await withD1(async (db) => {
+    await seedProfile(db, 1, PATIENT_A, "Patient Alpha", PHONE);
+    await seedProfile(db, 2, PATIENT_OTHER_TENANT, "Other Tenant", OTHER_PHONE);
+    await seedCommunication(db, 2, PATIENT_OTHER_TENANT, OTHER_PHONE, "OTHER_TENANT_SECRET");
+
+    const cookie = await seedStaffSession(db, { email:"registrar@example.com", role:"registrar", organizationId:1 });
+
+    const stale = await callWorker(staffPost("/api/staff/chat", cookie, {
+      patientId:PATIENT_A, phone:OTHER_PHONE, text:"Do not send", channel:"whatsapp",
+    }), db);
+    assert.equal(stale.status, 409);
+
+    // Supplying a same-tenant compatibility phone must never rescue a foreign exact patient ID.
+    const crossTenant = await callWorker(
+      staffGet(`/api/staff/chat?patientId=${PATIENT_OTHER_TENANT}&phone=${PHONE}`, cookie),
+      db,
+    );
+    assert.equal(crossTenant.status, 404);
+    assert.doesNotMatch(await crossTenant.text(), /OTHER_TENANT_SECRET/);
+  });
+});


### PR DESCRIPTION
## Security finding
Staff contact-center history must not use a phone number as patient identity. Two exact patients can legitimately share one family/contact phone; mixing those messages risks disclosure of one patient's communication history to another identity scope.

## Fix
- exact conversations are keyed/read only by immutable `patient_id`
- legacy rows with `patient_id=''` remain a separate explicit phone bucket
- phone-only compatibility reads fail closed with `409` when more than one identity scope exists, including cross-channel ambiguity
- exact patient lookups are tenant-scoped and never fall back to phone
- outbound exact replies require the current exact patient/contact and reject stale client phone values
- legacy outbound replies fail closed when an exact profile exists or the legacy phone is not uniquely backed by one unlinked booking
- delivery issues are scoped by patient identity
- staff UI selects `conversationKey`, not phone, and blocks replies for shared/ambiguous contacts

## Regression coverage
- two exact patients plus legacy history sharing one phone stay isolated
- phone-only ambiguous reads return `409` without content leakage
- ambiguity remains fail-closed across channel filters
- legacy outbound is blocked when an exact profile exists
- stale exact contact is rejected before transport
- cross-tenant exact patient IDs return `404` without phone fallback
- primary global messaging isolation remains covered

This is the clean reapplication of the final #318 patch-set onto current `main`; it intentionally omits the old branch's diagnostic history.

No database migration. No production deploy.