### PR TITLE
Add inventory count workspace and journal integration

### DIFF
--- a/app/staff/inventory/counts/page.tsx
+++ b/app/staff/inventory/counts/page.tsx
@@ -50,6 +50,11 @@ export default function InventoryCountsPage(){
     }catch(e){setError(e instanceof Error?e.message:"Не вдалося завантажити інвентаризації");}
   }
   useEffect(()=>{const timer=window.setTimeout(()=>void load(),0);return()=>window.clearTimeout(timer);/* eslint-disable-next-line react-hooks/exhaustive-deps */},[]);
+  useEffect(()=>{
+    const requested=Number(new URL(window.location.href).searchParams.get("id"));
+    if(!Number.isInteger(requested)||requested<=0)return;
+    const timer=window.setTimeout(()=>void openCount(requested),0);return()=>window.clearTimeout(timer);
+  },[]);
 
   const activeWarehouses=useMemo(()=>inventory?.warehouses.filter(w=>w.active)||[],[inventory]);
   const lotMap=useMemo(()=>new Map((inventory?.lots||[]).map(lot=>[lot.id,lot])),[inventory]);

--- a/app/staff/inventory/counts/page.tsx
+++ b/app/staff/inventory/counts/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect,useMemo,useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+import {bookQuantityForBucket,discrepancy,initialCountSheet,normalizeCountSheet,type CountSheetLine} from "../../../../lib/inventory-count-workspace";
+
+type Staff={email:string;displayName:string;role:string};
+type Warehouse={id:number;code:string;name:string;active:number;isDefault:number};
+type Lot={id:number;itemId:number;itemName:string;lotNumber:string;stock:number};
+type Balance={warehouseId:number;lotId:number;stock:number};
+type InventoryPayload={warehouses:Warehouse[];lots:Lot[];warehouseBalances:Balance[];staff:Staff;error?:string};
+type CountSummary={id:number;number:string;occurredAt:string;state:string;comment:string;lineCount:number;totalBookQuantity:number;totalCountedQuantity:number;discrepancyQuantity:number};
+type CountLine={id:number;lineNo:number;itemId:number;lotId:number;warehouseId:number;warehouseName:string;itemName:string;itemUnit:string;lotNumber:string;bookQuantity:number;countedQuantity:number;discrepancyQuantity:number;reason:string};
+type CountDetail={document:CountSummary;lines:CountLine[];staff?:Staff;canManage?:boolean;error?:string};
+type CountsPayload={documents:CountSummary[];staff:Staff;canManage:boolean;error?:string};
+
+const STATE_UK:Record<string,string>={draft:"Чернетка",posted:"Проведено",cancelled:"Скасовано",reversed:"Сторновано"};
+function fmt(value:number){return Number(value||0).toLocaleString("uk-UA",{maximumFractionDigits:2});}
+function dt(value:string){const d=new Date(value);return Number.isNaN(d.getTime())?value:d.toLocaleString("uk-UA",{dateStyle:"short",timeStyle:"short"});}
+
+export default function InventoryCountsPage(){
+  const [inventory,setInventory]=useState<InventoryPayload|null>(null);
+  const [documents,setDocuments]=useState<CountSummary[]>([]);
+  const [selected,setSelected]=useState<CountDetail|null>(null);
+  const [warehouseId,setWarehouseId]=useState(0);
+  const [sheet,setSheet]=useState<CountSheetLine[]>([]);
+  const [lotToAdd,setLotToAdd]=useState(0);
+  const [comment,setComment]=useState("");
+  const [error,setError]=useState("");
+  const [toast,setToast]=useState("");
+  const [busy,setBusy]=useState(false);
+  const [canManage,setCanManage]=useState(false);
+
+  async function load(){
+    try{
+      const [inventoryResponse,countsResponse]=await Promise.all([
+        fetch("/api/staff/inventory",{cache:"no-store"}),
+        fetch("/api/staff/inventory/counts",{cache:"no-store"}),
+      ]);
+      const inv=await inventoryResponse.json().catch(()=>({})) as InventoryPayload;
+      const counts=await countsResponse.json().catch(()=>({})) as CountsPayload;
+      if(!inventoryResponse.ok)throw new Error(inv.error||"Не вдалося завантажити склад");
+      if(!countsResponse.ok)throw new Error(counts.error||"Не вдалося завантажити інвентаризації");
+      setInventory(inv);setDocuments(counts.documents||[]);setCanManage(!!counts.canManage);setError("");
+      const fallback=inv.warehouses.find(w=>w.active&&w.isDefault)||inv.warehouses.find(w=>w.active);
+      if(fallback&&!warehouseId){
+        setWarehouseId(fallback.id);
+        setSheet(initialCountSheet(fallback.id,inv.lots,inv.warehouseBalances));
+      }
+    }catch(e){setError(e instanceof Error?e.message:"Не вдалося завантажити інвентаризації");}
+  }
+  useEffect(()=>{const timer=window.setTimeout(()=>void load(),0);return()=>window.clearTimeout(timer);/* eslint-disable-next-line react-hooks/exhaustive-deps */},[]);
+
+  const activeWarehouses=useMemo(()=>inventory?.warehouses.filter(w=>w.active)||[],[inventory]);
+  const lotMap=useMemo(()=>new Map((inventory?.lots||[]).map(lot=>[lot.id,lot])),[inventory]);
+  const availableLots=useMemo(()=>{
+    const used=new Set(sheet.map(line=>line.lotId));
+    return (inventory?.lots||[]).filter(lot=>!used.has(lot.id));
+  },[inventory,sheet]);
+
+  function changeWarehouse(id:number){
+    setWarehouseId(id);setLotToAdd(0);setSelected(null);
+    if(inventory)setSheet(initialCountSheet(id,inventory.lots,inventory.warehouseBalances));
+  }
+  function addLot(){
+    if(!inventory||!warehouseId||!lotToAdd)return;
+    const book=bookQuantityForBucket(inventory.warehouseBalances,warehouseId,lotToAdd);
+    setSheet(current=>[...current,{warehouseId,lotId:lotToAdd,countedQuantity:book}]);setLotToAdd(0);
+  }
+  function setCounted(lotId:number,value:number){
+    setSheet(current=>current.map(line=>line.lotId===lotId?{...line,countedQuantity:value}:line));
+  }
+  async function createDraft(){
+    setBusy(true);setToast("");
+    try{
+      const lines=normalizeCountSheet(sheet);
+      if(!lines.length)throw new Error("Додайте хоча б один рядок інвентаризації");
+      const response=await fetch("/api/staff/inventory/counts",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({action:"create",comment,lines})});
+      const payload=await response.json().catch(()=>({})) as CountDetail;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося створити інвентаризацію");
+      setSelected(payload);setToast("✓ Чернетку інвентаризації створено");setComment("");await load();
+    }catch(e){setToast(`⚠ ${e instanceof Error?e.message:"Помилка інвентаризації"}`);}finally{setBusy(false);}
+  }
+  async function openCount(id:number){
+    setBusy(true);setToast("");
+    try{
+      const response=await fetch(`/api/staff/inventory/counts?id=${id}`,{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as CountDetail;
+      if(!response.ok)throw new Error(payload.error||"Інвентаризацію не знайдено");
+      setSelected(payload);
+    }catch(e){setToast(`⚠ ${e instanceof Error?e.message:"Помилка інвентаризації"}`);}finally{setBusy(false);}
+  }
+  async function documentAction(action:"post"|"cancel"){
+    if(!selected)return;setBusy(true);setToast("");
+    try{
+      const response=await fetch("/api/staff/inventory/counts",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({action,documentId:selected.document.id})});
+      const payload=await response.json().catch(()=>({})) as CountDetail&{ok?:boolean};
+      if(!response.ok)throw new Error(payload.error||"Не вдалося виконати дію");
+      setToast(action==="post"?"✓ Інвентаризацію проведено":"✓ Чернетку скасовано");setSelected(null);await load();
+      if(inventory){
+        const invResponse=await fetch("/api/staff/inventory",{cache:"no-store"});const inv=await invResponse.json() as InventoryPayload;
+        setInventory(inv);setSheet(initialCountSheet(warehouseId,inv.lots,inv.warehouseBalances));
+      }
+    }catch(e){setToast(`⚠ ${e instanceof Error?e.message:"Помилка інвентаризації"}`);}finally{setBusy(false);}
+  }
+
+  return <StaffWorkspaceShell active="inventory" title="Інвентаризація" description="BAS-документ фактичного перерахунку: обліковий залишок фіксує сервер, проведення створює лише різницю в immutable регістрі." staffName={inventory?.staff.displayName||inventory?.staff.email} staffRole={inventory?.staff.role}>
+    {error&&<p className="notice error">{error}</p>}
+    {toast&&<p className={`inventoryToast${toast.startsWith("⚠")?" warn":""}`} role="status">{toast}</p>}
+    <div className="inventoryTabs"><button onClick={()=>window.location.assign("/staff/inventory")}>← Склад</button><button className="active">Інвентаризації <span className="inventoryTabCount">{documents.length}</span></button></div>
+
+    {inventory&&canManage&&<section className="financeJournal">
+      <header className="financeToolbar"><div><b>Новий перерахунок</b><small>Фактична кількість може бути 0. Обліковий залишок і дельту UI не надсилає.</small></div>
+        <label><span>Склад</span><select value={warehouseId} onChange={e=>changeWarehouse(Number(e.target.value))}>{activeWarehouses.map(w=><option key={w.id} value={w.id}>{w.name} · {w.code}</option>)}</select></label>
+        <button type="button" disabled={busy||sheet.length===0} onClick={()=>void createDraft()}>Створити чернетку</button>
+      </header>
+      <div className="inventoryToolbar"><select value={lotToAdd} onChange={e=>setLotToAdd(Number(e.target.value))}><option value={0}>Додати партію з нульовим/іншим залишком…</option>{availableLots.map(lot=><option key={lot.id} value={lot.id}>{lot.itemName} · партія {lot.lotNumber||`#${lot.id}`}</option>)}</select><button type="button" disabled={!lotToAdd} onClick={addLot}>Додати</button><input value={comment} onChange={e=>setComment(e.target.value)} placeholder="Коментар до інвентаризації" maxLength={500}/></div>
+      <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Матеріал / партія</th><th className="num">Обліковий</th><th className="num">Фактичний</th><th className="num">Різниця</th><th/></tr></thead><tbody>
+        {sheet.map(line=>{const lot=lotMap.get(line.lotId);const book=inventory?bookQuantityForBucket(inventory.warehouseBalances,line.warehouseId,line.lotId):0;const delta=discrepancy(book,line.countedQuantity);return <tr key={`${line.warehouseId}-${line.lotId}`}><td><b>{lot?.itemName||`Lot #${line.lotId}`}</b><small>{lot?.lotNumber||`#${line.lotId}`}</small></td><td className="num">{fmt(book)}</td><td className="num"><input type="number" min="0" step="0.01" value={line.countedQuantity} onChange={e=>setCounted(line.lotId,Number(e.target.value))}/></td><td className={`num ${delta<0?"negative":delta>0?"positive":""}`}>{delta>0?"+":""}{fmt(delta)}</td><td><button type="button" onClick={()=>setSheet(current=>current.filter(row=>row!==line))}>Прибрати</button></td></tr>;})}
+        {sheet.length===0&&<tr><td colSpan={5}>Додайте хоча б одну партію.</td></tr>}
+      </tbody></table></div>
+    </section>}
+
+    <section className="financeJournal"><header className="financeToolbar"><div><b>Журнал інвентаризацій</b><small>Проведений документ незмінний; stale balance вимагає нової інвентаризації.</small></div><button onClick={()=>void load()} disabled={busy}>Оновити</button></header>
+      <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Документ</th><th>Дата</th><th>Стан</th><th className="num">Обліковий</th><th className="num">Фактичний</th><th className="num">Різниця</th><th/></tr></thead><tbody>{documents.map(doc=><tr key={doc.id}><td><b>{doc.number}</b><small>{doc.lineCount} ряд.</small></td><td>{dt(doc.occurredAt)}</td><td>{STATE_UK[doc.state]||doc.state}</td><td className="num">{fmt(doc.totalBookQuantity)}</td><td className="num">{fmt(doc.totalCountedQuantity)}</td><td className={`num ${doc.discrepancyQuantity<0?"negative":doc.discrepancyQuantity>0?"positive":""}`}>{doc.discrepancyQuantity>0?"+":""}{fmt(doc.discrepancyQuantity)}</td><td><button onClick={()=>void openCount(doc.id)}>Відкрити</button></td></tr>)}{documents.length===0&&<tr><td colSpan={7}>Інвентаризацій ще немає.</td></tr>}</tbody></table></div>
+    </section>
+
+    {selected&&<section className="financeJournal"><header className="financeToolbar"><div><b>{selected.document.number}</b><small>{STATE_UK[selected.document.state]||selected.document.state}</small></div>{canManage&&selected.document.state==="draft"&&<><button disabled={busy} onClick={()=>void documentAction("post")}>Провести</button><button disabled={busy} onClick={()=>void documentAction("cancel")}>Скасувати</button></>}</header>
+      <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Склад</th><th>Матеріал / партія</th><th className="num">Обліковий snapshot</th><th className="num">Фактичний</th><th className="num">Різниця</th></tr></thead><tbody>{selected.lines.map(line=><tr key={line.id}><td>{line.warehouseName}</td><td><b>{line.itemName}</b><small>{line.lotNumber||`#${line.lotId}`} · {line.itemUnit}</small></td><td className="num">{fmt(line.bookQuantity)}</td><td className="num">{fmt(line.countedQuantity)}</td><td className={`num ${line.discrepancyQuantity<0?"negative":line.discrepancyQuantity>0?"positive":""}`}>{line.discrepancyQuantity>0?"+":""}{fmt(line.discrepancyQuantity)}</td></tr>)}</tbody></table></div>
+    </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/inventory/page.tsx
+++ b/app/staff/inventory/page.tsx
@@ -26,6 +26,11 @@ const CATEGORY_UK:Record<string,string> = {
 const CATEGORY_OPTIONS = Object.entries(CATEGORY_UK);
 const STATE_UK:Record<DocumentState,string> = { draft:"Чернетка",posted:"Проведено",reversed:"Сторновано",cancelled:"Скасовано" };
 const TYPE_UK:Record<DocumentType,string> = { inventory_receipt:"Надходження матеріалів",inventory_writeoff:"Списання матеріалів" };
+const MOVEMENT_UK:Record<string,string> = {
+  receipt:"Надходження",writeoff:"Списання",
+  transfer_out:"Переміщення: вибуття",transfer_in:"Переміщення: надходження",
+  count_adjustment:"Інвентаризація",
+};
 function fmt(n:number) { return Number(n || 0).toLocaleString("uk-UA", { maximumFractionDigits:2 }); }
 function fmtDate(value:string) { const d=new Date(value); return Number.isNaN(d.getTime())?value:d.toLocaleString("uk-UA",{dateStyle:"short",timeStyle:"short"}); }
 
@@ -121,6 +126,17 @@ export default function InventoryPage() {
     } finally {setBusy(false);}
   }
 
+  function openMovementDocument(movement:Movement) {
+    if(!movement.documentId)return;
+    if(movement.movementType==="count_adjustment"){
+      window.location.assign(`/staff/inventory/counts?id=${movement.documentId}`);return;
+    }
+    if(movement.movementType==="transfer_out"||movement.movementType==="transfer_in"){
+      window.location.assign("/staff/inventory/transfers");return;
+    }
+    void openDocument(movement.documentId);
+  }
+
   async function createItem(e:React.FormEvent) {
     e.preventDefault();
     const ok=await postInventory({ action:"create_item", ...itemForm, minStock:Number(itemForm.minStock) },"Матеріал додано");
@@ -151,6 +167,7 @@ export default function InventoryPage() {
         <button className={mode==="stock"?"active":""} onClick={()=>setMode("stock")}>Залишки</button>
         <button className={mode==="documents"?"active":""} onClick={()=>setMode("documents")}>Документи <span className="inventoryTabCount">{documents.length}</span></button>
         <button className={mode==="movements"?"active":""} onClick={()=>setMode("movements")}>Рухи</button>
+        <button onClick={()=>window.location.assign("/staff/inventory/counts")}>Інвентаризація</button>
         <button onClick={()=>window.location.assign("/staff/warehouses")}>Склади</button>
       </div>
 
@@ -189,7 +206,7 @@ export default function InventoryPage() {
         </section>}
       </div>}
 
-      {mode === "movements" && <section className="inventoryMainTable movements"><div className="inventorySectionHead"><h2>Регістр рухів запасів</h2><span>останні {data.movements.length}</span></div><div className="inventoryTableWrap"><table><thead><tr><th>Дата</th><th>Склад</th><th>Матеріал / партія</th><th>Операція</th><th>Кількість</th><th>Документ</th><th>Причина</th><th>Хто</th></tr></thead><tbody>{data.movements.map(m=><tr key={m.id}><td>{m.createdAt}</td><td>{m.warehouseName||"Legacy"}<small>{m.warehouseCode}</small></td><td><b>{m.itemName}</b><small>{m.lotNumber || "без №"}</small></td><td>{m.movementType==="receipt"?"Надходження":"Списання"}</td><td className={`num ${m.quantityDelta<0?"negative":"positive"}`}>{m.quantityDelta>0?"+":""}{fmt(m.quantityDelta)} {m.unit}</td><td>{m.documentId?<button className="inventoryDocLink" onClick={()=>void openDocument(m.documentId!)}>#{m.documentId}</button>:<span className="legacyMovement">Legacy</span>}</td><td>{m.reason}{m.bookingId?<small>дослідження #{m.bookingId}</small>:null}</td><td>{m.actorEmail}</td></tr>)}</tbody></table></div></section>}
+      {mode === "movements" && <section className="inventoryMainTable movements"><div className="inventorySectionHead"><h2>Регістр рухів запасів</h2><span>останні {data.movements.length}</span></div><div className="inventoryTableWrap"><table><thead><tr><th>Дата</th><th>Склад</th><th>Матеріал / партія</th><th>Операція</th><th>Кількість</th><th>Документ</th><th>Причина</th><th>Хто</th></tr></thead><tbody>{data.movements.map(m=><tr key={m.id}><td>{m.createdAt}</td><td>{m.warehouseName||"Legacy"}<small>{m.warehouseCode}</small></td><td><b>{m.itemName}</b><small>{m.lotNumber || "без №"}</small></td><td>{MOVEMENT_UK[m.movementType]||m.movementType}</td><td className={`num ${m.quantityDelta<0?"negative":"positive"}`}>{m.quantityDelta>0?"+":""}{fmt(m.quantityDelta)} {m.unit}</td><td>{m.documentId?<button className="inventoryDocLink" onClick={()=>openMovementDocument(m)}>#{m.documentId}</button>:<span className="legacyMovement">Legacy</span>}</td><td>{m.reason}{m.bookingId?<small>дослідження #{m.bookingId}</small>:null}</td><td>{m.actorEmail}</td></tr>)}</tbody></table></div></section>}
     </>}
   </StaffWorkspaceShell>;
 }

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -74,6 +74,7 @@ const businessModules:BusinessModule[]=[
   { key:"inventory",label:"Склад",items:[
     {label:"Складський облік",href:"/staff/inventory",hint:"Залишки, надходження і списання"},
     {label:"Переміщення запасів",href:"/staff/inventory/transfers"},
+    {label:"Інвентаризація",href:"/staff/inventory/counts",hint:"Фактичний перерахунок і коригування залишків"},
     {label:"Склади",href:"/staff/warehouses"},
   ]},
   { key:"purchases",label:"Закупівлі",items:[

--- a/lib/business-document-journal.ts
+++ b/lib/business-document-journal.ts
@@ -38,10 +38,16 @@ const SUMMARY_SELECT=`
            WHEN d.reversed_document_id IS NOT NULL THEN 'reversal_of'
            ELSE ''
          END AS relationType,
-         (SELECT COUNT(*) FROM inventory_document_lines il
-          WHERE il.organization_id=d.organization_id AND il.document_id=d.id) AS lineCount,
-         COALESCE((SELECT SUM(il.quantity) FROM inventory_document_lines il
-          WHERE il.organization_id=d.organization_id AND il.document_id=d.id),0) AS totalQuantity
+         CASE WHEN d.document_type='inventory_count' THEN
+           (SELECT COUNT(*) FROM inventory_count_lines ic WHERE ic.organization_id=d.organization_id AND ic.document_id=d.id)
+         ELSE
+           (SELECT COUNT(*) FROM inventory_document_lines il WHERE il.organization_id=d.organization_id AND il.document_id=d.id)
+         END AS lineCount,
+         CASE WHEN d.document_type='inventory_count' THEN
+           COALESCE((SELECT SUM(ic.counted_quantity) FROM inventory_count_lines ic WHERE ic.organization_id=d.organization_id AND ic.document_id=d.id),0)
+         ELSE
+           COALESCE((SELECT SUM(il.quantity) FROM inventory_document_lines il WHERE il.organization_id=d.organization_id AND il.document_id=d.id),0)
+         END AS totalQuantity
   FROM business_documents d
   LEFT JOIN patient_order_details o
     ON o.document_id=d.id AND o.organization_id=d.organization_id

--- a/lib/inventory-count-workspace.ts
+++ b/lib/inventory-count-workspace.ts
@@ -1,0 +1,42 @@
+export type CountWarehouse={id:number;code:string;name:string;active:number;isDefault:number};
+export type CountLot={id:number;itemId:number;itemName:string;lotNumber:string;stock:number};
+export type CountWarehouseBalance={warehouseId:number;lotId:number;stock:number};
+export type CountSheetLine={warehouseId:number;lotId:number;countedQuantity:number};
+
+const EPS=0.000001;
+
+export function bookQuantityForBucket(
+  balances:readonly CountWarehouseBalance[],warehouseId:number,lotId:number,
+){
+  const value=balances.find(row=>row.warehouseId===warehouseId&&row.lotId===lotId)?.stock??0;
+  const n=Number(value);
+  return Number.isFinite(n)&&Math.abs(n)>EPS?n:0;
+}
+
+export function initialCountSheet(
+  warehouseId:number,lots:readonly CountLot[],balances:readonly CountWarehouseBalance[],
+):CountSheetLine[]{
+  if(!Number.isInteger(warehouseId)||warehouseId<=0)return[];
+  return lots
+    .map(lot=>({warehouseId,lotId:lot.id,countedQuantity:bookQuantityForBucket(balances,warehouseId,lot.id)}))
+    .filter(line=>line.countedQuantity>EPS);
+}
+
+export function normalizeCountSheet(lines:readonly CountSheetLine[]){
+  const seen=new Set<string>();
+  return lines.map(line=>{
+    const warehouseId=Number(line.warehouseId),lotId=Number(line.lotId),countedQuantity=Number(line.countedQuantity);
+    if(!Number.isInteger(warehouseId)||warehouseId<=0)throw new Error("inventory_count_warehouse_required");
+    if(!Number.isInteger(lotId)||lotId<=0)throw new Error("inventory_count_lot_required");
+    if(!Number.isFinite(countedQuantity)||countedQuantity<0)throw new Error("inventory_count_invalid_quantity");
+    const key=`${warehouseId}:${lotId}`;
+    if(seen.has(key))throw new Error("inventory_count_duplicate_bucket");
+    seen.add(key);
+    return{warehouseId,lotId,countedQuantity};
+  });
+}
+
+export function discrepancy(bookQuantity:number,countedQuantity:number){
+  const delta=Number(countedQuantity)-Number(bookQuantity);
+  return Math.abs(delta)<EPS?0:delta;
+}

--- a/tests/inventory-count-workspace.test.mjs
+++ b/tests/inventory-count-workspace.test.mjs
@@ -45,7 +45,7 @@ test("inventory movement history labels and routes registrar documents by moveme
   assert.match(source,/count_adjustment:\"Інвентаризація\"/);
   assert.match(source,/transfer_out:\"Переміщення: вибуття\"/);
   assert.match(source,/transfer_in:\"Переміщення: надходження\"/);
-  assert.match(source,/\/staff\/inventory\/counts\?id=\$\{movement\.documentId\}/);
+  assert.ok(source.includes('/staff/inventory/counts?id=${movement.documentId}'));
   assert.match(source,/\/staff\/inventory\/transfers/);
   assert.match(source,/MOVEMENT_UK\[m\.movementType\]\|\|m\.movementType/);
 });

--- a/tests/inventory-count-workspace.test.mjs
+++ b/tests/inventory-count-workspace.test.mjs
@@ -39,3 +39,13 @@ test("inventory module exposes counts and global journal reads count-line totals
   assert.match(journal,/COUNT\(\*\) FROM inventory_count_lines/);
   assert.match(journal,/SUM\(ic\.counted_quantity\) FROM inventory_count_lines/);
 });
+
+test("inventory movement history labels and routes registrar documents by movement type",async()=>{
+  const source=await readFile(new URL("../app/staff/inventory/page.tsx",import.meta.url),"utf8");
+  assert.match(source,/count_adjustment:\"Інвентаризація\"/);
+  assert.match(source,/transfer_out:\"Переміщення: вибуття\"/);
+  assert.match(source,/transfer_in:\"Переміщення: надходження\"/);
+  assert.match(source,/\/staff\/inventory\/counts\?id=\$\{movement\.documentId\}/);
+  assert.match(source,/\/staff\/inventory\/transfers/);
+  assert.match(source,/MOVEMENT_UK\[m\.movementType\]\|\|m\.movementType/);
+});

--- a/tests/inventory-count-workspace.test.mjs
+++ b/tests/inventory-count-workspace.test.mjs
@@ -30,3 +30,12 @@ test("workspace uses registrar API and never submits client book quantity",async
   assert.match(helper,/return\{warehouseId,lotId,countedQuantity\}/);
   assert.doesNotMatch(helper,/bookQuantity:[^F]/);
 });
+
+test("inventory module exposes counts and global journal reads count-line totals",async()=>{
+  const shell=await readFile(new URL("../app/staff/workspace-shell.tsx",import.meta.url),"utf8");
+  assert.match(shell,/Інвентаризація[^\n]+\/staff\/inventory\/counts/);
+  const journal=await readFile(new URL("../lib/business-document-journal.ts",import.meta.url),"utf8");
+  assert.match(journal,/d\.document_type='inventory_count'/);
+  assert.match(journal,/COUNT\(\*\) FROM inventory_count_lines/);
+  assert.match(journal,/SUM\(ic\.counted_quantity\) FROM inventory_count_lines/);
+});

--- a/tests/inventory-count-workspace.test.mjs
+++ b/tests/inventory-count-workspace.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {readFile} from "node:fs/promises";
+import {bookQuantityForBucket,discrepancy,initialCountSheet,normalizeCountSheet} from "../lib/inventory-count-workspace.ts";
+
+const balances=[{warehouseId:10,lotId:1,stock:5},{warehouseId:10,lotId:2,stock:0},{warehouseId:20,lotId:1,stock:9}];
+const lots=[{id:1,itemId:100,itemName:"Контраст",lotNumber:"A",stock:14},{id:2,itemId:200,itemName:"Шприц",lotNumber:"B",stock:0}];
+
+test("count workspace snapshots only visible positive buckets and keeps zero valid",()=>{
+  assert.equal(bookQuantityForBucket(balances,10,1),5);
+  assert.equal(bookQuantityForBucket(balances,10,2),0);
+  assert.deepEqual(initialCountSheet(10,lots,balances),[{warehouseId:10,lotId:1,countedQuantity:5}]);
+  assert.deepEqual(normalizeCountSheet([{warehouseId:10,lotId:2,countedQuantity:0}]),[{warehouseId:10,lotId:2,countedQuantity:0}]);
+  assert.equal(discrepancy(5,3),-2);assert.equal(discrepancy(5,8),3);assert.equal(discrepancy(5,5),0);
+});
+
+test("count workspace rejects forged/duplicate bucket shapes before request",()=>{
+  assert.throws(()=>normalizeCountSheet([{warehouseId:0,lotId:1,countedQuantity:1}]),/warehouse_required/);
+  assert.throws(()=>normalizeCountSheet([{warehouseId:10,lotId:0,countedQuantity:1}]),/lot_required/);
+  assert.throws(()=>normalizeCountSheet([{warehouseId:10,lotId:1,countedQuantity:-1}]),/invalid_quantity/);
+  assert.throws(()=>normalizeCountSheet([{warehouseId:10,lotId:1,countedQuantity:1},{warehouseId:10,lotId:1,countedQuantity:2}]),/duplicate_bucket/);
+});
+
+test("workspace uses registrar API and never submits client book quantity",async()=>{
+  const source=await readFile(new URL("../app/staff/inventory/counts/page.tsx",import.meta.url),"utf8");
+  assert.match(source,/\/api\/staff\/inventory\/counts/);
+  assert.match(source,/action:\"create\",comment,lines/);
+  assert.match(source,/normalizeCountSheet\(sheet\)/);
+  const helper=await readFile(new URL("../lib/inventory-count-workspace.ts",import.meta.url),"utf8");
+  assert.match(helper,/return\{warehouseId,lotId,countedQuantity\}/);
+  assert.doesNotMatch(helper,/bookQuantity:[^F]/);
+});


### PR DESCRIPTION
## Goal
Expose the #386 inventory-count registrar to staff without weakening its server/D1 invariants.

## Scope
- add `/staff/inventory/counts` workspace for admin/radiographer;
- show active warehouses, all active-item lots (including lots whose current warehouse balance is zero), and current book balance;
- build a local multi-line count sheet, then create one immutable draft through `/api/staff/inventory/counts`;
- open existing count documents and post/cancel drafts using the existing #386 API;
- surface count entry from the main inventory workspace;
- label `count_adjustment`, transfer movements, receipt and writeoff correctly in inventory movement history; count movement links open the count document instead of the receipt/writeoff document endpoint;
- make the global business-document journal derive `lineCount` and `totalQuantity` from `inventory_count_lines` for `inventory_count` documents;
- add focused UI/journal contract tests;
- no schema/migration changes and no production deploy.

## Invariants
- UI never sends or chooses `book_quantity`; server snapshots it;
- actual count may be zero;
- saved draft lines remain immutable once created;
- all posting safety stays in #386 D1 registrar;
- no client-computed inventory movement is persisted.