### PR TITLE
Expose studies-performed register projection

### DIFF
--- a/docs/studies-performed-register.md
+++ b/docs/studies-performed-register.md
@@ -1,0 +1,29 @@
+# Studies performed register
+
+RadiologyOS exposes `studies_performed` as the canonical business-core register for the operational fact that an imaging study was performed.
+
+## Current compatibility projection
+
+Until the dedicated `study_performance` business document becomes the physical registrar, the register is projected from the immutable movements already produced by the completion/storno lifecycle:
+
+- `services_delivered_movements` contributes positive performed-study facts;
+- `service_correction_movements` contributes explicit negative storno facts.
+
+The projection never infers completion from mutable booking fields and never rewrites historical movements.
+
+The staff register-turnover API exposes this projection as `registers.studies` with:
+
+- `increase` — performed studies in the selected period;
+- `decrease` — explicitly reversed studies;
+- `net` — performed minus reversed studies;
+- `regionsNet` — net anatomical-region count.
+
+`breakdowns.studiesByService` exposes the same performed/reversed/net counts grouped by service code. The pre-existing `registers.services` field remains available as a backward-compatible projection over the same immutable movement union.
+
+## Security and tenancy
+
+The projection is calculated only for the current organization and inherits the existing report authorization boundary. It does not expose patient names, phone numbers, report/protocol text, or other medical content.
+
+## Next architectural step
+
+A later block will introduce the dedicated `study_performance` document/registrar and move ownership of operational study facts there. That transition must preserve existing immutable history and must not duplicate study, equipment-load, or staff-output movements.

--- a/lib/register-turnover-report.ts
+++ b/lib/register-turnover-report.ts
@@ -47,7 +47,10 @@ async function settlementTurnover(db:D1Database,organizationId:number,period:Reg
   return {opening,increase,decrease,net:increase-decrease,closing};
 }
 
-async function serviceTurnover(db:D1Database,organizationId:number,period:RegisterPeriod) {
+// Compatibility projection for the canonical studies_performed register. Until the dedicated
+// study_performance registrar owns these facts, performed-study counts are the immutable union
+// of positive service-delivery movements and their explicit storno movements.
+async function performedStudyTurnover(db:D1Database,organizationId:number,period:RegisterPeriod) {
   const row=await db.prepare(
     `SELECT
        COALESCE(SUM(CASE WHEN quantity_delta>0 THEN quantity_delta ELSE 0 END),0) AS increase,
@@ -66,6 +69,28 @@ async function serviceTurnover(db:D1Database,organizationId:number,period:Regist
   return {
     increase:Number(row?.increase||0),decrease:Number(row?.decrease||0),net:Number(row?.net||0),regionsNet:Number(row?.regionsNet||0),
   };
+}
+
+async function studiesByService(db:D1Database,organizationId:number,period:RegisterPeriod) {
+  const rows=await db.prepare(
+    `SELECT service_code AS serviceCode,
+       COALESCE(SUM(CASE WHEN quantity_delta>0 THEN quantity_delta ELSE 0 END),0) AS performed,
+       COALESCE(SUM(CASE WHEN quantity_delta<0 THEN -quantity_delta ELSE 0 END),0) AS reversed,
+       COALESCE(SUM(quantity_delta),0) AS net,
+       COALESCE(SUM(regions_delta),0) AS regionsNet
+     FROM (
+       SELECT service_code,quantity AS quantity_delta,anatomical_regions_count AS regions_delta,occurred_at
+       FROM services_delivered_movements WHERE organization_id=?
+       UNION ALL
+       SELECT service_code,quantity_delta,anatomical_regions_delta AS regions_delta,occurred_at
+       FROM service_correction_movements WHERE organization_id=?
+     ) x
+     WHERE substr(occurred_at,1,10) BETWEEN ? AND ?
+     GROUP BY service_code
+     ORDER BY ABS(net) DESC,service_code
+     LIMIT 100`
+  ).bind(organizationId,organizationId,period.from,period.to).all();
+  return rows.results;
 }
 
 async function inventoryBalances(db:D1Database,organizationId:number,period:RegisterPeriod) {
@@ -161,11 +186,11 @@ async function staffByMember(db:D1Database,organizationId:number,period:Register
 }
 
 export async function buildRegisterTurnoverReport(db:D1Database,organizationId:number,period:RegisterPeriod) {
-  const [revenue,cash,settlements,services,equipment,staff,inventory,inventoryByWarehouse,revenueServices,cashMethods,equipmentRows,staffRows]=await Promise.all([
+  const [revenue,cash,settlements,services,equipment,staff,inventory,inventoryByWarehouse,revenueServices,cashMethods,equipmentRows,staffRows,studyRows]=await Promise.all([
     deltaTurnover(db,"revenue_movements","amount_delta",organizationId,period),
     deltaTurnover(db,"cash_movements","amount_delta",organizationId,period),
     settlementTurnover(db,organizationId,period),
-    serviceTurnover(db,organizationId,period),
+    performedStudyTurnover(db,organizationId,period),
     deltaTurnover(db,"equipment_load_movements","minutes_delta",organizationId,period),
     deltaTurnover(db,"staff_output_movements","units_delta",organizationId,period),
     inventoryBalances(db,organizationId,period),
@@ -174,11 +199,13 @@ export async function buildRegisterTurnoverReport(db:D1Database,organizationId:n
     cashByMethod(db,organizationId,period),
     equipmentByUnit(db,organizationId,period),
     staffByMember(db,organizationId,period),
+    studiesByService(db,organizationId,period),
   ]);
+  const studies={...services};
   return {
     period,
     generatedAt:new Date().toISOString(),
-    registers:{revenue,cash,settlements,services,equipment,staff},
-    breakdowns:{revenueByService:revenueServices,cashByMethod:cashMethods,equipment:equipmentRows,staff:staffRows,inventory,inventoryByWarehouse},
+    registers:{revenue,cash,settlements,services,studies,equipment,staff},
+    breakdowns:{revenueByService:revenueServices,cashByMethod:cashMethods,studiesByService:studyRows,equipment:equipmentRows,staff:staffRows,inventory,inventoryByWarehouse},
   };
 }

--- a/tests/studies-performed-register.behavior.test.mjs
+++ b/tests/studies-performed-register.behavior.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedCompleted(db,{
+  organizationId=1,
+  code,
+  amount=0,
+  category="civilian",
+  performedAt,
+  duration=30,
+  regions=1,
+  serviceCode="ct-chest",
+  service="КТ ОГК",
+}={}) {
+  const result=await db.prepare(
+    `INSERT INTO bookings (
+      organization_id,code,name,phone,phone_normalized,service,service_code,equipment_id,
+      duration_minutes,desired_date,desired_time,patient_category,payment_status,payment_amount,paid_amount,
+      status,anatomical_regions_count,assigned_radiologist_email,assigned_radiographer_email
+     ) VALUES (?,?,?,'+380501112233','380501112233',?,?,'ct',?,
+       ?,?,?,'pending',?,0,'confirmed',?,'studies-doctor@example.com','studies-tech@example.com')`
+  ).bind(
+    organizationId,code,`Patient ${code}`,service,serviceCode,duration,
+    performedAt.slice(0,10),performedAt.slice(11,16),category,amount,regions,
+  ).run();
+  const bookingId=Number(result.meta.last_row_id);
+  await db.prepare(
+    "UPDATE bookings SET performed_at=?,status='completed' WHERE organization_id=? AND id=?"
+  ).bind(performedAt,organizationId,bookingId).run();
+  return bookingId;
+}
+
+async function serviceDocumentId(db,organizationId,bookingId) {
+  const row=await db.prepare(
+    `SELECT d.id FROM business_documents d
+     JOIN service_delivery_details s ON s.document_id=d.id AND s.organization_id=d.organization_id
+     WHERE d.organization_id=? AND s.booking_id=? AND d.document_type='service_delivery' LIMIT 1`
+  ).bind(organizationId,bookingId).first();
+  return Number(row?.id||0);
+}
+
+async function storno(db,cookie,sourceDocumentId) {
+  return callWorker(jsonRequest("/api/staff/service-deliveries/corrections",{
+    sourceDocumentId,
+    reason:"Сторно для регістру виконаних досліджень",
+  },{headers:{cookie}}),db);
+}
+
+async function report(db,cookie) {
+  return callWorker(new Request(
+    "http://localhost/api/staff/reports/registers?from=2026-08-01&to=2026-08-31",
+    {headers:{cookie}},
+  ),db);
+}
+
+test("studies_performed projection includes civilian, military and explicit storno facts",async()=>{
+  await withD1(async(db)=>{
+    const admin=await seedStaffSession(db,{email:"studies-admin@example.com",role:"admin",organizationId:1});
+
+    const civilian=await seedCompleted(db,{
+      code:"RD-STUDIES-CIV",amount:3000,category:"civilian",performedAt:"2026-08-10T10:00:00",regions:2,
+    });
+    const military=await seedCompleted(db,{
+      code:"RD-STUDIES-MIL",amount:5000,category:"military",performedAt:"2026-08-11T11:00:00",regions:1,
+    });
+    assert.ok(civilian>0);
+    assert.ok(military>0);
+
+    const sourceId=await serviceDocumentId(db,1,civilian);
+    assert.ok(sourceId>0);
+    const reversed=await storno(db,admin,sourceId);
+    assert.equal(reversed.status,201);
+
+    const response=await report(db,admin);
+    assert.equal(response.status,200);
+    const body=await response.json();
+
+    assert.deepEqual(body.registers.studies,{increase:2,decrease:1,net:1,regionsNet:1});
+    assert.deepEqual(body.registers.services,body.registers.studies,"legacy services projection must remain compatible");
+
+    const chest=body.breakdowns.studiesByService.find(row=>row.serviceCode==="ct-chest");
+    assert.deepEqual(chest,{serviceCode:"ct-chest",performed:2,reversed:1,net:1,regionsNet:1});
+
+    assert.equal(body.registers.revenue.net,0,"storned civilian + military-free completion must not leave revenue");
+  });
+});
+
+test("studies_performed projection is tenant scoped",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Studies Org 2','studies-org-2',1)");
+    const org1=await seedStaffSession(db,{email:"studies-org1@example.com",role:"admin",organizationId:1});
+    const org2=await seedStaffSession(db,{email:"studies-org2@example.com",role:"admin",organizationId:2});
+
+    await seedCompleted(db,{
+      organizationId:1,code:"RD-STUDIES-ORG1",amount:0,category:"military",performedAt:"2026-08-12T09:00:00",regions:1,
+    });
+    await seedCompleted(db,{
+      organizationId:2,code:"RD-STUDIES-ORG2",amount:0,category:"military",performedAt:"2026-08-12T09:30:00",regions:4,
+      serviceCode:"ct-abdomen",service:"КТ ОЧП",
+    });
+
+    const one=await report(db,org1);const oneBody=await one.json();
+    const two=await report(db,org2);const twoBody=await two.json();
+    assert.deepEqual(oneBody.registers.studies,{increase:1,decrease:0,net:1,regionsNet:1});
+    assert.deepEqual(twoBody.registers.studies,{increase:1,decrease:0,net:1,regionsNet:4});
+    assert.equal(oneBody.breakdowns.studiesByService.some(row=>row.serviceCode==="ct-abdomen"),false);
+    assert.equal(twoBody.breakdowns.studiesByService.some(row=>row.serviceCode==="ct-abdomen"),true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose the canonical `studies_performed` compatibility projection in the register turnover API as `registers.studies`
- derive it only from immutable `services_delivered_movements` + explicit `service_correction_movements`
- add `studiesByService` performed/reversed/net/regions breakdown
- preserve the existing `registers.services` field over the same movement union for backward compatibility
- document the compatibility boundary before the later dedicated `study_performance` registrar split
- cover civilian completion, military completion, storno, per-service totals and cross-tenant isolation with behavioral tests

## Safety
- no D1 migration
- no Drizzle schema change
- no historical rewrite/backfill
- no production deploy

Closes #349