### PR TITLE
Remove temporary behavioral diagnostic upload from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload behavioral diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: behavioral-test-diagnostics
-          path: test-output.log
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate


### PR DESCRIPTION
PR #379 was merged after its diagnostic run and therefore carried the temporary failure-only `actions/upload-artifact` step into `main`. Remove only that temporary step and restore `.github/workflows/ci.yml` to the pre-diagnostic workflow. No production code, schema or deploy changes. Merge only after CI/CodeQL green.