### PR TITLE
Tenant-scope integration settings

### DIFF
--- a/app/api/my-telegram-link/route.ts
+++ b/app/api/my-telegram-link/route.ts
@@ -1,11 +1,5 @@
 // Видає пацієнту (за активною сесією кабінету) deep-link для під'єднання
-// Telegram-бота: t.me/<bot>?start=<token>. Токен прив'язаний до tenant,
-// телефону та доведеної ідентичності пацієнта. Exact sessions additionally
-// carry immutable patient_id. Any DOB proof is canonicalized to a concrete
-// booking code before persistence so relatives with the same phone and DOB do
-// not collide in the legacy identity-key primary key.
-// Telegram bot config is still legacy-global and belongs to org 1, so secondary
-// tenants must not receive a deep-link until bot configuration is tenantized.
+// Telegram-бота. Bot username/token are loaded only from the session tenant.
 
 import {
   patientSessionScopeIsUnambiguous,
@@ -16,8 +10,6 @@ import { createTelegramLinkToken } from "../../../lib/telegram-link";
 import { telegramBotUsername } from "../../../lib/telegram";
 import { isRateLimited } from "../../../lib/rate-limit";
 import { dbBinding } from "../../../lib/db";
-
-const PRIMARY_ORGANIZATION_ID = 1;
 
 export async function POST(request: Request) {
   const db = dbBinding();
@@ -30,25 +22,16 @@ export async function POST(request: Request) {
       { status: 409, headers: { "cache-control": "no-store" } },
     );
   }
-  if (session.organizationId !== PRIMARY_ORGANIZATION_ID) {
-    return Response.json(
-      { error: "Telegram-канал ще не налаштований відділенням", botConfigured: false },
-      { status: 503, headers: { "cache-control": "no-store" } },
-    );
-  }
   if (await isRateLimited(db, request, "telegram-link", 6, 15)) {
     return Response.json({ error: "Забагато спроб. Спробуйте трохи пізніше." }, { status: 429 });
   }
 
-  const username = await telegramBotUsername(db);
+  const username = await telegramBotUsername(db, session.organizationId);
   if (!username) {
     return Response.json({ error: "Telegram-канал ще не налаштований відділенням", botConfigured: false }, { status: 503 });
   }
 
-  let telegramIdentity: PatientIdentityScope = {
-    kind: session.identityKind,
-    value: session.identityValue,
-  };
+  let telegramIdentity: PatientIdentityScope = { kind:session.identityKind, value:session.identityValue };
   if (session.identityKind === "dob") {
     const exactClause = session.patientId ? "AND patient_id = ?" : "";
     const bindings = session.patientId
@@ -59,11 +42,6 @@ export async function POST(request: Request) {
        WHERE organization_id = ? AND phone_normalized = ? AND date_of_birth = ? ${exactClause}
        ORDER BY id DESC LIMIT 2`,
     ).bind(...bindings).all<{ code:string }>();
-
-    // A legacy DOB session is permitted only while it maps to one booking.
-    // An exact patient_id session may have many bookings; any one explicitly
-    // linked booking is sufficient as a unique proof-key because patient_id is
-    // the persisted delivery authority.
     const chosen = session.patientId ? rows.results[0] : rows.results.length === 1 ? rows.results[0] : null;
     if (!chosen?.code) {
       return Response.json(
@@ -75,12 +53,7 @@ export async function POST(request: Request) {
   }
 
   const token = await createTelegramLinkToken(
-    db,
-    session.phoneNormalized,
-    session.organizationId,
-    telegramIdentity,
-    session.patientId || "",
+    db, session.phoneNormalized, session.organizationId, telegramIdentity, session.patientId || "",
   );
-  const url = `https://t.me/${username}?start=${token}`;
-  return Response.json({ url }, { headers: { "cache-control":"no-store" } });
+  return Response.json({ url:`https://t.me/${username}?start=${token}` }, { headers:{ "cache-control":"no-store" } });
 }

--- a/app/api/pay-link/route.ts
+++ b/app/api/pay-link/route.ts
@@ -1,8 +1,8 @@
-// Public GET exposes the primary department's generic payment link. POST starts a
-// booking-bound manual payment for an OTP-authenticated patient only while the
-// legacy payment destination remains primary-tenant scoped.
+// Public GET exposes the primary storefront payment link. Patient POST resolves
+// the destination from the authenticated patient's organization and never falls
+// back to the primary destination for secondary tenants.
 
-import { getSetting } from "../../../lib/settings";
+import { getOrganizationIntegrationSetting } from "../../../lib/settings";
 import { dbBinding } from "../../../lib/db";
 import { requirePatientSession } from "../../../lib/patient-auth";
 import { createPendingPayment, latestPaymentForBooking } from "../../../lib/payments";
@@ -11,15 +11,16 @@ import { recordAnalyticsEvent } from "../../../lib/analytics";
 const PRIMARY_ORGANIZATION_ID = 1;
 const DEFAULT_PRIVAT24_PAY_LINK = 'https://irc.privatbank.ua/qrstickws/route/qr?type=nextfastpay&params=%7B%22token%22%3A%22cadc7a4d-d56c-4005-9cfe-04a96077f8c1%22%7D';
 
-async function configuredPayLink(db: D1Database | null | undefined) {
-  if (!db) return DEFAULT_PRIVAT24_PAY_LINK;
-  return (await getSetting(db, "pay_link")) || DEFAULT_PRIVAT24_PAY_LINK;
+async function configuredPayLink(db: D1Database | null | undefined, organizationId: number) {
+  if (!db) return organizationId === PRIMARY_ORGANIZATION_ID ? DEFAULT_PRIVAT24_PAY_LINK : "";
+  const configured = await getOrganizationIntegrationSetting(db, organizationId, "pay_link");
+  return configured || (organizationId === PRIMARY_ORGANIZATION_ID ? DEFAULT_PRIVAT24_PAY_LINK : "");
 }
 
 export async function GET() {
   const db = dbBinding();
   return Response.json(
-    { payLink: await configuredPayLink(db) },
+    { payLink: await configuredPayLink(db, PRIMARY_ORGANIZATION_ID) },
     { headers: { "cache-control": "no-store" } },
   );
 }
@@ -30,7 +31,8 @@ export async function POST(request: Request) {
 
   const session = await requirePatientSession(request, db);
   if (!session) return Response.json({ error: "Потрібне підтвердження номера телефону" }, { status: 401 });
-  if (session.organizationId !== PRIMARY_ORGANIZATION_ID) {
+  const payLink = await configuredPayLink(db, session.organizationId);
+  if (!payLink) {
     return Response.json(
       { error: "Онлайн-оплата ще не налаштована для цієї організації" },
       { status: 503, headers: { "cache-control": "no-store" } },
@@ -49,17 +51,8 @@ export async function POST(request: Request) {
      FROM bookings
      WHERE organization_id = ? AND phone_normalized = ? AND code = ? AND ${identityClause} LIMIT 1`,
   ).bind(session.organizationId, session.phoneNormalized, code, session.identityValue).first<{
-    id: number;
-    code: string;
-    service: string;
-    serviceCode: string;
-    desiredDate: string;
-    desiredTime: string;
-    paymentStatus: string;
-    paymentAmount: number;
-    paidAmount: number;
-    category: string;
-    status: string;
+    id:number; code:string; service:string; serviceCode:string; desiredDate:string; desiredTime:string;
+    paymentStatus:string; paymentAmount:number; paidAmount:number; category:string; status:string;
   }>();
   if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
   if (booking.category !== "civilian" || booking.paymentAmount <= 0) {
@@ -75,45 +68,27 @@ export async function POST(request: Request) {
   const providerReference = `manual:${booking.code}`;
   try {
     const pending = await createPendingPayment(db as never, {
-      organizationId: session.organizationId,
-      bookingId: booking.id,
-      provider: "manual",
-      currency: "UAH",
-      providerReference,
+      organizationId:session.organizationId, bookingId:booking.id, provider:"manual", currency:"UAH", providerReference,
     });
     const payment = await latestPaymentForBooking(db as never, session.organizationId, booking.id);
     await recordAnalyticsEvent(db, {
-      eventName: "payment_started",
-      organizationId: session.organizationId,
-      serviceCode: booking.serviceCode,
-      patientCategory: "civilian",
-      source: "server",
+      eventName:"payment_started", organizationId:session.organizationId,
+      serviceCode:booking.serviceCode, patientCategory:"civilian", source:"server",
     });
     return Response.json({
-      booking: {
-        code: booking.code,
-        service: booking.service,
-        serviceCode: booking.serviceCode,
-        desiredDate: booking.desiredDate,
-        desiredTime: booking.desiredTime,
-        amount: booking.paymentAmount,
-        currency: "UAH",
-        paymentStatus: booking.paymentStatus,
+      booking:{
+        code:booking.code, service:booking.service, serviceCode:booking.serviceCode,
+        desiredDate:booking.desiredDate, desiredTime:booking.desiredTime,
+        amount:booking.paymentAmount, currency:"UAH", paymentStatus:booking.paymentStatus,
       },
-      payment,
-      created: pending.created,
-      payLink: await configuredPayLink(db),
-      purpose: `Сплата за медичні послуги, заявка ${booking.code}: ${booking.service}`,
-    }, { headers: { "cache-control": "no-store" } });
+      payment, created:pending.created, payLink,
+      purpose:`Сплата за медичні послуги, заявка ${booking.code}: ${booking.service}`,
+    }, { headers:{ "cache-control":"no-store" } });
   } catch (error) {
     const message = error instanceof Error ? error.message : "";
-    if (message === "payment_already_settled") {
-      return Response.json({ error: "Ця заявка вже повністю оплачена" }, { status: 409 });
-    }
-    if (message === "payment_reference_conflict") {
-      return Response.json({ error: "Платіжний референс уже використано" }, { status: 409 });
-    }
+    if (message === "payment_already_settled") return Response.json({ error:"Ця заявка вже повністю оплачена" }, { status:409 });
+    if (message === "payment_reference_conflict") return Response.json({ error:"Платіжний референс уже використано" }, { status:409 });
     console.error("payment_start_failed", booking.id, error);
-    return Response.json({ error: "Не вдалося підготувати оплату" }, { status: 500 });
+    return Response.json({ error:"Не вдалося підготувати оплату" }, { status:500 });
   }
 }

--- a/app/api/site-booking/route.ts
+++ b/app/api/site-booking/route.ts
@@ -249,7 +249,7 @@ export async function POST(request: Request) {
       codes,
       desiredDate: appointments[0].date,
       desiredTime: appointments[0].time,
-    })).catch((error) => { console.error("telegram_notify_failed", codes[0], error); return false; });
+    }), PUBLIC_ORGANIZATION_ID).catch((error) => { console.error("telegram_notify_failed", codes[0], error); return false; });
 
     return Response.json(responseBody, { status: 201, headers: { "cache-control": "no-store" } });
   } catch (error) {

--- a/app/api/staff/chat/route.ts
+++ b/app/api/staff/chat/route.ts
@@ -1,6 +1,5 @@
 // Єдиний контакт-центр пацієнтів. Історія береться з patient_communications
-// незалежно від каналу; ручні відповіді поки відправляються через legacy-global
-// WhatsApp-шлюз org 1.
+// незалежно від каналу; WhatsApp replies use only the current tenant gateway.
 //
 // КРИТИЧНА ІНВАРІАНТА: phone — лише контакт, а не identity. Exact-діалоги
 // групуються та читаються виключно за immutable patient_id. Старі записи без
@@ -10,11 +9,10 @@
 import { canViewPatientRegistry } from "../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../lib/tenant";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
-import { sendWhatsApp } from "../../../../lib/whatsapp";
+import { sendWhatsApp, whatsappConfig, whatsappConfigured } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
 
-const PRIMARY_ORGANIZATION_ID = 1;
 const CHANNELS = new Set(["whatsapp", "telegram", "sms", "email"]);
 const PATIENT_ID = /^[a-f0-9]{32}$/i;
 
@@ -71,6 +69,8 @@ export async function GET(request: Request) {
   if (!canViewPatientRegistry(member.role)) {
     return Response.json({ error: "Контакт-центр доступний реєстратору або адміністратору" }, { status: 403 });
   }
+  const wa = await whatsappConfig(db, orgId);
+  const canReplyWhatsApp = whatsappConfigured(wa) && wa.enabled;
 
   const url = new URL(request.url);
   const channel = channelFilter(request);
@@ -78,10 +78,6 @@ export async function GET(request: Request) {
   let legacyPhone = normalizeUkrainianPhone(url.searchParams.get("legacyPhone") || "");
   const compatibilityPhone = normalizeUkrainianPhone(url.searchParams.get("phone") || "");
 
-  // Backward compatibility for old bookmarks/callers: phone-only reads are
-  // accepted only when that phone maps to exactly one communication scope.
-  // Scope ambiguity is global across channels: a channel filter may narrow
-  // messages only after identity has already been resolved safely.
   if (!patientId && !legacyPhone && compatibilityPhone) {
     const scope = await resolvePhoneCompatibilityScope(db, orgId, compatibilityPhone, "");
     if (scope.ambiguous) {
@@ -100,11 +96,9 @@ export async function GET(request: Request) {
          FROM patient_profiles
          WHERE organization_id = ? AND patient_id = ? LIMIT 1`
       ).bind(orgId, patientId).first<{ name:string; phone:string; doNotContact:number }>();
-
       if (!profile) {
         return Response.json({ error:"Діалог пацієнта не знайдено" }, { status:404, headers:{ "cache-control":"no-store" } });
       }
-
       const rows = channel
         ? await db.prepare(
             `SELECT id, patient_id AS patientId, channel, direction, summary AS text, actor,
@@ -120,7 +114,6 @@ export async function GET(request: Request) {
              WHERE organization_id = ? AND patient_id = ?
              ORDER BY created_at ASC, id ASC LIMIT 400`
           ).bind(orgId, patientId).all();
-
       const issues = await db.prepare(
         `SELECT n.id, n.channel, n.kind, n.status, n.error, n.created_at AS createdAt, n.booking_id AS bookingId
          FROM patient_notifications n
@@ -128,19 +121,16 @@ export async function GET(request: Request) {
          WHERE n.organization_id = ? AND b.patient_id = ? AND n.status = 'failed'
          ORDER BY n.id DESC LIMIT 30`
       ).bind(orgId, patientId).all();
-
       const telegram = await db.prepare(
         `SELECT 1 AS linked FROM patient_telegram_identities
          WHERE organization_id = ? AND patient_id = ? AND telegram_chat_id != '' LIMIT 1`
       ).bind(orgId, patientId).first<{ linked:number }>();
-
       const shared = profile.phone
         ? await db.prepare(
             `SELECT COUNT(*) AS count FROM patient_profiles
              WHERE organization_id = ? AND phone_normalized = ?`
           ).bind(orgId, profile.phone).first<{ count:number }>()
         : null;
-
       await audit(db, {
         organizationId: orgId,
         actorEmail: member.email,
@@ -149,7 +139,6 @@ export async function GET(request: Request) {
         targetId: patientId,
         details: { channel:channel || "all", identityKind:"patient" },
       });
-
       return Response.json({
         conversationKey:`patient:${patientId}`,
         identityKind:"patient",
@@ -160,7 +149,7 @@ export async function GET(request: Request) {
         messages:rows.results,
         issues:issues.results,
         availableReplyChannels:
-          orgId === PRIMARY_ORGANIZATION_ID
+          canReplyWhatsApp
           && !!profile.phone
           && Number(profile.doNotContact || 0) !== 1
           && Number(shared?.count || 0) <= 1
@@ -185,11 +174,9 @@ export async function GET(request: Request) {
            WHERE organization_id = ? AND patient_id = '' AND phone_normalized = ?
            ORDER BY created_at ASC, id ASC LIMIT 400`
         ).bind(orgId, legacyPhone).all();
-
     if (rows.results.length === 0) {
       return Response.json({ error:"Legacy-діалог не знайдено" }, { status:404, headers:{ "cache-control":"no-store" } });
     }
-
     const identity = await db.prepare(
       `WITH input(org_id, phone) AS (VALUES (?, ?))
        SELECT
@@ -202,7 +189,6 @@ export async function GET(request: Request) {
           HAVING COUNT(*) = 1), '') AS name
        FROM input i`
     ).bind(orgId, legacyPhone).first<{ exactProfileCount:number; legacyBookingCount:number; name:string }>();
-
     const issues = await db.prepare(
       `SELECT n.id, n.channel, n.kind, n.status, n.error, n.created_at AS createdAt, n.booking_id AS bookingId
        FROM patient_notifications n
@@ -210,10 +196,8 @@ export async function GET(request: Request) {
        WHERE n.organization_id = ? AND b.patient_id = '' AND b.phone_normalized = ? AND n.status = 'failed'
        ORDER BY n.id DESC LIMIT 30`
     ).bind(orgId, legacyPhone).all();
-
     const exactProfileCount = Number(identity?.exactProfileCount || 0);
     const legacyBookingCount = Number(identity?.legacyBookingCount || 0);
-
     await audit(db, {
       organizationId:orgId,
       actorEmail:member.email,
@@ -222,7 +206,6 @@ export async function GET(request: Request) {
       targetId:`legacy:${legacyPhone}`,
       details:{ channel:channel || "all", identityKind:"legacy", exactProfileCount, legacyBookingCount },
     });
-
     return Response.json({
       conversationKey:`legacy:${legacyPhone}`,
       identityKind:"legacy",
@@ -233,7 +216,7 @@ export async function GET(request: Request) {
       messages:rows.results,
       issues:issues.results,
       availableReplyChannels:
-        orgId === PRIMARY_ORGANIZATION_ID && exactProfileCount === 0 && legacyBookingCount === 1
+        canReplyWhatsApp && exactProfileCount === 0 && legacyBookingCount === 1
           ? ["whatsapp"] : [],
       linkedTelegram:false,
       legacyAmbiguous:exactProfileCount > 0 || legacyBookingCount !== 1,
@@ -354,13 +337,11 @@ export async function GET(request: Request) {
   const failed = await db.prepare(
     `SELECT COUNT(*) AS count FROM patient_notifications WHERE organization_id = ? AND status = 'failed'`
   ).bind(orgId).first<{ count:number }>();
-
   const normalizedConversations = (conversations.results as Array<Record<string, unknown>>).map((row) => ({
     ...row,
     sharedPhone:Number(row.exactProfileCount || 0) > 1,
     legacyAmbiguous:row.identityKind === "legacy" && Number(row.exactProfileCount || 0) > 0,
   }));
-
   return Response.json({
     conversations:normalizedConversations,
     channelStats:channelStats.results,
@@ -379,9 +360,6 @@ export async function POST(request: Request) {
   if (!canViewPatientRegistry(member.role)) {
     return Response.json({ error:"Відповідати може реєстратор або адміністратору" }, { status:403 });
   }
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID) {
-    return Response.json({ error:"Вихідний WhatsApp ще не налаштований для цієї організації" }, { status:403 });
-  }
 
   const body = await request.json().catch(() => ({})) as {
     patientId?:string; phone?:string; text?:string; channel?:string; identityKind?:string;
@@ -397,7 +375,6 @@ export async function POST(request: Request) {
 
   let phone = requestedPhone;
   let storedPatientId = "";
-
   if (patientId) {
     const profile = await db.prepare(
       `SELECT phone_normalized AS phone, do_not_contact AS doNotContact
@@ -440,9 +417,7 @@ export async function POST(request: Request) {
         error:"Цей номер належить exact-профілю. Виберіть конкретного пацієнта перед відправленням.",
       }, { status:409 });
     }
-    if (legacyBookingCount === 0) {
-      return Response.json({ error:"Пацієнта не знайдено в цій організації" }, { status:404 });
-    }
+    if (legacyBookingCount === 0) return Response.json({ error:"Пацієнта не знайдено в цій організації" }, { status:404 });
     if (legacyBookingCount !== 1) {
       return Response.json({
         error:"Legacy-номер пов'язаний з кількома записами. Спочатку ідентифікуйте пацієнта в CRM.",
@@ -450,9 +425,8 @@ export async function POST(request: Request) {
     }
   }
 
-  const result = await sendWhatsApp(db, phone, text);
+  const result = await sendWhatsApp(db, phone, text, ctx.organizationId);
   if (!result.ok) return Response.json({ error:result.error || "Не вдалося надіслати" }, { status:400 });
-
   await db.prepare(
     `INSERT INTO patient_communications
        (organization_id, patient_id, phone_normalized, channel, direction, summary, actor, external_id)
@@ -466,7 +440,6 @@ export async function POST(request: Request) {
     targetId:storedPatientId || `legacy:${phone}`,
     details:{ channel:"whatsapp", length:text.length, identityKind:storedPatientId ? "patient" : "legacy" },
   });
-
   return Response.json({
     ok:true,
     message:{ patientId:storedPatientId, direction:"outbound", channel:"whatsapp", text, actor:member.email, createdAt:new Date().toISOString() },

--- a/app/api/staff/settings/messaging-test/route.ts
+++ b/app/api/staff/settings/messaging-test/route.ts
@@ -1,24 +1,24 @@
-// Надсилає тестове SMS / e-mail через збережений шлюз, щоб адміністратор міг
-// перевірити налаштування в один клік (аналог telegram-test). Помилку шлюзу
-// повертає дослівно, щоб було видно причину (401, таймаут, заборонена адреса).
-// Messaging gateway settings are legacy-global, so only org 1 may use them.
+// Надсилає тестове SMS / e-mail через шлюз поточної організації.
+// Integration credentials are resolved only from the server-derived tenant
+// context; secondary organizations never inherit org1 gateways.
 
-import { requireOrgContext } from "../../../../../lib/tenant";
-import { getSettings } from "../../../../../lib/settings";
+import { canManageSystem } from "../../../../../lib/staff-auth";
+import { requireSystemOrgContext } from "../../../../../lib/tenant";
+import { getOrganizationIntegrationSettings } from "../../../../../lib/settings";
 import { createMessagingProvider } from "../../../../../lib/providers/messaging";
 import { normalizeUkrainianPhone } from "../../../../../lib/phone";
 import { dbBinding } from "../../../../../lib/db";
+import { audit } from "../../../../../lib/audit";
 
-const PRIMARY_ORGANIZATION_ID = 1;
 const TEST_TEXT = "RadiologyOS: тестове повідомлення. Канал сповіщень налаштовано правильно.";
 
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
+  const ctx = await requireSystemOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "Доступно лише адміністратору основної організації" }, { status: 403 });
+  if (!canManageSystem(ctx.role)) {
+    return Response.json({ error: "Доступно лише системному адміністратору організації" }, { status: 403 });
   }
 
   const body = await request.json().catch(() => ({})) as { channel?: string; to?: string };
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
   if (!channel) return Response.json({ error: "Невідомий канал" }, { status: 400 });
   if (!to) return Response.json({ error: "Вкажіть отримувача для тесту" }, { status: 400 });
 
-  const cfg = await getSettings(db, [
+  const cfg = await getOrganizationIntegrationSettings(db, ctx.organizationId, [
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
   ]);
@@ -50,5 +50,13 @@ export async function POST(request: Request) {
   } catch (error) {
     return Response.json({ error: error instanceof Error ? error.message : "Не вдалося надіслати" }, { status: 400 });
   }
+
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "messaging_integration_test",
+    resource: "settings",
+    details: { scope: "organization_integrations", channel },
+  });
   return Response.json({ ok: true });
 }

--- a/app/api/staff/settings/route.ts
+++ b/app/api/staff/settings/route.ts
@@ -1,17 +1,16 @@
-// Department settings managed by an administrator: Telegram notifications for
-// new bookings and the PrivatBank payment link for civilian patients.
-// These settings are still legacy-global in app_settings, so until they are
-// tenantized only the primary/public organization may administer them.
+// Integration settings managed in the current organization control plane.
+// Every read/write is scoped by the server-derived organization context.
 
 import { canManageSystem } from "../../../../lib/staff-auth";
 import { requireSystemOrgContext } from "../../../../lib/tenant";
-import { getSettings, setSetting } from "../../../../lib/settings";
+import {
+  getOrganizationIntegrationSettings,
+  setOrganizationIntegrationSetting,
+} from "../../../../lib/settings";
 import { safeOutboundUrl } from "../../../../lib/outbound";
 import { parseLeadHours, REMINDER_LEAD_KEY } from "../../../../lib/reminders";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
-
-const PRIMARY_ORGANIZATION_ID = 1;
 
 function clean(value: unknown, max: number) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
@@ -47,11 +46,11 @@ export async function GET(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireSystemOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || !canManageSystem(ctx.role)) {
-    return Response.json({ error: "Налаштування доступні лише системному адміністратору основної організації" }, { status: 403 });
+  if (!canManageSystem(ctx.role)) {
+    return Response.json({ error: "Налаштування доступні лише системному адміністратору організації" }, { status: 403 });
   }
 
-  const values = await getSettings(db, SETTING_KEYS);
+  const values = await getOrganizationIntegrationSettings(db, ctx.organizationId, SETTING_KEYS);
   return Response.json({
     settings: settingsView(values),
     staff: ctx.member,
@@ -63,8 +62,8 @@ export async function PUT(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requireSystemOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || !canManageSystem(ctx.role)) {
-    return Response.json({ error: "Змінювати налаштування може лише системний адміністратор основної організації" }, { status: 403 });
+  if (!canManageSystem(ctx.role)) {
+    return Response.json({ error: "Змінювати налаштування може лише системний адміністратор організації" }, { status: 403 });
   }
 
   const body = await request.json().catch(() => ({})) as {
@@ -79,19 +78,12 @@ export async function PUT(request: Request) {
   const smsGatewayUrl = clean(body.smsGatewayUrl, 600);
   const emailGatewayUrl = clean(body.emailGatewayUrl, 600);
   const emailGatewayFrom = clean(body.emailGatewayFrom, 254);
-  // Секрети шлюзів: порожнє зберігає поточне, "-" очищує (як токен Telegram).
   const smsAuth = clean(body.smsGatewayAuth, 400);
   const emailAuth = clean(body.emailGatewayAuth, 400);
-  // Empty token keeps the stored one (so the admin isn't forced to re-enter the
-  // secret on every save); a value of "-" explicitly clears it.
   const token = clean(body.telegramBotToken, 120);
 
   let paymentUrl: URL | null = null;
-  try {
-    paymentUrl = payLink ? new URL(payLink) : null;
-  } catch {
-    paymentUrl = null;
-  }
+  try { paymentUrl = payLink ? new URL(payLink) : null; } catch { paymentUrl = null; }
   if (payLink && (!paymentUrl || paymentUrl.protocol !== "https:" || paymentUrl.username || paymentUrl.password)) {
     return Response.json({ error: "Посилання на оплату має починатися з https://" }, { status: 400 });
   }
@@ -110,27 +102,31 @@ export async function PUT(request: Request) {
   if (token && token !== "-" && !/^\d{6,}:[A-Za-z0-9_-]{20,}$/.test(token)) {
     return Response.json({ error: "Некоректний токен бота Telegram" }, { status: 400 });
   }
-  if (token === "-") await setSetting(db, "telegram_bot_token", "");
-  else if (token) await setSetting(db, "telegram_bot_token", token);
-  await setSetting(db, "telegram_chat_id", chatId);
-  await setSetting(db, "pay_link", payLink);
-  await setSetting(db, "external_ics_url", externalIcsUrl);
-  await setSetting(db, "patient_reminders_enabled", body.remindersEnabled ? "1" : "");
-  await setSetting(db, REMINDER_LEAD_KEY, parseLeadHours(clean(body.reminderLeadHours, 40)).join(", "));
-  await setSetting(db, "sms_gateway_url", smsGatewayUrl);
-  await setSetting(db, "email_gateway_url", emailGatewayUrl);
-  await setSetting(db, "email_gateway_from", emailGatewayFrom);
-  if (smsAuth === "-") await setSetting(db, "sms_gateway_auth", "");
-  else if (smsAuth) await setSetting(db, "sms_gateway_auth", smsAuth);
-  if (emailAuth === "-") await setSetting(db, "email_gateway_auth", "");
-  else if (emailAuth) await setSetting(db, "email_gateway_auth", emailAuth);
+
+  const set = (key: string, value: string) =>
+    setOrganizationIntegrationSetting(db, ctx.organizationId, key, value, ctx.member.email);
+  if (token === "-") await set("telegram_bot_token", "");
+  else if (token) await set("telegram_bot_token", token);
+  await set("telegram_chat_id", chatId);
+  await set("pay_link", payLink);
+  await set("external_ics_url", externalIcsUrl);
+  await set("patient_reminders_enabled", body.remindersEnabled ? "1" : "");
+  await set(REMINDER_LEAD_KEY, parseLeadHours(clean(body.reminderLeadHours, 40)).join(", "));
+  await set("sms_gateway_url", smsGatewayUrl);
+  await set("email_gateway_url", emailGatewayUrl);
+  await set("email_gateway_from", emailGatewayFrom);
+  if (smsAuth === "-") await set("sms_gateway_auth", "");
+  else if (smsAuth) await set("sms_gateway_auth", smsAuth);
+  if (emailAuth === "-") await set("email_gateway_auth", "");
+  else if (emailAuth) await set("email_gateway_auth", emailAuth);
 
   await audit(db, {
     organizationId: ctx.organizationId,
     actorEmail: ctx.member.email,
     action: "settings_update",
     resource: "settings",
+    details: { scope: "organization_integrations" },
   });
-  const values = await getSettings(db, SETTING_KEYS);
+  const values = await getOrganizationIntegrationSettings(db, ctx.organizationId, SETTING_KEYS);
   return Response.json({ ok: true, settings: settingsView(values) });
 }

--- a/app/api/staff/settings/telegram-test/route.ts
+++ b/app/api/staff/settings/telegram-test/route.ts
@@ -1,24 +1,23 @@
-// Sends a test message to the department Telegram chat using the saved
-// settings, so an admin can verify the bot token and chat id in one click.
-// Telegram bot settings are legacy-global, so only org 1 may use them.
+// Sends a test message to the current organization's Telegram chat using its
+// organization-scoped integration settings. Authorization follows the same
+// system control plane as the settings endpoint.
 
-import { requireOrgContext } from "../../../../../lib/tenant";
+import { canManageSystem } from "../../../../../lib/staff-auth";
+import { requireSystemOrgContext } from "../../../../../lib/tenant";
 import { sendTelegramResult } from "../../../../../lib/telegram";
 import { dbBinding } from "../../../../../lib/db";
-
-const PRIMARY_ORGANIZATION_ID = 1;
 
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
+  const ctx = await requireSystemOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "Доступно лише адміністратору основної організації" }, { status: 403 });
+  if (!canManageSystem(ctx.role)) {
+    return Response.json({ error: "Доступно лише системному адміністратору організації" }, { status: 403 });
   }
 
   const text = "✅ <b>RadiologyOS</b>\nТестове повідомлення. Сповіщення про заявки налаштовано правильно.";
-  const result = await sendTelegramResult(db, text);
+  const result = await sendTelegramResult(db, text, ctx.organizationId);
   if (!result.ok) return Response.json({ error: result.error || "Не вдалося надіслати" }, { status: 400 });
   return Response.json({ ok: true });
 }

--- a/app/api/staff/settings/telegram-webhook/route.ts
+++ b/app/api/staff/settings/telegram-webhook/route.ts
@@ -1,34 +1,57 @@
-// Вмикає Telegram-канал для пацієнтів: реєструє webhook бота на наш публічний
-// ендпоінт із секретним заголовком. Telegram config is legacy-global, so only
-// the primary/public organization may administer it until storage is tenantized.
+// Enables the patient Telegram channel for the current organization by
+// registering this installation's public webhook with an organization-scoped
+// secret. Authorization follows the same system control plane as integration
+// settings; medical roles do not gain integration-administration privileges.
 
-import { requireOrgContext } from "../../../../../lib/tenant";
-import { getSettings, setSetting } from "../../../../../lib/settings";
+import { canManageSystem } from "../../../../../lib/staff-auth";
+import { requireSystemOrgContext } from "../../../../../lib/tenant";
+import {
+  getOrganizationIntegrationSettings,
+  setOrganizationIntegrationSetting,
+} from "../../../../../lib/settings";
 import { setTelegramWebhook, telegramBotUsername } from "../../../../../lib/telegram";
 import { newSessionToken } from "../../../../../lib/auth";
 import { dbBinding } from "../../../../../lib/db";
-
-const PRIMARY_ORGANIZATION_ID = 1;
+import { audit } from "../../../../../lib/audit";
 
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
+  const ctx = await requireSystemOrgContext(request, db);
   if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "Доступно лише адміністратору основної організації" }, { status: 403 });
+  if (!canManageSystem(ctx.role)) {
+    return Response.json({ error: "Доступно лише системному адміністратору організації" }, { status: 403 });
   }
 
   const { telegram_bot_token: token, telegram_webhook_secret: existing } =
-    await getSettings(db, ["telegram_bot_token", "telegram_webhook_secret"]);
+    await getOrganizationIntegrationSettings(
+      db,
+      ctx.organizationId,
+      ["telegram_bot_token", "telegram_webhook_secret"],
+    );
   if (!token) return Response.json({ error: "Спочатку збережіть токен бота Telegram" }, { status: 400 });
 
   const secret = existing || newSessionToken();
   const webhookUrl = `${new URL(request.url).origin}/api/telegram/webhook`;
-  const result = await setTelegramWebhook(db, webhookUrl, secret);
+  const result = await setTelegramWebhook(db, webhookUrl, secret, ctx.organizationId);
   if (!result.ok) return Response.json({ error: result.error || "Не вдалося зареєструвати webhook" }, { status: 400 });
 
-  if (!existing) await setSetting(db, "telegram_webhook_secret", secret);
-  const username = await telegramBotUsername(db);
+  if (!existing) {
+    await setOrganizationIntegrationSetting(
+      db,
+      ctx.organizationId,
+      "telegram_webhook_secret",
+      secret,
+      ctx.member.email,
+    );
+  }
+  const username = await telegramBotUsername(db, ctx.organizationId);
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "telegram_webhook_enable",
+    resource: "settings",
+    details: { scope: "organization_integrations" },
+  });
   return Response.json({ ok: true, username });
 }

--- a/app/api/staff/whatsapp/route.ts
+++ b/app/api/staff/whatsapp/route.ts
@@ -1,37 +1,54 @@
-// Підключення WhatsApp (green-api). Storage is still legacy-global in
-// app_settings, so only the primary/public organization may administer it
-// until WhatsApp configuration becomes per-tenant.
+// Підключення WhatsApp (green-api) для поточної організації.
+// Credentials and webhook secret live in the organization-scoped integration
+// store and authorization follows the system control plane.
 
-import { requireOrgContext } from "../../../../lib/tenant";
-import { getSetting, getSettings, setSetting } from "../../../../lib/settings";
+import { canManageSystem } from "../../../../lib/staff-auth";
+import { requireSystemOrgContext } from "../../../../lib/tenant";
+import {
+  getOrganizationIntegrationSetting,
+  setOrganizationIntegrationSetting,
+} from "../../../../lib/settings";
 import { whatsappConfig, whatsappConfigured } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
-
-const PRIMARY_ORGANIZATION_ID = 1;
+import { audit } from "../../../../lib/audit";
 
 function clean(value: unknown, max: number) {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
 }
 
-async function ensureWebhookToken(db: D1Database): Promise<string> {
-  const existing = await getSetting(db, "whatsapp_webhook_token");
+async function ensureWebhookToken(
+  db: D1Database,
+  organizationId: number,
+  actorEmail: string,
+): Promise<string> {
+  const existing = await getOrganizationIntegrationSetting(db, organizationId, "whatsapp_webhook_token");
   if (existing) return existing;
   const token = crypto.randomUUID().replace(/-/g, "");
-  await setSetting(db, "whatsapp_webhook_token", token);
+  await setOrganizationIntegrationSetting(db, organizationId, "whatsapp_webhook_token", token, actorEmail);
+  await audit(db, {
+    organizationId,
+    actorEmail,
+    action: "whatsapp_webhook_secret_create",
+    resource: "settings",
+    details: { scope: "organization_integrations" },
+  });
   return token;
+}
+
+async function requireIntegrationAdmin(request: Request, db: D1Database) {
+  const ctx = await requireSystemOrgContext(request, db);
+  if (!ctx || !canManageSystem(ctx.role)) return null;
+  return ctx;
 }
 
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
-  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "WhatsApp налаштовує лише адміністратор основної організації" }, { status: 403 });
-  }
+  const ctx = await requireIntegrationAdmin(request, db);
+  if (!ctx) return Response.json({ error: "WhatsApp доступний лише системному адміністратору організації" }, { status: 403 });
 
-  const cfg = await whatsappConfig(db);
-  const token = await ensureWebhookToken(db);
+  const cfg = await whatsappConfig(db, ctx.organizationId);
+  const token = await ensureWebhookToken(db, ctx.organizationId, ctx.member.email);
   const origin = new URL(request.url).origin;
   return Response.json({
     settings: {
@@ -48,24 +65,32 @@ export async function GET(request: Request) {
 export async function PUT(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
-  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
-  if (ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "Змінювати WhatsApp може лише адміністратор основної організації" }, { status: 403 });
-  }
+  const ctx = await requireIntegrationAdmin(request, db);
+  if (!ctx) return Response.json({ error: "Змінювати WhatsApp може лише системний адміністратор організації" }, { status: 403 });
 
   const body = await request.json().catch(() => ({})) as { idInstance?: string; apiToken?: string; enabled?: boolean };
   const idInstance = clean(body.idInstance, 40);
   const apiToken = clean(body.apiToken, 200);
-  // Порожнє поле лишає збережене; "-" очищає (як з іншими секретами).
-  if (idInstance === "-") await setSetting(db, "whatsapp_id_instance", "");
-  else if (idInstance) await setSetting(db, "whatsapp_id_instance", idInstance);
-  if (apiToken === "-") await setSetting(db, "whatsapp_api_token_instance", "");
-  else if (apiToken) await setSetting(db, "whatsapp_api_token_instance", apiToken);
-  await setSetting(db, "whatsapp_enabled", body.enabled ? "1" : "");
+  const set = (key: string, value: string) =>
+    setOrganizationIntegrationSetting(db, ctx.organizationId, key, value, ctx.member.email);
 
-  const cfg = await whatsappConfig(db);
-  const { whatsapp_webhook_token: token } = await getSettings(db, ["whatsapp_webhook_token"]);
+  // Порожнє поле лишає збережене; "-" очищає (як з іншими секретами).
+  if (idInstance === "-") await set("whatsapp_id_instance", "");
+  else if (idInstance) await set("whatsapp_id_instance", idInstance);
+  if (apiToken === "-") await set("whatsapp_api_token_instance", "");
+  else if (apiToken) await set("whatsapp_api_token_instance", apiToken);
+  await set("whatsapp_enabled", body.enabled ? "1" : "");
+
+  const token = await ensureWebhookToken(db, ctx.organizationId, ctx.member.email);
+  const cfg = await whatsappConfig(db, ctx.organizationId);
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "whatsapp_settings_update",
+    resource: "settings",
+    details: { scope: "organization_integrations" },
+  });
+
   const origin = new URL(request.url).origin;
   return Response.json({
     ok: true,

--- a/app/api/staff/whatsapp/test/route.ts
+++ b/app/api/staff/whatsapp/test/route.ts
@@ -1,24 +1,36 @@
-// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест»).
-// WhatsApp config is legacy-global, so only the primary/public organization
-// may use the test endpoint until configuration is tenantized.
-import { requireOrgContext } from "../../../../../lib/tenant";
+// Тестове WhatsApp-повідомлення (кнопка «Надіслати тест») через
+// integration settings поточної організації.
+
+import { canManageSystem } from "../../../../../lib/staff-auth";
+import { requireSystemOrgContext } from "../../../../../lib/tenant";
 import { normalizeUkrainianPhone } from "../../../../../lib/phone";
 import { sendWhatsApp } from "../../../../../lib/whatsapp";
 import { dbBinding } from "../../../../../lib/db";
-
-const PRIMARY_ORGANIZATION_ID = 1;
+import { audit } from "../../../../../lib/audit";
 
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
-  const ctx = await requireOrgContext(request, db);
-  if (!ctx || ctx.organizationId !== PRIMARY_ORGANIZATION_ID || ctx.role !== "admin") {
-    return Response.json({ error: "Лише адміністратор основної організації" }, { status: 403 });
+  const ctx = await requireSystemOrgContext(request, db);
+  if (!ctx || !canManageSystem(ctx.role)) {
+    return Response.json({ error: "Лише системний адміністратор організації" }, { status: 403 });
   }
   const body = await request.json().catch(() => ({})) as { phone?: string };
   const phone = normalizeUkrainianPhone(String(body.phone || ""));
   if (!phone) return Response.json({ error: "Вкажіть коректний номер для тесту" }, { status: 400 });
-  const result = await sendWhatsApp(db, phone, "Тестове повідомлення від відділення променевої діагностики. WhatsApp підключено ✅");
+  const result = await sendWhatsApp(
+    db,
+    phone,
+    "Тестове повідомлення від відділення променевої діагностики. WhatsApp підключено ✅",
+    ctx.organizationId,
+  );
   if (!result.ok) return Response.json({ error: result.error || "Не вдалося надіслати" }, { status: 400 });
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "whatsapp_integration_test",
+    resource: "settings",
+    details: { scope: "organization_integrations" },
+  });
   return Response.json({ ok: true });
 }

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -1,25 +1,23 @@
-// Публічний webhook бота Telegram. Приймає оновлення (натискання «Старт» із
-// токеном) і прив'язує chat_id до пацієнта. Захищено секретним заголовком, який
-// ми задали у setWebhook — сторонні запити відхиляються.
+// Public Telegram webhook. The bot API secret resolves exactly one organization;
+// duplicate or stale secrets fail closed. Patient links can then bind only to
+// that bot's tenant.
 
-import { getSettings } from "../../../../lib/settings";
+import { resolveOrganizationByIntegrationSecret } from "../../../../lib/settings";
 import { handleTelegramUpdate } from "../../../../lib/telegram-link";
 import { sendTelegramTo } from "../../../../lib/telegram";
 import { dbBinding } from "../../../../lib/db";
 
 export async function POST(request: Request) {
   const db = dbBinding();
-  if (!db) return new Response("ok"); // best-effort: не даємо Telegram ретраїти вічно
-  const { telegram_webhook_secret: secret } = await getSettings(db, ["telegram_webhook_secret"]);
+  if (!db) return new Response("ok");
   const provided = request.headers.get("x-telegram-bot-api-secret-token") || "";
-  if (!secret || provided !== secret) {
-    return new Response("forbidden", { status: 401 });
-  }
+  const organizationId = await resolveOrganizationByIntegrationSecret(db, "telegram_webhook_secret", provided);
+  if (!organizationId) return new Response("forbidden", { status: 401 });
 
   const update = await request.json().catch(() => ({}));
-  const { chatId, reply } = await handleTelegramUpdate(db, update);
+  const { chatId, reply } = await handleTelegramUpdate(db, update, organizationId);
   if (chatId && reply) {
-    await sendTelegramTo(db, chatId, reply).catch(() => ({ ok: false }));
+    await sendTelegramTo(db, chatId, reply, organizationId).catch(() => ({ ok: false }));
   }
   return new Response("ok");
 }

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,100 +1,81 @@
-// Публічний вебхук green-api для вхідних WhatsApp-повідомлень. Захищений
-// секретним ?token=. Глобальна green-api конфігурація належить org 1, тому
-// весь webhook data-path явно прив'язаний до основної організації: lookup
-// записів, inbound/outbound communications і bot replies.
+// Public Green API webhook. The webhook secret resolves exactly one organization;
+// every lookup, communication insert and bot reply stays inside that tenant.
 
-import { getSetting } from "../../../../lib/settings";
+import { resolveOrganizationByIntegrationSecret } from "../../../../lib/settings";
 import { isRateLimited } from "../../../../lib/rate-limit";
-import { parseSiteContent, SITE_CONTENT_KEY } from "../../../../lib/site-content";
+import { getOrgProfile } from "../../../../lib/org-profile";
 import { interpretBotCommand, menuText, parseIncomingWebhook, sendWhatsApp } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
 
-const PRIMARY_ORGANIZATION_ID = 1;
-
 function todayKyiv(): string {
-  return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv", year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
+  return new Intl.DateTimeFormat("en-CA", { timeZone:"Europe/Kyiv", year:"numeric", month:"2-digit", day:"2-digit" }).format(new Date());
 }
 
-// Порівняння токена за сталий час: хешуємо обидва значення й звіряємо дайджести
-// (32 байти незалежно від довжини входу), тож ані значення, ані довжина секрета
-// не витікають через тайминг.
-async function tokenMatches(provided: string, expected: string): Promise<boolean> {
-  if (!expected) return false;
-  const enc = new TextEncoder();
-  const [a, b] = await Promise.all([
-    crypto.subtle.digest("SHA-256", enc.encode(provided)),
-    crypto.subtle.digest("SHA-256", enc.encode(expected)),
-  ]);
-  const x = new Uint8Array(a);
-  const y = new Uint8Array(b);
-  let diff = 0;
-  for (let i = 0; i < x.length; i += 1) diff |= x[i] ^ y[i];
-  return diff === 0;
-}
-
-async function botReply(db: D1Database, phone: string, text: string, origin: string): Promise<string | null> {
-  const action = interpretBotCommand(text);
-  if (action === "menu") return menuText();
-  if (action === "human") return "Передав ваше звернення адміністратору — незабаром звʼяжемося.";
-  if (action === "booking") return `Записатися можна тут: ${origin}\nОберіть послугу й натисніть «Записатися».`;
-  if (action === "info") {
-    const content = parseSiteContent(await getSetting(db, SITE_CONTENT_KEY));
-    return [content.brandTitle, `📍 ${content.address}`, `🕒 ${content.workHours}`, `📞 ${content.phone}`, `Ціни: ${origin}`].filter(Boolean).join("\n");
+async function botReply(
+  db:D1Database,
+  organizationId:number,
+  phone:string,
+  text:string,
+  origin:string,
+):Promise<string|null> {
+  const action=interpretBotCommand(text);
+  if(action==="menu") return menuText();
+  if(action==="human") return "Передав ваше звернення адміністратору — незабаром звʼяжемося.";
+  if(action==="booking") return `Записатися можна тут: ${origin}\nОберіть послугу й натисніть «Записатися».`;
+  if(action==="info") {
+    const profile=await getOrgProfile(db,{organizationId} as never).catch(()=>null);
+    const name=profile?.name || "Медичний заклад";
+    return `${name}\nІнформація та запис: ${origin}`;
   }
-  if (action === "appointments") {
-    const rows = await db.prepare(
+  if(action==="appointments") {
+    const rows=await db.prepare(
       `SELECT service, desired_date AS d, desired_time AS t, status FROM bookings
        WHERE organization_id = ? AND phone_normalized = ? AND desired_date >= ? AND status NOT IN ('cancelled','completed')
        ORDER BY desired_date, desired_time LIMIT 5`
-    ).bind(PRIMARY_ORGANIZATION_ID, phone, todayKyiv()).all();
-    const list = (rows.results || []) as Array<{ service: string; d: string; t: string }>;
-    if (!list.length) return "У вас немає найближчих записів. Надішліть 2, щоб записатися.";
-    return ["Ваші найближчі записи:", ...list.map((r) => `• ${r.d}${r.t ? ` ${r.t}` : ""} — ${r.service}`)].join("\n");
+    ).bind(organizationId,phone,todayKyiv()).all();
+    const list=(rows.results||[]) as Array<{service:string;d:string;t:string}>;
+    if(!list.length) return "У вас немає найближчих записів. Надішліть 2, щоб записатися.";
+    return ["Ваші найближчі записи:",...list.map((r)=>`• ${r.d}${r.t?` ${r.t}`:""} — ${r.service}`)].join("\n");
   }
-  return null; // не з меню — лишаємо персоналу, без автовідповіді
+  return null;
 }
 
-export async function POST(request: Request) {
-  const db = dbBinding();
-  if (!db) return Response.json({ ok: false }, { status: 503 });
+export async function POST(request:Request) {
+  const db=dbBinding();
+  if(!db) return Response.json({ok:false},{status:503});
 
-  const url = new URL(request.url);
-  // Токен приймаємо із заголовка (не тече в логи/Referer), із сумісним
-  // фолбеком на ?token= для наявних налаштувань green-api.
-  const token = request.headers.get("x-webhook-token") || url.searchParams.get("token") || "";
-  const expected = await getSetting(db, "whatsapp_webhook_token");
-  if (!(await tokenMatches(token, expected))) return Response.json({ ok: false }, { status: 401 });
-  // Нижча стеля: обмежує спровокований зловмисником вихідний трафік (платні
-  // green-api надсилання) навіть якщо токен витік.
-  if (await isRateLimited(db, request, "whatsapp-webhook", 60, 15)) return Response.json({ ok: true });
+  const url=new URL(request.url);
+  const token=request.headers.get("x-webhook-token") || url.searchParams.get("token") || "";
+  const organizationId=await resolveOrganizationByIntegrationSecret(db,"whatsapp_webhook_token",token);
+  if(!organizationId) return Response.json({ok:false},{status:401});
+  if(await isRateLimited(db,request,`whatsapp-webhook:${organizationId}`,60,15)) return Response.json({ok:true});
 
-  const body = await request.json().catch(() => null);
-  const msg = parseIncomingWebhook(body);
-  if (!msg) return Response.json({ ok: true }); // не текстове/не вхідне — ігноруємо
+  const body=await request.json().catch(()=>null);
+  const msg=parseIncomingWebhook(body);
+  if(!msg) return Response.json({ok:true});
 
-  // Дедуплікація повторних вебхуків за idMessage всередині org 1.
-  const inserted = await db.prepare(
+  const inserted=await db.prepare(
     `INSERT OR IGNORE INTO patient_communications
       (organization_id, phone_normalized, channel, direction, summary, actor, external_id)
      VALUES (?, ?, 'whatsapp', 'inbound', ?, 'patient', ?)`
   ).bind(
-    PRIMARY_ORGANIZATION_ID,
+    organizationId,
     msg.phoneNormalized,
-    msg.text || "(без тексту)",
-    msg.idMessage || `${msg.phoneNormalized}-${msg.text.slice(0, 40)}`,
+    msg.text||"(без тексту)",
+    msg.idMessage||`${msg.phoneNormalized}-${msg.text.slice(0,40)}`,
   ).run();
-  if (!inserted.meta.changes) return Response.json({ ok: true }); // вже опрацьовано
+  if(!inserted.meta.changes) return Response.json({ok:true});
 
-  const reply = await botReply(db, msg.phoneNormalized, msg.text, url.origin);
-  if (reply) {
-    const sent = await sendWhatsApp(db, msg.phoneNormalized, reply);
-    if (sent.ok) {
+  const reply=await botReply(db,organizationId,msg.phoneNormalized,msg.text,url.origin);
+  if(reply) {
+    const sent=await sendWhatsApp(db,msg.phoneNormalized,reply,organizationId);
+    if(sent.ok) {
       await db.prepare(
         `INSERT INTO patient_communications
           (organization_id, phone_normalized, channel, direction, summary, actor, external_id)
          VALUES (?, ?, 'whatsapp', 'outbound', ?, 'bot', ?)`
-      ).bind(PRIMARY_ORGANIZATION_ID, msg.phoneNormalized, reply, sent.idMessage || "").run();
+      ).bind(organizationId,msg.phoneNormalized,reply,sent.idMessage||"").run();
     }
   }
-  return Response.json({ ok: true });
+  return Response.json({ok:true});
 }

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -3,7 +3,6 @@
 
 import { resolveOrganizationByIntegrationSecret } from "../../../../lib/settings";
 import { isRateLimited } from "../../../../lib/rate-limit";
-import { getOrgProfile } from "../../../../lib/org-profile";
 import { interpretBotCommand, menuText, parseIncomingWebhook, sendWhatsApp } from "../../../../lib/whatsapp";
 import { dbBinding } from "../../../../lib/db";
 
@@ -22,11 +21,9 @@ async function botReply(
   if(action==="menu") return menuText();
   if(action==="human") return "Передав ваше звернення адміністратору — незабаром звʼяжемося.";
   if(action==="booking") return `Записатися можна тут: ${origin}\nОберіть послугу й натисніть «Записатися».`;
-  if(action==="info") {
-    const profile=await getOrgProfile(db,{organizationId} as never).catch(()=>null);
-    const name=profile?.name || "Медичний заклад";
-    return `${name}\nІнформація та запис: ${origin}`;
-  }
+  // Global storefront/site-content still belongs to org1. Until site content is
+  // itself tenantized, never expose org1 address/phone to another tenant bot.
+  if(action==="info") return `Інформація та запис: ${origin}`;
   if(action==="appointments") {
     const rows=await db.prepare(
       `SELECT service, desired_date AS d, desired_time AS t, status FROM bookings
@@ -43,29 +40,20 @@ async function botReply(
 export async function POST(request:Request) {
   const db=dbBinding();
   if(!db) return Response.json({ok:false},{status:503});
-
   const url=new URL(request.url);
   const token=request.headers.get("x-webhook-token") || url.searchParams.get("token") || "";
   const organizationId=await resolveOrganizationByIntegrationSecret(db,"whatsapp_webhook_token",token);
   if(!organizationId) return Response.json({ok:false},{status:401});
   if(await isRateLimited(db,request,`whatsapp-webhook:${organizationId}`,60,15)) return Response.json({ok:true});
-
   const body=await request.json().catch(()=>null);
   const msg=parseIncomingWebhook(body);
   if(!msg) return Response.json({ok:true});
-
   const inserted=await db.prepare(
     `INSERT OR IGNORE INTO patient_communications
       (organization_id, phone_normalized, channel, direction, summary, actor, external_id)
      VALUES (?, ?, 'whatsapp', 'inbound', ?, 'patient', ?)`
-  ).bind(
-    organizationId,
-    msg.phoneNormalized,
-    msg.text||"(без тексту)",
-    msg.idMessage||`${msg.phoneNormalized}-${msg.text.slice(0,40)}`,
-  ).run();
+  ).bind(organizationId,msg.phoneNormalized,msg.text||"(без тексту)",msg.idMessage||`${msg.phoneNormalized}-${msg.text.slice(0,40)}`).run();
   if(!inserted.meta.changes) return Response.json({ok:true});
-
   const reply=await botReply(db,organizationId,msg.phoneNormalized,msg.text,url.origin);
   if(reply) {
     const sent=await sendWhatsApp(db,msg.phoneNormalized,reply,organizationId);

--- a/drizzle/0089_organization_integration_settings.sql
+++ b/drizzle/0089_organization_integration_settings.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS `organization_integration_settings` (
+  `organization_id` integer NOT NULL,
+  `key` text NOT NULL,
+  `value` text NOT NULL DEFAULT '',
+  `updated_at` text NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_by` text,
+  PRIMARY KEY (`organization_id`, `key`),
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `organization_integration_settings_org_idx`
+ON `organization_integration_settings` (`organization_id`, `key`);
+--> statement-breakpoint
+-- Only known integration/reminder keys have unambiguous legacy ownership.
+-- Copy those values to organization 1; do not infer ownership for unrelated
+-- app_settings rows and do not delete legacy data during the compatibility phase.
+INSERT OR IGNORE INTO `organization_integration_settings`
+  (`organization_id`, `key`, `value`)
+SELECT 1, `key`, `value`
+FROM `app_settings`
+WHERE `key` IN (
+  'telegram_bot_token',
+  'telegram_bot_username',
+  'telegram_chat_id',
+  'telegram_webhook_secret',
+  'whatsapp_id_instance',
+  'whatsapp_api_token_instance',
+  'whatsapp_enabled',
+  'whatsapp_webhook_token',
+  'sms_gateway_url',
+  'sms_gateway_auth',
+  'email_gateway_url',
+  'email_gateway_auth',
+  'email_gateway_from',
+  'pay_link',
+  'external_ics_url',
+  'patient_reminders_enabled',
+  'patient_reminder_lead_hours'
+);

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -6,10 +6,10 @@
 // успіху, в історії комунікацій пацієнта. Ніколи не кидає виняток —
 // підтвердження / перенесення не має падати через недоступний шлюз.
 //
-// Messaging credentials are still legacy-global and belong to org 1. Until
-// they are tenantized, secondary-tenant bookings must never use those gateways.
+// Messaging credentials are organization-scoped. Every tenant-aware send path
+// resolves gateways from the booking's server-derived organization id.
 
-import { getSettings } from "./settings";
+import { getOrganizationIntegrationSettings } from "./settings";
 import { createMessagingProvider } from "./providers/messaging";
 import { sendWhatsApp, whatsappConfig, whatsappConfigured } from "./whatsapp";
 import { sendTelegramTo } from "./telegram";
@@ -36,7 +36,6 @@ export interface ReminderSummary {
 }
 
 const DEPARTMENT = "Відділення променевої діагностики, Чернігівський військовий госпіталь";
-const PRIMARY_ORGANIZATION_ID = 1;
 
 export function reminderText(kind: ReminderKind, booking: ReminderBooking): string {
   const when = `${booking.desiredDate}${booking.desiredTime ? ` о ${booking.desiredTime}` : ""}`;
@@ -58,13 +57,12 @@ async function bookingOrganizationId(db: D1Database, bookingId: number): Promise
   return Number.isInteger(id) && id > 0 ? id : 0;
 }
 
-async function globalMessagingSettings(
+async function messagingSettings(
   db: D1Database,
   organizationId: number,
   keys: string[],
 ): Promise<Record<string, string>> {
-  if (organizationId !== PRIMARY_ORGANIZATION_ID) return {};
-  return getSettings(db, keys);
+  return getOrganizationIntegrationSettings(db, organizationId, keys);
 }
 
 async function record(
@@ -184,7 +182,7 @@ export async function sendPatientReminder(
   if (!organizationId) return summary;
   const body = reminderText(kind, booking);
 
-  const cfg = await globalMessagingSettings(db, organizationId, [
+  const cfg = await messagingSettings(db, organizationId, [
     "patient_reminders_enabled", "telegram_bot_token",
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
@@ -212,17 +210,15 @@ export async function sendPatientReminder(
   if (telegramChatId) {
     channels.push({
       channel: "telegram", recipient: "Telegram", url: cfg.telegram_bot_token ? telegramChatId : "",
-      send: async () => { const r = await sendTelegramTo(db, telegramChatId, body); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
+      send: async () => { const r = await sendTelegramTo(db, telegramChatId, body, organizationId); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
     });
   }
-  if (organizationId === PRIMARY_ORGANIZATION_ID) {
-    const wa = await whatsappConfig(db);
-    if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
-      channels.push({
-        channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
-        send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
-      });
-    }
+  const wa = await whatsappConfig(db, organizationId);
+  if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
+    channels.push({
+      channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
+      send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body, organizationId); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
+    });
   }
   if (booking.phone) {
     channels.push({
@@ -278,7 +274,7 @@ export async function sendPatientMessage(
   const body = (text || "").trim();
   if (!body) return summary;
 
-  const cfg = await globalMessagingSettings(db, organizationId, [
+  const cfg = await messagingSettings(db, organizationId, [
     "telegram_bot_token",
     "sms_gateway_url", "sms_gateway_auth",
     "email_gateway_url", "email_gateway_auth", "email_gateway_from",
@@ -304,17 +300,15 @@ export async function sendPatientMessage(
   if (telegramChatId) {
     channels.push({
       channel: "telegram", recipient: "Telegram", url: cfg.telegram_bot_token ? telegramChatId : "",
-      send: async () => { const r = await sendTelegramTo(db, telegramChatId, body); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
+      send: async () => { const r = await sendTelegramTo(db, telegramChatId, body, organizationId); if (!r.ok) throw new Error(r.error || "Telegram помилка"); },
     });
   }
-  if (organizationId === PRIMARY_ORGANIZATION_ID) {
-    const wa = await whatsappConfig(db);
-    if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
-      channels.push({
-        channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
-        send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
-      });
-    }
+  const wa = await whatsappConfig(db, organizationId);
+  if (booking.phoneNormalized && whatsappConfigured(wa) && wa.enabled) {
+    channels.push({
+      channel: "whatsapp", recipient: booking.phone, url: wa.idInstance,
+      send: async () => { const r = await sendWhatsApp(db, booking.phoneNormalized, body, organizationId); if (!r.ok) throw new Error(r.error || "WhatsApp помилка"); },
+    });
   }
   if (booking.phone) {
     channels.push({ channel: "sms", recipient: booking.phone, url: cfg.sms_gateway_url || "", send: () => messaging.sendSms(booking.phone, body) });

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,11 +1,9 @@
 // Резолвер провайдерів — добирає реалізації інтеграцій у tenant-контексті.
-//
-// Messaging configuration and the external calendar URL are still legacy-global
-// in app_settings and belong to the primary/public tenant. Secondary tenants
-// must not receive those credentials/capabilities until storage is tenantized.
-// PACS та payment вже мають per-org джерела.
+// Integration settings are scoped by organization. Organization 1 alone may
+// use the legacy app_settings compatibility read; secondary tenants never fall
+// back to primary credentials.
 
-import { getSettings } from "../settings";
+import { getOrganizationIntegrationSettings } from "../settings";
 import { getOrgProfile } from "../org-profile";
 import type { OrgContext } from "../tenant";
 import { createMessagingProvider } from "./messaging";
@@ -13,13 +11,11 @@ import { createCalendarProvider } from "./calendar";
 import { createPaymentProvider, type PaymentConfig } from "./payment";
 import type { PacsProvider, ResolvedProviders } from "./types";
 
-const PRIMARY_ORGANIZATION_ID = 1;
 const MESSAGING_SETTING_KEYS = [
   "sms_gateway_url", "sms_gateway_auth",
   "email_gateway_url", "email_gateway_auth", "email_gateway_from",
 ];
 
-// Дістає конфіг оплат із settings_json профілю організації (безпечно).
 function paymentConfig(settings: Record<string, unknown>): PaymentConfig {
   const raw = settings.payment;
   if (!raw || typeof raw !== "object") return {};
@@ -32,21 +28,13 @@ function paymentConfig(settings: Record<string, unknown>): PaymentConfig {
 }
 
 export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise<ResolvedProviders> {
-  const primaryTenant = ctx.organizationId === PRIMARY_ORGANIZATION_ID;
-  const messagingSettings = primaryTenant
-    ? getSettings(db, MESSAGING_SETTING_KEYS)
-    : Promise.resolve({} as Record<string, string>);
-  const calendarUrl = primaryTenant
-    ? getSettings(db, ["external_ics_url"]).then((s) => s.external_ics_url || "").catch(() => "")
-    : Promise.resolve("");
-
-  const [cfg, profile, pacsRow, icsUrl] = await Promise.all([
-    messagingSettings,
+  const [cfg, profile, pacsRow, calendarCfg] = await Promise.all([
+    getOrganizationIntegrationSettings(db, ctx.organizationId, MESSAGING_SETTING_KEYS),
     getOrgProfile(db, ctx),
     db.prepare(
       "SELECT enabled, viewer_base_url AS viewer, dicomweb_base_url AS dicomweb FROM pacs_settings WHERE organization_id = ? LIMIT 1"
     ).bind(ctx.organizationId).first<{ enabled: number; viewer: string; dicomweb: string }>().catch(() => null),
-    calendarUrl,
+    getOrganizationIntegrationSettings(db, ctx.organizationId, ["external_ics_url"]),
   ]);
 
   const messaging = createMessagingProvider({
@@ -54,7 +42,6 @@ export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise
     email: { url: cfg.email_gateway_url || "", auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
   });
 
-  // PACS доступний, коли його увімкнено в налаштуваннях саме цього tenant.
   const pacsEnabled = Boolean(pacsRow?.enabled);
   const pacs: PacsProvider = {
     name: pacsEnabled ? "dicomweb" : "none",
@@ -66,9 +53,7 @@ export async function resolveProviders(db: D1Database, ctx: OrgContext): Promise
     }),
   };
 
-  const calendar = createCalendarProvider(icsUrl);
-
-  // Платіжний провайдер добирається з профілю організації (per-org).
+  const calendar = createCalendarProvider(calendarCfg.external_ics_url || "");
   const payment = createPaymentProvider(paymentConfig(profile.settings));
 
   return { messaging, payment, pacs, calendar };

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -97,7 +97,7 @@ export async function runDueReminders(
       }
       const body = leadReminderText(b.service, b.desiredTime, due.hours);
       try {
-        const r = await sendWhatsApp(db, organizationId, b.phoneNormalized, body);
+        const r = await sendWhatsApp(db, b.phoneNormalized, body, organizationId);
         if (r.ok) { await record(db, organizationId, b, kind, "sent", ""); result.sent += 1; }
         else { await record(db, organizationId, b, kind, "failed", r.error || "WhatsApp помилка"); result.failed += 1; }
       } catch (error) {

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -1,9 +1,7 @@
-// Планові нагадування пацієнтам за N годин до візиту (напр. за 3 год і за 1 год).
-// Запускається cron-тригером Cloudflare (scheduled-handler у worker/index.ts).
-// Чиста логіка «які нагадування настали» — у lib/reminders-core.ts (тестована);
-// тут лише ввід-вивід: читання БД, надсилання WhatsApp, дедуплікація.
+// Планові нагадування пацієнтам за N годин до візиту.
+// Раннер завжди отримує явний tenant і використовує тільки його integration settings.
 
-import { getSettings } from "./settings";
+import { getOrganizationIntegrationSettings } from "./settings";
 import { sendWhatsApp, whatsappConfig, whatsappConfigured } from "./whatsapp";
 import {
   REMINDER_LEAD_KEY, dueReminders, kyivNow, leadReminderText, minutesOfTime,
@@ -18,9 +16,6 @@ type ReminderRow = {
   staleLinkedContact:number;
 };
 
-// Раннер завжди отримує явний tenant. Поки messaging credentials зберігаються
-// глобально в app_settings, production scheduled-handler викликає його лише для
-// початкової організації; це не дає одному каналу повідомлень обробляти чужі записи.
 export async function runDueReminders(
   db: D1Database,
   nowMs: number,
@@ -29,12 +24,14 @@ export async function runDueReminders(
   const result = { sent: 0, skipped: 0, failed: 0 };
   if (!Number.isInteger(organizationId) || organizationId <= 0) return result;
   try {
-    const cfg = await getSettings(db, ["patient_reminders_enabled", REMINDER_LEAD_KEY]);
+    const cfg = await getOrganizationIntegrationSettings(db, organizationId, [
+      "patient_reminders_enabled", REMINDER_LEAD_KEY,
+    ]);
     if (!["1", "true", "on", "yes"].includes((cfg.patient_reminders_enabled || "").trim().toLowerCase())) {
-      return result; // нагадування вимкнені
+      return result;
     }
-    const wa = await whatsappConfig(db);
-    if (!whatsappConfigured(wa) || !wa.enabled) return result; // немає куди слати
+    const wa = await whatsappConfig(db, organizationId);
+    if (!whatsappConfigured(wa) || !wa.enabled) return result;
 
     const leads = parseLeadHours(cfg[REMINDER_LEAD_KEY]);
     const { date, minutes: nowMin } = kyivNow(nowMs);
@@ -48,9 +45,7 @@ export async function runDueReminders(
              WHERE p.organization_id = b.organization_id
                AND p.patient_id = b.patient_id
                AND p.do_not_contact = 1
-           ) THEN 1
-           ELSE 0
-         END AS doNotContact,
+           ) THEN 1 ELSE 0 END AS doNotContact,
          CASE WHEN b.patient_id = '' THEN (
            SELECT COUNT(*) FROM patient_profiles p
            WHERE p.organization_id = b.organization_id
@@ -62,13 +57,11 @@ export async function runDueReminders(
              WHERE p.organization_id = b.organization_id
                AND p.patient_id = b.patient_id
                AND p.phone_normalized = b.phone_normalized
-           ) THEN 1
-           ELSE 0
-         END AS staleLinkedContact
+           ) THEN 1 ELSE 0 END AS staleLinkedContact
        FROM bookings b
        WHERE b.organization_id = ? AND b.desired_date = ? AND b.status IN ('confirmed','rescheduled')`
     ).bind(organizationId, date).all<ReminderRow>();
-    const bookings = (rows.results || []);
+    const bookings = rows.results || [];
     if (!bookings.length) return result;
 
     const leadBookings: LeadBooking[] = [];
@@ -92,11 +85,6 @@ export async function runDueReminders(
       const b = byId.get(due.id);
       if (!b || !b.phoneNormalized) continue;
       const kind = `reminder_${due.hours}h`;
-      // Exact bookings use only their own profile's DNC flag and current phone.
-      // If the profile phone changed since the booking snapshot was created, the
-      // old destination is no longer trusted and automated messaging fails closed.
-      // For an unlinked legacy booking, any CRM profile on that phone is also
-      // identity-ambiguous and must not receive appointment details automatically.
       if (b.doNotContact || b.staleLinkedContact || (!b.patientId && b.sharedProfileCount > 0)) {
         const reason = b.doNotContact
           ? "Пацієнт у списку «не турбувати»"
@@ -109,7 +97,7 @@ export async function runDueReminders(
       }
       const body = leadReminderText(b.service, b.desiredTime, due.hours);
       try {
-        const r = await sendWhatsApp(db, b.phoneNormalized, body);
+        const r = await sendWhatsApp(db, organizationId, b.phoneNormalized, body);
         if (r.ok) { await record(db, organizationId, b, kind, "sent", ""); result.sent += 1; }
         else { await record(db, organizationId, b, kind, "failed", r.error || "WhatsApp помилка"); result.failed += 1; }
       } catch (error) {
@@ -118,7 +106,7 @@ export async function runDueReminders(
       }
     }
   } catch {
-    // мовчазна відмова — cron не має падати; наступний запуск спробує знову
+    // Cron must fail closed for this tenant and retry on the next run.
   }
   return result;
 }

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -75,3 +75,38 @@ export async function setOrganizationIntegrationSetting(
        updated_by = excluded.updated_by`
   ).bind(organizationId, key, value, updatedBy || null).run();
 }
+
+// Public webhooks have no authenticated tenant context. Resolve their tenant
+// only from an exact secret that belongs to exactly one organization. Duplicate
+// secrets fail closed. Legacy app_settings is accepted for org1 only until that
+// key has an authoritative org1 scoped row; a stale legacy secret can therefore
+// never override a rotated org1 secret.
+export async function resolveOrganizationByIntegrationSecret(
+  db: D1Database,
+  key: string,
+  providedSecret: string,
+): Promise<number | null> {
+  const secret = String(providedSecret || "");
+  if (!secret) return null;
+
+  const rows = await db.prepare(
+    `SELECT organization_id AS organizationId
+     FROM organization_integration_settings
+     WHERE key = ? AND value = ?
+     ORDER BY organization_id
+     LIMIT 2`
+  ).bind(key, secret).all<{ organizationId:number }>().catch(() => ({ results: [] } as { results:Array<{organizationId:number}> }));
+  const matches = rows.results || [];
+  if (matches.length !== 0) {
+    return matches.length === 1 ? Number(matches[0].organizationId) : null;
+  }
+
+  const org1Scoped = await db.prepare(
+    `SELECT 1 AS present FROM organization_integration_settings
+     WHERE organization_id = ? AND key = ? LIMIT 1`
+  ).bind(LEGACY_INTEGRATION_ORGANIZATION_ID, key).first<{ present:number }>().catch(() => null);
+  if (org1Scoped) return null;
+
+  const legacy = await getSetting(db, key).catch(() => "");
+  return legacy && legacy === secret ? LEGACY_INTEGRATION_ORGANIZATION_ID : null;
+}

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,5 +1,12 @@
-// Shared key/value access for the `app_settings` table — department-configurable
-// values such as the Telegram bot credentials and the payment link.
+// Shared key/value access. `app_settings` is the legacy single-organization
+// store. Integration credentials use organization_integration_settings and are
+// always read with an explicit server-derived organization id.
+
+const LEGACY_INTEGRATION_ORGANIZATION_ID = 1;
+
+function validOrganizationId(organizationId: number): boolean {
+  return Number.isInteger(organizationId) && organizationId > 0;
+}
 
 export async function getSetting(db: D1Database, key: string): Promise<string> {
   const row = await db.prepare("SELECT value FROM app_settings WHERE key = ? LIMIT 1")
@@ -18,4 +25,53 @@ export async function setSetting(db: D1Database, key: string, value: string): Pr
     `INSERT INTO app_settings (key, value) VALUES (?, ?)
      ON CONFLICT(key) DO UPDATE SET value = excluded.value`
   ).bind(key, value).run();
+}
+
+export async function getOrganizationIntegrationSetting(
+  db: D1Database,
+  organizationId: number,
+  key: string,
+): Promise<string> {
+  if (!validOrganizationId(organizationId)) return "";
+  const row = await db.prepare(
+    `SELECT value FROM organization_integration_settings
+     WHERE organization_id = ? AND key = ? LIMIT 1`
+  ).bind(organizationId, key).first<{ value:string }>().catch(() => null);
+  if (row) return row.value || "";
+  // Compatibility is deliberately one-way: only org1 may read legacy values.
+  // Secondary tenants fail closed rather than inheriting primary credentials.
+  return organizationId === LEGACY_INTEGRATION_ORGANIZATION_ID
+    ? getSetting(db, key).catch(() => "")
+    : "";
+}
+
+export async function getOrganizationIntegrationSettings(
+  db: D1Database,
+  organizationId: number,
+  keys: string[],
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const key of keys) {
+    out[key] = await getOrganizationIntegrationSetting(db, organizationId, key);
+  }
+  return out;
+}
+
+export async function setOrganizationIntegrationSetting(
+  db: D1Database,
+  organizationId: number,
+  key: string,
+  value: string,
+  updatedBy?: string | null,
+): Promise<void> {
+  if (!validOrganizationId(organizationId)) throw new Error("invalid_organization_id");
+  await db.prepare(
+    `INSERT INTO organization_integration_settings
+       (organization_id, key, value, updated_at, updated_by)
+     VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)
+     ON CONFLICT(organization_id, key) DO UPDATE SET
+       value = excluded.value,
+       updated_at = CURRENT_TIMESTAMP,
+       updated_by = excluded.updated_by`
+  ).bind(organizationId, key, value, updatedBy || null).run();
 }

--- a/lib/telegram-link.ts
+++ b/lib/telegram-link.ts
@@ -1,13 +1,10 @@
 // Прив'язка Telegram пацієнта: короткоживучі токени для deep-link «Старт»
-// і обробник вхідних оновлень від бота (webhook). Пацієнт натискає «Старт»
-// у боті один раз — ми зіставляємо токен із tenant + телефоном + доведеною
-// ідентичністю та, коли вона відома, immutable patient_id.
+// і обробник вхідних оновлень конкретного tenant-бота.
 
 import { hashToken, newSessionToken } from "./auth";
 import type { PatientIdentityScope } from "./patient-auth";
 
 export const TELEGRAM_LINK_TTL_SECONDS = 15 * 60;
-const PRIMARY_ORGANIZATION_ID = 1;
 const STALE_LINK_REPLY = "Посилання застаріло. Відкрийте кабінет і натисніть «Підключити Telegram» ще раз.";
 
 export async function createTelegramLinkToken(
@@ -23,15 +20,7 @@ export async function createTelegramLinkToken(
     `INSERT INTO telegram_link_tokens
       (token_hash, organization_id, phone_normalized, identity_kind, identity_value, patient_id, expires_at)
      VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?))`
-  ).bind(
-    tokenHash,
-    organizationId,
-    phoneNormalized,
-    identity.kind,
-    identity.value,
-    patientId,
-    `+${TELEGRAM_LINK_TTL_SECONDS} seconds`,
-  ).run();
+  ).bind(tokenHash, organizationId, phoneNormalized, identity.kind, identity.value, patientId, `+${TELEGRAM_LINK_TTL_SECONDS} seconds`).run();
   await db.prepare("DELETE FROM telegram_link_tokens WHERE expires_at <= CURRENT_TIMESTAMP").run();
   return rawToken;
 }
@@ -48,32 +37,23 @@ export async function consumeTelegramLinkToken(
        identity_kind AS identityKind, identity_value AS identityValue, patient_id AS patientId
      FROM telegram_link_tokens
      WHERE token_hash = ? AND expires_at > CURRENT_TIMESTAMP
-       AND identity_kind IN ('dob','booking') AND identity_value != ''
-     LIMIT 1`
+       AND identity_kind IN ('dob','booking') AND identity_value != '' LIMIT 1`
   ).bind(tokenHash).first<{
-    organizationId: number;
-    phone: string;
-    identityKind: "dob" | "booking";
-    identityValue: string;
-    patientId: string;
+    organizationId:number; phone:string; identityKind:"dob"|"booking"; identityValue:string; patientId:string;
   }>().catch(() => null);
   await db.prepare("DELETE FROM telegram_link_tokens WHERE token_hash = ?").bind(tokenHash).run();
   return row ? {
-    organizationId: row.organizationId,
-    phone: row.phone,
-    identity: { kind:row.identityKind, value:row.identityValue },
-    patientId: row.patientId || "",
+    organizationId:row.organizationId,
+    phone:row.phone,
+    identity:{ kind:row.identityKind, value:row.identityValue },
+    patientId:row.patientId || "",
   } : null;
 }
 
 export async function linkPatientTelegram(
-  db: D1Database,
-  organizationId: number,
-  phoneNormalized: string,
-  identity: PatientIdentityScope,
-  chatId: string,
-  patientId = "",
-): Promise<void> {
+  db:D1Database, organizationId:number, phoneNormalized:string,
+  identity:PatientIdentityScope, chatId:string, patientId="",
+):Promise<void> {
   await db.prepare(
     `INSERT INTO patient_telegram_identities
       (organization_id, phone_normalized, identity_kind, identity_value, patient_id, telegram_chat_id, updated_at)
@@ -85,50 +65,37 @@ export async function linkPatientTelegram(
   ).bind(organizationId, phoneNormalized, identity.kind, identity.value, patientId, chatId).run();
 }
 
-// /stop is bot-wide consent revocation for this chat. If the same human linked
-// the same bot for more than one identity/tenant, remove every matching link.
-export async function unlinkPatientTelegram(db: D1Database, chatId: string): Promise<void> {
+export async function unlinkPatientTelegram(db:D1Database, organizationId:number, chatId:string):Promise<void> {
   await db.prepare(
-    "UPDATE patient_telegram_identities SET telegram_chat_id = '', updated_at = CURRENT_TIMESTAMP WHERE telegram_chat_id = ?"
-  ).bind(chatId).run();
-  // Keep legacy phone-wide storage inert if a pre-0046 database is encountered
-  // during a rolling upgrade.
+    `UPDATE patient_telegram_identities SET telegram_chat_id = '', updated_at = CURRENT_TIMESTAMP
+     WHERE organization_id = ? AND telegram_chat_id = ?`
+  ).bind(organizationId, chatId).run();
   await db.prepare(
-    "UPDATE patient_profiles SET telegram_chat_id = '', updated_at = CURRENT_TIMESTAMP WHERE telegram_chat_id = ?"
-  ).bind(chatId).run().catch(() => undefined);
+    `UPDATE patient_profiles SET telegram_chat_id = '', updated_at = CURRENT_TIMESTAMP
+     WHERE organization_id = ? AND telegram_chat_id = ?`
+  ).bind(organizationId, chatId).run().catch(() => undefined);
 }
 
-interface TelegramUpdate {
-  message?: { chat?: { id?: number | string }; text?: string };
-}
+interface TelegramUpdate { message?: { chat?: { id?:number|string }; text?:string } }
 
-export async function handleTelegramUpdate(db: D1Database, update: TelegramUpdate): Promise<{ chatId: string; reply: string }> {
+export async function handleTelegramUpdate(
+  db:D1Database,
+  update:TelegramUpdate,
+  organizationId:number,
+):Promise<{chatId:string;reply:string}> {
   const chatId = update?.message?.chat?.id != null ? String(update.message.chat.id) : "";
   const text = (update?.message?.text || "").trim();
-  if (!chatId || !text) return { chatId: "", reply: "" };
+  if (!chatId || !text || !Number.isInteger(organizationId) || organizationId <= 0) return { chatId:"", reply:"" };
 
   if (/^\/stop\b/.test(text)) {
-    await unlinkPatientTelegram(db, chatId);
-    return { chatId, reply: "Ви відписались від сповіщень. Щоб знову підключити — натисніть кнопку в кабінеті." };
+    await unlinkPatientTelegram(db, organizationId, chatId);
+    return { chatId, reply:"Ви відписались від сповіщень. Щоб знову підключити — натисніть кнопку в кабінеті." };
   }
 
   const m = text.match(/^\/start\s+([a-f0-9]{64})$/);
-  if (!m) {
-    return { chatId, reply: "Щоб підключити сповіщення, відкрийте кабінет на сайті й натисніть «Підключити Telegram»." };
-  }
+  if (!m) return { chatId, reply:"Щоб підключити сповіщення, відкрийте кабінет на сайті й натисніть «Підключити Telegram»." };
   const target = await consumeTelegramLinkToken(db, m[1]);
-  // This webhook belongs to the legacy-global bot of the primary organization.
-  // Consume any foreign token once, but never bind that tenant to the org1 bot.
-  if (!target || target.organizationId !== PRIMARY_ORGANIZATION_ID) {
-    return { chatId, reply: STALE_LINK_REPLY };
-  }
-  await linkPatientTelegram(
-    db,
-    target.organizationId,
-    target.phone,
-    target.identity,
-    chatId,
-    target.patientId,
-  );
-  return { chatId, reply: "✅ Готово! Сповіщення про ваші дослідження надходитимуть у цей чат." };
+  if (!target || target.organizationId !== organizationId) return { chatId, reply:STALE_LINK_REPLY };
+  await linkPatientTelegram(db, target.organizationId, target.phone, target.identity, chatId, target.patientId);
+  return { chatId, reply:"✅ Готово! Сповіщення про ваші дослідження надходитимуть у цей чат." };
 }

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -1,116 +1,107 @@
-// Best-effort Telegram notifications for the registrar. Disabled (a no-op)
-// until an admin saves a bot token and chat id in /staff/settings.
+// Best-effort Telegram notifications. Bot credentials are organization-scoped.
+// Optional organization ids preserve the legacy public org1 path; tenant-aware
+// routes must pass their server-derived organization id explicitly.
 
-import { getSettings, setSetting } from "./settings";
+import {
+  getOrganizationIntegrationSettings,
+  setOrganizationIntegrationSetting,
+} from "./settings";
+
+const LEGACY_PUBLIC_ORGANIZATION_ID = 1;
 
 function escapeHtml(value: string): string {
-  return value.replace(/[&<>]/g, (m) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[m] as string));
+  return value.replace(/[&<>]/g, (m) => ({ "&":"&amp;", "<":"&lt;", ">":"&gt;" }[m] as string));
 }
 
-export interface BookingNotice {
-  codes: string[];
-  desiredDate: string;
-  desiredTime: string;
-}
+export interface BookingNotice { codes:string[]; desiredDate:string; desiredTime:string }
 
 export function bookingMessage(notice: BookingNotice): string {
   const when = notice.desiredDate
     ? `${notice.desiredDate}${notice.desiredTime ? ` о ${notice.desiredTime}` : ""}`
     : "реєстратура погоджує з пацієнтом";
-  const lines = [
+  return [
     "🆕 <b>Нова заявка</b>",
     `📅 Бажаний час: ${escapeHtml(when)}`,
     `🔖 Код: ${notice.codes.map(escapeHtml).join(", ")}`,
     "Відкрийте захищений кабінет персоналу для перегляду деталей.",
-  ];
-  return lines.join("\n");
+  ].join("\n");
 }
 
-// Sends a message to the department chat and reports the outcome. Returns a
-// human-readable Ukrainian error on failure (used by the "send test" button).
-export async function sendTelegramResult(db: D1Database, text: string): Promise<{ ok: boolean; error?: string }> {
-  const { telegram_bot_token: token, telegram_chat_id: chatId } =
-    await getSettings(db, ["telegram_bot_token", "telegram_chat_id"]);
-  if (!token || !chatId) return { ok: false, error: "Спочатку збережіть токен бота та ID чату" };
+export async function sendTelegramResult(
+  db:D1Database,
+  text:string,
+  organizationId=LEGACY_PUBLIC_ORGANIZATION_ID,
+):Promise<{ok:boolean;error?:string}> {
+  const { telegram_bot_token:token, telegram_chat_id:chatId } =
+    await getOrganizationIntegrationSettings(db, organizationId, ["telegram_bot_token", "telegram_chat_id"]);
+  if (!token || !chatId) return { ok:false, error:"Спочатку збережіть токен бота та ID чату" };
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML", disable_web_page_preview: true }),
-      signal: controller.signal,
+    const controller=new AbortController();
+    const timer=setTimeout(()=>controller.abort(),3000);
+    const response=await fetch(`https://api.telegram.org/bot${token}/sendMessage`,{
+      method:"POST", headers:{"content-type":"application/json"},
+      body:JSON.stringify({chat_id:chatId,text,parse_mode:"HTML",disable_web_page_preview:true}), signal:controller.signal,
     });
     clearTimeout(timer);
-    if (response.ok) return { ok: true };
-    const data = await response.json().catch(() => ({})) as { description?: string };
-    return { ok: false, error: data.description || `Telegram відповів помилкою (${response.status})` };
-  } catch {
-    return { ok: false, error: "Не вдалося з'єднатися з Telegram" };
-  }
+    if(response.ok) return {ok:true};
+    const data=await response.json().catch(()=>({})) as {description?:string};
+    return {ok:false,error:data.description||`Telegram відповів помилкою (${response.status})`};
+  } catch { return {ok:false,error:"Не вдалося з'єднатися з Telegram"}; }
 }
 
-// Best-effort variant for the booking path — never throws, ignores the reason.
-export async function sendTelegram(db: D1Database, text: string): Promise<boolean> {
-  return (await sendTelegramResult(db, text)).ok;
+export async function sendTelegram(db:D1Database,text:string,organizationId=LEGACY_PUBLIC_ORGANIZATION_ID):Promise<boolean>{
+  return (await sendTelegramResult(db,text,organizationId)).ok;
 }
 
-// Надсилає повідомлення конкретному chat_id (пацієнту, який під'єднав бота).
-// Використовує той самий токен відділення. Повертає причину помилки укр.
-export async function sendTelegramTo(db: D1Database, chatId: string, text: string): Promise<{ ok: boolean; error?: string }> {
-  const { telegram_bot_token: token } = await getSettings(db, ["telegram_bot_token"]);
-  if (!token) return { ok: false, error: "Бот Telegram не налаштований" };
-  if (!chatId) return { ok: false, error: "Немає chat_id пацієнта" };
+export async function sendTelegramTo(
+  db:D1Database, chatId:string, text:string, organizationId=LEGACY_PUBLIC_ORGANIZATION_ID,
+):Promise<{ok:boolean;error?:string}> {
+  const {telegram_bot_token:token}=await getOrganizationIntegrationSettings(db,organizationId,["telegram_bot_token"]);
+  if(!token) return {ok:false,error:"Бот Telegram не налаштований"};
+  if(!chatId) return {ok:false,error:"Немає chat_id пацієнта"};
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML", disable_web_page_preview: true }),
-      signal: controller.signal,
+    const controller=new AbortController(); const timer=setTimeout(()=>controller.abort(),3000);
+    const response=await fetch(`https://api.telegram.org/bot${token}/sendMessage`,{
+      method:"POST",headers:{"content-type":"application/json"},
+      body:JSON.stringify({chat_id:chatId,text,parse_mode:"HTML",disable_web_page_preview:true}),signal:controller.signal,
     });
     clearTimeout(timer);
-    if (response.ok) return { ok: true };
-    const data = await response.json().catch(() => ({})) as { description?: string };
-    return { ok: false, error: data.description || `Telegram відповів помилкою (${response.status})` };
-  } catch {
-    return { ok: false, error: "Не вдалося з'єднатися з Telegram" };
-  }
+    if(response.ok) return {ok:true};
+    const data=await response.json().catch(()=>({})) as {description?:string};
+    return {ok:false,error:data.description||`Telegram відповів помилкою (${response.status})`};
+  } catch { return {ok:false,error:"Не вдалося з'єднатися з Telegram"}; }
 }
 
-// Ім'я бота (@username) для побудови deep-link t.me/<username>?start=…
-// Кешується в налаштуваннях, щоб не смикати getMe на кожен запит.
-export async function telegramBotUsername(db: D1Database): Promise<string> {
-  const { telegram_bot_token: token, telegram_bot_username: cached } =
-    await getSettings(db, ["telegram_bot_token", "telegram_bot_username"]);
-  if (!token) return "";
-  if (cached) return cached;
+export async function telegramBotUsername(
+  db:D1Database,
+  organizationId=LEGACY_PUBLIC_ORGANIZATION_ID,
+):Promise<string> {
+  const {telegram_bot_token:token,telegram_bot_username:cached}=await getOrganizationIntegrationSettings(
+    db,organizationId,["telegram_bot_token","telegram_bot_username"]
+  );
+  if(!token) return "";
+  if(cached) return cached;
   try {
-    const response = await fetch(`https://api.telegram.org/bot${token}/getMe`);
-    const data = await response.json().catch(() => ({})) as { ok?: boolean; result?: { username?: string } };
-    const username = data.ok && data.result?.username ? data.result.username : "";
-    if (username) await setSetting(db, "telegram_bot_username", username);
+    const response=await fetch(`https://api.telegram.org/bot${token}/getMe`);
+    const data=await response.json().catch(()=>({})) as {ok?:boolean;result?:{username?:string}};
+    const username=data.ok&&data.result?.username?data.result.username:"";
+    if(username) await setOrganizationIntegrationSetting(db,organizationId,"telegram_bot_username",username,"telegram:getMe");
     return username;
-  } catch {
-    return "";
-  }
+  } catch { return ""; }
 }
 
-// Реєструє webhook бота на наш публічний ендпоінт із секретом-заголовком.
-export async function setTelegramWebhook(db: D1Database, url: string, secret: string): Promise<{ ok: boolean; error?: string }> {
-  const { telegram_bot_token: token } = await getSettings(db, ["telegram_bot_token"]);
-  if (!token) return { ok: false, error: "Спочатку збережіть токен бота" };
+export async function setTelegramWebhook(
+  db:D1Database, url:string, secret:string, organizationId=LEGACY_PUBLIC_ORGANIZATION_ID,
+):Promise<{ok:boolean;error?:string}> {
+  const {telegram_bot_token:token}=await getOrganizationIntegrationSettings(db,organizationId,["telegram_bot_token"]);
+  if(!token) return {ok:false,error:"Спочатку збережіть токен бота"};
   try {
-    const response = await fetch(`https://api.telegram.org/bot${token}/setWebhook`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, secret_token: secret, allowed_updates: ["message"] }),
+    const response=await fetch(`https://api.telegram.org/bot${token}/setWebhook`,{
+      method:"POST",headers:{"content-type":"application/json"},
+      body:JSON.stringify({url,secret_token:secret,allowed_updates:["message"]}),
     });
-    const data = await response.json().catch(() => ({})) as { ok?: boolean; description?: string };
-    if (data.ok) return { ok: true };
-    return { ok: false, error: data.description || `Telegram відповів помилкою (${response.status})` };
-  } catch {
-    return { ok: false, error: "Не вдалося з'єднатися з Telegram" };
-  }
+    const data=await response.json().catch(()=>({})) as {ok?:boolean;description?:string};
+    if(data.ok) return {ok:true};
+    return {ok:false,error:data.description||`Telegram відповів помилкою (${response.status})`};
+  } catch { return {ok:false,error:"Не вдалося з'єднатися з Telegram"}; }
 }

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -1,10 +1,8 @@
-// Best-effort WhatsApp через green-api.com. Тихий no-op, поки адміністратор
-// не збереже idInstance + apiToken на сторінці «WhatsApp» у кабінеті.
-// Дзеркалить lib/telegram.ts: прямий fetch до сталого хоста green-api.
+// Best-effort WhatsApp through green-api.com. Configuration is organization-
+// scoped; callers must provide the tenant id that owns the patient/workflow.
 
-import { getSettings } from "./settings";
+import { getOrganizationIntegrationSettings } from "./settings";
 
-// Чисті функції бота/розбору — у окремому модулі (тестовані без залежностей).
 export { interpretBotCommand, menuText, parseIncomingWebhook } from "./whatsapp-bot";
 export type { BotAction, IncomingMessage } from "./whatsapp-bot";
 
@@ -12,8 +10,10 @@ const GREEN_API_HOST = "https://api.green-api.com";
 
 export type WhatsAppConfig = { idInstance: string; apiToken: string; enabled: boolean };
 
-export async function whatsappConfig(db: D1Database): Promise<WhatsAppConfig> {
-  const s = await getSettings(db, ["whatsapp_id_instance", "whatsapp_api_token_instance", "whatsapp_enabled"]);
+export async function whatsappConfig(db: D1Database, organizationId: number): Promise<WhatsAppConfig> {
+  const s = await getOrganizationIntegrationSettings(db, organizationId, [
+    "whatsapp_id_instance", "whatsapp_api_token_instance", "whatsapp_enabled",
+  ]);
   const enabled = ["1", "true", "on", "yes"].includes((s.whatsapp_enabled || "").trim().toLowerCase());
   return { idInstance: s.whatsapp_id_instance || "", apiToken: s.whatsapp_api_token_instance || "", enabled };
 }
@@ -22,15 +22,16 @@ export function whatsappConfigured(cfg: WhatsAppConfig): boolean {
   return Boolean(cfg.idInstance && cfg.apiToken);
 }
 
-// Надсилає повідомлення пацієнту. Нічого не записує — облік лишається за
-// викликачем (нагадування / чат / вебхук).
 export async function sendWhatsApp(
   db: D1Database,
+  organizationId: number,
   phoneNormalized: string,
   text: string,
 ): Promise<{ ok: boolean; error?: string; idMessage?: string }> {
-  const cfg = await whatsappConfig(db);
-  if (!whatsappConfigured(cfg)) return { ok: false, error: "WhatsApp не підключено (немає idInstance / apiToken)" };
+  const cfg = await whatsappConfig(db, organizationId);
+  if (!whatsappConfigured(cfg) || !cfg.enabled) {
+    return { ok: false, error: "WhatsApp не підключено для цієї організації" };
+  }
   const phone = String(phoneNormalized || "").replace(/\D/g, "");
   if (!phone) return { ok: false, error: "Некоректний номер отримувача" };
   try {

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -1,5 +1,6 @@
 // Best-effort WhatsApp through green-api.com. Configuration is organization-
-// scoped; callers must provide the tenant id that owns the patient/workflow.
+// scoped. The optional organization id is explicit at tenant-aware call sites;
+// omitted means the legacy public org1 path only.
 
 import { getOrganizationIntegrationSettings } from "./settings";
 
@@ -7,10 +8,14 @@ export { interpretBotCommand, menuText, parseIncomingWebhook } from "./whatsapp-
 export type { BotAction, IncomingMessage } from "./whatsapp-bot";
 
 const GREEN_API_HOST = "https://api.green-api.com";
+const LEGACY_PUBLIC_ORGANIZATION_ID = 1;
 
 export type WhatsAppConfig = { idInstance: string; apiToken: string; enabled: boolean };
 
-export async function whatsappConfig(db: D1Database, organizationId: number): Promise<WhatsAppConfig> {
+export async function whatsappConfig(
+  db: D1Database,
+  organizationId = LEGACY_PUBLIC_ORGANIZATION_ID,
+): Promise<WhatsAppConfig> {
   const s = await getOrganizationIntegrationSettings(db, organizationId, [
     "whatsapp_id_instance", "whatsapp_api_token_instance", "whatsapp_enabled",
   ]);
@@ -24,9 +29,9 @@ export function whatsappConfigured(cfg: WhatsAppConfig): boolean {
 
 export async function sendWhatsApp(
   db: D1Database,
-  organizationId: number,
   phoneNormalized: string,
   text: string,
+  organizationId = LEGACY_PUBLIC_ORGANIZATION_ID,
 ): Promise<{ ok: boolean; error?: string; idMessage?: string }> {
   const cfg = await whatsappConfig(db, organizationId);
   if (!whatsappConfigured(cfg) || !cfg.enabled) {

--- a/tests/control-plane-membership-role.behavior.test.mjs
+++ b/tests/control-plane-membership-role.behavior.test.mjs
@@ -32,11 +32,11 @@ test("stale global admin cannot use integration control plane after membership d
     }
 
     const reminders = await db.prepare(
-      "SELECT value FROM app_settings WHERE key = 'patient_reminders_enabled'"
+      "SELECT value FROM organization_integration_settings WHERE organization_id = 1 AND key = 'patient_reminders_enabled'"
     ).first();
     assert.ok(!reminders || reminders.value !== "1", "denied settings PUT must not mutate config");
     const whatsapp = await db.prepare(
-      "SELECT value FROM app_settings WHERE key = 'whatsapp_id_instance'"
+      "SELECT value FROM organization_integration_settings WHERE organization_id = 1 AND key = 'whatsapp_id_instance'"
     ).first();
     assert.ok(!whatsapp || whatsapp.value !== "123", "denied WhatsApp PUT must not mutate config");
   });
@@ -57,52 +57,91 @@ test("membership admin remains authoritative for the primary organization even w
   });
 });
 
-test("secondary tenant admin cannot administer legacy-global integration settings", async () => {
+test("secondary tenant admin can administer only its own integration settings", async () => {
   await withD1(async (db) => {
     await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'control-two', 'Control Two', 1)").run();
     const email = "org2-admin@example.com";
     const cookie = await seedStaffSession(db, { email, role:"admin", organizationId:2 });
 
-    for (const request of protectedRequests()) {
-      request.headers.set("cookie", cookie);
+    const settingsPut = jsonRequest("/api/staff/settings", { remindersEnabled:true }, { method:"PUT", headers:{ cookie } });
+    const settingsResponse = await callWorker(settingsPut, db);
+    assert.equal(settingsResponse.status, 200);
+
+    const whatsappPut = jsonRequest(
+      "/api/staff/whatsapp",
+      { idInstance:"123", apiToken:"secret", enabled:true },
+      { method:"PUT", headers:{ cookie } },
+    );
+    const whatsappResponse = await callWorker(whatsappPut, db);
+    assert.equal(whatsappResponse.status, 200);
+
+    // Test/registration endpoints are authorized for org2. With no corresponding
+    // gateway/bot configuration they may return a validation/provider error, but
+    // must not fail the tenant solely because it is not org1.
+    for (const request of [
+      jsonRequest("/api/staff/settings/messaging-test", { channel:"sms", to:"+380501112233" }, { headers:{ cookie } }),
+      jsonRequest("/api/staff/settings/telegram-test", {}, { headers:{ cookie } }),
+      jsonRequest("/api/staff/settings/telegram-webhook", {}, { headers:{ cookie } }),
+      jsonRequest("/api/staff/whatsapp/test", { phone:"+380501112233" }, { headers:{ cookie } }),
+    ]) {
       const response = await callWorker(request, db);
-      assert.equal(response.status, 403, `${request.method} ${new URL(request.url).pathname} must fail closed outside org 1`);
+      assert.notEqual(response.status, 403, `${request.method} ${new URL(request.url).pathname} must accept org2 system admin`);
     }
 
-    const reminders = await db.prepare(
-      "SELECT value FROM app_settings WHERE key = 'patient_reminders_enabled'"
-    ).first();
-    assert.ok(!reminders || reminders.value !== "1");
-    const whatsapp = await db.prepare(
+    const org2Reminders = await db.prepare(
+      "SELECT value FROM organization_integration_settings WHERE organization_id = 2 AND key = 'patient_reminders_enabled'"
+    ).first("value");
+    assert.equal(org2Reminders, "1");
+    const org2Whatsapp = await db.prepare(
+      "SELECT value FROM organization_integration_settings WHERE organization_id = 2 AND key = 'whatsapp_id_instance'"
+    ).first("value");
+    assert.equal(org2Whatsapp, "123");
+
+    const org1Whatsapp = await db.prepare(
+      "SELECT value FROM organization_integration_settings WHERE organization_id = 1 AND key = 'whatsapp_id_instance'"
+    ).first("value");
+    assert.notEqual(org1Whatsapp, "123", "org2 WhatsApp write must not mutate org1");
+    const legacyWhatsapp = await db.prepare(
       "SELECT value FROM app_settings WHERE key = 'whatsapp_id_instance'"
-    ).first();
-    assert.ok(!whatsapp || whatsapp.value !== "123");
+    ).first("value");
+    assert.notEqual(legacyWhatsapp, "123", "org2 WhatsApp write must not mutate legacy app_settings");
   });
 });
 
-test("integration control-plane routes derive authorization from the correct tenant context and fail closed outside the primary tenant", async () => {
+test("integration control-plane routes derive authorization and settings from tenant context", async () => {
   const { readFile } = await import("node:fs/promises");
-  const medicalContextPaths = [
+  const controlPlanePaths = [
     "../app/api/staff/settings/messaging-test/route.ts",
     "../app/api/staff/settings/telegram-test/route.ts",
     "../app/api/staff/settings/telegram-webhook/route.ts",
     "../app/api/staff/whatsapp/route.ts",
     "../app/api/staff/whatsapp/test/route.ts",
   ];
-  for (const path of medicalContextPaths) {
+  for (const path of controlPlanePaths) {
     const source = await readFile(new URL(path, import.meta.url), "utf8");
-    assert.match(source, /requireOrgContext\(request, db\)/, path);
+    assert.match(source, /requireSystemOrgContext\(request, db\)/, path);
+    assert.match(source, /canManageSystem\(ctx\.role\)/, path);
     assert.doesNotMatch(source, /requireStaff\(request, db\)/, path);
-    assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/, path);
-    assert.match(source, /ctx\.organizationId !== PRIMARY_ORGANIZATION_ID/, path);
+    assert.doesNotMatch(source, /PRIMARY_ORGANIZATION_ID/, path);
   }
+
+  const messagingTest = await readFile(new URL("../app/api/staff/settings/messaging-test/route.ts", import.meta.url), "utf8");
+  assert.match(messagingTest, /getOrganizationIntegrationSettings\(db, ctx\.organizationId/);
+  assert.doesNotMatch(messagingTest, /getSettings\(db/);
+
+  const whatsapp = await readFile(new URL("../app/api/staff/whatsapp/route.ts", import.meta.url), "utf8");
+  assert.match(whatsapp, /setOrganizationIntegrationSetting\(db, ctx\.organizationId/);
+  assert.match(whatsapp, /whatsappConfig\(db, ctx\.organizationId\)/);
+  assert.doesNotMatch(whatsapp, /setSetting\(db/);
+
+  const whatsappTest = await readFile(new URL("../app/api/staff/whatsapp/test/route.ts", import.meta.url), "utf8");
+  assert.match(whatsappTest, /sendWhatsApp\([\s\S]*ctx\.organizationId/);
 
   const settings = await readFile(new URL("../app/api/staff/settings/route.ts", import.meta.url), "utf8");
   assert.match(settings, /requireSystemOrgContext\(request, db\)/);
   assert.match(settings, /canManageSystem\(ctx\.role\)/);
   assert.doesNotMatch(settings, /requireStaff\(request, db\)/);
-  assert.match(settings, /PRIMARY_ORGANIZATION_ID = 1/);
-  assert.match(settings, /ctx\.organizationId !== PRIMARY_ORGANIZATION_ID/);
+  assert.doesNotMatch(settings, /PRIMARY_ORGANIZATION_ID/);
   assert.match(settings, /organizationId: ctx\.organizationId/);
   assert.doesNotMatch(settings, /organizationId: 1/);
 });

--- a/tests/external-calendar-tenant-isolation.behavior.test.mjs
+++ b/tests/external-calendar-tenant-isolation.behavior.test.mjs
@@ -35,8 +35,13 @@ test("secondary tenant cannot resolve or read the primary tenant external calend
   });
 });
 
-test("primary tenant provider diagnostics still see the configured external calendar", async () => {
+test("primary tenant provider diagnostics still see a genuinely legacy-only external calendar", async () => {
   await withD1(async (db) => {
+    // Migration 0089 seeds org1-scoped integration values. Remove the scoped
+    // calendar row so this fixture exercises the intentional org1 legacy read.
+    await db.prepare(
+      "DELETE FROM organization_integration_settings WHERE organization_id = 1 AND key = 'external_ics_url'"
+    ).run();
     await db.prepare(
       `INSERT INTO app_settings (key, value) VALUES ('external_ics_url', 'https://calendar.example/private.ics')
        ON CONFLICT(key) DO UPDATE SET value=excluded.value`
@@ -53,11 +58,10 @@ test("primary tenant provider diagnostics still see the configured external cale
   });
 });
 
-test("provider resolver fails closed for legacy-global calendar URL outside org 1", async () => {
+test("provider resolver asks for the external calendar in the authenticated tenant scope", async () => {
   const { readFile } = await import("node:fs/promises");
   const source = await readFile(new URL("../lib/providers/index.ts", import.meta.url), "utf8");
-  assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/);
-  assert.match(source, /ctx\.organizationId === PRIMARY_ORGANIZATION_ID/);
-  assert.match(source, /getSettings\(db, \["external_ics_url"\]\)/);
-  assert.match(source, /: Promise\.resolve\(""\)/);
+  assert.match(source, /getOrganizationIntegrationSettings\(db, ctx\.organizationId, \["external_ics_url"\]\)/);
+  assert.doesNotMatch(source, /getSettings\(db, \["external_ics_url"\]\)/);
+  assert.doesNotMatch(source, /PRIMARY_ORGANIZATION_ID/);
 });

--- a/tests/external-calendar.test.mjs
+++ b/tests/external-calendar.test.mjs
@@ -34,10 +34,11 @@ test("external-calendar endpoint serves the tenant feed via the calendar provide
   assert.match(provider, /safeOutboundUrl\(url\)/);
   assert.match(provider, /fetchLimited\(safeUrl/);
 
-  // Резолвер добирає джерело (external_ics_url) у tenant-контексті.
+  // Резолвер добирає external_ics_url лише у tenant-контексті.
   const resolver = await read("lib/providers/index.ts");
-  assert.match(resolver, /external_ics_url/);
-  assert.match(resolver, /createCalendarProvider\(icsUrl\)/);
+  assert.match(resolver, /getOrganizationIntegrationSettings\(db, ctx\.organizationId, \["external_ics_url"\]\)/);
+  assert.match(resolver, /createCalendarProvider\(calendarCfg\.external_ics_url \|\| ""\)/);
+  assert.doesNotMatch(resolver, /getSettings\(db, \["external_ics_url"\]\)/);
 });
 
 test("settings expose the external calendar URL and the dashboard shows events", async () => {

--- a/tests/global-messaging-primary-tenant.behavior.test.mjs
+++ b/tests/global-messaging-primary-tenant.behavior.test.mjs
@@ -45,6 +45,22 @@ test("secondary provider diagnostics use only explicit tenant settings",async()=
     await setOrg(db,2,"email_gateway_url","https://secondary.example/email");
     response=await callWorker(jsonRequest("/api/staff/providers",undefined,{method:"GET",headers:{cookie}}),db);
     body=await response.json(); assert.equal(body.providers.messaging.sms,true); assert.equal(body.providers.messaging.email,true);
+
+    // Model a genuinely legacy-only org1: migration 0089 normally seeds scoped rows,
+    // and scoped values must remain authoritative whenever they exist.
+    await db.prepare(`
+      DELETE FROM organization_integration_settings
+      WHERE organization_id = 1
+        AND key IN (
+          'telegram_bot_username',
+          'telegram_bot_token',
+          'sms_gateway_url',
+          'sms_gateway_auth',
+          'email_gateway_url',
+          'email_gateway_auth',
+          'email_gateway_from'
+        )
+    `).run();
     cookie=await seedStaffSession(db,{email:"org1-provider@example.com",role:"admin",organizationId:1});
     response=await callWorker(jsonRequest("/api/staff/providers",undefined,{method:"GET",headers:{cookie}}),db);
     body=await response.json(); assert.equal(body.providers.messaging.sms,true); assert.equal(body.providers.messaging.email,true);

--- a/tests/global-messaging-primary-tenant.behavior.test.mjs
+++ b/tests/global-messaging-primary-tenant.behavior.test.mjs
@@ -1,216 +1,124 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  callWorker,
-  jsonRequest,
-  seedPatientSession,
-  seedStaffSession,
-  withD1,
-} from "./helpers/d1.mjs";
+import { callWorker, jsonRequest, seedPatientSession, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
 async function addOrganizationTwo(db) {
-  await db.prepare(
-    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'messaging-two', 'Messaging Two', 1)"
-  ).run();
+  await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'messaging-two', 'Messaging Two', 1)").run();
 }
-
-async function setGlobal(db, key, value) {
-  await db.prepare(
-    `INSERT INTO app_settings (key, value) VALUES (?, ?)
-     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
-  ).bind(key, value).run();
+async function setGlobal(db,key,value) {
+  await db.prepare(`INSERT INTO app_settings (key,value) VALUES (?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value`).bind(key,value).run();
 }
-
-async function addBooking(db, {
-  id,
-  organizationId,
-  code,
-  phone = "380501112233",
-  email = "",
-  date = "2026-09-01",
-  time = "10:00",
-}) {
+async function setOrg(db,organizationId,key,value) {
+  await db.prepare(`INSERT INTO organization_integration_settings (organization_id,key,value) VALUES (?,?,?) ON CONFLICT(organization_id,key) DO UPDATE SET value=excluded.value`).bind(organizationId,key,value).run();
+}
+async function addBooking(db,{id,organizationId,code,phone="380501112233",email="",date="2026-09-01",time="10:00"}) {
   await db.prepare(
     `INSERT INTO bookings
       (id, organization_id, code, name, phone, phone_normalized, patient_email,
        service, service_code, desired_date, desired_time, status, date_of_birth, patient_category)
      VALUES (?, ?, ?, ?, ?, ?, ?, 'КТ', 'CT-01', ?, ?, 'confirmed', '1990-05-05', 'civilian')`
-  ).bind(id, organizationId, code, `Patient ${code}`, `+${phone}`, phone, email, date, time).run();
+  ).bind(id,organizationId,code,`Patient ${code}`,`+${phone}`,phone,email,date,time).run();
 }
 
-test("secondary tenant manual notify never uses primary global gateways", async () => {
-  await withD1(async (db) => {
-    await addOrganizationTwo(db);
-    await addBooking(db, { id:201, organizationId:2, code:"MSG-ORG2" });
-    await setGlobal(db, "sms_gateway_url", "https://gateway.example/sms");
-    await setGlobal(db, "sms_gateway_auth", "org1-secret");
-    await setGlobal(db, "email_gateway_url", "https://gateway.example/email");
-    await setGlobal(db, "telegram_bot_token", "123456:abcdefghijklmnopqrstuvwxyzABCDE");
-    await setGlobal(db, "whatsapp_id_instance", "org1-instance");
-    await setGlobal(db, "whatsapp_api_token_instance", "org1-token");
-    await setGlobal(db, "whatsapp_enabled", "1");
-
-    const cookie = await seedStaffSession(db, {
-      email:"org2-registrar@example.com", role:"registrar", organizationId:2,
-    });
-    const response = await callWorker(
-      jsonRequest(
-        "/api/staff/notify",
-        { bookingId:201, message:"Повідомлення для пацієнта" },
-        { headers:{ cookie } },
-      ),
-      db,
-    );
-    assert.equal(response.status, 200);
-    const body = await response.json();
-    assert.equal(body.summary.sent, 0);
-    assert.equal(body.summary.failed, 0);
-    assert.ok(body.summary.skipped >= 1);
-
-    const rows = await db.prepare(
-      `SELECT organization_id AS organizationId, channel, status
-       FROM patient_notifications WHERE booking_id = 201 ORDER BY id`
-    ).all();
-    assert.ok(rows.results.length >= 1);
-    assert.ok(rows.results.every((row) => row.organizationId === 2));
-    assert.ok(rows.results.every((row) => row.status === "skipped"));
-    assert.ok(rows.results.every((row) => row.channel !== "whatsapp"));
+test("secondary tenant never inherits primary global messaging gateways", async()=>{
+  await withD1(async(db)=>{
+    await addOrganizationTwo(db); await addBooking(db,{id:201,organizationId:2,code:"MSG-ORG2"});
+    await setGlobal(db,"sms_gateway_url","https://gateway.example/sms");
+    await setGlobal(db,"sms_gateway_auth","org1-secret");
+    await setGlobal(db,"email_gateway_url","https://gateway.example/email");
+    const cookie=await seedStaffSession(db,{email:"org2-registrar@example.com",role:"registrar",organizationId:2});
+    const response=await callWorker(jsonRequest("/api/staff/notify",{bookingId:201,message:"Повідомлення"},{headers:{cookie}}),db);
+    assert.equal(response.status,200); const body=await response.json();
+    assert.equal(body.summary.sent,0); assert.equal(body.summary.failed,0); assert.ok(body.summary.skipped>=1);
   });
 });
 
-test("secondary tenant contact-center cannot reply through primary WhatsApp", async () => {
-  await withD1(async (db) => {
+test("secondary provider diagnostics use only explicit tenant settings",async()=>{
+  await withD1(async(db)=>{
     await addOrganizationTwo(db);
-    const phone = "380502223344";
-    await addBooking(db, { id:202, organizationId:2, code:"CHAT-ORG2", phone });
-    await db.prepare(
-      `INSERT INTO patient_communications
-        (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
-       VALUES (2, '', ?, 'whatsapp', 'inbound', 'Org2 legacy thread', 'system')`
-    ).bind(phone).run();
-    await setGlobal(db, "whatsapp_id_instance", "org1-instance");
-    await setGlobal(db, "whatsapp_api_token_instance", "org1-token");
-    await setGlobal(db, "whatsapp_enabled", "1");
-
-    const cookie = await seedStaffSession(db, {
-      email:"org2-chat@example.com", role:"registrar", organizationId:2,
-    });
-    const thread = await callWorker(
-      jsonRequest(`/api/staff/chat?phone=${phone}`, undefined, { method:"GET", headers:{ cookie } }),
-      db,
-    );
-    assert.equal(thread.status, 200);
-    assert.deepEqual((await thread.json()).availableReplyChannels, []);
-
-    const reply = await callWorker(
-      jsonRequest(
-        "/api/staff/chat",
-        { phone:`+${phone}`, text:"Не використовуйте org1 gateway", channel:"whatsapp" },
-        { headers:{ cookie } },
-      ),
-      db,
-    );
-    assert.equal(reply.status, 403);
-    const outbound = await db.prepare(
-      `SELECT COUNT(*) AS n FROM patient_communications
-       WHERE organization_id = 2 AND phone_normalized = ? AND direction = 'outbound'`
-    ).bind(phone).first("n");
-    assert.equal(outbound, 0);
+    await setGlobal(db,"sms_gateway_url","https://primary.example/sms");
+    await setGlobal(db,"email_gateway_url","https://primary.example/email");
+    let cookie=await seedStaffSession(db,{email:"org2-provider@example.com",role:"admin",organizationId:2});
+    let response=await callWorker(jsonRequest("/api/staff/providers",undefined,{method:"GET",headers:{cookie}}),db);
+    let body=await response.json(); assert.equal(body.providers.messaging.sms,false); assert.equal(body.providers.messaging.email,false);
+    await setOrg(db,2,"sms_gateway_url","https://secondary.example/sms");
+    await setOrg(db,2,"email_gateway_url","https://secondary.example/email");
+    response=await callWorker(jsonRequest("/api/staff/providers",undefined,{method:"GET",headers:{cookie}}),db);
+    body=await response.json(); assert.equal(body.providers.messaging.sms,true); assert.equal(body.providers.messaging.email,true);
+    cookie=await seedStaffSession(db,{email:"org1-provider@example.com",role:"admin",organizationId:1});
+    response=await callWorker(jsonRequest("/api/staff/providers",undefined,{method:"GET",headers:{cookie}}),db);
+    body=await response.json(); assert.equal(body.providers.messaging.sms,true); assert.equal(body.providers.messaging.email,true);
   });
 });
 
-test("secondary tenant patient cannot receive a deep-link to the primary Telegram bot", async () => {
-  await withD1(async (db) => {
-    await addOrganizationTwo(db);
-    const phone = "380503334455";
-    await addBooking(db, { id:203, organizationId:2, code:"TG-ORG2", phone });
-    await setGlobal(db, "telegram_bot_token", "123456:abcdefghijklmnopqrstuvwxyzABCDE");
-    const cookie = await seedPatientSession(db, phone, 2);
-
-    const response = await callWorker(
-      jsonRequest("/api/my-telegram-link", {}, { headers:{ cookie } }),
-      db,
-    );
-    assert.equal(response.status, 503);
-    const body = await response.json();
-    assert.equal(body.botConfigured, false);
-    const tokens = await db.prepare(
-      "SELECT COUNT(*) AS n FROM telegram_link_tokens WHERE organization_id = 2"
-    ).first("n");
-    assert.equal(tokens, 0);
+test("secondary patient cannot receive primary Telegram bot link but can use its own cached bot",async()=>{
+  await withD1(async(db)=>{
+    await addOrganizationTwo(db); const phone="380503334455"; await addBooking(db,{id:203,organizationId:2,code:"TG-ORG2",phone});
+    await setGlobal(db,"telegram_bot_token","123456:abcdefghijklmnopqrstuvwxyzABCDE");
+    const cookie=await seedPatientSession(db,phone,2);
+    let response=await callWorker(jsonRequest("/api/my-telegram-link",{},{headers:{cookie}}),db);
+    assert.equal(response.status,503);
+    await setOrg(db,2,"telegram_bot_token","654321:abcdefghijklmnopqrstuvwxyzABCDE");
+    await setOrg(db,2,"telegram_bot_username","OrgTwoBot");
+    response=await callWorker(jsonRequest("/api/my-telegram-link",{},{headers:{cookie}}),db);
+    assert.equal(response.status,200); const body=await response.json(); assert.match(body.url,/^https:\/\/t\.me\/OrgTwoBot\?start=/);
+    const tokens=await db.prepare("SELECT COUNT(*) AS n FROM telegram_link_tokens WHERE organization_id=2").first("n"); assert.equal(tokens,1);
   });
 });
 
-test("provider diagnostics hide primary SMS/email capabilities from secondary tenant", async () => {
-  await withD1(async (db) => {
-    await addOrganizationTwo(db);
-    await setGlobal(db, "sms_gateway_url", "https://gateway.example/sms");
-    await setGlobal(db, "email_gateway_url", "https://gateway.example/email");
-
-    const org2Cookie = await seedStaffSession(db, {
-      email:"org2-provider@example.com", role:"admin", organizationId:2,
-    });
-    const org2 = await callWorker(
-      jsonRequest("/api/staff/providers", undefined, { method:"GET", headers:{ cookie:org2Cookie } }),
-      db,
-    );
-    assert.equal(org2.status, 200);
-    const org2Body = await org2.json();
-    assert.equal(org2Body.providers.messaging.sms, false);
-    assert.equal(org2Body.providers.messaging.email, false);
-
-    const org1Cookie = await seedStaffSession(db, {
-      email:"org1-provider@example.com", role:"admin", organizationId:1,
-    });
-    const org1 = await callWorker(
-      jsonRequest("/api/staff/providers", undefined, { method:"GET", headers:{ cookie:org1Cookie } }),
-      db,
-    );
-    assert.equal(org1.status, 200);
-    const org1Body = await org1.json();
-    assert.equal(org1Body.providers.messaging.sms, true);
-    assert.equal(org1Body.providers.messaging.email, true);
+test("legacy WhatsApp webhook secret remains org1 compatible",async()=>{
+  await withD1(async(db)=>{
+    await addOrganizationTwo(db); const phone="380504445566";
+    await addBooking(db,{id:204,organizationId:1,code:"WA-ORG1",phone}); await addBooking(db,{id:205,organizationId:2,code:"WA-ORG2",phone});
+    await setGlobal(db,"whatsapp_webhook_token","legacy-secret");
+    const response=await callWorker(jsonRequest("/api/whatsapp/webhook",{
+      typeWebhook:"incomingMessageReceived",idMessage:"MSG-PRIMARY-SCOPE",senderData:{chatId:`${phone}@c.us`},
+      messageData:{typeMessage:"textMessage",textMessageData:{textMessage:"невідома команда"}},
+    },{headers:{"x-webhook-token":"legacy-secret"}}),db);
+    assert.equal(response.status,200);
+    const rows=await db.prepare("SELECT organization_id AS organizationId FROM patient_communications WHERE external_id='MSG-PRIMARY-SCOPE'").all();
+    assert.equal(rows.results.length,1); assert.equal(rows.results[0].organizationId,1);
   });
 });
 
-test("global WhatsApp webhook writes and looks up only primary-tenant data", async () => {
-  await withD1(async (db) => {
-    await addOrganizationTwo(db);
-    const phone = "380504445566";
-    await addBooking(db, { id:204, organizationId:1, code:"WA-ORG1", phone, time:"09:00" });
-    await addBooking(db, { id:205, organizationId:2, code:"WA-ORG2", phone, time:"11:00" });
-    await setGlobal(db, "whatsapp_webhook_token", "webhook-secret");
-
-    const response = await callWorker(
-      jsonRequest(
-        "/api/whatsapp/webhook",
-        {
-          typeWebhook:"incomingMessageReceived",
-          idMessage:"MSG-PRIMARY-SCOPE",
-          senderData:{ chatId:`${phone}@c.us`, senderName:"Patient" },
-          messageData:{ typeMessage:"textMessage", textMessageData:{ textMessage:"невідома команда" } },
-        },
-        { headers:{ "x-webhook-token":"webhook-secret" } },
-      ),
-      db,
-    );
-    assert.equal(response.status, 200);
-
-    const rows = await db.prepare(
-      `SELECT organization_id AS organizationId, external_id AS externalId
-       FROM patient_communications WHERE external_id = 'MSG-PRIMARY-SCOPE'`
-    ).all();
-    assert.equal(rows.results.length, 1);
-    assert.equal(rows.results[0].organizationId, 1);
+test("tenant WhatsApp webhook routes same-phone data only to owning organization",async()=>{
+  await withD1(async(db)=>{
+    await addOrganizationTwo(db); const phone="380505556677";
+    await addBooking(db,{id:206,organizationId:1,code:"WA1",phone}); await addBooking(db,{id:207,organizationId:2,code:"WA2",phone});
+    await setOrg(db,2,"whatsapp_webhook_token","org2-secret");
+    const response=await callWorker(jsonRequest("/api/whatsapp/webhook",{
+      typeWebhook:"incomingMessageReceived",idMessage:"MSG-ORG2-SCOPE",senderData:{chatId:`${phone}@c.us`},
+      messageData:{typeMessage:"textMessage",textMessageData:{textMessage:"невідома команда"}},
+    },{headers:{"x-webhook-token":"org2-secret"}}),db);
+    assert.equal(response.status,200);
+    const rows=await db.prepare("SELECT organization_id AS organizationId FROM patient_communications WHERE external_id='MSG-ORG2-SCOPE'").all();
+    assert.deepEqual(rows.results.map(r=>r.organizationId),[2]);
   });
 });
 
-test("WhatsApp webhook source scopes appointment lookup and communication inserts to org 1", async () => {
-  const { readFile } = await import("node:fs/promises");
-  const source = await readFile(new URL("../app/api/whatsapp/webhook/route.ts", import.meta.url), "utf8");
-  assert.match(source, /PRIMARY_ORGANIZATION_ID = 1/);
-  assert.match(source, /WHERE organization_id = \? AND phone_normalized = \?/);
-  assert.match(source, /\.bind\(PRIMARY_ORGANIZATION_ID, phone, todayKyiv\(\)\)/);
-  assert.match(source, /\(organization_id, phone_normalized, channel, direction, summary, actor, external_id\)/);
-  assert.doesNotMatch(source, /INSERT OR IGNORE INTO patient_communications \(phone_normalized/);
+test("duplicate tenant webhook secrets fail closed",async()=>{
+  await withD1(async(db)=>{
+    await addOrganizationTwo(db); await setOrg(db,1,"whatsapp_webhook_token","duplicate-secret"); await setOrg(db,2,"whatsapp_webhook_token","duplicate-secret");
+    const response=await callWorker(jsonRequest("/api/whatsapp/webhook",{}, {headers:{"x-webhook-token":"duplicate-secret"}}),db);
+    assert.equal(response.status,401);
+  });
+});
+
+test("scoped org1 secret makes stale legacy webhook secret invalid",async()=>{
+  await withD1(async(db)=>{
+    await setGlobal(db,"whatsapp_webhook_token","old-secret"); await setOrg(db,1,"whatsapp_webhook_token","new-secret");
+    const oldResponse=await callWorker(jsonRequest("/api/whatsapp/webhook",{}, {headers:{"x-webhook-token":"old-secret"}}),db);
+    assert.equal(oldResponse.status,401);
+  });
+});
+
+test("integration source has no primary-only Telegram or webhook routing guard",async()=>{
+  const {readFile}=await import("node:fs/promises");
+  const telegram=await readFile(new URL("../app/api/my-telegram-link/route.ts",import.meta.url),"utf8");
+  const whatsappWebhook=await readFile(new URL("../app/api/whatsapp/webhook/route.ts",import.meta.url),"utf8");
+  assert.doesNotMatch(telegram,/session\.organizationId !== PRIMARY_ORGANIZATION_ID/);
+  assert.match(telegram,/telegramBotUsername\(db, session\.organizationId\)/);
+  assert.match(whatsappWebhook,/resolveOrganizationByIntegrationSecret/);
+  assert.match(whatsappWebhook,/\.bind\(organizationId,phone,todayKyiv\(\)\)/);
+  assert.doesNotMatch(whatsappWebhook,/PRIMARY_ORGANIZATION_ID = 1/);
 });

--- a/tests/messaging-test.test.mjs
+++ b/tests/messaging-test.test.mjs
@@ -4,11 +4,14 @@ import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-test("messaging-test endpoint is admin-only and sends via the saved gateway", async () => {
+test("messaging-test endpoint uses system control-plane auth and the tenant gateway", async () => {
   const route = await read("app/api/staff/settings/messaging-test/route.ts");
-  assert.match(route, /requireOrgContext\(request, db\)/);
-  assert.match(route, /ctx\.role !== "admin"/);
+  assert.match(route, /requireSystemOrgContext\(request, db\)/);
+  assert.match(route, /canManageSystem\(ctx\.role\)/);
   assert.doesNotMatch(route, /requireStaff\(request, db\)/);
+  assert.doesNotMatch(route, /PRIMARY_ORGANIZATION_ID/);
+  assert.match(route, /getOrganizationIntegrationSettings\(db, ctx\.organizationId/);
+  assert.doesNotMatch(route, /getSettings\(db/);
   assert.match(route, /createMessagingProvider\(/);
   assert.match(route, /messaging\.sendSms\(/);
   assert.match(route, /messaging\.sendEmail\(/);

--- a/tests/reminders-tenant.behavior.test.mjs
+++ b/tests/reminders-tenant.behavior.test.mjs
@@ -70,13 +70,13 @@ test("scheduled reminder SQL isolates bookings, dedupe and exact contact consent
   });
 });
 
-test("production scheduled handler keeps patient reminders on org1 and operational jobs isolated", () => {
-  assert.match(workerSource, /const INITIAL_ORGANIZATION_ID = 1/);
+test("production scheduled handler runs patient reminders for every active organization and keeps operational jobs isolated", () => {
+  assert.match(workerSource, /async function runTenantReminders\(db: D1Database, now: number\)/);
+  assert.match(workerSource, /SELECT id FROM organizations WHERE active = 1 ORDER BY id/);
+  assert.match(workerSource, /runDueReminders\(db, now, Number\(org\.id\)\)/);
+  assert.doesNotMatch(workerSource, /INITIAL_ORGANIZATION_ID/);
   assert.match(workerSource, /const now=Date\.now\(\)/);
-  assert.match(
-    workerSource,
-    /runDueReminders\(env\.DB,\s*now,\s*INITIAL_ORGANIZATION_ID\)/,
-  );
+  assert.match(workerSource, /runTenantReminders\(env\.DB, now\)/);
   assert.match(workerSource, /runOperationalTasks\(env\.DB,\s*now\)/);
   assert.match(workerSource, /Promise\.allSettled\(\[/);
   assert.match(workerSource, /async scheduled\s*\(/);

--- a/tests/reminders.test.mjs
+++ b/tests/reminders.test.mjs
@@ -54,12 +54,15 @@ test("kyivNow converts a UTC instant to Kyiv date and minutes", () => {
 
 test("worker schedules tenant-limited reminders and internal operational tasks every 15 minutes", async () => {
   const worker = await read("worker/index.ts");
+  assert.match(worker, /async function runTenantReminders\(db: D1Database, now: number\)/);
+  assert.match(worker, /SELECT id FROM organizations WHERE active = 1 ORDER BY id/);
+  assert.match(worker, /runDueReminders\(db, now, Number\(org\.id\)\)/);
   assert.match(worker, /async scheduled\(/);
   assert.match(worker, /const now=Date\.now\(\)/);
-  assert.match(worker, /runDueReminders\(env\.DB,\s*now,\s*INITIAL_ORGANIZATION_ID\)/);
-  assert.match(worker, /runOperationalTasks\(env\.DB,\s*now\)/);
+  assert.match(worker, /runTenantReminders\(env\.DB, now\)/);
+  assert.match(worker, /runOperationalTasks\(env\.DB, now\)/);
   assert.match(worker, /Promise\.allSettled\(\[/);
-  assert.match(worker, /const INITIAL_ORGANIZATION_ID = 1/);
+  assert.doesNotMatch(worker, /INITIAL_ORGANIZATION_ID/);
   assert.match(worker, /ctx\.waitUntil/);
   const wrangler = await read("wrangler.cloudflare.toml");
   assert.match(wrangler, /workers_dev = false/);
@@ -75,7 +78,7 @@ test("runner scopes bookings, dedupe and contact consent by exact identity and o
   assert.match(src, /sharedProfileCount/);
   assert.match(src, /staleLinkedContact/);
   assert.match(src, /!b\.patientId && b\.sharedProfileCount > 0/);
-  assert.match(src, /sendWhatsApp\(db, b\.phoneNormalized, body\)/);
+  assert.match(src, /sendWhatsApp\(db, b\.phoneNormalized, body, organizationId\)/);
   assert.match(src, /kind LIKE 'reminder_%h'/);
   assert.match(src, /status IN \('confirmed','rescheduled'\)/);
 });

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -97,12 +97,13 @@ test("department settings use system-admin authority and validate input", async 
   assert.ok(journal.entries.some((e) => e.tag === "0010_department_settings"));
 });
 
-test("a test-message endpoint verifies the Telegram connection (admin-only)", async () => {
+test("a test-message endpoint verifies the current organization's Telegram connection", async () => {
   const route = await read("app/api/staff/settings/telegram-test/route.ts");
-  assert.match(route, /requireOrgContext\(request, db\)/);
-  assert.match(route, /ctx\.role !== "admin"/);
+  assert.match(route, /requireSystemOrgContext\(request, db\)/);
+  assert.match(route, /canManageSystem\(ctx\.role\)/);
+  assert.doesNotMatch(route, /PRIMARY_ORGANIZATION_ID/);
   assert.doesNotMatch(route, /requireStaff\(request, db\)/);
-  assert.match(route, /sendTelegramResult\(/);
+  assert.match(route, /sendTelegramResult\(db, text, ctx\.organizationId\)/);
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /export async function sendTelegramResult/);
   assert.match(lib, /description \|\|/);

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -74,7 +74,7 @@ test("new public bookings notify the registrar via the public organization's Tel
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /api\.telegram\.org\/bot/);
   assert.match(lib, /getOrganizationIntegrationSettings\(db, organizationId/);
-  assert.match(lib, /if \(!token \|\| !chatId\) return \{ ok: false/);
+  assert.match(lib, /if \(!token \|\| !chatId\) return \{ ok:\s*false/);
   const route = await read("app/api/site-booking/route.ts");
   assert.match(route, /sendTelegram\(db,\s*bookingMessage\([\s\S]*?\),\s*PUBLIC_ORGANIZATION_ID\)/);
   assert.match(route, /bookingMessage\(/);

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -70,12 +70,13 @@ test("my-protocol returns issued protocol through immutable patient_id or the ex
   assert.match(route, /FROM protocols WHERE organization_id = \? AND booking_id = \?/);
 });
 
-test("new bookings notify the registrar via Telegram (best-effort)", async () => {
+test("new public bookings notify the registrar via the public organization's Telegram credentials", async () => {
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /api\.telegram\.org\/bot/);
+  assert.match(lib, /getOrganizationIntegrationSettings\(db, organizationId/);
   assert.match(lib, /if \(!token \|\| !chatId\) return \{ ok: false/);
   const route = await read("app/api/site-booking/route.ts");
-  assert.match(route, /sendTelegram\(/);
+  assert.match(route, /sendTelegram\(db,\s*bookingMessage\([\s\S]*?\),\s*PUBLIC_ORGANIZATION_ID\)/);
   assert.match(route, /bookingMessage\(/);
 });
 
@@ -83,7 +84,6 @@ test("department settings use system-admin authority and validate input", async 
   const route = await read("app/api/staff/settings/route.ts");
   assert.match(route, /requireSystemOrgContext\(request, db\)/);
   assert.match(route, /canManageSystem\(ctx\.role\)/);
-  assert.match(route, /ctx\.organizationId !== PRIMARY_ORGANIZATION_ID/);
   assert.doesNotMatch(route, /requireStaff\(request, db\)/);
   assert.match(route, /telegram_bot_token/);
   assert.match(route, /pay_link/);

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -106,7 +106,7 @@ test("a test-message endpoint verifies the current organization's Telegram conne
   assert.match(route, /sendTelegramResult\(db, text, ctx\.organizationId\)/);
   const lib = await read("lib/telegram.ts");
   assert.match(lib, /export async function sendTelegramResult/);
-  assert.match(lib, /description \|\|/);
+  assert.match(lib, /description\s*\|\|/);
 });
 
 test("payment link is served publicly and used by the site, not hardcoded", async () => {

--- a/tests/telegram-patient-id-access.behavior.test.mjs
+++ b/tests/telegram-patient-id-access.behavior.test.mjs
@@ -11,8 +11,11 @@ const CODE_B = "RD-260930-2";
 
 async function setSetting(db, key, value) {
   await db.prepare(
-    `INSERT INTO app_settings (key, value) VALUES (?, ?)
-     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    `INSERT INTO organization_integration_settings (organization_id, key, value, updated_by)
+     VALUES (1, ?, ?, 'test@example.com')
+     ON CONFLICT(organization_id, key) DO UPDATE SET
+       value = excluded.value,
+       updated_by = excluded.updated_by`,
   ).bind(key, value).run();
 }
 

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -54,12 +54,13 @@ test("patient link endpoint binds Telegram to patient_id and canonicalizes DOB p
   assert.match(route, /isRateLimited\(/);
 });
 
-test("public webhook is protected by the secret header set on setWebhook", async () => {
+test("public webhook resolves exactly one tenant from the secret header and fails closed", async () => {
   const route = await read("app/api/telegram/webhook/route.ts");
   assert.match(route, /x-telegram-bot-api-secret-token/);
-  assert.match(route, /provided !== secret/);
-  assert.match(route, /status: 401/);
-  assert.match(route, /handleTelegramUpdate\(/);
+  assert.match(route, /resolveOrganizationByIntegrationSecret\(db, "telegram_webhook_secret", provided\)/);
+  assert.match(route, /if \(!organizationId\) return new Response\("forbidden", \{ status: 401 \}\)/);
+  assert.match(route, /handleTelegramUpdate\(db, update, organizationId\)/);
+  assert.match(route, /sendTelegramTo\(db, chatId, reply, organizationId\)/);
 });
 
 test("admin enable endpoint registers the webhook with a stored secret", async () => {
@@ -81,9 +82,10 @@ test("telegram lib can message an arbitrary chat and register a webhook", async 
   assert.match(lib, /secret_token: secret/);
 });
 
-test("notify selects exact Telegram chat by patient_id and legacy chat by booking code only", async () => {
+test("notify selects exact Telegram chat by patient_id and sends with booking tenant credentials", async () => {
   const notify = await read("lib/notify.ts");
   assert.match(notify, /import \{ sendTelegramTo \} from ".\/telegram"/);
+  assert.match(notify, /getOrganizationIntegrationSettings/);
   assert.match(notify, /FROM patient_telegram_identities ti/);
   assert.match(notify, /b\.patient_id != '' AND ti\.patient_id = b\.patient_id/);
   assert.match(notify, /b\.patient_id = '' AND ti\.patient_id = ''/);
@@ -91,7 +93,10 @@ test("notify selects exact Telegram chat by patient_id and legacy chat by bookin
   assert.doesNotMatch(notify, /ti\.identity_kind = 'dob'.*ti\.identity_value = b\.date_of_birth/s);
   const pushes = notify.match(/channel: "telegram"/g) || [];
   assert.ok(pushes.length >= 2, "очікуємо Telegram-канал у reminder і message");
-  assert.match(notify, /sendTelegramTo\(db, telegramChatId, body\)/);
+  const sends = notify.match(/sendTelegramTo\(db, telegramChatId, body, organizationId\)/g) || [];
+  assert.ok(sends.length >= 2, "очікуємо tenant-aware Telegram send у reminder і message");
+  assert.match(notify, /whatsappConfig\(db, organizationId\)/);
+  assert.match(notify, /sendWhatsApp\(db, booking\.phoneNormalized, body, organizationId\)/);
 });
 
 test("cabinet offers a Telegram connect button that calls the link endpoint", async () => {

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -63,14 +63,17 @@ test("public webhook resolves exactly one tenant from the secret header and fail
   assert.match(route, /sendTelegramTo\(db, chatId, reply, organizationId\)/);
 });
 
-test("admin enable endpoint registers the webhook with a stored secret", async () => {
+test("system admin enables Telegram webhook with organization-scoped credentials", async () => {
   const route = await read("app/api/staff/settings/telegram-webhook/route.ts");
-  assert.match(route, /requireOrgContext\(request, db\)/);
-  assert.match(route, /ctx\.role !== "admin"/);
-  assert.doesNotMatch(route, /requireStaff\(request, db\)/);
-  assert.match(route, /setTelegramWebhook\(db, webhookUrl, secret\)/);
-  assert.match(route, /\/api\/telegram\/webhook/);
-  assert.match(route, /setSetting\(db, "telegram_webhook_secret"/);
+  assert.match(route, /requireSystemOrgContext\(request, db\)/);
+  assert.match(route, /canManageSystem\(ctx\.role\)/);
+  assert.doesNotMatch(route, /PRIMARY_ORGANIZATION_ID/);
+  assert.match(route, /getOrganizationIntegrationSettings\([\s\S]*ctx\.organizationId/);
+  assert.match(route, /setTelegramWebhook\(db, webhookUrl, secret, ctx\.organizationId\)/);
+  assert.match(route, /setOrganizationIntegrationSetting\([\s\S]*ctx\.organizationId,[\s\S]*"telegram_webhook_secret"/);
+  assert.match(route, /telegramBotUsername\(db, ctx\.organizationId\)/);
+  assert.match(route, /action: "telegram_webhook_enable"/);
+  assert.doesNotMatch(route, /\bgetSettings\(|\bsetSetting\(/);
 });
 
 test("telegram lib can message an arbitrary chat and register a webhook", async () => {

--- a/tests/telegram-patient.test.mjs
+++ b/tests/telegram-patient.test.mjs
@@ -82,7 +82,7 @@ test("telegram lib can message an arbitrary chat and register a webhook", async 
   assert.match(lib, /export async function telegramBotUsername/);
   assert.match(lib, /export async function setTelegramWebhook/);
   assert.match(lib, /getMe/);
-  assert.match(lib, /secret_token: secret/);
+  assert.match(lib, /secret_token\s*:\s*secret/);
 });
 
 test("notify selects exact Telegram chat by patient_id and sends with booking tenant credentials", async () => {

--- a/tests/whatsapp.test.mjs
+++ b/tests/whatsapp.test.mjs
@@ -47,27 +47,35 @@ test("migration 0021 adds external_id and dedupes by unique index", async () => 
 
 test("whatsapp send is a guarded no-op until configured", async () => {
   const lib = await read("lib/whatsapp.ts");
+  assert.match(lib, /getOrganizationIntegrationSettings\(db, organizationId/);
   assert.match(lib, /WhatsApp не підключено/);
   assert.match(lib, /waInstance\$\{encodeURIComponent\(cfg\.idInstance\)\}\/sendMessage/);
   assert.match(lib, /@c\.us/);
 });
 
-test("webhook route is token-guarded (constant-time + header), deduped and rate-limited", async () => {
+test("webhook route resolves one tenant by secret, dedupes and rate-limits inside that tenant", async () => {
   const route = await read("app/api/whatsapp/webhook/route.ts");
-  assert.match(route, /tokenMatches\(token, expected\)/); // звірка за сталий час
-  assert.match(route, /crypto\.subtle\.digest\("SHA-256"/); // хеш-порівняння
-  assert.match(route, /x-webhook-token/); // токен приймається із заголовка
-  assert.match(route, /isRateLimited\(db, request, "whatsapp-webhook", 60, 15\)/); // нижча стеля
+  assert.match(route, /resolveOrganizationByIntegrationSecret\(db,"whatsapp_webhook_token",token\)/);
+  assert.match(route, /if\(!organizationId\) return Response\.json\(\{ok:false\},\{status:401\}\)/);
+  assert.match(route, /x-webhook-token/); // секрет приймається із заголовка
+  assert.match(route, /`whatsapp-webhook:\$\{organizationId\}`/); // rate-limit tenant-scoped
   assert.match(route, /INSERT OR IGNORE INTO patient_communications/);
+  assert.match(route, /\.bind\(organizationId,msg\.phoneNormalized/);
+  assert.match(route, /sendWhatsApp\(db,msg\.phoneNormalized,reply,organizationId\)/);
   assert.match(route, /interpretBotCommand|botReply/);
 });
 
-test("staff whatsapp + contact-center routes are permission-guarded", async () => {
+test("staff WhatsApp administration uses system control-plane tenant scope; contact center remains medical-role guarded", async () => {
   const wa = await read("app/api/staff/whatsapp/route.ts");
-  assert.match(wa, /requireOrgContext\(request, db\)/);
-  assert.match(wa, /ctx\.role !== "admin"/);
+  assert.match(wa, /requireSystemOrgContext\(request, db\)/);
+  assert.match(wa, /canManageSystem\(ctx\.role\)/);
+  assert.doesNotMatch(wa, /PRIMARY_ORGANIZATION_ID/);
   assert.doesNotMatch(wa, /requireStaff\(request, db\)/);
+  assert.match(wa, /setOrganizationIntegrationSetting\(db, ctx\.organizationId/);
+  assert.match(wa, /whatsappConfig\(db, ctx\.organizationId\)/);
   assert.match(wa, /whatsapp_api_token_instance/);
+  assert.doesNotMatch(wa, /\bsetSetting\(db/);
+
   const chat = await read("app/api/staff/chat/route.ts");
   assert.match(chat, /canViewPatientRegistry\(member\.role\)/);
   assert.match(chat, /const CHANNELS = new Set\(\["whatsapp", "telegram", "sms", "email"\]\)/);

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -59,7 +59,6 @@ const STATIC_ASSET_PATHS = new Set([
   "/hospital-emblem.jpg",
   "/window.svg",
 ]);
-const INITIAL_ORGANIZATION_ID = 1;
 
 function secure(response: Response, request?: Request): Response {
   const headers = new Headers(response.headers);
@@ -143,6 +142,11 @@ async function recoverStaffCancellationConflict(
   return blocker ? Response.json({ error: patientOrderBlockerMessage(blocker) }, { status: 409 }) : null;
 }
 
+async function runTenantReminders(db: D1Database, now: number): Promise<void> {
+  const rows = await db.prepare("SELECT id FROM organizations WHERE active = 1 ORDER BY id").all<{ id:number }>();
+  await Promise.allSettled((rows.results || []).map((org) => runDueReminders(db, now, Number(org.id))));
+}
+
 const worker = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__ = env.DB;
@@ -213,9 +217,7 @@ const worker = {
     (globalThis as typeof globalThis & { __RADIOLOGY_DB__?: D1Database }).__RADIOLOGY_DB__ = env.DB;
     const now=Date.now();
     ctx.waitUntil(Promise.allSettled([
-      // Patient messaging remains limited to org1 until credentials are tenant-scoped.
-      runDueReminders(env.DB, now, INITIAL_ORGANIZATION_ID),
-      // Internal operational tasks use no external credentials and are safe for all active tenants.
+      runTenantReminders(env.DB, now),
       runOperationalTasks(env.DB, now),
     ]));
   },


### PR DESCRIPTION
Closes #314.

- adds organization-scoped integration settings with org1-only legacy migration/fallback
- keeps current system/organization-admin control-plane authorization
- scopes SMS/e-mail/calendar provider resolution by organization
- scopes staff integration settings writes and audit attribution
- scopes WhatsApp and Telegram credentials, patient links, and webhook routing by tenant
- rejects duplicate/stale webhook secrets fail-closed
- scopes patient payment destinations by session organization
- scopes reminder configuration and WhatsApp gateway selection

Secondary tenants never fall back to org1 credentials. Production deploy is not part of this PR.