### PR TITLE
Add service material margin report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,14 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload failing test output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr409-test-output
+          path: test-output.log
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload failing test output
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr409-test-output
-          path: test-output.log
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate

--- a/app/api/staff/reports/material-margin/route.ts
+++ b/app/api/staff/reports/material-margin/route.ts
@@ -1,0 +1,44 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import {
+  buildServiceMaterialMarginReport,normalizeServiceMaterialMarginPeriod,
+} from "../../../../../lib/service-material-margin-report";
+import { canViewReports } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+function kyivToday(){
+  return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+
+export async function GET(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canViewReports(ctx.member.role))return Response.json({error:"Маржинальність послуг доступна лише адміністратору"},{status:403});
+
+  const today=kyivToday();
+  const defaults={from:`${today.slice(0,7)}-01`,to:today};
+  try{
+    const url=new URL(request.url);
+    const period=normalizeServiceMaterialMarginPeriod(url.searchParams.get("from"),url.searchParams.get("to"),defaults);
+    const report=await buildServiceMaterialMarginReport(db,ctx.organizationId,period);
+    await audit(db,{
+      organizationId:ctx.organizationId,
+      actorEmail:ctx.member.email,
+      action:"report_viewed",
+      resource:"report",
+      targetId:"service_material_margin",
+      details:{from:period.from,to:period.to,rows:report.rows.length,scope:report.scope},
+    });
+    return Response.json(report,{headers:{"cache-control":"no-store"}});
+  }catch(error){
+    if(error instanceof Error&&error.message==="invalid_report_period"){
+      return Response.json({error:"Некоректний період звіту"},{status:400});
+    }
+    if(error instanceof Error&&error.message==="report_period_too_large"){
+      return Response.json({error:"Період звіту не може перевищувати 366 днів"},{status:400});
+    }
+    throw error;
+  }
+}

--- a/app/staff/reports/material-margin/page.tsx
+++ b/app/staff/reports/material-margin/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect,useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type Row={
+  serviceCode:string;serviceTitle:string;performedNet:number;revenueBookings:number;costBookings:number;
+  netRevenue:number;materialCost:number;contribution:number;marginPct:number|null;
+};
+type Report={
+  period:{from:string;to:string};generatedAt:string;scope:"material_contribution";
+  summary:{netRevenue:number;linkedMaterialCost:number;unlinkedMaterialCost:number;contribution:number;marginPct:number|null;serviceCount:number};
+  rows:Row[];error?:string;
+};
+
+function todayInKyiv(){return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());}
+const initialTo=todayInKyiv();
+const initialFrom=`${initialTo.slice(0,7)}-01`;
+function money(value:number){return new Intl.NumberFormat("uk-UA",{style:"currency",currency:"UAH",maximumFractionDigits:0}).format(Number(value||0));}
+function pct(value:number|null){return value===null?"—":`${new Intl.NumberFormat("uk-UA",{maximumFractionDigits:1}).format(value)}%`;}
+function qty(value:number){return new Intl.NumberFormat("uk-UA",{maximumFractionDigits:2}).format(Number(value||0));}
+
+export default function ServiceMaterialMarginPage(){
+  const [from,setFrom]=useState(initialFrom);
+  const [to,setTo]=useState(initialTo);
+  const [data,setData]=useState<Report|null>(null);
+  const [loading,setLoading]=useState(true);
+  const [error,setError]=useState("");
+
+  async function load(){
+    setLoading(true);setError("");
+    try{
+      const query=new URLSearchParams({from,to}).toString();
+      const response=await fetch(`/api/staff/reports/material-margin?${query}`,{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as Report;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося сформувати звіт маржинальності");
+      setData(payload);
+    }catch(e){setData(null);setError(e instanceof Error?e.message:"Не вдалося сформувати звіт маржинальності");}
+    finally{setLoading(false);}
+  }
+
+  useEffect(()=>{const timer=window.setTimeout(()=>{void load();},0);return()=>window.clearTimeout(timer);/* eslint-disable-next-line react-hooks/exhaustive-deps */},[]);
+
+  return <StaffWorkspaceShell
+    active="reports"
+    title="Маржинальність послуг — матеріали"
+    description="Read-only BAS-подібний зріз: проведений дохід мінус фактична собівартість списаних матеріалів."
+  >
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div><b>Період оборотів</b><small>Суми беруться тільки з immutable revenue та expense movements за датою проведення.</small></div>
+        <label><span>Від</span><input type="date" value={from} onChange={e=>setFrom(e.target.value)}/></label>
+        <label><span>До</span><input type="date" value={to} onChange={e=>setTo(e.target.value)}/></label>
+        <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
+        <a className="excelButton" href="/staff/reports/registers">Обороти регістрів</a>
+        <a className="excelButton" href="/staff/reports">Звіти</a>
+      </header>
+      {error&&<p className="financeError">{error}</p>}
+      <p className="financeHint"><b>Не є повним прибутком.</b> У розрахунок входить лише матеріальна собівартість. Зарплата, амортизація обладнання, електроенергія та інші накладні витрати не розподіляються.</p>
+      {data&&data.summary.unlinkedMaterialCost>0&&<p className="financeError">Неприв’язані до заявки списання: {money(data.summary.unlinkedMaterialCost)}. Вони не розподіляються по послугах автоматично і не зменшують їхню маржу.</p>}
+    </section>
+
+    {data&&<>
+      <section className="financeSummary" aria-label="Матеріальна маржинальність">
+        <article><span>Чистий дохід</span><b>{money(data.summary.netRevenue)}</b><small>service delivery з урахуванням storno</small></article>
+        <article><span>Матеріали</span><b>{money(data.summary.linkedMaterialCost)}</b><small>лише списання, прив’язані до заявки</small></article>
+        <article><span>Матеріальний внесок</span><b>{money(data.summary.contribution)}</b><small>дохід − матеріальна собівартість</small></article>
+        <article><span>Матеріальна маржа</span><b>{pct(data.summary.marginPct)}</b><small>не розраховується при нульовому/від’ємному доході</small></article>
+        <article><span>Неприв’язані списання</span><b>{money(data.summary.unlinkedMaterialCost)}</b><small>окремо, без штучного розподілу</small></article>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>По послугах</b><small>{data.summary.serviceCount} кодів із проведеними виконаннями, доходом або матеріальною собівартістю за період.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr>
+          <th>Послуга</th><th className="num">Виконано, нетто</th><th className="num">Дохід</th><th className="num">Матеріали</th><th className="num">Внесок</th><th className="num">Маржа</th>
+        </tr></thead><tbody>
+          {data.rows.map(row=><tr key={row.serviceCode}>
+            <td><b>{row.serviceTitle||row.serviceCode}</b><small>{row.serviceCode} · дохід: {row.revenueBookings} заявок · матеріали: {row.costBookings} заявок</small></td>
+            <td className="num">{qty(row.performedNet)}</td>
+            <td className="num">{money(row.netRevenue)}</td>
+            <td className="num">{money(row.materialCost)}</td>
+            <td className="num"><b>{money(row.contribution)}</b></td>
+            <td className="num"><b>{pct(row.marginPct)}</b></td>
+          </tr>)}
+          {data.rows.length===0&&<tr><td colSpan={6}>За обраний період немає проведених доходів, виконань або прив’язаних матеріальних витрат.</td></tr>}
+        </tbody></table></div>
+      </section>
+    </>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/reports/receivables/page.tsx
+++ b/app/staff/reports/receivables/page.tsx
@@ -48,6 +48,7 @@ export default function ReceivablesPage(){
         <label><span>Дата</span><input type="date" value={asOf} onChange={e=>setAsOf(e.target.value)}/></label>
         <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
         <a className="excelButton" href="/staff/reports/registers">Обороти регістрів</a>
+        <a className="excelButton" href="/staff/reports/material-margin">Матеріальна маржа</a>
       </header>
       {error&&<p className="financeError">{error}</p>}
       {data?.truncated&&<p className="financeError">Показано перші 2000 ненульових сальдо. Для повної відомості звузьте контур даних або використайте експорт після його додавання.</p>}

--- a/docs/service-material-margin-report.md
+++ b/docs/service-material-margin-report.md
@@ -1,0 +1,29 @@
+# Service material margin report
+
+RadiologyOS exposes a read-only BAS-style contribution report for service revenue versus acquisition-cost material expense.
+
+## Source of truth
+
+The report never writes or reconstructs business facts. For the selected period it reads only posted append-only registers:
+
+- `revenue_movements` for net service revenue, including service correction / storno rows;
+- `expense_movements` for acquisition-cost material expense created from exact consumed inventory lots;
+- `services_delivered_movements` plus `service_correction_movements` for net performed service quantity.
+
+Material expense is assigned to a service only when the expense movement has an explicit `booking_id`. The booking is joined inside the same organization and supplies the service code. Expense without a booking is shown separately as unlinked material expense and is never allocated heuristically.
+
+## Meaning of margin
+
+`material contribution = net service revenue - linked material acquisition cost`
+
+`material margin % = material contribution / net service revenue`
+
+The percentage is deliberately absent when net revenue is zero or negative.
+
+This is **not full accounting profit**. Payroll, equipment depreciation, electricity, maintenance, rent and other overhead are not allocated by this report. A future full-cost model must introduce explicit cost drivers rather than silently distributing those costs.
+
+## Period and tenant rules
+
+Revenue, expense and execution movements are included by their own immutable `occurred_at` date. The maximum report period is 366 days. Every query is scoped to the organization derived from the authenticated staff session; the browser cannot choose an organization ID.
+
+The report is administrator-only, does not return patient identity fields, uses `cache-control: no-store`, and audits only period/scope/row-count metadata without patient or booking identifiers.

--- a/lib/service-material-margin-report.ts
+++ b/lib/service-material-margin-report.ts
@@ -1,0 +1,153 @@
+const DATE_RE=/^\d{4}-\d{2}-\d{2}$/;
+
+export type ServiceMaterialMarginPeriod={from:string;to:string};
+
+export type ServiceMaterialMarginRow={
+  serviceCode:string;
+  serviceTitle:string;
+  performedNet:number;
+  revenueBookings:number;
+  costBookings:number;
+  netRevenue:number;
+  materialCost:number;
+  contribution:number;
+  marginPct:number|null;
+};
+
+function validDate(value:string){
+  if(!DATE_RE.test(value))return false;
+  const date=new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime())&&date.toISOString().slice(0,10)===value;
+}
+
+export function normalizeServiceMaterialMarginPeriod(
+  fromValue:unknown,toValue:unknown,defaults:ServiceMaterialMarginPeriod,
+):ServiceMaterialMarginPeriod{
+  const from=typeof fromValue==="string"&&fromValue.trim()?fromValue.trim():defaults.from;
+  const to=typeof toValue==="string"&&toValue.trim()?toValue.trim():defaults.to;
+  if(!validDate(from)||!validDate(to)||from>to)throw new Error("invalid_report_period");
+  const days=Math.floor((Date.parse(`${to}T00:00:00Z`)-Date.parse(`${from}T00:00:00Z`))/86400000)+1;
+  if(days>366)throw new Error("report_period_too_large");
+  return {from,to};
+}
+
+function marginPct(revenue:number,contribution:number){
+  if(revenue<=0)return null;
+  return Math.round((contribution/revenue)*1000)/10;
+}
+
+type RawRow={
+  serviceCode:string;serviceTitle:string;performedNet:number;revenueBookings:number;costBookings:number;
+  netRevenue:number;materialCost:number;
+};
+
+export async function buildServiceMaterialMarginReport(
+  db:D1Database,organizationId:number,period:ServiceMaterialMarginPeriod,
+){
+  const result=await db.prepare(`
+    WITH params(organization_id,from_date,to_date) AS (VALUES(?,?,?)),
+    performed AS (
+      SELECT service_code AS serviceCode,COALESCE(SUM(quantity_delta),0) AS performedNet
+      FROM (
+        SELECT m.service_code,m.quantity AS quantity_delta
+        FROM services_delivered_movements m,params p
+        WHERE m.organization_id=p.organization_id
+          AND substr(m.occurred_at,1,10) BETWEEN p.from_date AND p.to_date
+        UNION ALL
+        SELECT c.service_code,c.quantity_delta
+        FROM service_correction_movements c,params p
+        WHERE c.organization_id=p.organization_id
+          AND substr(c.occurred_at,1,10) BETWEEN p.from_date AND p.to_date
+      ) movements
+      GROUP BY service_code
+    ),
+    revenue AS (
+      SELECT r.service_code AS serviceCode,
+        COALESCE(SUM(r.amount_delta),0) AS netRevenue,
+        COUNT(DISTINCT r.booking_id) AS revenueBookings
+      FROM revenue_movements r,params p
+      WHERE r.organization_id=p.organization_id
+        AND substr(r.occurred_at,1,10) BETWEEN p.from_date AND p.to_date
+      GROUP BY r.service_code
+    ),
+    cost AS (
+      SELECT b.service_code AS serviceCode,
+        COALESCE(SUM(e.amount_delta),0) AS materialCost,
+        COUNT(DISTINCT e.booking_id) AS costBookings
+      FROM expense_movements e
+      JOIN bookings b ON b.organization_id=e.organization_id AND b.id=e.booking_id
+      JOIN params p ON p.organization_id=e.organization_id
+      WHERE e.booking_id IS NOT NULL
+        AND substr(e.occurred_at,1,10) BETWEEN p.from_date AND p.to_date
+      GROUP BY b.service_code
+    ),
+    codes AS (
+      SELECT serviceCode FROM performed
+      UNION SELECT serviceCode FROM revenue
+      UNION SELECT serviceCode FROM cost
+    )
+    SELECT codes.serviceCode AS serviceCode,
+      COALESCE(
+        (SELECT sd.service_title FROM service_delivery_details sd,params p
+         WHERE sd.organization_id=p.organization_id AND sd.service_code=codes.serviceCode
+         ORDER BY sd.document_id DESC LIMIT 1),
+        (SELECT b.service FROM bookings b,params p
+         WHERE b.organization_id=p.organization_id AND b.service_code=codes.serviceCode
+         ORDER BY b.id DESC LIMIT 1),
+        codes.serviceCode
+      ) AS serviceTitle,
+      COALESCE(performed.performedNet,0) AS performedNet,
+      COALESCE(revenue.revenueBookings,0) AS revenueBookings,
+      COALESCE(cost.costBookings,0) AS costBookings,
+      COALESCE(revenue.netRevenue,0) AS netRevenue,
+      COALESCE(cost.materialCost,0) AS materialCost
+    FROM codes
+    LEFT JOIN performed ON performed.serviceCode=codes.serviceCode
+    LEFT JOIN revenue ON revenue.serviceCode=codes.serviceCode
+    LEFT JOIN cost ON cost.serviceCode=codes.serviceCode
+    ORDER BY ABS(COALESCE(revenue.netRevenue,0)-COALESCE(cost.materialCost,0)) DESC,codes.serviceCode
+    LIMIT 300
+  `).bind(organizationId,period.from,period.to).all<RawRow>();
+
+  const unlinked=await db.prepare(`
+    SELECT COALESCE(SUM(e.amount_delta),0) AS amount
+    FROM expense_movements e
+    LEFT JOIN bookings b ON b.organization_id=e.organization_id AND b.id=e.booking_id
+    WHERE e.organization_id=?
+      AND substr(e.occurred_at,1,10) BETWEEN ? AND ?
+      AND (e.booking_id IS NULL OR b.id IS NULL)
+  `).bind(organizationId,period.from,period.to).first<{amount:number}>();
+
+  const rows:ServiceMaterialMarginRow[]=result.results.map(raw=>{
+    const netRevenue=Number(raw.netRevenue||0);
+    const materialCost=Number(raw.materialCost||0);
+    const contribution=netRevenue-materialCost;
+    return {
+      serviceCode:String(raw.serviceCode||""),
+      serviceTitle:String(raw.serviceTitle||raw.serviceCode||""),
+      performedNet:Number(raw.performedNet||0),
+      revenueBookings:Number(raw.revenueBookings||0),
+      costBookings:Number(raw.costBookings||0),
+      netRevenue,materialCost,contribution,marginPct:marginPct(netRevenue,contribution),
+    };
+  });
+
+  const netRevenue=rows.reduce((sum,row)=>sum+row.netRevenue,0);
+  const linkedMaterialCost=rows.reduce((sum,row)=>sum+row.materialCost,0);
+  const contribution=netRevenue-linkedMaterialCost;
+  const unlinkedMaterialCost=Number(unlinked?.amount||0);
+  return {
+    period,
+    generatedAt:new Date().toISOString(),
+    scope:"material_contribution" as const,
+    summary:{
+      netRevenue,
+      linkedMaterialCost,
+      unlinkedMaterialCost,
+      contribution,
+      marginPct:marginPct(netRevenue,contribution),
+      serviceCount:rows.length,
+    },
+    rows,
+  };
+}

--- a/tests/service-material-margin-report.behavior.test.mjs
+++ b/tests/service-material-margin-report.behavior.test.mjs
@@ -11,11 +11,11 @@ async function seedBooking(db,{organizationId=1,code,serviceCode,serviceTitle}){
   return Number(result.meta.last_row_id);
 }
 
-async function seedDocument(db,{organizationId=1,type="service_delivery",number,occurredAt}){
+async function seedDocument(db,{organizationId=1,number,occurredAt}){
   const result=await db.prepare(`INSERT INTO business_documents
     (organization_id,document_type,number,occurred_at,state,created_by,posted_by,posted_at)
-    VALUES (?,?,?,?, 'posted','margin-test','margin-test',?)`)
-    .bind(organizationId,type,number,occurredAt,occurredAt).run();
+    VALUES (?,'service_delivery',?,?, 'posted','margin-test','margin-test',?)`)
+    .bind(organizationId,number,occurredAt,occurredAt).run();
   return Number(result.meta.last_row_id);
 }
 
@@ -57,7 +57,7 @@ test("service material margin uses posted revenue and booking-linked acquisition
     const military=await seedBooking(db,{code:"MARG03",serviceCode:"ct-head",serviceTitle:"КТ голови"});
 
     const ctDelivery=await seedDocument(db,{number:"M-D-1",occurredAt:"2026-08-10T10:00:00"});
-    const ctCorrection=await seedDocument(db,{type:"service_correction",number:"M-C-1",occurredAt:"2026-08-11T10:00:00"});
+    const ctCorrection=await seedDocument(db,{number:"M-C-1",occurredAt:"2026-08-11T10:00:00"});
     const xrayDelivery=await seedDocument(db,{number:"M-D-2",occurredAt:"2026-08-12T10:00:00"});
     await addRevenue(db,{documentId:ctDelivery,bookingId:ct,serviceCode:"ct-chest",amount:1000,occurredAt:"2026-08-10T10:00:00"});
     await addRevenue(db,{documentId:ctCorrection,bookingId:ct,serviceCode:"ct-chest",amount:-200,occurredAt:"2026-08-11T10:00:00",type:"service_correction"});

--- a/tests/service-material-margin-report.behavior.test.mjs
+++ b/tests/service-material-margin-report.behavior.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+async function seedBooking(db,{organizationId=1,code,serviceCode,serviceTitle}){
+  const result=await db.prepare(`INSERT INTO bookings
+    (organization_id,code,name,phone,phone_normalized,date_of_birth,service,service_code,equipment_id,
+     duration_minutes,desired_date,desired_time,patient_category,status,payment_amount)
+    VALUES (?,?,?,? ,?,'1980-01-02',?,?,'ct',30,'2026-08-19','10:00','civilian','completed',0)`)
+    .bind(organizationId,code,`Patient ${code}`,`+38050${code.slice(-6)}`,`38050${code.slice(-6)}`,serviceTitle,serviceCode).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function seedDocument(db,{organizationId=1,type="service_delivery",number,occurredAt}){
+  const result=await db.prepare(`INSERT INTO business_documents
+    (organization_id,document_type,number,occurred_at,state,created_by,posted_by,posted_at)
+    VALUES (?,?,?,?, 'posted','margin-test','margin-test',?)`)
+    .bind(organizationId,type,number,occurredAt,occurredAt).run();
+  return Number(result.meta.last_row_id);
+}
+
+function dropInsertGuards(raw,table){
+  const rows=raw.prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=? AND upper(sql) LIKE '%BEFORE INSERT%'").all(table);
+  for(const row of rows){
+    const name=String(row.name).replaceAll('"','""');
+    raw.exec(`DROP TRIGGER "${name}"`);
+  }
+}
+
+async function addRevenue(db,{organizationId=1,documentId,bookingId,serviceCode,amount,occurredAt,type="service_delivery"}){
+  await db.prepare(`INSERT INTO revenue_movements
+    (organization_id,document_id,booking_id,patient_id,service_code,movement_type,amount_delta,currency,actor_email,occurred_at)
+    VALUES (?,?,?,'',?,?,?,'UAH','margin-test',?)`)
+    .bind(organizationId,documentId,bookingId,serviceCode,type,amount,occurredAt).run();
+}
+
+async function addExpense(db,{organizationId=1,id,bookingId,amount,occurredAt}){
+  await db.prepare(`INSERT INTO expense_movements
+    (organization_id,inventory_movement_id,document_id,document_line_id,source_receipt_document_id,source_receipt_line_id,
+     booking_id,item_id,lot_id,warehouse_id,unit_cost,amount_delta,currency,reason,actor_email,occurred_at)
+    VALUES (?,?,?,?,?,?,?,?,?,?,1,?,'UAH','margin-test','margin-test',?)`)
+    .bind(organizationId,id,id,id,id,id,bookingId,1,1,1,amount,occurredAt).run();
+}
+
+async function report(db,cookie,from="2026-08-01",to="2026-08-31"){
+  return callWorker(new Request(`http://localhost/api/staff/reports/material-margin?from=${from}&to=${to}`,{headers:{cookie}}),db);
+}
+
+test("service material margin uses posted revenue and booking-linked acquisition cost without cross-tenant allocation",async()=>{
+  await withD1(async(db,raw)=>{
+    dropInsertGuards(raw,"revenue_movements");
+    dropInsertGuards(raw,"expense_movements");
+
+    const admin=await seedStaffSession(db,{email:"margin-admin@example.com",role:"admin",organizationId:1});
+    const ct=await seedBooking(db,{code:"MARG01",serviceCode:"ct-chest",serviceTitle:"КТ ОГК"});
+    const xray=await seedBooking(db,{code:"MARG02",serviceCode:"xray-chest",serviceTitle:"Рентген ОГК"});
+    const military=await seedBooking(db,{code:"MARG03",serviceCode:"ct-head",serviceTitle:"КТ голови"});
+
+    const ctDelivery=await seedDocument(db,{number:"M-D-1",occurredAt:"2026-08-10T10:00:00"});
+    const ctCorrection=await seedDocument(db,{type:"service_correction",number:"M-C-1",occurredAt:"2026-08-11T10:00:00"});
+    const xrayDelivery=await seedDocument(db,{number:"M-D-2",occurredAt:"2026-08-12T10:00:00"});
+    await addRevenue(db,{documentId:ctDelivery,bookingId:ct,serviceCode:"ct-chest",amount:1000,occurredAt:"2026-08-10T10:00:00"});
+    await addRevenue(db,{documentId:ctCorrection,bookingId:ct,serviceCode:"ct-chest",amount:-200,occurredAt:"2026-08-11T10:00:00",type:"service_correction"});
+    await addRevenue(db,{documentId:xrayDelivery,bookingId:xray,serviceCode:"xray-chest",amount:500,occurredAt:"2026-08-12T10:00:00"});
+    await addExpense(db,{id:1001,bookingId:ct,amount:300,occurredAt:"2026-08-10T10:05:00"});
+    await addExpense(db,{id:1002,bookingId:military,amount:150,occurredAt:"2026-08-13T10:05:00"});
+    await addExpense(db,{id:1003,bookingId:null,amount:90,occurredAt:"2026-08-14T10:05:00"});
+
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Margin Org 2','margin-org-2',1)");
+    const other=await seedBooking(db,{organizationId:2,code:"MARG99",serviceCode:"ct-chest",serviceTitle:"Other tenant CT"});
+    const otherDoc=await seedDocument(db,{organizationId:2,number:"M-D-99",occurredAt:"2026-08-10T10:00:00"});
+    await addRevenue(db,{organizationId:2,documentId:otherDoc,bookingId:other,serviceCode:"ct-chest",amount:9000,occurredAt:"2026-08-10T10:00:00"});
+    await addExpense(db,{organizationId:2,id:2001,bookingId:other,amount:8000,occurredAt:"2026-08-10T10:05:00"});
+
+    const response=await report(db,admin);
+    assert.equal(response.status,200);
+    const body=await response.json();
+    assert.equal(body.scope,"material_contribution");
+    assert.deepEqual(body.period,{from:"2026-08-01",to:"2026-08-31"});
+    assert.equal(body.summary.netRevenue,1300);
+    assert.equal(body.summary.linkedMaterialCost,450);
+    assert.equal(body.summary.unlinkedMaterialCost,90);
+    assert.equal(body.summary.contribution,850);
+    assert.equal(body.summary.marginPct,65.4);
+
+    const ctRow=body.rows.find(row=>row.serviceCode==="ct-chest");
+    assert.ok(ctRow);assert.equal(ctRow.serviceTitle,"КТ ОГК");assert.equal(ctRow.netRevenue,800);assert.equal(ctRow.materialCost,300);assert.equal(ctRow.contribution,500);assert.equal(ctRow.marginPct,62.5);
+    const xrayRow=body.rows.find(row=>row.serviceCode==="xray-chest");
+    assert.ok(xrayRow);assert.equal(xrayRow.netRevenue,500);assert.equal(xrayRow.materialCost,0);assert.equal(xrayRow.marginPct,100);
+    const militaryRow=body.rows.find(row=>row.serviceCode==="ct-head");
+    assert.ok(militaryRow);assert.equal(militaryRow.netRevenue,0);assert.equal(militaryRow.materialCost,150);assert.equal(militaryRow.contribution,-150);assert.equal(militaryRow.marginPct,null);
+    assert.ok(!body.rows.some(row=>row.serviceTitle==="Other tenant CT"));
+
+    const auditRow=raw.prepare(`SELECT details_json AS details FROM security_audit_log
+      WHERE organization_id=1 AND actor_email='margin-admin@example.com'
+        AND action='report_viewed' AND target_id='service_material_margin'
+      ORDER BY id DESC LIMIT 1`).get();
+    assert.ok(auditRow);
+    assert.deepEqual(JSON.parse(auditRow.details),{from:"2026-08-01",to:"2026-08-31",rows:3,scope:"material_contribution"});
+    assert.ok(!auditRow.details.includes("MARG"));
+    assert.ok(!auditRow.details.includes("Patient"));
+  });
+});
+
+test("service material margin validates period and stays admin-only",async()=>{
+  await withD1(async(db)=>{
+    const admin=await seedStaffSession(db,{email:"margin-date-admin@example.com",role:"admin",organizationId:1});
+    const registrar=await seedStaffSession(db,{email:"margin-registrar@example.com",role:"registrar",organizationId:1});
+    assert.equal((await report(db,registrar)).status,403);
+    assert.equal((await report(db,admin,"bad-date","2026-08-31")).status,400);
+    assert.equal((await report(db,admin,"2025-01-01","2026-08-31")).status,400);
+  });
+});


### PR DESCRIPTION
Adds an admin-only, read-only BAS-style service material contribution report. It combines only existing append-only registers: net service revenue (including storno), booking-linked acquisition-cost material expense, and net performed service movements. Unlinked inventory expense is shown separately and never allocated heuristically. No D1 schema or posting logic changes. Includes UI, cross-report navigation, behavioral tenant/RBAC/audit coverage, and semantics documentation.