### PR TITLE
Fix D1 deferred foreign-key migration finalization

### DIFF
--- a/scripts/apply-d1-migrations-remote.sh
+++ b/scripts/apply-d1-migrations-remote.sh
@@ -53,6 +53,15 @@ for name in "${MIGRATIONS[@]}"; do
   echo "Applying D1 migration via file import: ${name}"
   IMPORT_FILE="${TMP_DIR}/${name}"
   cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"
+
+  # D1 keeps foreign_keys enabled for every migration. A migration may temporarily defer
+  # those checks while rebuilding a referenced table, but it must finish with all
+  # relationships valid. Force an explicit validation boundary before the registry insert
+  # so a schema migration cannot be marked applied while deferred FK work is unresolved.
+  if grep -Eiq '^[[:space:]]*PRAGMA[[:space:]]+defer_foreign_keys[[:space:]]*=[[:space:]]*(ON|TRUE|1)[[:space:]]*;?[[:space:]]*$' "${MIGRATIONS_DIR}/${name}"; then
+    printf '\nPRAGMA defer_foreign_keys = OFF;\n' >> "${IMPORT_FILE}"
+  fi
+
   printf "\nINSERT INTO d1_migrations (name) VALUES ('%s');\n" "${name}" >> "${IMPORT_FILE}"
 
   # --file uses Wrangler's remote D1 import path rather than the /query path used

--- a/tests/d1-deferred-fk-finalization.test.mjs
+++ b/tests/d1-deferred-fk-finalization.test.mjs
@@ -84,8 +84,8 @@ test("explicit deferred-FK finalization permits a referenced parent-table rebuil
     assert.equal(db.prepare("PRAGMA defer_foreign_keys").get().defer_foreign_keys, 0);
     assert.deepEqual(db.prepare("PRAGMA foreign_key_check").all(), []);
     assert.deepEqual(
-      db.prepare("SELECT organization_id, document_id FROM child_register").all(),
-      [{ organization_id: 1, document_id: 1 }],
+      { ...db.prepare("SELECT organization_id, document_id FROM child_register").get() },
+      { organization_id: 1, document_id: 1 },
     );
     assert.match(
       db.prepare("SELECT sql FROM sqlite_schema WHERE type='table' AND name='business_documents'").get().sql,

--- a/tests/d1-deferred-fk-finalization.test.mjs
+++ b/tests/d1-deferred-fk-finalization.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("remote D1 runner explicitly finalizes deferred foreign keys before migration tracking", async () => {
+  const script = await read("scripts/apply-d1-migrations-remote.sh");
+  const copySql = script.indexOf('cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"');
+  const detectDeferred = script.indexOf("PRAGMA[[:space:]]+defer_foreign_keys");
+  const finalizeDeferred = script.indexOf("PRAGMA defer_foreign_keys = OFF;");
+  const tracking = script.indexOf("INSERT INTO d1_migrations (name) VALUES ('%s');");
+  const executeFile = script.indexOf('--file "${IMPORT_FILE}"');
+
+  assert.notEqual(copySql, -1);
+  assert.notEqual(detectDeferred, -1);
+  assert.notEqual(finalizeDeferred, -1);
+  assert.notEqual(tracking, -1);
+  assert.notEqual(executeFile, -1);
+  assert.ok(copySql < detectDeferred);
+  assert.ok(detectDeferred < finalizeDeferred);
+  assert.ok(finalizeDeferred < tracking);
+  assert.ok(tracking < executeFile);
+});
+
+test("explicit deferred-FK finalization permits a referenced parent-table rebuild only after references are valid", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec(`
+      CREATE TABLE organizations (id INTEGER PRIMARY KEY);
+      INSERT INTO organizations (id) VALUES (1);
+      CREATE TABLE business_documents (
+        id INTEGER PRIMARY KEY,
+        organization_id INTEGER NOT NULL,
+        document_type TEXT NOT NULL CHECK (document_type IN ('service_delivery','study_performance')),
+        reversed_document_id INTEGER,
+        FOREIGN KEY (organization_id) REFERENCES organizations(id),
+        FOREIGN KEY (reversed_document_id) REFERENCES business_documents(id)
+      );
+      CREATE UNIQUE INDEX business_documents_id_org_idx
+        ON business_documents(id, organization_id);
+      CREATE TABLE child_register (
+        id INTEGER PRIMARY KEY,
+        organization_id INTEGER NOT NULL,
+        document_id INTEGER NOT NULL,
+        FOREIGN KEY (document_id, organization_id)
+          REFERENCES business_documents(id, organization_id)
+      );
+      INSERT INTO business_documents
+        (id, organization_id, document_type)
+        VALUES (1, 1, 'service_delivery');
+      INSERT INTO child_register
+        (id, organization_id, document_id)
+        VALUES (1, 1, 1);
+    `);
+
+    db.exec("BEGIN;");
+    db.exec("PRAGMA defer_foreign_keys = ON;");
+    db.exec(`
+      CREATE TABLE __new_business_documents (
+        id INTEGER PRIMARY KEY,
+        organization_id INTEGER NOT NULL,
+        document_type TEXT NOT NULL CHECK (
+          document_type IN ('service_delivery','study_performance','study_correction')
+        ),
+        reversed_document_id INTEGER,
+        FOREIGN KEY (organization_id) REFERENCES organizations(id),
+        FOREIGN KEY (reversed_document_id) REFERENCES business_documents(id)
+      );
+      INSERT INTO __new_business_documents
+        SELECT * FROM business_documents;
+      DROP TABLE business_documents;
+      ALTER TABLE __new_business_documents RENAME TO business_documents;
+      CREATE UNIQUE INDEX business_documents_id_org_idx
+        ON business_documents(id, organization_id);
+    `);
+
+    assert.deepEqual(db.prepare("PRAGMA foreign_key_check").all(), []);
+    db.exec("PRAGMA defer_foreign_keys = OFF;");
+    db.exec("COMMIT;");
+
+    assert.equal(db.prepare("PRAGMA defer_foreign_keys").get().defer_foreign_keys, 0);
+    assert.deepEqual(db.prepare("PRAGMA foreign_key_check").all(), []);
+    assert.deepEqual(
+      db.prepare("SELECT organization_id, document_id FROM child_register").all(),
+      [{ organization_id: 1, document_id: 1 }],
+    );
+    assert.match(
+      db.prepare("SELECT sql FROM sqlite_schema WHERE type='table' AND name='business_documents'").get().sql,
+      /study_correction/,
+    );
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
Production deploy exposed a D1-specific failure while applying 0093_study_correction_registrar.sql: the migration rebuilt business_documents under PRAGMA defer_foreign_keys=ON, restored the referenced parent and unique keys, but relied on implicit transaction finalization. D1 rolled the import back at the transaction boundary with SQLITE_CONSTRAINT_FOREIGNKEY.

This change keeps migrations fail-closed and does not disable foreign_keys. The shared remote migration runner now appends an explicit PRAGMA defer_foreign_keys=OFF before the d1_migrations registry insert whenever a migration enabled deferred FK checks. D1 therefore validates the restored graph before the migration can be marked applied.

A behavioral node:sqlite regression test covers a referenced parent-table rebuild with a live child row and verifies the row and FK integrity survive explicit finalization.

No application behavior or production data is modified by this PR.