### PR TITLE
Bridge live Patient Order FK during D1 migration 0093

### DIFF
--- a/scripts/apply-d1-migrations-remote.sh
+++ b/scripts/apply-d1-migrations-remote.sh
@@ -52,7 +52,8 @@ for name in "${MIGRATIONS[@]}"; do
 
   echo "Applying D1 migration via file import: ${name}"
   IMPORT_FILE="${TMP_DIR}/${name}"
-  cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"
+  node scripts/prepare-d1-migration-remote.mjs \
+    "${MIGRATIONS_DIR}/${name}" "${IMPORT_FILE}" "${name}"
 
   # D1 keeps foreign_keys enabled for every migration. A migration may temporarily defer
   # those checks while rebuilding a referenced table, but it must finish with all

--- a/scripts/prepare-d1-migration-remote.mjs
+++ b/scripts/prepare-d1-migration-remote.mjs
@@ -1,0 +1,133 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const [sourcePath, destinationPath, migrationName] = process.argv.slice(2);
+
+if (!sourcePath || !destinationPath || !migrationName) {
+  console.error("Usage: node scripts/prepare-d1-migration-remote.mjs <source> <destination> <migration-name>");
+  process.exit(2);
+}
+
+const source = await readFile(sourcePath, "utf8");
+
+if (migrationName !== "0093_study_correction_registrar.sql") {
+  await writeFile(destinationPath, source);
+  process.exit(0);
+}
+
+// D1 keeps foreign_keys enabled. Production 0092 contains a live Patient Order detail row
+// referencing business_documents, so Drizzle's parent-table DROP/recreate leaves an unresolved
+// deferred FK in D1 even though the canonical parent name is restored later in the transaction.
+//
+// This one-migration bridge is intentionally fail-closed:
+//   * only patient_order_details may contain live external references to business_documents;
+//   * business_documents may not contain reversal self-links;
+//   * Patient Order rows are copied byte-for-byte to a no-FK shadow table;
+//   * the live FK rows are absent only inside the same D1 import transaction;
+//   * the original migration runs unchanged;
+//   * rows are restored and compared in both directions before FK deferral is finalized.
+//
+// A new/empty database is also safe: the backup can contain zero Patient Order rows.
+
+const requiredMarkers = [
+  "PRAGMA defer_foreign_keys = ON;",
+  "CREATE TABLE `__new_business_documents`",
+  "DROP TABLE `business_documents`;",
+  "ALTER TABLE `__new_business_documents` RENAME TO `business_documents`;",
+];
+for (const marker of requiredMarkers) {
+  const first = source.indexOf(marker);
+  if (first === -1 || source.indexOf(marker, first + marker.length) !== -1) {
+    throw new Error(`0093 D1 bridge source assertion failed for marker: ${marker}`);
+  }
+}
+
+const columns = [
+  "organization_id",
+  "document_id",
+  "booking_id",
+  "patient_id",
+  "patient_category",
+  "service_code",
+  "service_title",
+  "equipment_id",
+  "duration_minutes",
+  "price_amount",
+  "charge_amount",
+  "currency",
+  "created_at",
+];
+const columnList = columns.map((column) => `\`${column}\``).join(",");
+
+const emptyExternalReferences = [
+  "cash_movements",
+  "equipment_load_movements",
+  "finance_document_details",
+  "inventory_document_lines",
+  "patient_settlement_movements",
+  "printed_form_snapshots",
+  "result_delivery_details",
+  "revenue_movements",
+  "service_correction_details",
+  "service_correction_movements",
+  "service_delivery_details",
+  "services_delivered_movements",
+  "staff_output_movements",
+  "supplier_payable_movements",
+  "supplier_payment_allocations",
+];
+
+const prelude = `-- D1 0093 live-FK bridge: begin.\n` +
+`CREATE TABLE \`__d1_0093_bridge_guard\` (\`ok\` integer NOT NULL CHECK (\`ok\` = 1));\n` +
+`INSERT INTO \`__d1_0093_bridge_guard\` (\`ok\`)\n` +
+`SELECT CASE WHEN\n` +
+`  NOT EXISTS (SELECT 1 FROM \`business_documents\` WHERE \`reversed_document_id\` IS NOT NULL)\n` +
+emptyExternalReferences.map((table) => `  AND NOT EXISTS (SELECT 1 FROM \`${table}\`)`).join("\n") +
+`\nTHEN 1 ELSE 0 END;\n` +
+`CREATE TABLE \`__d1_0093_patient_order_backup\` AS\n` +
+`SELECT ${columnList} FROM \`patient_order_details\`;\n` +
+`DROP TRIGGER IF EXISTS \`patient_order_details_integrity_insert\`;\n` +
+`DROP TRIGGER IF EXISTS \`patient_order_details_no_delete_posted\`;\n` +
+`DELETE FROM \`patient_order_details\`;\n` +
+`-- D1 0093 live-FK bridge: original migration follows.\n\n`;
+
+const postlude = `\n\n-- D1 0093 live-FK bridge: restore immutable Patient Order facts.\n` +
+`INSERT INTO \`patient_order_details\` (${columnList})\n` +
+`SELECT ${columnList} FROM \`__d1_0093_patient_order_backup\`;\n` +
+`INSERT INTO \`__d1_0093_bridge_guard\` (\`ok\`)\n` +
+`SELECT CASE WHEN\n` +
+`  NOT EXISTS (SELECT ${columnList} FROM \`__d1_0093_patient_order_backup\` EXCEPT SELECT ${columnList} FROM \`patient_order_details\`)\n` +
+`  AND NOT EXISTS (SELECT ${columnList} FROM \`patient_order_details\` EXCEPT SELECT ${columnList} FROM \`__d1_0093_patient_order_backup\`)\n` +
+`THEN 1 ELSE 0 END;\n` +
+`CREATE TRIGGER IF NOT EXISTS \`patient_order_details_integrity_insert\`\n` +
+`BEFORE INSERT ON \`patient_order_details\`\n` +
+`BEGIN\n` +
+`  SELECT CASE WHEN NOT EXISTS (\n` +
+`    SELECT 1 FROM business_documents d\n` +
+`    WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id\n` +
+`      AND d.document_type='patient_order' AND d.state='draft' AND d.basis_document_id IS NULL\n` +
+`  ) THEN RAISE(ABORT,'patient_order_document_invalid') END;\n` +
+`  SELECT CASE WHEN NOT EXISTS (\n` +
+`    SELECT 1 FROM bookings b\n` +
+`    WHERE b.id=NEW.booking_id AND b.organization_id=NEW.organization_id\n` +
+`      AND b.patient_id=NEW.patient_id\n` +
+`      AND b.patient_category=NEW.patient_category\n` +
+`      AND b.service_code=NEW.service_code\n` +
+`      AND b.service=NEW.service_title\n` +
+`      AND b.equipment_id=NEW.equipment_id\n` +
+`      AND b.duration_minutes=NEW.duration_minutes\n` +
+`      AND b.payment_amount=NEW.price_amount\n` +
+`      AND NEW.charge_amount=CASE WHEN b.patient_category='civilian' THEN b.payment_amount ELSE 0 END\n` +
+`  ) THEN RAISE(ABORT,'patient_order_booking_snapshot_mismatch') END;\n` +
+`END;\n` +
+`CREATE TRIGGER IF NOT EXISTS \`patient_order_details_no_delete_posted\`\n` +
+`BEFORE DELETE ON \`patient_order_details\`\n` +
+`WHEN NOT EXISTS (\n` +
+`  SELECT 1 FROM business_documents d\n` +
+`  WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'\n` +
+`)\n` +
+`BEGIN SELECT RAISE(ABORT,'patient_order_not_draft'); END;\n` +
+`DROP TABLE \`__d1_0093_patient_order_backup\`;\n` +
+`DROP TABLE \`__d1_0093_bridge_guard\`;\n` +
+`-- D1 0093 live-FK bridge: end.\n`;
+
+await writeFile(destinationPath, prelude + source + postlude);

--- a/tests/d1-0093-live-patient-order-bridge.test.mjs
+++ b/tests/d1-0093-live-patient-order-bridge.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+const preparer = fileURLToPath(new URL("../scripts/prepare-d1-migration-remote.mjs", import.meta.url));
+const migrationName = "0093_study_correction_registrar.sql";
+
+const synthetic0093 = `
+PRAGMA defer_foreign_keys = ON;
+PRAGMA legacy_alter_table = ON;
+CREATE TABLE \`__new_business_documents\` (
+  \`id\` integer PRIMARY KEY NOT NULL,
+  \`organization_id\` integer NOT NULL,
+  \`document_type\` text NOT NULL CHECK (\`document_type\` IN ('patient_order','study_correction')),
+  \`state\` text NOT NULL,
+  \`basis_document_id\` integer,
+  \`reversed_document_id\` integer,
+  FOREIGN KEY (\`reversed_document_id\`) REFERENCES \`business_documents\`(\`id\`)
+);
+INSERT INTO \`__new_business_documents\`
+  (\`id\`,\`organization_id\`,\`document_type\`,\`state\`,\`basis_document_id\`,\`reversed_document_id\`)
+SELECT \`id\`,\`organization_id\`,\`document_type\`,\`state\`,\`basis_document_id\`,\`reversed_document_id\`
+FROM \`business_documents\`;
+DROP TABLE \`business_documents\`;
+ALTER TABLE \`__new_business_documents\` RENAME TO \`business_documents\`;
+PRAGMA legacy_alter_table = OFF;
+CREATE UNIQUE INDEX \`business_documents_id_org_idx\`
+  ON \`business_documents\` (\`id\`,\`organization_id\`);
+`;
+
+const emptyDependencyTables = [
+  "cash_movements",
+  "equipment_load_movements",
+  "finance_document_details",
+  "inventory_document_lines",
+  "patient_settlement_movements",
+  "printed_form_snapshots",
+  "result_delivery_details",
+  "revenue_movements",
+  "service_correction_details",
+  "service_correction_movements",
+  "service_delivery_details",
+  "services_delivered_movements",
+  "staff_output_movements",
+  "supplier_payable_movements",
+  "supplier_payment_allocations",
+];
+
+function prepareSyntheticMigration() {
+  const dir = mkdtempSync(join(tmpdir(), "radiologyos-d1-0093-"));
+  const source = join(dir, migrationName);
+  const output = join(dir, "prepared.sql");
+  writeFileSync(source, synthetic0093);
+  const result = spawnSync(process.execPath, [preparer, source, output, migrationName], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const sql = readFileSync(output, "utf8");
+  rmSync(dir, { recursive: true, force: true });
+  return sql;
+}
+
+function createDatabase() {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys = ON;");
+  db.exec(`
+    CREATE TABLE bookings (
+      id integer PRIMARY KEY,
+      organization_id integer NOT NULL,
+      patient_id text NOT NULL,
+      patient_category text NOT NULL,
+      service_code text NOT NULL,
+      service text NOT NULL,
+      equipment_id text NOT NULL,
+      duration_minutes integer NOT NULL,
+      payment_amount integer NOT NULL
+    );
+    CREATE TABLE business_documents (
+      id integer PRIMARY KEY NOT NULL,
+      organization_id integer NOT NULL,
+      document_type text NOT NULL CHECK (document_type IN ('patient_order')),
+      state text NOT NULL,
+      basis_document_id integer,
+      reversed_document_id integer,
+      FOREIGN KEY (reversed_document_id) REFERENCES business_documents(id)
+    );
+    CREATE UNIQUE INDEX business_documents_id_org_idx
+      ON business_documents(id, organization_id);
+    CREATE TABLE patient_order_details (
+      organization_id integer NOT NULL,
+      document_id integer PRIMARY KEY NOT NULL,
+      booking_id integer NOT NULL,
+      patient_id text DEFAULT '' NOT NULL,
+      patient_category text DEFAULT '' NOT NULL,
+      service_code text NOT NULL,
+      service_title text NOT NULL,
+      equipment_id text NOT NULL,
+      duration_minutes integer NOT NULL CHECK (duration_minutes > 0),
+      price_amount integer DEFAULT 0 NOT NULL CHECK (price_amount >= 0),
+      charge_amount integer DEFAULT 0 NOT NULL CHECK (charge_amount >= 0),
+      currency text DEFAULT 'UAH' NOT NULL,
+      created_at text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      FOREIGN KEY (document_id, organization_id) REFERENCES business_documents(id, organization_id),
+      FOREIGN KEY (booking_id) REFERENCES bookings(id)
+    );
+    CREATE UNIQUE INDEX patient_order_booking_unique
+      ON patient_order_details(organization_id, booking_id);
+  `);
+  for (const table of emptyDependencyTables) {
+    db.exec(`CREATE TABLE ${table} (id integer PRIMARY KEY);`);
+  }
+  db.exec(`
+    INSERT INTO bookings
+      (id,organization_id,patient_id,patient_category,service_code,service,equipment_id,duration_minutes,payment_amount)
+    VALUES (1,1,'patient-1','civilian','CT','CT chest','ct-1',20,4700);
+    INSERT INTO business_documents
+      (id,organization_id,document_type,state,basis_document_id,reversed_document_id)
+    VALUES (1,1,'patient_order','posted',NULL,NULL);
+    INSERT INTO patient_order_details
+      (organization_id,document_id,booking_id,patient_id,patient_category,service_code,service_title,
+       equipment_id,duration_minutes,price_amount,charge_amount,currency,created_at)
+    VALUES (1,1,1,'patient-1','civilian','CT','CT chest','ct-1',20,4700,4700,'UAH','2026-08-19 10:00:00');
+    CREATE TRIGGER patient_order_details_integrity_insert
+    BEFORE INSERT ON patient_order_details
+    BEGIN
+      SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM business_documents d
+        WHERE d.id=NEW.document_id AND d.organization_id=NEW.organization_id
+          AND d.document_type='patient_order' AND d.state='draft' AND d.basis_document_id IS NULL
+      ) THEN RAISE(ABORT,'patient_order_document_invalid') END;
+    END;
+    CREATE TRIGGER patient_order_details_no_delete_posted
+    BEFORE DELETE ON patient_order_details
+    WHEN NOT EXISTS (
+      SELECT 1 FROM business_documents d
+      WHERE d.id=OLD.document_id AND d.organization_id=OLD.organization_id AND d.state='draft'
+    )
+    BEGIN SELECT RAISE(ABORT,'patient_order_not_draft'); END;
+  `);
+  return db;
+}
+
+function executeAsSingleTransaction(db, sql) {
+  db.exec("BEGIN;");
+  try {
+    db.exec(sql);
+    db.exec("PRAGMA defer_foreign_keys = OFF;");
+    db.exec("COMMIT;");
+  } catch (error) {
+    try {
+      db.exec("ROLLBACK;");
+    } catch {}
+    throw error;
+  }
+}
+
+test("0093 D1 bridge preserves a posted Patient Order row while rebuilding its referenced parent", () => {
+  const prepared = prepareSyntheticMigration();
+  assert.match(prepared, /D1 0093 live-FK bridge: begin/);
+  assert.match(prepared, /__d1_0093_patient_order_backup/);
+  assert.match(prepared, /EXCEPT SELECT/);
+
+  const db = createDatabase();
+  try {
+    assert.throws(
+      () => db.exec("DELETE FROM patient_order_details WHERE document_id=1;"),
+      /patient_order_not_draft/,
+    );
+
+    executeAsSingleTransaction(db, prepared);
+
+    assert.deepEqual(db.prepare("PRAGMA foreign_key_check").all(), []);
+    assert.deepEqual(
+      { ...db.prepare(`
+        SELECT organization_id,document_id,booking_id,patient_id,patient_category,service_code,
+               service_title,equipment_id,duration_minutes,price_amount,charge_amount,currency,created_at
+        FROM patient_order_details
+      `).get() },
+      {
+        organization_id: 1,
+        document_id: 1,
+        booking_id: 1,
+        patient_id: "patient-1",
+        patient_category: "civilian",
+        service_code: "CT",
+        service_title: "CT chest",
+        equipment_id: "ct-1",
+        duration_minutes: 20,
+        price_amount: 4700,
+        charge_amount: 4700,
+        currency: "UAH",
+        created_at: "2026-08-19 10:00:00",
+      },
+    );
+    assert.match(
+      db.prepare("SELECT sql FROM sqlite_schema WHERE type='table' AND name='business_documents'").get().sql,
+      /study_correction/,
+    );
+    assert.throws(
+      () => db.exec("DELETE FROM patient_order_details WHERE document_id=1;"),
+      /patient_order_not_draft/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("0093 D1 bridge fails before mutation when another business-document dependency has rows", () => {
+  const prepared = prepareSyntheticMigration();
+  const db = createDatabase();
+  try {
+    db.exec("INSERT INTO cash_movements(id) VALUES (1);");
+    assert.throws(() => executeAsSingleTransaction(db, prepared), /CHECK constraint failed/);
+
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM patient_order_details").get().count, 1);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM business_documents").get().count, 1);
+    assert.match(
+      db.prepare("SELECT sql FROM sqlite_schema WHERE type='table' AND name='business_documents'").get().sql,
+      /patient_order/,
+    );
+    assert.doesNotMatch(
+      db.prepare("SELECT sql FROM sqlite_schema WHERE type='table' AND name='business_documents'").get().sql,
+      /study_correction/,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("non-0093 migrations are copied byte-for-byte by the remote preparer", () => {
+  const dir = mkdtempSync(join(tmpdir(), "radiologyos-d1-copy-"));
+  try {
+    const source = join(dir, "0094_example.sql");
+    const output = join(dir, "prepared.sql");
+    const body = "CREATE TABLE example (id integer PRIMARY KEY);\n";
+    writeFileSync(source, body);
+    const result = spawnSync(process.execPath, [preparer, source, output, "0094_example.sql"], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(readFileSync(output, "utf8"), body);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/d1-deferred-fk-finalization.test.mjs
+++ b/tests/d1-deferred-fk-finalization.test.mjs
@@ -7,18 +7,18 @@ const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
 test("remote D1 runner explicitly finalizes deferred foreign keys before migration tracking", async () => {
   const script = await read("scripts/apply-d1-migrations-remote.sh");
-  const copySql = script.indexOf('cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"');
+  const prepareSql = script.indexOf("node scripts/prepare-d1-migration-remote.mjs");
   const detectDeferred = script.indexOf("PRAGMA[[:space:]]+defer_foreign_keys");
   const finalizeDeferred = script.indexOf("PRAGMA defer_foreign_keys = OFF;");
   const tracking = script.indexOf("INSERT INTO d1_migrations (name) VALUES ('%s');");
   const executeFile = script.indexOf('--file "${IMPORT_FILE}"');
 
-  assert.notEqual(copySql, -1);
+  assert.notEqual(prepareSql, -1);
   assert.notEqual(detectDeferred, -1);
   assert.notEqual(finalizeDeferred, -1);
   assert.notEqual(tracking, -1);
   assert.notEqual(executeFile, -1);
-  assert.ok(copySql < detectDeferred);
+  assert.ok(prepareSql < detectDeferred);
   assert.ok(detectDeferred < finalizeDeferred);
   assert.ok(finalizeDeferred < tracking);
   assert.ok(tracking < executeFile);

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -39,20 +39,23 @@ test("local deploy uses valid remote D1 command contracts", async () => {
   );
 });
 
-test("remote D1 migration executor keeps migration tracking in the imported SQL file", async () => {
+test("remote D1 migration executor keeps migration tracking in the prepared SQL file", async () => {
   const script = await read("scripts/apply-d1-migrations-remote.sh");
-  const copySql = script.indexOf('cat "${MIGRATIONS_DIR}/${name}" > "${IMPORT_FILE}"');
+  const prepareSql = script.indexOf("node scripts/prepare-d1-migration-remote.mjs");
+  const preparedInput = script.indexOf('"${MIGRATIONS_DIR}/${name}" "${IMPORT_FILE}" "${name}"');
   const tracking = script.indexOf("INSERT INTO d1_migrations (name) VALUES ('%s');");
   const executeFile = script.indexOf('--file "${IMPORT_FILE}"');
   const verifyRegistry = script.indexOf("SELECT COUNT(*) AS applied FROM d1_migrations WHERE name='${name}';");
 
-  assert.notEqual(copySql, -1, "migration SQL must be copied unchanged into the import file");
+  assert.notEqual(prepareSql, -1, "committed migration SQL must pass through the controlled remote preparer");
+  assert.notEqual(preparedInput, -1, "the preparer must receive the committed migration, import path, and exact migration name");
   assert.notEqual(tracking, -1, "migration registry insert must be appended to the import file");
-  assert.notEqual(executeFile, -1, "the combined SQL file must be sent through --file");
+  assert.notEqual(executeFile, -1, "the prepared SQL file must be sent through --file");
   assert.notEqual(verifyRegistry, -1, "the registry must be verified after each imported migration");
-  assert.ok(copySql < tracking && tracking < executeFile && executeFile < verifyRegistry);
+  assert.ok(prepareSql <= preparedInput && preparedInput < tracking && tracking < executeFile && executeFile < verifyRegistry);
   assert.match(script, /Unsafe D1 migration filename/);
   assert.match(script, /still unapplied/);
+  assert.doesNotMatch(script, /db:generate|drizzle-kit generate/);
 });
 
 test("remote D1 migration executor has valid bash syntax", () => {

--- a/tests/drizzle-generation-guard.test.mjs
+++ b/tests/drizzle-generation-guard.test.mjs
@@ -36,7 +36,7 @@ test("db:generate stays guarded and is a no-op after Drizzle metadata rebaseline
   assert.match(`${result.stdout}\n${result.stderr}`, /No schema changes, nothing to migrate/i);
 });
 
-test("production deploy applies committed SQL migrations directly instead of generating schema", async () => {
+test("production deploy applies committed SQL migrations through the controlled preparer instead of generating schema", async () => {
   const [deploy, migrationExecutor] = await Promise.all([
     read("scripts/deploy-cloudflare.sh"),
     read("scripts/apply-d1-migrations-remote.sh"),
@@ -47,8 +47,13 @@ test("production deploy applies committed SQL migrations directly instead of gen
   );
   assert.match(
     migrationExecutor,
-    /cat \"\$\{MIGRATIONS_DIR\}\/\$\{name\}\" > \"\$\{IMPORT_FILE\}\"/,
-    "the executor must import committed migration SQL files directly",
+    /node scripts\/prepare-d1-migration-remote\.mjs/,
+    "the executor must route committed migration SQL through the controlled preparer",
+  );
+  assert.match(
+    migrationExecutor,
+    /"\$\{MIGRATIONS_DIR\}\/\$\{name\}" "\$\{IMPORT_FILE\}" "\$\{name\}"/,
+    "the preparer must receive the committed migration, import path, and exact migration name",
   );
   assert.match(
     migrationExecutor,


### PR DESCRIPTION
Fix the production D1 0093 failure without changing business data or disabling foreign_keys.

Production diagnostics proved the 0092 graph is clean (`foreign_key_check = 0`) and the only live external reference to `business_documents` is `patient_order_details`. The remote importer now wraps only 0093 in a single fail-closed transaction bridge: require every other business-document dependency to be empty and no reversal self-link, copy Patient Order rows to a no-FK shadow table, temporarily remove those FK rows, run the original 0093 SQL unchanged, restore the rows byte-for-byte, compare both directions with EXCEPT, recreate the two temporarily removed Patient Order triggers, then rely on the existing explicit D1 deferred-FK finalization before recording the migration.

All other migrations remain byte-for-byte unchanged. Behavioral tests cover a posted immutable Patient Order row, guard rollback when another dependency is populated, FK validity, trigger restoration, and passthrough for unrelated migrations.