### PR TITLE
Persist sanitized D1 FK diagnostic summary

### DIFF
--- a/.github/workflows/d1-fk-diagnose-once.yml
+++ b/.github/workflows/d1-fk-diagnose-once.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/d1-fk-diagnose-once.yml
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   diagnose:
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Verify exact diagnostic base
         env:
-          EXPECTED_BEFORE: cc60c7db5f19c394915429a2a2de795a89aefdc6
+          EXPECTED_BEFORE: 54981d717d8c4678fe585c26cae55e2476391982
           ACTUAL_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
@@ -46,41 +46,107 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo '=== Applied migrations near 0093 ==='
           npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-            --command "SELECT name FROM d1_migrations WHERE name >= '0088' ORDER BY name;"
+            --command "SELECT name FROM d1_migrations WHERE name >= '0088' ORDER BY name;" \
+            | tee /tmp/migrations.json
 
-          echo '=== Pre-migration foreign_key_check ==='
           npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-            --command "PRAGMA foreign_key_check;"
+            --command "PRAGMA foreign_key_check;" \
+            | tee /tmp/fkcheck.json
 
-          echo '=== business_documents link counts (aggregate only) ==='
           npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-            --command "SELECT COUNT(*) AS document_count, SUM(CASE WHEN reversed_document_id IS NOT NULL THEN 1 ELSE 0 END) AS reversed_link_count FROM business_documents;"
+            --command "SELECT COUNT(*) AS document_count, SUM(CASE WHEN reversed_document_id IS NOT NULL THEN 1 ELSE 0 END) AS reversed_link_count FROM business_documents;" \
+            | tee /tmp/doccounts.json
 
           DEP_SQL=$(cat <<'SQL'
           SELECT name, sql
           FROM sqlite_schema
           WHERE type='table'
-            AND instr(lower(sql), 'references `business_documents`') > 0
+            AND (
+              instr(lower(sql), 'references `business_documents`') > 0
+              OR instr(lower(sql), 'references business_documents') > 0
+              OR instr(lower(sql), 'references "business_documents"') > 0
+            )
           ORDER BY name;
           SQL
           )
 
-          echo '=== Tables whose DDL references business_documents ==='
           npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
             --command "$DEP_SQL" | tee /tmp/business-document-deps.json
 
-          echo '=== Dependent-table row counts and FK metadata (no row contents) ==='
           jq -r '.[].results[]?.name // empty' /tmp/business-document-deps.json | sort -u | while IFS= read -r table; do
             test -n "$table" || continue
             if [[ ! "$table" =~ ^[A-Za-z0-9_]+$ ]]; then
               echo "Unsafe schema identifier returned: $table" >&2
               exit 1
             fi
-            echo "--- $table ---"
             npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-              --command "SELECT '$table' AS table_name, COUNT(*) AS row_count FROM \"$table\";"
+              --command "SELECT '$table' AS table_name, COUNT(*) AS row_count FROM \"$table\";" \
+              > "/tmp/count-${table}.json"
             npx wrangler d1 execute radiologyos --remote --config wrangler.cloudflare.toml --json \
-              --command "PRAGMA foreign_key_list(\"$table\");"
+              --command "PRAGMA foreign_key_list(\"$table\");" \
+              > "/tmp/fk-${table}.json"
           done
+
+      - name: Build sanitized diagnostic summary
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const rows = (file) => {
+            const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+            return parsed.flatMap((entry) => Array.isArray(entry.results) ? entry.results : []);
+          };
+
+          const migrations = rows('/tmp/migrations.json').map((row) => row.name);
+          const violations = rows('/tmp/fkcheck.json');
+          const documentCounts = rows('/tmp/doccounts.json')[0] ?? {};
+          const dependencies = rows('/tmp/business-document-deps.json').map((row) => {
+            const name = row.name;
+            if (!/^[A-Za-z0-9_]+$/.test(name)) throw new Error(`unsafe table name: ${name}`);
+            const countRows = rows(`/tmp/count-${name}.json`);
+            const fkRows = rows(`/tmp/fk-${name}.json`);
+            return {
+              name,
+              row_count: Number(countRows[0]?.row_count ?? 0),
+              foreign_keys_to_business_documents: fkRows
+                .filter((fk) => fk.table === 'business_documents')
+                .map((fk) => ({
+                  id: fk.id,
+                  seq: fk.seq,
+                  from: fk.from,
+                  to: fk.to,
+                  on_update: fk.on_update,
+                  on_delete: fk.on_delete,
+                  match: fk.match,
+                })),
+            };
+          });
+
+          const summary = {
+            generated_from_sha: process.env.GITHUB_SHA,
+            migrations,
+            foreign_key_check_violation_count: violations.length,
+            business_documents: {
+              row_count: Number(documentCounts.document_count ?? 0),
+              reversed_link_count: Number(documentCounts.reversed_link_count ?? 0),
+            },
+            dependencies,
+          };
+          fs.writeFileSync('/tmp/d1-fk-diagnostic.json', JSON.stringify(summary, null, 2) + '\n');
+          console.log(JSON.stringify(summary, null, 2));
+          NODE
+
+      - name: Record sanitized diagnostic summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SUMMARY_PATH=".github/deploy-status/d1-fk-diagnostic-${GITHUB_RUN_ID}.json"
+          ENCODED="$(base64 -w0 /tmp/d1-fk-diagnostic.json)"
+          gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${SUMMARY_PATH}" \
+            -f message="ops: record D1 FK diagnostic" \
+            -f content="$ENCODED" \
+            -f branch="main" > /dev/null


### PR DESCRIPTION
Follow-up to #401. The diagnostic remains read-only against D1, but now records a sanitized structural summary in the repository so the exact production FK state can be retrieved without relying on the Actions UI. Recorded fields are migration names, foreign_key_check violation count, aggregate document/link counts, dependent table names, row counts, and FK metadata only. No application rows or PHI are written.