### PR TITLE
Add immutable printed forms for inventory counts

### DIFF
--- a/app/api/staff/inventory/counts/print/route.ts
+++ b/app/api/staff/inventory/counts/print/route.ts
@@ -1,0 +1,123 @@
+import { audit } from "../../../../../../lib/audit";
+import { dbBinding } from "../../../../../../lib/db";
+import { getInventoryCount } from "../../../../../../lib/inventory-counts";
+import { printedFormStorageKey } from "../../../../../../lib/printed-form-storage-key";
+import { requireOrgContext } from "../../../../../../lib/tenant";
+
+const TEMPLATE_VERSION=1;
+const FORM_TYPE="inventory_count";
+
+type SnapshotRow={
+  id:number;documentId:number;formType:string;templateVersion:number;documentState:string;
+  payloadJson:string;generatedBy:string;generatedAt:string;storageKey:string;sha256:string;
+};
+
+function int(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
+async function sha256(value:string){
+  const bytes=new TextEncoder().encode(value);
+  const digest=await crypto.subtle.digest("SHA-256",bytes);
+  return Array.from(new Uint8Array(digest),b=>b.toString(16).padStart(2,"0")).join("");
+}
+function publicSnapshot(row:SnapshotRow){const {payloadJson:_,...snapshot}=row;void _;return snapshot;}
+
+async function renderPayload(db:D1Database,organizationId:number,documentId:number){
+  const detail=await getInventoryCount(db,organizationId,documentId);
+  if(!detail)return null;
+  const organization=await db.prepare("SELECT name FROM organizations WHERE id=? LIMIT 1")
+    .bind(organizationId).first<{name:string}>();
+  return{
+    templateVersion:TEMPLATE_VERSION,
+    formType:FORM_TYPE,
+    organization:{name:organization?.name||"Організація"},
+    document:{
+      id:detail.document.id,
+      number:detail.document.number,
+      documentType:detail.document.documentType,
+      occurredAt:detail.document.occurredAt,
+      state:detail.document.state,
+      comment:detail.document.comment,
+      createdBy:detail.document.createdBy,
+      createdAt:detail.document.createdAt,
+      postedBy:detail.document.postedBy,
+      postedAt:detail.document.postedAt,
+    },
+    lines:detail.lines.map(line=>({
+      lineNo:line.lineNo,
+      itemId:line.itemId,
+      itemName:line.itemName,
+      unit:line.itemUnit,
+      lotId:line.lotId,
+      lotNumber:line.lotNumber,
+      warehouseId:line.warehouseId,
+      warehouseCode:line.warehouseCode,
+      warehouseName:line.warehouseName,
+      bookQuantity:line.bookQuantity,
+      countedQuantity:line.countedQuantity,
+      discrepancyQuantity:line.discrepancyQuantity,
+      reason:line.reason,
+    })),
+  };
+}
+
+export async function GET(request:Request){
+  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const snapshotId=int(new URL(request.url).searchParams.get("snapshotId"));
+  if(!snapshotId)return Response.json({error:"Некоректна друкована форма"},{status:400});
+  const row=await db.prepare(
+    `SELECT s.id,s.document_id AS documentId,s.form_type AS formType,s.template_version AS templateVersion,
+            s.document_state AS documentState,s.payload_json AS payloadJson,s.generated_by AS generatedBy,
+            s.generated_at AS generatedAt,s.storage_key AS storageKey,s.sha256
+     FROM printed_form_snapshots s
+     JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+     WHERE s.organization_id=? AND s.id=? AND s.form_type='inventory_count' AND d.document_type='inventory_count' LIMIT 1`
+  ).bind(ctx.organizationId,snapshotId).first<SnapshotRow>();
+  if(!row)return Response.json({error:"Друковану форму не знайдено"},{status:404});
+  return Response.json({snapshot:publicSnapshot(row),payload:JSON.parse(row.payloadJson)});
+}
+
+export async function POST(request:Request){
+  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const documentId=int(body.documentId);if(!documentId)return Response.json({error:"Некоректний документ"},{status:400});
+  const detail=await getInventoryCount(db,ctx.organizationId,documentId);
+  if(!detail)return Response.json({error:"Документ інвентаризації не знайдено"},{status:404});
+  const documentState=detail.document.state;
+
+  if(documentState!=="draft"){
+    const existing=await db.prepare(
+      `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+              document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+              generated_at AS generatedAt,storage_key AS storageKey,sha256
+       FROM printed_form_snapshots
+       WHERE organization_id=? AND document_id=? AND form_type='inventory_count' AND document_state=?
+       ORDER BY id ASC LIMIT 1`
+    ).bind(ctx.organizationId,documentId,documentState).first<SnapshotRow>();
+    if(existing){
+      await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"printed_form_reprinted",resource:"business_document",targetId:documentId,details:{formType:FORM_TYPE,templateVersion:existing.templateVersion,snapshotId:existing.id}});
+      return Response.json({snapshot:publicSnapshot(existing),payload:JSON.parse(existing.payloadJson)});
+    }
+  }
+
+  const payload=await renderPayload(db,ctx.organizationId,documentId);
+  if(!payload)return Response.json({error:"Документ інвентаризації не знайдено"},{status:404});
+  const payloadJson=JSON.stringify(payload),hash=await sha256(payloadJson);
+  const storageKey=printedFormStorageKey({organizationId:ctx.organizationId,documentId,formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,documentState,sha256:hash});
+  await db.prepare(
+    `INSERT OR IGNORE INTO printed_form_snapshots
+      (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,storage_key,sha256)
+     VALUES (? ,?,'inventory_count',?,?,?,?,?,?)`
+  ).bind(ctx.organizationId,documentId,TEMPLATE_VERSION,documentState,payloadJson,ctx.member.email,storageKey,hash).run();
+  const snapshot=await db.prepare(
+    `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+            document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+            generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=? AND form_type='inventory_count' AND template_version=? AND document_state=? AND sha256=?
+     LIMIT 1`
+  ).bind(ctx.organizationId,documentId,TEMPLATE_VERSION,documentState,hash).first<SnapshotRow>();
+  if(!snapshot)return Response.json({error:"Не вдалося зберегти друковану форму"},{status:500});
+  await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"printed_form_generated",resource:"business_document",targetId:documentId,details:{formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,snapshotId:snapshot.id}});
+  return Response.json({snapshot:publicSnapshot(snapshot),payload},{status:201});
+}

--- a/app/api/staff/printed-forms/pdf/route.ts
+++ b/app/api/staff/printed-forms/pdf/route.ts
@@ -7,7 +7,7 @@ import {canManageFinance,type AccessRole} from "../../../../../lib/staff-auth";
 import {requireOrgContext} from "../../../../../lib/tenant";
 type Row=PrintedFormArtifactSnapshot&{documentType:string};
 const int=(v:unknown)=>{const n=Number(v);return Number.isInteger(n)&&n>0?n:null;};
-function allowed(row:Row,role:AccessRole){if(row.formType==="inventory_receipt"||row.formType==="inventory_writeoff")return row.documentType===row.formType;if(row.formType==="payment_receipt")return canManageFinance(role)&&(row.documentType==="payment"||row.documentType==="refund");if(row.formType==="service_act")return canManageFinance(role)&&row.documentType==="service_delivery";return false;}
+function allowed(row:Row,role:AccessRole){if(row.formType==="inventory_receipt"||row.formType==="inventory_writeoff"||row.formType==="inventory_count")return row.documentType===row.formType;if(row.formType==="payment_receipt")return canManageFinance(role)&&(row.documentType==="payment"||row.documentType==="refund");if(row.formType==="service_act")return canManageFinance(role)&&row.documentType==="service_delivery";return false;}
 export async function GET(request:Request){
  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});

--- a/lib/printed-form-render/index.ts
+++ b/lib/printed-form-render/index.ts
@@ -1,4 +1,5 @@
 import {asObject,escapeHtml,PRINT_CSS,type PrintedFormRenderSnapshot} from "./common.ts";
+import {renderInventoryCountPrintedForm} from "./inventory-count.ts";
 import {renderInventoryPrintedForm} from "./inventory.ts";
 import {renderPaymentPrintedForm} from "./payment.ts";
 import {renderServiceActPrintedForm} from "./service-act.ts";
@@ -6,6 +7,7 @@ export type {PrintedFormRenderSnapshot} from "./common.ts";
 export function renderPrintedFormHtml(s:PrintedFormRenderSnapshot,payload:unknown){
  const p=asObject(payload);let body="";
  if(s.formType==="inventory_receipt"||s.formType==="inventory_writeoff")body=renderInventoryPrintedForm(p);
+ else if(s.formType==="inventory_count")body=renderInventoryCountPrintedForm(p);
  else if(s.formType==="payment_receipt")body=renderPaymentPrintedForm(p);
  else if(s.formType==="service_act")body=renderServiceActPrintedForm(p);
  if(!body)throw new Error("unsupported_printed_form");

--- a/lib/printed-form-render/inventory-count.ts
+++ b/lib/printed-form-render/inventory-count.ts
@@ -1,0 +1,23 @@
+import {asArray,asObject,detail,documentHeader,escapeHtml,formatDate,meta,type RenderObject} from "./common.ts";
+
+function quantity(value:unknown){
+  const n=Number(value||0);
+  return Number.isFinite(n)?n.toLocaleString("uk-UA",{maximumFractionDigits:3}):"0";
+}
+function discrepancy(value:unknown){
+  const n=Number(value||0);
+  if(!Number.isFinite(n))return"0";
+  const text=Math.abs(n).toLocaleString("uk-UA",{maximumFractionDigits:3});
+  return n>0?`+${text}`:n<0?`−${text}`:"0";
+}
+
+export function renderInventoryCountPrintedForm(payload:RenderObject){
+  const doc=asObject(payload.document);
+  const lines=asArray(payload.lines).map(raw=>{
+    const line=asObject(raw);
+    const warehouse=`${escapeHtml(line.warehouseName||"—")}${line.warehouseCode?`<br><small>${escapeHtml(line.warehouseCode)}</small>`:""}`;
+    const lot=escapeHtml(line.lotNumber||"—");
+    return `<tr><td>${escapeHtml(line.lineNo)}</td><td>${warehouse}</td><td><b>${escapeHtml(line.itemName||"—")}</b><br><small>${escapeHtml(line.unit||"")}</small></td><td>${lot}</td><td>${escapeHtml(quantity(line.bookQuantity))}</td><td>${escapeHtml(quantity(line.countedQuantity))}</td><td><b>${escapeHtml(discrepancy(line.discrepancyQuantity))}</b></td><td>${escapeHtml(line.reason||"—")}</td></tr>`;
+  }).join("");
+  return `${documentHeader(payload,"Інвентаризація запасів")}<section class="grid">${meta("Номер",doc.number)}${meta("Дата",formatDate(doc.occurredAt))}${meta("Створив",doc.createdBy)}${meta("Стан",doc.state)}${doc.postedBy?meta("Провів",doc.postedBy)+meta("Проведено",formatDate(doc.postedAt)):""}</section>${doc.comment?`<section class="rows">${detail("Примітка",doc.comment)}</section>`:""}<table><thead><tr><th>№</th><th>Склад</th><th>Матеріал / од.</th><th>Партія</th><th>Облік</th><th>Факт</th><th>Δ</th><th>Причина</th></tr></thead><tbody>${lines}</tbody></table>`;
+}

--- a/lib/printed-form-storage-key.ts
+++ b/lib/printed-form-storage-key.ts
@@ -1,5 +1,5 @@
 export type PrintedFormStorageIdentity={organizationId:number;documentId:number;formType:string;templateVersion:number;documentState:string;sha256:string};
-const FORMS=new Set(["inventory_receipt","inventory_writeoff","payment_receipt","service_act"]);
+const FORMS=new Set(["inventory_receipt","inventory_writeoff","inventory_count","payment_receipt","service_act"]);
 const SHA=/^[a-f0-9]{64}$/;
 function state(value:string){const v=String(value||"unknown").trim().toLowerCase();return /^[a-z0-9_-]{1,32}$/.test(v)?v:"unknown";}
 export function printedFormStorageKey(s:PrintedFormStorageIdentity){

--- a/tests/inventory-count-printed-form.test.mjs
+++ b/tests/inventory-count-printed-form.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import {readFile} from "node:fs/promises";
+import test from "node:test";
+import {renderPrintedFormHtml} from "../lib/printed-form-render/index.ts";
+
+const read=(path)=>readFile(new URL(`../${path}`,import.meta.url),"utf8");
+const HASH="b".repeat(64);
+const snapshot={id:19,organizationId:1,documentId:88,formType:"inventory_count",templateVersion:1,documentState:"posted",payloadJson:"{}",storageKey:"",sha256:HASH};
+const payload={
+  templateVersion:1,formType:"inventory_count",organization:{name:"Hospital"},
+  document:{id:88,number:"ІНВ-000088",documentType:"inventory_count",occurredAt:"2026-08-19T00:00:00Z",state:"posted",comment:"Планова",createdBy:"admin@example.com",createdAt:"2026-08-19T00:00:00Z",postedBy:"admin@example.com",postedAt:"2026-08-19T00:05:00Z"},
+  lines:[{lineNo:1,itemId:7,itemName:"Контраст <script>alert(1)</script>",unit:"фл.",lotId:3,lotNumber:"LOT-7",warehouseId:2,warehouseCode:"CT",warehouseName:"КТ склад",bookQuantity:5,countedQuantity:7,discrepancyQuantity:2,reason:"Перерахунок <b>факт</b>"}],
+};
+
+test("inventory count renderer is quantity-only and escapes operator-entered text",()=>{
+  const html=renderPrintedFormHtml(snapshot,payload);
+  assert.match(html,/Інвентаризація запасів/);
+  assert.match(html,/Облік/);assert.match(html,/Факт/);assert.match(html,/Δ/);assert.match(html,/\+2/);
+  assert.match(html,/Контраст &lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html,/Перерахунок &lt;b&gt;факт&lt;\/b&gt;/);
+  assert.doesNotMatch(html,/<script>alert\(1\)<\/script>/);
+  assert.doesNotMatch(html,/грн|Ціна|Сума|unitCost|lineAmount|totalAmount/i);
+});
+
+test("inventory count snapshot source is tenant-scoped and uses dedicated count lines",async()=>{
+  const source=await read("app/api/staff/inventory/counts/print/route.ts");
+  assert.match(source,/getInventoryCount\(db,ctx\.organizationId,documentId\)/);
+  assert.match(source,/getInventoryCount\(db,organizationId,documentId\)/);
+  assert.match(source,/s\.organization_id=\? AND s\.id=\? AND s\.form_type='inventory_count' AND d\.document_type='inventory_count'/);
+  assert.match(source,/bookQuantity:line\.bookQuantity/);
+  assert.match(source,/countedQuantity:line\.countedQuantity/);
+  assert.match(source,/discrepancyQuantity:line\.discrepancyQuantity/);
+  assert.doesNotMatch(source,/inventory_document_lines/);
+  assert.doesNotMatch(source,/unitCost|lineAmount|totalAmount/);
+});
+
+test("posted count reprints preserve the earliest snapshot for that exact state",async()=>{
+  const source=await read("app/api/staff/inventory/counts/print/route.ts");
+  assert.match(source,/if\(documentState!=="draft"\)/);
+  assert.match(source,/form_type='inventory_count' AND document_state=\?/);
+  assert.match(source,/ORDER BY id ASC LIMIT 1/);
+  assert.match(source,/action:"printed_form_reprinted"/);
+  assert.match(source,/printedFormStorageKey/);
+});
+
+test("generic immutable PDF endpoint authorizes count only against the matching business document type",async()=>{
+  const source=await read("app/api/staff/printed-forms/pdf/route.ts");
+  assert.match(source,/row\.formType==="inventory_receipt"\|\|row\.formType==="inventory_writeoff"\|\|row\.formType==="inventory_count"/);
+  assert.match(source,/return row\.documentType===row\.formType/);
+  assert.match(source,/WHERE s\.organization_id=\? AND s\.id=\?/);
+});
+
+test("inventory count form type is already schema-approved, so this feature needs no migration",async()=>{
+  const migration=await read("drizzle/0059_business_inventory_documents.sql");
+  assert.match(migration,/form_type[\s\S]*'inventory_count'/);
+});

--- a/tests/inventory-count-printed-form.test.mjs
+++ b/tests/inventory-count-printed-form.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {readFile} from "node:fs/promises";
 import test from "node:test";
 import {renderPrintedFormHtml} from "../lib/printed-form-render/index.ts";
+import {printedFormStorageKey} from "../lib/printed-form-storage-key.ts";
 
 const read=(path)=>readFile(new URL(`../${path}`,import.meta.url),"utf8");
 const HASH="b".repeat(64);
@@ -20,6 +21,12 @@ test("inventory count renderer is quantity-only and escapes operator-entered tex
   assert.match(html,/Перерахунок &lt;b&gt;факт&lt;\/b&gt;/);
   assert.doesNotMatch(html,/<script>alert\(1\)<\/script>/);
   assert.doesNotMatch(html,/грн|Ціна|Сума|unitCost|lineAmount|totalAmount/i);
+});
+
+test("inventory count PDF storage keys are deterministic and tenant-separated",()=>{
+  const one=printedFormStorageKey(snapshot),same=printedFormStorageKey(snapshot),two=printedFormStorageKey({...snapshot,organizationId:2});
+  assert.equal(one,same);assert.notEqual(one,two);
+  assert.match(one,/^organizations\/1\/printed-forms\/88\/inventory_count\/posted\/v1\/[a-f0-9]{64}\.pdf$/);
 });
 
 test("inventory count snapshot source is tenant-scoped and uses dedicated count lines",async()=>{


### PR DESCRIPTION
## Goal
Materialize the already-declared `inventory_count` printed-form contract over the dedicated inventory-count registrar without inventing monetary valuation.

## Scope
- add `/api/staff/inventory/counts/print` for tenant-scoped immutable count snapshots;
- snapshot only canonical count-document identity plus dedicated `inventory_count_lines` observations: warehouse, item, lot, book quantity, counted quantity, discrepancy and reason;
- preserve the existing canonical reprint rule: once a document is no longer draft, the earliest snapshot for that exact document/form/state is reused across later template changes;
- reserve the canonical R2 storage key at snapshot creation using the existing `printedFormStorageKey` contract;
- add a dedicated `inventory_count` HTML renderer for Browser Run → PDF;
- allow the generic immutable PDF endpoint only when `form_type='inventory_count'` belongs to an `inventory_count` business document in the same tenant;
- add focused tests for escaping, quantity-only semantics, tenant scoping, reprint identity and schema compatibility;
- no schema/migration changes and no production deploy.

## Invariants
- no `unitCost`, `lineAmount`, `totalAmount` or synthetic valuation in the count form;
- `inventory_count_lines` remains the source for book/count/discrepancy evidence;
- snapshots and stored PDFs remain immutable and tenant-separated;
- draft forms may evolve, but first printed non-draft state is canonical for reprint;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.