### PR TITLE
Add CSV export for service material margin report

### DIFF
--- a/app/api/staff/reports/material-margin/export/route.ts
+++ b/app/api/staff/reports/material-margin/export/route.ts
@@ -1,0 +1,48 @@
+import { audit } from "../../../../../../lib/audit";
+import { dbBinding } from "../../../../../../lib/db";
+import { buildServiceMaterialMarginCsv } from "../../../../../../lib/service-material-margin-csv";
+import {
+  buildServiceMaterialMarginReport,normalizeServiceMaterialMarginPeriod,
+} from "../../../../../../lib/service-material-margin-report";
+import { canViewReports } from "../../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../../lib/tenant";
+
+function kyivToday(){
+  return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+function safeFilenameDate(value:string){return /^\d{4}-\d{2}-\d{2}$/.test(value)?value:"date";}
+
+export async function GET(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canViewReports(ctx.member.role))return Response.json({error:"Експорт маржинальності доступний лише адміністратору"},{status:403});
+
+  const today=kyivToday();
+  const defaults={from:`${today.slice(0,7)}-01`,to:today};
+  try{
+    const url=new URL(request.url);
+    const period=normalizeServiceMaterialMarginPeriod(url.searchParams.get("from"),url.searchParams.get("to"),defaults);
+    const report=await buildServiceMaterialMarginReport(db,ctx.organizationId,period);
+    const csv=buildServiceMaterialMarginCsv(report);
+    await audit(db,{
+      organizationId:ctx.organizationId,
+      actorEmail:ctx.member.email,
+      action:"report_exported",
+      resource:"report",
+      targetId:"service_material_margin",
+      details:{from:period.from,to:period.to,rows:report.rows.length,scope:report.scope,format:"csv"},
+    });
+    return new Response(csv,{headers:{
+      "content-type":"text/csv; charset=utf-8",
+      "content-disposition":`attachment; filename="service-material-margin-${safeFilenameDate(period.from)}-${safeFilenameDate(period.to)}.csv"`,
+      "cache-control":"private, no-store",
+    }});
+  }catch(error){
+    if(error instanceof Error&&error.message==="report_period_too_large"){
+      return Response.json({error:"Період звіту не може перевищувати 366 днів"},{status:400});
+    }
+    return Response.json({error:"Некоректний період звіту"},{status:400});
+  }
+}

--- a/app/staff/reports/material-margin/page.tsx
+++ b/app/staff/reports/material-margin/page.tsx
@@ -26,6 +26,7 @@ export default function ServiceMaterialMarginPage(){
   const [data,setData]=useState<Report|null>(null);
   const [loading,setLoading]=useState(true);
   const [error,setError]=useState("");
+  const exportUrl=`/api/staff/reports/material-margin/export?${new URLSearchParams({from,to}).toString()}`;
 
   async function load(){
     setLoading(true);setError("");
@@ -52,6 +53,7 @@ export default function ServiceMaterialMarginPage(){
         <label><span>Від</span><input type="date" value={from} onChange={e=>setFrom(e.target.value)}/></label>
         <label><span>До</span><input type="date" value={to} onChange={e=>setTo(e.target.value)}/></label>
         <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
+        <a className="excelButton" href={exportUrl}>CSV</a>
         <a className="excelButton" href="/staff/reports/registers">Обороти регістрів</a>
         <a className="excelButton" href="/staff/reports">Звіти</a>
       </header>

--- a/lib/service-material-margin-csv.ts
+++ b/lib/service-material-margin-csv.ts
@@ -3,6 +3,7 @@ import type { buildServiceMaterialMarginReport } from "./service-material-margin
 type Report=Awaited<ReturnType<typeof buildServiceMaterialMarginReport>>;
 
 function safeValue(value:unknown){
+  if(typeof value==="number"&&Number.isFinite(value))return `"${value}"`;
   let text=value===null||value===undefined?"":String(value);
   if(/^[\s]*[=+\-@]/.test(text)||/^[\t\r]/.test(text))text=`'${text}`;
   return `"${text.replaceAll('"','""')}"`;

--- a/lib/service-material-margin-csv.ts
+++ b/lib/service-material-margin-csv.ts
@@ -1,0 +1,32 @@
+import type { buildServiceMaterialMarginReport } from "./service-material-margin-report.ts";
+
+type Report=Awaited<ReturnType<typeof buildServiceMaterialMarginReport>>;
+
+function safeValue(value:unknown){
+  let text=value===null||value===undefined?"":String(value);
+  if(/^[\s]*[=+\-@]/.test(text)||/^[\t\r]/.test(text))text=`'${text}`;
+  return `"${text.replaceAll('"','""')}"`;
+}
+function line(...values:unknown[]){return values.map(safeValue).join(",");}
+
+export function buildServiceMaterialMarginCsv(report:Report){
+  const rows:Array<Array<unknown>>=[
+    ["RadiologyOS — маржинальність послуг: матеріали"],
+    ["Період",report.period.from,report.period.to],
+    ["Сформовано",report.generatedAt],
+    [],
+    ["Підсумок"],
+    ["Чистий дохід",report.summary.netRevenue],
+    ["Матеріали, прив’язані до заявок",report.summary.linkedMaterialCost],
+    ["Неприв’язані списання",report.summary.unlinkedMaterialCost],
+    ["Матеріальний внесок",report.summary.contribution],
+    ["Матеріальна маржа, %",report.summary.marginPct??""],
+    [],
+    ["Код послуги","Послуга","Виконано, нетто","Заявок з доходом","Заявок з матеріалами","Чистий дохід","Матеріали","Матеріальний внесок","Маржа, %"],
+    ...report.rows.map(row=>[
+      row.serviceCode,row.serviceTitle,row.performedNet,row.revenueBookings,row.costBookings,
+      row.netRevenue,row.materialCost,row.contribution,row.marginPct??"",
+    ]),
+  ];
+  return "\uFEFF"+rows.map(row=>line(...row)).join("\r\n");
+}

--- a/tests/service-material-margin-csv.behavior.test.mjs
+++ b/tests/service-material-margin-csv.behavior.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildServiceMaterialMarginCsv } from "../lib/service-material-margin-csv.ts";
+
+test("service material margin CSV preserves report facts and neutralizes spreadsheet formulas",()=>{
+  const csv=buildServiceMaterialMarginCsv({
+    period:{from:"2026-08-01",to:"2026-08-31"},
+    generatedAt:"2026-08-19T17:00:00.000Z",
+    scope:"material_contribution",
+    summary:{netRevenue:1300,linkedMaterialCost:450,unlinkedMaterialCost:90,contribution:850,marginPct:65.4,serviceCount:2},
+    rows:[
+      {serviceCode:"ct-chest",serviceTitle:"КТ ОГК",performedNet:1,revenueBookings:1,costBookings:1,netRevenue:800,materialCost:300,contribution:500,marginPct:62.5},
+      {serviceCode:"=SUM(A1:A2)",serviceTitle:"+unsafe title",performedNet:0,revenueBookings:0,costBookings:1,netRevenue:0,materialCost:150,contribution:-150,marginPct:null},
+    ],
+  });
+  assert.ok(csv.startsWith("\uFEFF"));
+  assert.ok(csv.includes('"Чистий дохід","1300"'));
+  assert.ok(csv.includes('"ct-chest","КТ ОГК"'));
+  assert.ok(csv.includes('"\'=SUM(A1:A2)","\'+unsafe title"'));
+  assert.ok(csv.includes('"-150"')===false,"negative numeric values must also be neutralized for spreadsheet safety");
+  assert.ok(csv.includes('"\'-150"'));
+});

--- a/tests/service-material-margin-csv.behavior.test.mjs
+++ b/tests/service-material-margin-csv.behavior.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildServiceMaterialMarginCsv } from "../lib/service-material-margin-csv.ts";
 
-test("service material margin CSV preserves report facts and neutralizes spreadsheet formulas",()=>{
+test("service material margin CSV preserves numeric facts and neutralizes spreadsheet formulas",()=>{
   const csv=buildServiceMaterialMarginCsv({
     period:{from:"2026-08-01",to:"2026-08-31"},
     generatedAt:"2026-08-19T17:00:00.000Z",
@@ -17,6 +17,6 @@ test("service material margin CSV preserves report facts and neutralizes spreads
   assert.ok(csv.includes('"Чистий дохід","1300"'));
   assert.ok(csv.includes('"ct-chest","КТ ОГК"'));
   assert.ok(csv.includes('"\'=SUM(A1:A2)","\'+unsafe title"'));
-  assert.ok(csv.includes('"-150"')===false,"negative numeric values must also be neutralized for spreadsheet safety");
-  assert.ok(csv.includes('"\'-150"'));
+  assert.ok(csv.includes('"-150"'),"negative numeric facts must remain numeric for spreadsheet analysis");
+  assert.ok(!csv.includes('"\'-150"'));
 });


### PR DESCRIPTION
## Goal
Export the already-merged service material contribution report (#409) as a spreadsheet-safe CSV without duplicating or weakening its business semantics.

## Scope
- add a CSV renderer over the canonical `buildServiceMaterialMarginReport` result;
- add admin-only, tenant-scoped `/api/staff/reports/material-margin/export`;
- reuse the same period normalization and report builder as the JSON report;
- emit UTF-8 BOM, attachment headers, and `private, no-store`;
- preserve numeric financial values while neutralizing spreadsheet formulas in text fields;
- record a PHI-free export audit event;
- add a CSV action to the existing report UI;
- add focused behavioral coverage;
- no schema, migration, posting, or production-deploy changes.

## Invariants
- CSV and JSON values come from the same report builder;
- export never accepts tenant identity or report facts from the browser;
- unlinked material expense remains separate and is never heuristically allocated;
- text fields cannot execute spreadsheet formulas;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.