### PR TITLE
Make the D1 behavioral test adapter batch-atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,14 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload behavioral diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: behavioral-test-diagnostics
+          path: test-output.log
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/tests/d1-batch-atomicity.test.mjs
+++ b/tests/d1-batch-atomicity.test.mjs
@@ -10,7 +10,8 @@ test("behavioral D1 batch commits all successful statements in order",async()=>{
       db.prepare("INSERT INTO batch_atomicity_probe (id,value) VALUES (2,'second')"),
     ]);
     assert.equal(results.length,2);
-    assert.deepEqual(raw.prepare("SELECT id,value FROM batch_atomicity_probe ORDER BY id").all(),[
+    const rows=raw.prepare("SELECT id,value FROM batch_atomicity_probe ORDER BY id").all();
+    assert.deepEqual(rows.map(row=>({id:Number(row.id),value:String(row.value)})),[
       {id:1,value:"first"},{id:2,value:"second"},
     ]);
   });

--- a/tests/d1-batch-atomicity.test.mjs
+++ b/tests/d1-batch-atomicity.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1 } from "./helpers/d1.mjs";
+
+test("behavioral D1 batch commits all successful statements in order",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("CREATE TABLE batch_atomicity_probe (id INTEGER PRIMARY KEY,value TEXT NOT NULL)");
+    const results=await db.batch([
+      db.prepare("INSERT INTO batch_atomicity_probe (id,value) VALUES (1,'first')"),
+      db.prepare("INSERT INTO batch_atomicity_probe (id,value) VALUES (2,'second')"),
+    ]);
+    assert.equal(results.length,2);
+    assert.deepEqual(raw.prepare("SELECT id,value FROM batch_atomicity_probe ORDER BY id").all(),[
+      {id:1,value:"first"},{id:2,value:"second"},
+    ]);
+  });
+});
+
+test("behavioral D1 batch rolls back the whole sequence when any statement fails",async()=>{
+  await withD1(async(db,raw)=>{
+    raw.exec("CREATE TABLE batch_atomicity_probe (id INTEGER PRIMARY KEY,value TEXT NOT NULL)");
+    await assert.rejects(db.batch([
+      db.prepare("INSERT INTO batch_atomicity_probe (id,value) VALUES (1,'must-roll-back')"),
+      db.prepare("INSERT INTO batch_atomicity_probe (id,value) VALUES (1,'duplicate')"),
+      db.prepare("INSERT INTO batch_atomicity_probe (id,value) VALUES (2,'must-not-run')"),
+    ]),/UNIQUE constraint failed|constraint/i);
+    assert.deepEqual(raw.prepare("SELECT id,value FROM batch_atomicity_probe ORDER BY id").all(),[]);
+  });
+});

--- a/tests/helpers/d1.mjs
+++ b/tests/helpers/d1.mjs
@@ -48,8 +48,15 @@ function wrapAsD1(db) {
     prepare(sql) { return makeStmt(sql); },
     async batch(statements) {
       const out = [];
-      for (const s of statements) out.push(await s.run());
-      return out;
+      db.exec("BEGIN;");
+      try {
+        for (const s of statements) out.push(await s.run());
+        db.exec("COMMIT;");
+        return out;
+      } catch (error) {
+        try { db.exec("ROLLBACK;"); } catch {}
+        throw error;
+      }
     },
     async exec(sql) { db.exec(sql); return { count: 0, duration: 0 }; },
     _raw: db,


### PR DESCRIPTION
## Problem
The in-memory D1 adapter in `tests/helpers/d1.mjs` currently implements `db.batch()` by running statements sequentially without a transaction. Production Cloudflare D1 documents `D1Database.batch()` as transactional: if one statement fails, the whole sequence is aborted/rolled back.

This mismatch was exposed by the inventory expense registrar: a deliberately failing second statement leaves the first statement committed only in the test adapter, while production D1 would roll back the batch.

## Fix
- Wrap behavioral-adapter `batch()` in `BEGIN` / `COMMIT`, with `ROLLBACK` on error.
- Preserve statement order and returned result array.
- Add a focused adapter regression test proving both successful commit and all-or-nothing rollback.
- No production code, schema or deploy changes.

This should land independently before final validation of #378 so the expense test can keep its atomicity assertion rather than weakening it.