### PR TITLE
Show study-performance context in business document journal

### DIFF
--- a/lib/business-document-journal.ts
+++ b/lib/business-document-journal.ts
@@ -16,10 +16,10 @@ const SUMMARY_SELECT=`
          d.number,d.occurred_at AS occurredAt,d.state,d.comment,d.created_by AS createdBy,
          d.created_at AS createdAt,d.posted_by AS postedBy,d.posted_at AS postedAt,
          d.reversed_document_id AS reversedDocumentId,d.basis_document_id AS basisDocumentId,
-         COALESCE(o.booking_id,s.booking_id,c.booking_id,f.booking_id) AS bookingId,
+         COALESCE(o.booking_id,s.booking_id,sp.booking_id,c.booking_id,f.booking_id) AS bookingId,
          COALESCE(b.code,'') AS bookingCode,COALESCE(b.name,'') AS patientName,
-         COALESCE(o.patient_id,s.patient_id,c.patient_id,f.patient_id,'') AS patientId,
-         COALESCE(o.service_title,s.service_title,c.service_title,b.service,'') AS subject,
+         COALESCE(o.patient_id,s.patient_id,sp.patient_id,c.patient_id,f.patient_id,'') AS patientId,
+         COALESCE(o.service_title,s.service_title,sp.service_title,c.service_title,b.service,'') AS subject,
          COALESCE(o.charge_amount,s.charge_amount,c.charge_amount,f.amount,0) AS amount,
          COALESCE(o.currency,s.currency,c.currency,f.currency,'UAH') AS currency,
          COALESCE(
@@ -47,13 +47,17 @@ const SUMMARY_SELECT=`
     ON o.document_id=d.id AND o.organization_id=d.organization_id
   LEFT JOIN service_delivery_details s
     ON s.document_id=d.id AND s.organization_id=d.organization_id
+  LEFT JOIN service_delivery_details sp
+    ON d.document_type='study_performance'
+   AND sp.document_id=d.basis_document_id
+   AND sp.organization_id=d.organization_id
   LEFT JOIN service_correction_details c
     ON c.document_id=d.id AND c.organization_id=d.organization_id
   LEFT JOIN finance_document_details f
     ON f.document_id=d.id AND f.organization_id=d.organization_id
   LEFT JOIN bookings b
     ON b.organization_id=d.organization_id
-   AND b.id=COALESCE(o.booking_id,s.booking_id,c.booking_id,f.booking_id)`;
+   AND b.id=COALESCE(o.booking_id,s.booking_id,sp.booking_id,c.booking_id,f.booking_id)`;
 
 export async function listBusinessDocuments(db:D1Database,organizationId:number,limit=250) {
   const rows=await db.prepare(

--- a/tests/business-document-journal.behavior.test.mjs
+++ b/tests/business-document-journal.behavior.test.mjs
@@ -47,7 +47,7 @@ async function journal(db,cookie,id=null) {
   return callWorker(new Request(`http://localhost/api/staff/business-documents${suffix}`,{headers:{cookie}}),db);
 }
 
-test("unified journal exposes service, payment, refund and storno as one tenant-scoped document stream",async()=>{
+test("unified journal exposes service, study performance, payment, refund and storno as one tenant-scoped document stream",async()=>{
   await withD1(async(db,raw)=>{
     const seeded=await seedCompleted(db,raw);
     const cookie=await seedStaffSession(db,{email:"doc-journal@example.com",role:"registrar",organizationId:1});
@@ -68,6 +68,7 @@ test("unified journal exposes service, payment, refund and storno as one tenant-
     const rows=body.documents;
 
     const service=rows.find(row=>row.id===seeded.serviceDocumentId);
+    const performance=rows.find(row=>row.journalType==="study_performance" && row.sourceDocumentId===seeded.serviceDocumentId);
     const payRow=rows.find(row=>row.id===payment.documentId);
     const refundRow=rows.find(row=>row.id===returned.documentId);
     const stornoRow=rows.find(row=>row.id===correction.document.id);
@@ -75,6 +76,14 @@ test("unified journal exposes service, payment, refund and storno as one tenant-
     assert.equal(service.state,"reversed");
     assert.equal(service.bookingCode,"RD-DOC-JOURNAL");
     assert.equal(service.amount,3200);
+    assert.ok(performance?.id>0);
+    assert.equal(performance.state,"reversed");
+    assert.equal(performance.bookingId,seeded.bookingId);
+    assert.equal(performance.bookingCode,"RD-DOC-JOURNAL");
+    assert.equal(performance.patientName,"Journal Patient");
+    assert.equal(performance.subject,"КТ ОГК");
+    assert.equal(performance.amount,0);
+    assert.equal(performance.relationType,"based_on");
     assert.equal(payRow.journalType,"payment");
     assert.equal(refundRow.journalType,"refund");
     assert.equal(refundRow.sourceDocumentId,payment.documentId);
@@ -119,6 +128,11 @@ test("document structure shows canonical parents, children and exact register mo
       row=>row.id===seeded.serviceDocumentId && row.relationType==="based_on",
     ));
     assert.equal(performanceDetail.document.state,"reversed");
+    assert.equal(performanceDetail.document.bookingId,seeded.bookingId);
+    assert.equal(performanceDetail.document.bookingCode,"RD-DOC-STRUCT");
+    assert.equal(performanceDetail.document.patientName,"Journal Patient");
+    assert.equal(performanceDetail.document.subject,"КТ ОГК");
+    assert.equal(performanceDetail.document.amount,0);
     assert.equal(performanceDetail.movements.services.length,1);
     assert.equal(performanceDetail.movements.revenue.length,0);
     assert.equal(performanceDetail.movements.settlement.length,0);
@@ -181,6 +195,9 @@ test("business document journal is tenant isolated for both list and detail",asy
     const list1=await journal(db,org1);
     const body1=await list1.json();
     assert.equal(body1.documents.some(row=>row.id===foreign.serviceDocumentId),false);
+    assert.equal(body1.documents.some(
+      row=>row.journalType==="study_performance" && row.sourceDocumentId===foreign.serviceDocumentId,
+    ),false);
 
     const foreignDetail=await journal(db,org1,foreign.serviceDocumentId);
     assert.equal(foreignDetail.status,404);


### PR DESCRIPTION
Closes #355

## Summary
- inherit booking/patient/service-title context for `study_performance` from its exact same-tenant source `service_delivery_details`
- keep `study_performance.amount = 0` so economic ownership remains on `service_delivery`
- preserve exact `basis_document_id` lineage and exact register movements
- add list/detail regression coverage and a cross-tenant assertion

## Scope
No migration, no backfill, no production deploy.