### PR TITLE
Add immutable printed forms for inventory transfers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload failing test output
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ci-test-output
-          path: test-output.log
-          if-no-files-found: error
-
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,13 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload failing test output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-test-output
+          path: test-output.log
+          if-no-files-found: error
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/app/api/staff/inventory/transfers/print/route.ts
+++ b/app/api/staff/inventory/transfers/print/route.ts
@@ -1,0 +1,125 @@
+import { audit } from "../../../../../../lib/audit";
+import { dbBinding } from "../../../../../../lib/db";
+import { getInventoryTransfer } from "../../../../../../lib/inventory-transfers";
+import { printedFormStorageKey } from "../../../../../../lib/printed-form-storage-key";
+import { requireOrgContext } from "../../../../../../lib/tenant";
+
+const TEMPLATE_VERSION=1;
+const FORM_TYPE="inventory_transfer";
+
+type SnapshotRow={
+  id:number;documentId:number;formType:string;templateVersion:number;documentState:string;
+  payloadJson:string;generatedBy:string;generatedAt:string;storageKey:string;sha256:string;
+};
+
+function int(value:unknown){const n=Number(value);return Number.isInteger(n)&&n>0?n:null;}
+async function sha256(value:string){
+  const bytes=new TextEncoder().encode(value);
+  const digest=await crypto.subtle.digest("SHA-256",bytes);
+  return Array.from(new Uint8Array(digest),b=>b.toString(16).padStart(2,"0")).join("");
+}
+function publicSnapshot(row:SnapshotRow){const {payloadJson:_,...snapshot}=row;void _;return snapshot;}
+
+async function renderPayload(db:D1Database,organizationId:number,documentId:number){
+  const detail=await getInventoryTransfer(db,organizationId,documentId);
+  if(!detail)return null;
+  const organization=await db.prepare("SELECT name FROM organizations WHERE id=? LIMIT 1")
+    .bind(organizationId).first<{name:string}>();
+  return{
+    templateVersion:TEMPLATE_VERSION,
+    formType:FORM_TYPE,
+    organization:{name:organization?.name||"Організація"},
+    document:{
+      id:detail.document.id,
+      number:detail.document.number,
+      documentType:detail.document.documentType,
+      occurredAt:detail.document.occurredAt,
+      state:detail.document.state,
+      comment:detail.document.comment,
+      createdBy:detail.document.createdBy,
+      createdAt:detail.document.createdAt,
+      postedBy:detail.document.postedBy,
+      postedAt:detail.document.postedAt,
+    },
+    lines:detail.lines.map(line=>({
+      lineNo:line.lineNo,
+      itemId:line.itemId,
+      itemName:line.itemName,
+      unit:line.unit,
+      lotId:line.lotId,
+      lotNumber:line.lotNumber,
+      expiresOn:line.expiresOn,
+      sourceWarehouseId:line.sourceWarehouseId,
+      sourceWarehouseCode:line.sourceWarehouseCode,
+      sourceWarehouseName:line.sourceWarehouseName,
+      destinationWarehouseId:line.destinationWarehouseId,
+      destinationWarehouseCode:line.destinationWarehouseCode,
+      destinationWarehouseName:line.destinationWarehouseName,
+      quantity:line.quantity,
+      reason:line.reason,
+    })),
+  };
+}
+
+export async function GET(request:Request){
+  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const snapshotId=int(new URL(request.url).searchParams.get("snapshotId"));
+  if(!snapshotId)return Response.json({error:"Некоректна друкована форма"},{status:400});
+  const row=await db.prepare(
+    `SELECT s.id,s.document_id AS documentId,s.form_type AS formType,s.template_version AS templateVersion,
+            s.document_state AS documentState,s.payload_json AS payloadJson,s.generated_by AS generatedBy,
+            s.generated_at AS generatedAt,s.storage_key AS storageKey,s.sha256
+     FROM printed_form_snapshots s
+     JOIN business_documents d ON d.id=s.document_id AND d.organization_id=s.organization_id
+     WHERE s.organization_id=? AND s.id=? AND s.form_type='inventory_transfer' AND d.document_type='inventory_transfer' LIMIT 1`
+  ).bind(ctx.organizationId,snapshotId).first<SnapshotRow>();
+  if(!row)return Response.json({error:"Друковану форму не знайдено"},{status:404});
+  return Response.json({snapshot:publicSnapshot(row),payload:JSON.parse(row.payloadJson)});
+}
+
+export async function POST(request:Request){
+  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  const body=await request.json().catch(()=>({})) as Record<string,unknown>;
+  const documentId=int(body.documentId);if(!documentId)return Response.json({error:"Некоректний документ"},{status:400});
+  const detail=await getInventoryTransfer(db,ctx.organizationId,documentId);
+  if(!detail)return Response.json({error:"Документ переміщення не знайдено"},{status:404});
+  const documentState=detail.document.state;
+
+  if(documentState!=="draft"){
+    const existing=await db.prepare(
+      `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+              document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+              generated_at AS generatedAt,storage_key AS storageKey,sha256
+       FROM printed_form_snapshots
+       WHERE organization_id=? AND document_id=? AND form_type='inventory_transfer' AND document_state=?
+       ORDER BY id ASC LIMIT 1`
+    ).bind(ctx.organizationId,documentId,documentState).first<SnapshotRow>();
+    if(existing){
+      await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"printed_form_reprinted",resource:"business_document",targetId:documentId,details:{formType:FORM_TYPE,templateVersion:existing.templateVersion,snapshotId:existing.id}});
+      return Response.json({snapshot:publicSnapshot(existing),payload:JSON.parse(existing.payloadJson)});
+    }
+  }
+
+  const payload=await renderPayload(db,ctx.organizationId,documentId);
+  if(!payload)return Response.json({error:"Документ переміщення не знайдено"},{status:404});
+  const payloadJson=JSON.stringify(payload),hash=await sha256(payloadJson);
+  const storageKey=printedFormStorageKey({organizationId:ctx.organizationId,documentId,formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,documentState,sha256:hash});
+  await db.prepare(
+    `INSERT OR IGNORE INTO printed_form_snapshots
+      (organization_id,document_id,form_type,template_version,document_state,payload_json,generated_by,storage_key,sha256)
+     VALUES (?,?,'inventory_transfer',?,?,?,?,?,?)`
+  ).bind(ctx.organizationId,documentId,TEMPLATE_VERSION,documentState,payloadJson,ctx.member.email,storageKey,hash).run();
+  const snapshot=await db.prepare(
+    `SELECT id,document_id AS documentId,form_type AS formType,template_version AS templateVersion,
+            document_state AS documentState,payload_json AS payloadJson,generated_by AS generatedBy,
+            generated_at AS generatedAt,storage_key AS storageKey,sha256
+     FROM printed_form_snapshots
+     WHERE organization_id=? AND document_id=? AND form_type='inventory_transfer' AND template_version=? AND document_state=? AND sha256=?
+     LIMIT 1`
+  ).bind(ctx.organizationId,documentId,TEMPLATE_VERSION,documentState,hash).first<SnapshotRow>();
+  if(!snapshot)return Response.json({error:"Не вдалося зберегти друковану форму"},{status:500});
+  await audit(db,{organizationId:ctx.organizationId,actorEmail:ctx.member.email,action:"printed_form_generated",resource:"business_document",targetId:documentId,details:{formType:FORM_TYPE,templateVersion:TEMPLATE_VERSION,snapshotId:snapshot.id}});
+  return Response.json({snapshot:publicSnapshot(snapshot),payload},{status:201});
+}

--- a/app/api/staff/printed-forms/pdf/route.ts
+++ b/app/api/staff/printed-forms/pdf/route.ts
@@ -7,7 +7,7 @@ import {canManageFinance,type AccessRole} from "../../../../../lib/staff-auth";
 import {requireOrgContext} from "../../../../../lib/tenant";
 type Row=PrintedFormArtifactSnapshot&{documentType:string};
 const int=(v:unknown)=>{const n=Number(v);return Number.isInteger(n)&&n>0?n:null;};
-function allowed(row:Row,role:AccessRole){if(row.formType==="inventory_receipt"||row.formType==="inventory_writeoff"||row.formType==="inventory_count")return row.documentType===row.formType;if(row.formType==="payment_receipt")return canManageFinance(role)&&(row.documentType==="payment"||row.documentType==="refund");if(row.formType==="service_act")return canManageFinance(role)&&row.documentType==="service_delivery";return false;}
+function allowed(row:Row,role:AccessRole){if(row.formType==="inventory_receipt"||row.formType==="inventory_writeoff"||row.formType==="inventory_transfer"||row.formType==="inventory_count")return row.documentType===row.formType;if(row.formType==="payment_receipt")return canManageFinance(role)&&(row.documentType==="payment"||row.documentType==="refund");if(row.formType==="service_act")return canManageFinance(role)&&row.documentType==="service_delivery";return false;}
 export async function GET(request:Request){
  const db=dbBinding();if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
  const ctx=await requireOrgContext(request,db);if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});

--- a/lib/printed-form-render/index.ts
+++ b/lib/printed-form-render/index.ts
@@ -1,5 +1,6 @@
 import {asObject,escapeHtml,PRINT_CSS,type PrintedFormRenderSnapshot} from "./common.ts";
 import {renderInventoryCountPrintedForm} from "./inventory-count.ts";
+import {renderInventoryTransferPrintedForm} from "./inventory-transfer.ts";
 import {renderInventoryPrintedForm} from "./inventory.ts";
 import {renderPaymentPrintedForm} from "./payment.ts";
 import {renderServiceActPrintedForm} from "./service-act.ts";
@@ -8,6 +9,7 @@ export function renderPrintedFormHtml(s:PrintedFormRenderSnapshot,payload:unknow
  const p=asObject(payload);let body="";
  if(s.formType==="inventory_receipt"||s.formType==="inventory_writeoff")body=renderInventoryPrintedForm(p);
  else if(s.formType==="inventory_count")body=renderInventoryCountPrintedForm(p);
+ else if(s.formType==="inventory_transfer")body=renderInventoryTransferPrintedForm(p);
  else if(s.formType==="payment_receipt")body=renderPaymentPrintedForm(p);
  else if(s.formType==="service_act")body=renderServiceActPrintedForm(p);
  if(!body)throw new Error("unsupported_printed_form");

--- a/lib/printed-form-render/inventory-transfer.ts
+++ b/lib/printed-form-render/inventory-transfer.ts
@@ -1,0 +1,19 @@
+import {asArray,asObject,detail,documentHeader,escapeHtml,formatDate,meta,type RenderObject} from "./common.ts";
+
+function quantity(value:unknown){
+  const n=Number(value||0);
+  return Number.isFinite(n)?n.toLocaleString("uk-UA",{maximumFractionDigits:3}):"0";
+}
+function warehouse(name:unknown,code:unknown){
+  return `${escapeHtml(name||"—")}${code?`<br><small>${escapeHtml(code)}</small>`:""}`;
+}
+
+export function renderInventoryTransferPrintedForm(payload:RenderObject){
+  const doc=asObject(payload.document);
+  const lines=asArray(payload.lines).map(raw=>{
+    const line=asObject(raw);
+    const lot=`${escapeHtml(line.lotNumber||"—")}${line.expiresOn?`<br><small>до ${escapeHtml(line.expiresOn)}</small>`:""}`;
+    return `<tr><td>${escapeHtml(line.lineNo)}</td><td>${warehouse(line.sourceWarehouseName,line.sourceWarehouseCode)}</td><td>${warehouse(line.destinationWarehouseName,line.destinationWarehouseCode)}</td><td><b>${escapeHtml(line.itemName||"—")}</b><br><small>${escapeHtml(line.unit||"")}</small></td><td>${lot}</td><td>${escapeHtml(quantity(line.quantity))}</td><td>${escapeHtml(line.reason||"—")}</td></tr>`;
+  }).join("");
+  return `${documentHeader(payload,"Переміщення запасів")}<section class="grid">${meta("Номер",doc.number)}${meta("Дата",formatDate(doc.occurredAt))}${meta("Створив",doc.createdBy)}${meta("Стан",doc.state)}${doc.postedBy?meta("Провів",doc.postedBy)+meta("Проведено",formatDate(doc.postedAt)):""}</section>${doc.comment?`<section class="rows">${detail("Примітка",doc.comment)}</section>`:""}<table><thead><tr><th>№</th><th>Склад-відправник</th><th>Склад-одержувач</th><th>Матеріал / од.</th><th>Партія / термін</th><th>Кількість</th><th>Підстава</th></tr></thead><tbody>${lines}</tbody></table>`;
+}

--- a/lib/printed-form-storage-key.ts
+++ b/lib/printed-form-storage-key.ts
@@ -1,5 +1,5 @@
 export type PrintedFormStorageIdentity={organizationId:number;documentId:number;formType:string;templateVersion:number;documentState:string;sha256:string};
-const FORMS=new Set(["inventory_receipt","inventory_writeoff","inventory_count","payment_receipt","service_act"]);
+const FORMS=new Set(["inventory_receipt","inventory_writeoff","inventory_transfer","inventory_count","payment_receipt","service_act"]);
 const SHA=/^[a-f0-9]{64}$/;
 function state(value:string){const v=String(value||"unknown").trim().toLowerCase();return /^[a-z0-9_-]{1,32}$/.test(v)?v:"unknown";}
 export function printedFormStorageKey(s:PrintedFormStorageIdentity){

--- a/tests/inventory-count-printed-form.test.mjs
+++ b/tests/inventory-count-printed-form.test.mjs
@@ -52,7 +52,7 @@ test("posted count reprints preserve the earliest snapshot for that exact state"
 
 test("generic immutable PDF endpoint authorizes count only against the matching business document type",async()=>{
   const source=await read("app/api/staff/printed-forms/pdf/route.ts");
-  assert.match(source,/row\.formType==="inventory_receipt"\|\|row\.formType==="inventory_writeoff"\|\|row\.formType==="inventory_count"/);
+  assert.match(source,/row\.formType==="inventory_count"/);
   assert.match(source,/return row\.documentType===row\.formType/);
   assert.match(source,/WHERE s\.organization_id=\? AND s\.id=\?/);
 });

--- a/tests/inventory-transfer-printed-form.test.mjs
+++ b/tests/inventory-transfer-printed-form.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import {readFile} from "node:fs/promises";
+import test from "node:test";
+import {renderPrintedFormHtml} from "../lib/printed-form-render/index.ts";
+import {printedFormStorageKey} from "../lib/printed-form-storage-key.ts";
+
+const read=(path)=>readFile(new URL(`../${path}`,import.meta.url),"utf8");
+const HASH="c".repeat(64);
+const snapshot={id:21,organizationId:1,documentId:91,formType:"inventory_transfer",templateVersion:1,documentState:"posted",payloadJson:"{}",storageKey:"",sha256:HASH};
+const payload={
+  templateVersion:1,formType:"inventory_transfer",organization:{name:"Hospital"},
+  document:{id:91,number:"ПМ-000091",documentType:"inventory_transfer",occurredAt:"2026-08-19T00:00:00Z",state:"posted",comment:"Між складами",createdBy:"admin@example.com",createdAt:"2026-08-19T00:00:00Z",postedBy:"admin@example.com",postedAt:"2026-08-19T00:05:00Z"},
+  lines:[{lineNo:1,itemId:7,itemName:"Контраст <script>alert(1)</script>",unit:"фл.",lotId:3,lotNumber:"LOT-7",expiresOn:"2027-01-01",sourceWarehouseId:1,sourceWarehouseCode:"MAIN",sourceWarehouseName:"Основний",destinationWarehouseId:2,destinationWarehouseCode:"CT",destinationWarehouseName:"КТ склад",quantity:2.5,reason:"Переміщення <b>факт</b>"}],
+};
+
+test("inventory transfer renderer shows physical route and escapes operator-entered text",()=>{
+  const html=renderPrintedFormHtml(snapshot,payload);
+  assert.match(html,/Переміщення запасів/);
+  assert.match(html,/Склад-відправник/);assert.match(html,/Склад-одержувач/);
+  assert.match(html,/Основний/);assert.match(html,/КТ склад/);assert.match(html,/2,5/);
+  assert.match(html,/Контраст &lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html,/Переміщення &lt;b&gt;факт&lt;\/b&gt;/);
+  assert.doesNotMatch(html,/<script>alert\(1\)<\/script>/);
+  assert.doesNotMatch(html,/грн|Ціна|Сума|unitCost|lineAmount|totalAmount/i);
+});
+
+test("inventory transfer PDF storage keys are deterministic and tenant-separated",()=>{
+  const one=printedFormStorageKey(snapshot),same=printedFormStorageKey(snapshot),two=printedFormStorageKey({...snapshot,organizationId:2});
+  assert.equal(one,same);assert.notEqual(one,two);
+  assert.match(one,/^organizations\/1\/printed-forms\/91\/inventory_transfer\/posted\/v1\/[a-f0-9]{64}\.pdf$/);
+});
+
+test("inventory transfer snapshot source is tenant-scoped and carries exact warehouses",async()=>{
+  const source=await read("app/api/staff/inventory/transfers/print/route.ts");
+  assert.match(source,/getInventoryTransfer\(db,ctx\.organizationId,documentId\)/);
+  assert.match(source,/getInventoryTransfer\(db,organizationId,documentId\)/);
+  assert.match(source,/s\.organization_id=\? AND s\.id=\? AND s\.form_type='inventory_transfer' AND d\.document_type='inventory_transfer'/);
+  assert.match(source,/sourceWarehouseId:line\.sourceWarehouseId/);
+  assert.match(source,/destinationWarehouseId:line\.destinationWarehouseId/);
+  assert.match(source,/quantity:line\.quantity/);
+  assert.doesNotMatch(source,/unitCost|lineAmount|totalAmount/);
+});
+
+test("posted transfer reprints preserve the earliest snapshot for that exact state",async()=>{
+  const source=await read("app/api/staff/inventory/transfers/print/route.ts");
+  assert.match(source,/if\(documentState!=="draft"\)/);
+  assert.match(source,/form_type='inventory_transfer' AND document_state=\?/);
+  assert.match(source,/ORDER BY id ASC LIMIT 1/);
+  assert.match(source,/action:"printed_form_reprinted"/);
+  assert.match(source,/printedFormStorageKey/);
+});
+
+test("generic immutable PDF endpoint authorizes transfer only against matching business document type",async()=>{
+  const source=await read("app/api/staff/printed-forms/pdf/route.ts");
+  assert.match(source,/row\.formType==="inventory_transfer"/);
+  assert.match(source,/return row\.documentType===row\.formType/);
+  assert.match(source,/WHERE s\.organization_id=\? AND s\.id=\?/);
+});
+
+test("inventory transfer form type is already declared in business core and DB schema",async()=>{
+  const [core,migration]=await Promise.all([read("lib/business-core.ts"),read("drizzle/0059_business_inventory_documents.sql")]);
+  assert.match(core,/PRINTED_FORM_TYPES[\s\S]*inventory_transfer/);
+  assert.match(migration,/form_type[\s\S]*'inventory_transfer'/);
+});


### PR DESCRIPTION
## Goal
Complete the already-declared `inventory_transfer` printed-form contract over the existing tenant-safe transfer registrar.

## Scope
- add `/api/staff/inventory/transfers/print` for tenant-scoped immutable transfer snapshots;
- snapshot canonical transfer identity and server-owned line evidence: source warehouse, destination warehouse, item, lot/expiry, quantity and reason;
- preserve canonical non-draft reprint semantics by reusing the earliest snapshot for the exact document/form/state;
- reserve deterministic tenant-separated R2 keys for `inventory_transfer`;
- add a dedicated transfer renderer for Browser Run → PDF;
- allow the generic immutable PDF endpoint only when `form_type='inventory_transfer'` belongs to the exact matching transfer business document;
- add focused tests for routing evidence, escaping, no monetary synthesis, reprint identity and storage identity;
- no schema/migration changes and no production deploy.

## Invariants
- transfer forms are physical movement evidence only; no `unitCost`, `lineAmount`, `totalAmount` or synthetic expense/valuation;
- source/destination warehouse and quantity come from the canonical transfer document, not client print input;
- snapshots/PDFs remain immutable and tenant-separated;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.