### PR TITLE
Trigger approved production deploy

### DIFF
--- a/.github/workflows/deploy-once.yml
+++ b/.github/workflows/deploy-once.yml
@@ -1,0 +1,59 @@
+name: One-shot production deploy dispatcher
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/deploy-once.yml
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  dispatch:
+    name: Dispatch canonical deploy workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify exact trigger base
+        env:
+          EXPECTED_BEFORE: e52190889b10ef71f4a097d6c626a3325ced3298
+          ACTUAL_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          echo "Expected previous main: $EXPECTED_BEFORE"
+          echo "Actual previous main:   $ACTUAL_BEFORE"
+          test "$ACTUAL_BEFORE" = "$EXPECTED_BEFORE"
+
+      - name: Dispatch canonical production deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy.yml/dispatches" \
+            -f ref="main" \
+            -f 'inputs[confirmation]=DEPLOY'
+
+      - name: Capture dispatched run id
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          RUN_ID=""
+          for attempt in 1 2 3 4 5 6; do
+            RUN_ID="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy.yml/runs?event=workflow_dispatch&branch=main&per_page=20" \
+              --jq '.workflow_runs[] | select(.head_sha == env.GITHUB_SHA) | .id' | head -n1 || true)"
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            sleep 5
+          done
+          test -n "$RUN_ID"
+          printf '{"run_id":%s,"head_sha":"%s","approved_application_sha":"%s"}\n' \
+            "$RUN_ID" "$GITHUB_SHA" "e52190889b10ef71f4a097d6c626a3325ced3298" > /tmp/dispatched.json
+          ENCODED="$(base64 -w0 /tmp/dispatched.json)"
+          gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/.github/deploy-status/dispatched-${GITHUB_RUN_ID}.json" \
+            -f message="ops: record canonical production deploy run" \
+            -f content="$ENCODED" \
+            -f branch="main" > /dev/null


### PR DESCRIPTION
One-shot exact-base dispatcher to launch the canonical manual production deploy for the currently approved main SHA `e52190889b10ef71f4a097d6c626a3325ced3298`. No application code changes. The dispatcher fails closed if `main` moves before merge and will be removed immediately after the deploy completes.