### PR TITLE
Ops: trigger canonical production deploy once

### DIFF
--- a/.github/workflows/deploy-once.yml
+++ b/.github/workflows/deploy-once.yml
@@ -1,4 +1,4 @@
-name: One-shot production deploy
+name: One-shot production deploy dispatcher
 
 on:
   push:
@@ -8,177 +8,52 @@ on:
       - .github/workflows/deploy-once.yml
 
 permissions:
+  actions: write
   contents: write
 
-concurrency:
-  group: deploy-cloudflare
-  cancel-in-progress: false
-
 jobs:
-  deploy:
-    name: Build and deploy once
+  dispatch:
+    name: Dispatch canonical deploy workflow
     runs-on: ubuntu-latest
-    timeout-minutes: 25
-    environment: production
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 2
-
-      - name: Verify exact approved base
-        id: verify_base
+      - name: Verify exact trigger base
+        env:
+          EXPECTED_BEFORE: 7936c127116fd276632b1ee95cd89270421222db
+          ACTUAL_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          EXPECTED_BASE="96d055b1acb9c4763c0fd995d5ed8383faee1a90"
-          ACTUAL_BASE="$(git rev-parse HEAD^)"
-          echo "Expected base: $EXPECTED_BASE"
-          echo "Actual base:   $ACTUAL_BASE"
-          test "$ACTUAL_BASE" = "$EXPECTED_BASE"
+          echo "Expected previous main: $EXPECTED_BEFORE"
+          echo "Actual previous main:   $ACTUAL_BEFORE"
+          test "$ACTUAL_BEFORE" = "$EXPECTED_BEFORE"
 
-      - name: Set up Node.js
-        id: setup_node
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22.13.0
-          cache: npm
-
-      - name: Install dependencies deterministically
-        id: install
-        run: npm run install:ci
-
-      - name: Audit production dependencies
-        id: audit
-        run: npm audit --omit=dev --audit-level=high
-
-      - name: Production release gate
-        id: gate
-        run: npm run test:production-gate
-
-      - name: Build artifact
-        id: build
-        run: npm run build
-
-      - name: Verify printed-form R2 bucket exists
-        id: r2
-        run: npx wrangler r2 bucket info radiologyos-printed-forms --config wrangler.cloudflare.toml --json > /tmp/radiologyos-printed-forms-r2.json
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Record D1 recovery bookmark
-        id: recovery
-        run: npx wrangler d1 time-travel info radiologyos --config wrangler.cloudflare.toml
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Apply D1 migrations
-        id: migrations
-        run: bash scripts/apply-d1-migrations-remote.sh radiologyos wrangler.cloudflare.toml drizzle
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Verify a secure active administrator exists
-        id: admin_guard
-        run: |
-          ADMIN_GUARD_SQL=$(cat <<'SQL'
-          WITH admins AS (
-            SELECT password_hash,
-                   substr(password_hash,15,instr(substr(password_hash,15),'$')-1) AS iterations
-            FROM staff_members
-            WHERE role = 'admin' AND active = 1
-          )
-          SELECT COUNT(*) AS secure_admins
-          FROM admins
-          WHERE substr(password_hash,1,14) = 'pbkdf2$sha256$'
-            AND length(password_hash) - length(replace(password_hash,'$','')) = 4
-            AND iterations <> ''
-            AND iterations NOT GLOB '*[^0-9]*'
-            AND CAST(iterations AS INTEGER) >= 1000
-            AND length(password_hash) >= 80
-            AND password_hash NOT IN ('pbkdf2$sha256$100000$DIdGQmQdc8l2yyObk0lw0A==$btlwHhk42m8+m7NJlqXpZXQZYZ5d8gsRfxFMTqw59gc=');
-          SQL
-          )
-          npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-            --command "$ADMIN_GUARD_SQL" \
-            > /tmp/radiologyos-secure-admin.json
-          node -e '
-            const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-secure-admin.json", "utf8"));
-            const count = Number(payload?.[0]?.results?.[0]?.secure_admins ?? 0);
-            if (count < 1) {
-              console.error("Production deploy blocked: create an active administrator with a valid unique PBKDF2 password first.");
-              process.exit(1);
-            }
-          '
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Deploy Worker and assets
-        id: deploy
-        run: npx wrangler deploy --keep-vars --config wrangler.cloudflare.toml
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Smoke test production
-        id: smoke
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error --retry 5 --retry-all-errors https://radiologyos.tech/ > /dev/null
-          test "$(curl --silent --output /dev/null --write-out '%{http_code}' https://radiologyos.tech/site/)" = "308"
-          curl --fail --silent --show-error https://radiologyos.tech/robots.txt > /dev/null
-          curl --fail --silent --show-error --retry 5 --retry-all-errors \
-            https://radiologyos.tech/api/public-services > /tmp/radiologyos-public-services.json
-          node -e '
-            const payload = JSON.parse(require("node:fs").readFileSync("/tmp/radiologyos-public-services.json", "utf8"));
-            if (!Array.isArray(payload?.services)) {
-              console.error("Production smoke test failed: /api/public-services did not return a services array.");
-              process.exit(1);
-            }
-          '
-
-      - name: Record one-shot deploy result
-        if: always()
+      - name: Dispatch canonical production deploy
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          cat > /tmp/deploy-status.json <<EOF
-          {
-            "run_id": "${GITHUB_RUN_ID}",
-            "trigger_sha": "${GITHUB_SHA}",
-            "approved_application_base_sha": "96d055b1acb9c4763c0fd995d5ed8383faee1a90",
-            "job_status": "${{ job.status }}",
-            "verify_base": "${{ steps.verify_base.outcome }}",
-            "install": "${{ steps.install.outcome }}",
-            "audit": "${{ steps.audit.outcome }}",
-            "production_gate": "${{ steps.gate.outcome }}",
-            "build": "${{ steps.build.outcome }}",
-            "r2": "${{ steps.r2.outcome }}",
-            "recovery": "${{ steps.recovery.outcome }}",
-            "migrations": "${{ steps.migrations.outcome }}",
-            "admin_guard": "${{ steps.admin_guard.outcome }}",
-            "deploy": "${{ steps.deploy.outcome }}",
-            "smoke": "${{ steps.smoke.outcome }}"
-          }
-          EOF
-          ENCODED="$(base64 -w0 /tmp/deploy-status.json)"
-          gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/.github/deploy-status/${GITHUB_RUN_ID}.json" \
-            -f message="ops: record one-shot deploy ${GITHUB_RUN_ID}" \
+          gh api --method POST "/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy.yml/dispatches" \
+            -f ref="main" \
+            -f 'inputs[confirmation]=DEPLOY'
+
+      - name: Capture dispatched run id
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          RUN_ID=""
+          for attempt in 1 2 3 4 5 6; do
+            RUN_ID="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy.yml/runs?event=workflow_dispatch&branch=main&per_page=20" \
+              --jq '.workflow_runs[] | select(.head_sha == env.GITHUB_SHA) | .id' | head -n1 || true)"
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            sleep 5
+          done
+          test -n "$RUN_ID"
+          printf '{"run_id":%s,"head_sha":"%s","approved_application_sha":"%s"}\n' \
+            "$RUN_ID" "$GITHUB_SHA" "96d055b1acb9c4763c0fd995d5ed8383faee1a90" > /tmp/dispatched.json
+          ENCODED="$(base64 -w0 /tmp/dispatched.json)"
+          gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/.github/deploy-status/dispatched-${GITHUB_RUN_ID}.json" \
+            -f message="ops: record canonical production deploy run" \
             -f content="$ENCODED" \
-            -f branch="main" > /dev/null
-
-      - name: Remove one-shot trigger after success
-        if: success()
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          SELF_SHA="$(gh api "/repos/${GITHUB_REPOSITORY}/contents/.github/workflows/deploy-once.yml?ref=main" --jq .sha)"
-          gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/contents/.github/workflows/deploy-once.yml" \
-            -f message="ops: remove one-shot production deploy trigger" \
-            -f sha="$SELF_SHA" \
             -f branch="main" > /dev/null


### PR DESCRIPTION
One-shot operations-only change. It does not modify application source. On merge to main it dispatches the existing manual-only deploy.yml with confirmation=DEPLOY, records the resulting run ID, and leaves the canonical production workflow unchanged.