### PR TITLE
Arm one-shot production deploy after D1 fix

### DIFF
--- a/.github/workflows/deploy-once.yml
+++ b/.github/workflows/deploy-once.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Verify exact trigger base
         env:
-          EXPECTED_BEFORE: 7936c127116fd276632b1ee95cd89270421222db
+          EXPECTED_BEFORE: 0c9d13b3f02f4c819103d3927cc45d01c951ca6a
           ACTUAL_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
@@ -51,7 +51,7 @@ jobs:
           done
           test -n "$RUN_ID"
           printf '{"run_id":%s,"head_sha":"%s","approved_application_sha":"%s"}\n' \
-            "$RUN_ID" "$GITHUB_SHA" "96d055b1acb9c4763c0fd995d5ed8383faee1a90" > /tmp/dispatched.json
+            "$RUN_ID" "$GITHUB_SHA" "0c9d13b3f02f4c819103d3927cc45d01c951ca6a" > /tmp/dispatched.json
           ENCODED="$(base64 -w0 /tmp/dispatched.json)"
           gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/.github/deploy-status/dispatched-${GITHUB_RUN_ID}.json" \
             -f message="ops: record canonical production deploy run" \


### PR DESCRIPTION
Ops-only retry trigger for the canonical production deploy after PR #399 fixed D1 deferred-FK finalization.

The trigger is fail-closed: it only dispatches deploy.yml if the previous main SHA is exactly 0c9d13b3f02f4c819103d3927cc45d01c951ca6a. It does not duplicate deployment logic and does not modify application source. After a successful canonical deploy, the one-shot dispatcher will be removed so production returns to manual-only.