### PR TITLE
Add inventory count PDF download to the workspace

### DIFF
--- a/app/staff/inventory/counts/page.tsx
+++ b/app/staff/inventory/counts/page.tsx
@@ -15,6 +15,7 @@ type CountDetail={document:CountDoc;lines:CountLine[]};
 type DraftLine={warehouseId:number;lotId:number;itemId:number;itemName:string;lotNumber:string;unit:string;bookQuantity:number;countedQuantity:string;reason:string};
 type InventoryPayload={warehouses:Warehouse[];warehouseBalances:Balance[];lots:Lot[];items:Item[];staff:Staff;canManage:boolean;error?:string};
 type CountsPayload={documents:CountDoc[];staff:Staff;canManage:boolean;error?:string};
+type CountPrintPayload={snapshot?:{id:number};error?:string};
 
 function stateLabel(state:CountState){return state==="draft"?"Чернетка":state==="posted"?"Проведено":state==="cancelled"?"Скасовано":state==="reversed"?"Сторновано":state;}
 function fmt(value:number|undefined){return Number(value||0).toLocaleString("uk-UA",{maximumFractionDigits:3});}
@@ -32,6 +33,7 @@ export default function InventoryCountsPage(){
   const [error,setError]=useState("");
   const [notice,setNotice]=useState("");
   const [busy,setBusy]=useState(false);
+  const [printing,setPrinting]=useState(false);
 
   const load=useCallback(async()=>{
     const [inventoryResponse,countsResponse]=await Promise.all([
@@ -141,6 +143,20 @@ export default function InventoryCountsPage(){
     }finally{setBusy(false);}
   }
 
+  async function downloadPdf(){
+    if(!selected||printing)return;
+    setPrinting(true);setNotice("");
+    try{
+      const response=await fetch("/api/staff/inventory/counts/print",{
+        method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({documentId:selected.document.id}),
+      });
+      const payload=await response.json().catch(()=>({})) as CountPrintPayload;
+      const snapshotId=Number(payload.snapshot?.id||0);
+      if(!response.ok||!Number.isInteger(snapshotId)||snapshotId<1){setNotice(`⚠ ${payload.error||"Не вдалося сформувати PDF"}`);return;}
+      window.location.assign(`/api/staff/printed-forms/pdf?snapshotId=${snapshotId}`);
+    }finally{setPrinting(false);}
+  }
+
   return <StaffWorkspaceShell active="inventory" title="Інвентаризація" description="Фіксація фактичних залишків із серверним знімком облікового балансу та контрольованим коригуванням при проведенні." staffName={inventory?.staff.displayName||inventory?.staff.email} staffRole={inventory?.staff.role}>
     {error&&<p className="financeError">{error}</p>}
     {!inventory&&!error&&<p className="financeLoading">Завантаження…</p>}
@@ -169,6 +185,7 @@ export default function InventoryCountsPage(){
 
         {selected&&<div className="inventoryOperations"><h3>{selected.document.number} · {stateLabel(selected.document.state)}</h3>
           <p><small>{fmtDate(selected.document.occurredAt)}{selected.document.comment?` · ${selected.document.comment}`:""}</small></p>
+          <div><button disabled={printing} type="button" onClick={()=>void downloadPdf()}>{printing?"Формування PDF…":"Завантажити PDF"}</button></div>
           <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Матеріал / партія</th><th>Склад</th><th>Облік</th><th>Факт</th><th>Δ</th></tr></thead><tbody>{selected.lines.map(line=><tr key={line.id}><td><b>{line.itemName}</b><small>{line.lotNumber||`lot #${line.lotId}`} · {line.itemUnit}</small></td><td>{line.warehouseName}</td><td>{fmt(line.bookQuantity)}</td><td>{fmt(line.countedQuantity)}</td><td>{fmt(line.discrepancyQuantity)}</td></tr>)}</tbody></table></div>
           {inventory.canManage&&selected.document.state==="draft"&&<div><button className="primary" disabled={busy} type="button" onClick={()=>void action("post")}>Провести коригування</button><button disabled={busy} type="button" onClick={()=>void action("cancel")}>Скасувати чернетку</button></div>}
         </div>}

--- a/tests/inventory-count-pdf-ui.test.mjs
+++ b/tests/inventory-count-pdf-ui.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {readFile} from "node:fs/promises";
+
+const PAGE=new URL("../app/staff/inventory/counts/page.tsx",import.meta.url);
+
+test("inventory count workspace requests a server snapshot before downloading PDF",async()=>{
+  const source=await readFile(PAGE,"utf8");
+  assert.match(source,/fetch\("\/api\/staff\/inventory\/counts\/print"/);
+  assert.match(source,/body:JSON\.stringify\(\{documentId:selected\.document\.id\}\)/);
+  assert.match(source,/snapshotId=Number\(payload\.snapshot\?\.id\|\|0\)/);
+  assert.match(source,/window\.location\.assign\(`\/api\/staff\/printed-forms\/pdf\?snapshotId=\$\{snapshotId\}`\)/);
+});
+
+test("PDF download is not gated by inventory mutation permission",async()=>{
+  const source=await readFile(PAGE,"utf8");
+  assert.match(source,/<button disabled=\{printing\} type="button" onClick=\{\(\)=>void downloadPdf\(\)\}>/);
+  assert.doesNotMatch(source,/inventory\.canManage&&<button disabled=\{printing\}/);
+  assert.match(source,/inventory\.canManage&&selected\.document\.state==="draft"/);
+});
+
+test("inventory count PDF is always server-generated, never client-rendered",async()=>{
+  const source=await readFile(PAGE,"utf8");
+  assert.doesNotMatch(source,/window\.print\(/);
+  assert.doesNotMatch(source,/Blob\(|URL\.createObjectURL|application\/pdf/);
+  assert.match(source,/Не вдалося сформувати PDF/);
+});


### PR DESCRIPTION
## Goal
Expose the immutable inventory-count printed form from #392 directly in the count workspace without moving any print logic into the browser.

## Scope
- add a PDF action for the currently opened inventory-count document;
- POST only the selected `documentId` to `/api/staff/inventory/counts/print` to obtain the canonical server snapshot;
- download through the existing `/api/staff/printed-forms/pdf?snapshotId=...` immutable artifact endpoint;
- keep PDF viewing available to staff who can already view the count document, while `canManage` continues to gate only post/cancel mutations;
- surface server errors in the existing workspace notice channel;
- add focused UI contract tests;
- no API/schema/migration changes and no production deploy.

## Invariants
- browser never renders, uploads or synthesizes PDF bytes;
- browser never supplies count book values or economic facts to the print path;
- snapshot/PDF tenant isolation and integrity remain server-owned by #392;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.