### PR TITLE
Integrate inventory count into stock movements and business journal

### DIFF
--- a/app/staff/inventory/page.tsx
+++ b/app/staff/inventory/page.tsx
@@ -26,6 +26,11 @@ const CATEGORY_UK:Record<string,string> = {
 const CATEGORY_OPTIONS = Object.entries(CATEGORY_UK);
 const STATE_UK:Record<DocumentState,string> = { draft:"Чернетка",posted:"Проведено",reversed:"Сторновано",cancelled:"Скасовано" };
 const TYPE_UK:Record<DocumentType,string> = { inventory_receipt:"Надходження матеріалів",inventory_writeoff:"Списання матеріалів" };
+const MOVEMENT_UK:Record<string,string> = {
+  receipt:"Надходження",writeoff:"Списання",
+  transfer_out:"Переміщення: вибуття",transfer_in:"Переміщення: надходження",
+  count_adjustment:"Інвентаризація",
+};
 function fmt(n:number) { return Number(n || 0).toLocaleString("uk-UA", { maximumFractionDigits:2 }); }
 function fmtDate(value:string) { const d=new Date(value); return Number.isNaN(d.getTime())?value:d.toLocaleString("uk-UA",{dateStyle:"short",timeStyle:"short"}); }
 
@@ -121,6 +126,17 @@ export default function InventoryPage() {
     } finally {setBusy(false);}
   }
 
+  function openMovementDocument(movement:Movement) {
+    if(!movement.documentId)return;
+    if(movement.movementType==="count_adjustment"){
+      window.location.assign(`/staff/inventory/counts?id=${movement.documentId}`);return;
+    }
+    if(movement.movementType==="transfer_out"||movement.movementType==="transfer_in"){
+      window.location.assign("/staff/inventory/transfers");return;
+    }
+    void openDocument(movement.documentId);
+  }
+
   async function createItem(e:React.FormEvent) {
     e.preventDefault();
     const ok=await postInventory({ action:"create_item", ...itemForm, minStock:Number(itemForm.minStock) },"Матеріал додано");
@@ -151,6 +167,7 @@ export default function InventoryPage() {
         <button className={mode==="stock"?"active":""} onClick={()=>setMode("stock")}>Залишки</button>
         <button className={mode==="documents"?"active":""} onClick={()=>setMode("documents")}>Документи <span className="inventoryTabCount">{documents.length}</span></button>
         <button className={mode==="movements"?"active":""} onClick={()=>setMode("movements")}>Рухи</button>
+        <button onClick={()=>window.location.assign("/staff/inventory/counts")}>Інвентаризація</button>
         <button onClick={()=>window.location.assign("/staff/warehouses")}>Склади</button>
       </div>
 
@@ -189,7 +206,7 @@ export default function InventoryPage() {
         </section>}
       </div>}
 
-      {mode === "movements" && <section className="inventoryMainTable movements"><div className="inventorySectionHead"><h2>Регістр рухів запасів</h2><span>останні {data.movements.length}</span></div><div className="inventoryTableWrap"><table><thead><tr><th>Дата</th><th>Склад</th><th>Матеріал / партія</th><th>Операція</th><th>Кількість</th><th>Документ</th><th>Причина</th><th>Хто</th></tr></thead><tbody>{data.movements.map(m=><tr key={m.id}><td>{m.createdAt}</td><td>{m.warehouseName||"Legacy"}<small>{m.warehouseCode}</small></td><td><b>{m.itemName}</b><small>{m.lotNumber || "без №"}</small></td><td>{m.movementType==="receipt"?"Надходження":"Списання"}</td><td className={`num ${m.quantityDelta<0?"negative":"positive"}`}>{m.quantityDelta>0?"+":""}{fmt(m.quantityDelta)} {m.unit}</td><td>{m.documentId?<button className="inventoryDocLink" onClick={()=>void openDocument(m.documentId!)}>#{m.documentId}</button>:<span className="legacyMovement">Legacy</span>}</td><td>{m.reason}{m.bookingId?<small>дослідження #{m.bookingId}</small>:null}</td><td>{m.actorEmail}</td></tr>)}</tbody></table></div></section>}
+      {mode === "movements" && <section className="inventoryMainTable movements"><div className="inventorySectionHead"><h2>Регістр рухів запасів</h2><span>останні {data.movements.length}</span></div><div className="inventoryTableWrap"><table><thead><tr><th>Дата</th><th>Склад</th><th>Матеріал / партія</th><th>Операція</th><th>Кількість</th><th>Документ</th><th>Причина</th><th>Хто</th></tr></thead><tbody>{data.movements.map(m=><tr key={m.id}><td>{m.createdAt}</td><td>{m.warehouseName||"Legacy"}<small>{m.warehouseCode}</small></td><td><b>{m.itemName}</b><small>{m.lotNumber || "без №"}</small></td><td>{MOVEMENT_UK[m.movementType]||m.movementType}</td><td className={`num ${m.quantityDelta<0?"negative":"positive"}`}>{m.quantityDelta>0?"+":""}{fmt(m.quantityDelta)} {m.unit}</td><td>{m.documentId?<button className="inventoryDocLink" onClick={()=>openMovementDocument(m)}>#{m.documentId}</button>:<span className="legacyMovement">Legacy</span>}</td><td>{m.reason}{m.bookingId?<small>дослідження #{m.bookingId}</small>:null}</td><td>{m.actorEmail}</td></tr>)}</tbody></table></div></section>}
     </>}
   </StaffWorkspaceShell>;
 }

--- a/lib/business-document-journal.ts
+++ b/lib/business-document-journal.ts
@@ -38,10 +38,16 @@ const SUMMARY_SELECT=`
            WHEN d.reversed_document_id IS NOT NULL THEN 'reversal_of'
            ELSE ''
          END AS relationType,
-         (SELECT COUNT(*) FROM inventory_document_lines il
-          WHERE il.organization_id=d.organization_id AND il.document_id=d.id) AS lineCount,
-         COALESCE((SELECT SUM(il.quantity) FROM inventory_document_lines il
-          WHERE il.organization_id=d.organization_id AND il.document_id=d.id),0) AS totalQuantity
+         CASE WHEN d.document_type='inventory_count' THEN
+           (SELECT COUNT(*) FROM inventory_count_lines ic WHERE ic.organization_id=d.organization_id AND ic.document_id=d.id)
+         ELSE
+           (SELECT COUNT(*) FROM inventory_document_lines il WHERE il.organization_id=d.organization_id AND il.document_id=d.id)
+         END AS lineCount,
+         CASE WHEN d.document_type='inventory_count' THEN
+           COALESCE((SELECT SUM(ic.counted_quantity) FROM inventory_count_lines ic WHERE ic.organization_id=d.organization_id AND ic.document_id=d.id),0)
+         ELSE
+           COALESCE((SELECT SUM(il.quantity) FROM inventory_document_lines il WHERE il.organization_id=d.organization_id AND il.document_id=d.id),0)
+         END AS totalQuantity
   FROM business_documents d
   LEFT JOIN patient_order_details o
     ON o.document_id=d.id AND o.organization_id=d.organization_id

--- a/tests/inventory-count-journal-integration.test.mjs
+++ b/tests/inventory-count-journal-integration.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {readFile} from "node:fs/promises";
+
+const INVENTORY_PAGE=new URL("../app/staff/inventory/page.tsx",import.meta.url);
+const JOURNAL=new URL("../lib/business-document-journal.ts",import.meta.url);
+
+test("inventory movement history labels registrar movement types and routes documents correctly",async()=>{
+  const source=await readFile(INVENTORY_PAGE,"utf8");
+  assert.match(source,/count_adjustment:\"Інвентаризація\"/);
+  assert.match(source,/transfer_out:\"Переміщення: вибуття\"/);
+  assert.match(source,/transfer_in:\"Переміщення: надходження\"/);
+  assert.match(source,/movement\.movementType===\"count_adjustment\"/);
+  assert.ok(source.includes('/staff/inventory/counts?id=${movement.documentId}'));
+  assert.match(source,/movement\.movementType===\"transfer_out\"\|\|movement\.movementType===\"transfer_in\"/);
+  assert.match(source,/MOVEMENT_UK\[m\.movementType\]\|\|m\.movementType/);
+});
+
+test("inventory count is directly reachable from the main inventory workspace",async()=>{
+  const source=await readFile(INVENTORY_PAGE,"utf8");
+  assert.match(source,/window\.location\.assign\(\"\/staff\/inventory\/counts\"\)/);
+});
+
+test("business journal derives inventory-count totals from dedicated immutable count lines",async()=>{
+  const source=await readFile(JOURNAL,"utf8");
+  assert.match(source,/d\.document_type='inventory_count'/);
+  assert.match(source,/COUNT\(\*\) FROM inventory_count_lines ic/);
+  assert.match(source,/SUM\(ic\.counted_quantity\) FROM inventory_count_lines ic/);
+  assert.match(source,/SUM\(il\.quantity\) FROM inventory_document_lines il/);
+});


### PR DESCRIPTION
## Goal
Carry the non-overlapping integration pieces from #387 onto the already-merged #389 inventory-count workspace, without reintroducing the duplicate count page.

## Scope
- label stock movements by their real registrar type: receipt, writeoff, transfer in/out, inventory count adjustment;
- route count-adjustment document links to `/staff/inventory/counts?id=<documentId>` and transfer movements to the transfer workspace instead of treating every non-receipt as a writeoff;
- expose an Inventory → Інвентаризація shortcut from the main inventory tabs;
- make the global business-document journal derive `inventory_count` line count and total counted quantity from `inventory_count_lines` rather than generic `inventory_document_lines`;
- retain generic inventory-document totals for receipt/writeoff/transfer documents;
- add focused source-contract coverage;
- no schema/migration changes, no count registrar changes, no production deploy.

## Invariants
- `inventory_movements` stays the physical stock source of truth;
- `inventory_count_lines` stays the count-document line source of truth;
- no duplicated or client-computed economic facts are introduced;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.