### PR TITLE
Remove temporary CI diagnostic upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload behavioral diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: behavioral-test-diagnostics
-          path: test-output.log
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate


### PR DESCRIPTION
Cleanup only: restore `.github/workflows/ci.yml` to the canonical workflow after the temporary behavioral-test artifact upload used during diagnostics. No runtime, schema, test semantics, or production deploy changes.