### PR TITLE
Add material consumption plan fact control report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload second failing test output
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr412-test-output-2
-          path: test-output.log
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,14 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload failing test output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr412-test-output
+          path: test-output.log
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload failing test output
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr412-test-output
-          path: test-output.log
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,14 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload second failing test output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr412-test-output-2
+          path: test-output.log
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/app/api/staff/reports/material-consumption-control/route.ts
+++ b/app/api/staff/reports/material-consumption-control/route.ts
@@ -1,0 +1,44 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import {
+  buildMaterialConsumptionControlReport,normalizeMaterialConsumptionControlPeriod,
+} from "../../../../../lib/material-consumption-control-report";
+import { canViewReports } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+
+function kyivToday(){
+  return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+
+export async function GET(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canViewReports(ctx.member.role))return Response.json({error:"Контроль списання матеріалів доступний лише адміністратору"},{status:403});
+
+  const today=kyivToday();
+  const defaults={from:`${today.slice(0,7)}-01`,to:today};
+  try{
+    const url=new URL(request.url);
+    const period=normalizeMaterialConsumptionControlPeriod(url.searchParams.get("from"),url.searchParams.get("to"),defaults);
+    const report=await buildMaterialConsumptionControlReport(db,ctx.organizationId,period);
+    await audit(db,{
+      organizationId:ctx.organizationId,
+      actorEmail:ctx.member.email,
+      action:"report_viewed",
+      resource:"report",
+      targetId:"material_consumption_control",
+      details:{from:period.from,to:period.to,rows:report.rows.length,reservationFacts:report.summary.reservationFacts,scope:report.scope},
+    });
+    return Response.json(report,{headers:{"cache-control":"no-store"}});
+  }catch(error){
+    if(error instanceof Error&&error.message==="invalid_report_period"){
+      return Response.json({error:"Некоректний період звіту"},{status:400});
+    }
+    if(error instanceof Error&&error.message==="report_period_too_large"){
+      return Response.json({error:"Період звіту не може перевищувати 366 днів"},{status:400});
+    }
+    throw error;
+  }
+}

--- a/app/staff/reports/material-consumption-control/page.tsx
+++ b/app/staff/reports/material-consumption-control/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect,useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type Row={
+  serviceCode:string;serviceTitle:string;itemId:number;itemSku:string;itemName:string;itemUnit:string;
+  warehouseId:number;warehouseCode:string;warehouseName:string;reservationCount:number;bookingCount:number;
+  plannedQuantity:number;postedQuantity:number;draftQuantity:number;unpostedQuantity:number;unallocatedQuantity:number;
+  coveragePct:number;fullyPostedReservations:number;draftReservations:number;needsAllocationReservations:number;
+};
+type Report={
+  period:{from:string;to:string};generatedAt:string;actualAsOf:string;scope:"material_consumption_control";
+  summary:{completedBookings:number;reservationFacts:number;fullyPosted:number;withDraft:number;needsAllocation:number;fullyPostedPct:number;rowCount:number};
+  rows:Row[];error?:string;
+};
+
+function todayInKyiv(){return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());}
+const initialTo=todayInKyiv();
+const initialFrom=`${initialTo.slice(0,7)}-01`;
+function qty(value:number){return new Intl.NumberFormat("uk-UA",{maximumFractionDigits:3}).format(Number(value||0));}
+function pct(value:number){return `${new Intl.NumberFormat("uk-UA",{maximumFractionDigits:1}).format(Number(value||0))}%`;}
+function moment(value:string){
+  const date=new Date(value);if(Number.isNaN(date.getTime()))return value;
+  return new Intl.DateTimeFormat("uk-UA",{timeZone:"Europe/Kyiv",dateStyle:"short",timeStyle:"short"}).format(date);
+}
+
+export default function MaterialConsumptionControlPage(){
+  const [from,setFrom]=useState(initialFrom);
+  const [to,setTo]=useState(initialTo);
+  const [data,setData]=useState<Report|null>(null);
+  const [loading,setLoading]=useState(true);
+  const [error,setError]=useState("");
+
+  async function load(){
+    setLoading(true);setError("");
+    try{
+      const query=new URLSearchParams({from,to}).toString();
+      const response=await fetch(`/api/staff/reports/material-consumption-control?${query}`,{cache:"no-store"});
+      const payload=await response.json().catch(()=>({})) as Report;
+      if(!response.ok)throw new Error(payload.error||"Не вдалося сформувати контроль списання матеріалів");
+      setData(payload);
+    }catch(e){setData(null);setError(e instanceof Error?e.message:"Не вдалося сформувати контроль списання матеріалів");}
+    finally{setLoading(false);}
+  }
+
+  useEffect(()=>{const timer=window.setTimeout(()=>{void load();},0);return()=>window.clearTimeout(timer);/* eslint-disable-next-line react-hooks/exhaustive-deps */},[]);
+
+  return <StaffWorkspaceShell
+    active="reports"
+    title="Матеріали: план / факт списання"
+    description="Операційний контроль історичної норми матеріалів проти фактичного проведеного списання."
+  >
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div><b>Період виконання послуг</b><small>Відбір — за performed_at. План береться з immutable reserve поточної Appointment-версії.</small></div>
+        <label><span>Від</span><input type="date" value={from} onChange={e=>setFrom(e.target.value)}/></label>
+        <label><span>До</span><input type="date" value={to} onChange={e=>setTo(e.target.value)}/></label>
+        <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
+        <a className="excelButton" href="/staff/reports/material-margin">Маржинальність</a>
+        <a className="excelButton" href="/staff/inventory/material-consumption">Робочий список</a>
+        <a className="excelButton" href="/staff/reports">Звіти</a>
+      </header>
+      {error&&<p className="financeError">{error}</p>}
+      <p className="financeHint"><b>Факт = тільки фізичний posted writeoff.</b> Draft показується окремо. Списання може бути проведене пізніше за дату виконання послуги, тому стан факту фіксується на момент формування звіту.</p>
+      {data&&<p className="financeHint">Стан списань на: <b>{moment(data.actualAsOf)}</b>.</p>}
+      {data&&data.summary.needsAllocation>0&&<p className="financeError">Є {data.summary.needsAllocation} reservation-фактів, де частина плану ще не розподілена навіть у draft.</p>}
+    </section>
+
+    {data&&<>
+      <section className="financeSummary" aria-label="Контроль списання матеріалів">
+        <article><span>Виконані заявки</span><b>{data.summary.completedBookings}</b><small>із матеріальним reserve у періоді</small></article>
+        <article><span>Планові позиції</span><b>{data.summary.reservationFacts}</b><small>immutable reservation facts</small></article>
+        <article><span>Повністю списано</span><b>{data.summary.fullyPosted}</b><small>{pct(data.summary.fullyPostedPct)} планових позицій</small></article>
+        <article><span>Є draft</span><b>{data.summary.withDraft}</b><small>ще не фізичний факт складу</small></article>
+        <article><span>Потрібне розподілення</span><b>{data.summary.needsAllocation}</b><small>план − posted − draft &gt; 0</small></article>
+      </section>
+
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>По послугах і матеріалах</b><small>{data.summary.rowCount} однорідних груп; кількості не сумуються між різними одиницями виміру.</small></div></header>
+        <div className="financeTableWrap"><table className="financeTable"><thead><tr>
+          <th>Послуга / матеріал</th><th>Склад</th><th className="num">План</th><th className="num">Факт</th><th className="num">Draft</th><th className="num">Не проведено</th><th className="num">Не розподілено</th><th className="num">Покриття</th>
+        </tr></thead><tbody>
+          {data.rows.map(row=><tr key={`${row.serviceCode}:${row.itemId}:${row.warehouseId}`}>
+            <td><b>{row.serviceTitle||row.serviceCode}</b><small>{row.serviceCode}</small><br/><b>{row.itemName||row.itemSku}</b><small>{row.itemSku||`ID ${row.itemId}`} · {row.reservationCount} план. позицій / {row.bookingCount} заявок</small></td>
+            <td><b>{row.warehouseName}</b><small>{row.warehouseCode}</small></td>
+            <td className="num">{qty(row.plannedQuantity)} {row.itemUnit}</td>
+            <td className="num"><b>{qty(row.postedQuantity)} {row.itemUnit}</b></td>
+            <td className="num">{qty(row.draftQuantity)} {row.itemUnit}</td>
+            <td className="num">{qty(row.unpostedQuantity)} {row.itemUnit}</td>
+            <td className="num">{qty(row.unallocatedQuantity)} {row.itemUnit}</td>
+            <td className="num"><b>{pct(row.coveragePct)}</b></td>
+          </tr>)}
+          {data.rows.length===0&&<tr><td colSpan={8}>За обраний період немає виконаних заявок із плановими матеріалами.</td></tr>}
+        </tbody></table></div>
+      </section>
+    </>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/reports/material-margin/page.tsx
+++ b/app/staff/reports/material-margin/page.tsx
@@ -54,6 +54,7 @@ export default function ServiceMaterialMarginPage(){
         <label><span>До</span><input type="date" value={to} onChange={e=>setTo(e.target.value)}/></label>
         <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
         <a className="excelButton" href={exportUrl}>CSV</a>
+        <a className="excelButton" href="/staff/reports/material-consumption-control">План / факт</a>
         <a className="excelButton" href="/staff/reports/registers">Обороти регістрів</a>
         <a className="excelButton" href="/staff/reports">Звіти</a>
       </header>

--- a/lib/material-consumption-control-report.ts
+++ b/lib/material-consumption-control-report.ts
@@ -1,0 +1,155 @@
+const DATE_RE=/^\d{4}-\d{2}-\d{2}$/;
+
+export type MaterialConsumptionControlPeriod={from:string;to:string};
+
+export type MaterialConsumptionControlRow={
+  serviceCode:string;serviceTitle:string;
+  itemId:number;itemSku:string;itemName:string;itemUnit:string;
+  warehouseId:number;warehouseCode:string;warehouseName:string;
+  reservationCount:number;bookingCount:number;
+  plannedQuantity:number;postedQuantity:number;draftQuantity:number;
+  unpostedQuantity:number;unallocatedQuantity:number;coveragePct:number;
+  fullyPostedReservations:number;draftReservations:number;needsAllocationReservations:number;
+};
+
+function validDate(value:string){
+  if(!DATE_RE.test(value))return false;
+  const date=new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime())&&date.toISOString().slice(0,10)===value;
+}
+
+export function normalizeMaterialConsumptionControlPeriod(
+  fromValue:unknown,toValue:unknown,defaults:MaterialConsumptionControlPeriod,
+):MaterialConsumptionControlPeriod{
+  const from=typeof fromValue==="string"&&fromValue.trim()?fromValue.trim():defaults.from;
+  const to=typeof toValue==="string"&&toValue.trim()?toValue.trim():defaults.to;
+  if(!validDate(from)||!validDate(to)||from>to)throw new Error("invalid_report_period");
+  const days=Math.floor((Date.parse(`${to}T00:00:00Z`)-Date.parse(`${from}T00:00:00Z`))/86400000)+1;
+  if(days>366)throw new Error("report_period_too_large");
+  return {from,to};
+}
+
+function pct(actual:number,planned:number){
+  if(planned<=0)return 0;
+  return Math.round((actual/planned)*1000)/10;
+}
+
+type RawRow={
+  serviceCode:string;serviceTitle:string;
+  itemId:number;itemSku:string;itemName:string;itemUnit:string;
+  warehouseId:number;warehouseCode:string;warehouseName:string;
+  reservationCount:number;bookingCount:number;
+  plannedQuantity:number;postedQuantity:number;draftQuantity:number;
+  fullyPostedReservations:number;draftReservations:number;needsAllocationReservations:number;
+};
+
+export async function buildMaterialConsumptionControlReport(
+  db:D1Database,organizationId:number,period:MaterialConsumptionControlPeriod,
+){
+  const result=await db.prepare(`
+    WITH params(organization_id,from_date,to_date) AS (VALUES(?,?,?)),
+    current_reserves AS (
+      SELECT r.id AS reservationId,r.booking_id AS bookingId,r.service_code AS serviceCode,b.service AS serviceTitle,
+        r.item_id AS itemId,i.sku AS itemSku,i.name AS itemName,i.unit AS itemUnit,
+        r.warehouse_id AS warehouseId,w.code AS warehouseCode,w.name AS warehouseName,
+        r.quantity_delta AS plannedQuantity
+      FROM inventory_reservation_movements r
+      JOIN business_documents appointment
+        ON appointment.id=r.appointment_document_id AND appointment.organization_id=r.organization_id
+       AND appointment.document_type='appointment' AND appointment.state='posted'
+      JOIN bookings b ON b.id=r.booking_id AND b.organization_id=r.organization_id
+      JOIN inventory_items i ON i.id=r.item_id AND i.organization_id=r.organization_id
+      JOIN warehouses w ON w.id=r.warehouse_id AND w.organization_id=r.organization_id
+      JOIN params p ON p.organization_id=r.organization_id
+      WHERE r.movement_type='reserve' AND b.status='completed'
+        AND substr(b.performed_at,1,10) BETWEEN p.from_date AND p.to_date
+        AND EXISTS (
+          SELECT 1 FROM inventory_reservation_movements rel
+          WHERE rel.organization_id=r.organization_id
+            AND rel.appointment_document_id=r.appointment_document_id
+            AND rel.requirement_id=r.requirement_id
+            AND rel.movement_type='release'
+            AND ABS(rel.quantity_delta+r.quantity_delta)<0.000001
+        )
+    ),
+    facts AS (
+      SELECT cr.*,
+        COALESCE(SUM(CASE WHEN d.state='draft' THEN l.quantity ELSE 0 END),0) AS draftQuantity,
+        COALESCE(SUM(CASE WHEN d.state='posted' AND m.id IS NOT NULL AND m.quantity_delta<0 THEN -m.quantity_delta ELSE 0 END),0) AS postedQuantity
+      FROM current_reserves cr
+      LEFT JOIN inventory_document_lines l
+        ON l.organization_id=? AND l.reservation_movement_id=cr.reservationId
+      LEFT JOIN business_documents d
+        ON d.id=l.document_id AND d.organization_id=l.organization_id AND d.document_type='inventory_writeoff'
+      LEFT JOIN inventory_movements m
+        ON m.organization_id=l.organization_id AND m.document_line_id=l.id AND m.movement_type='writeoff'
+      GROUP BY cr.reservationId,cr.bookingId,cr.serviceCode,cr.serviceTitle,cr.itemId,cr.itemSku,cr.itemName,cr.itemUnit,
+        cr.warehouseId,cr.warehouseCode,cr.warehouseName,cr.plannedQuantity
+    )
+    SELECT serviceCode,MAX(serviceTitle) AS serviceTitle,
+      itemId,MAX(itemSku) AS itemSku,MAX(itemName) AS itemName,MAX(itemUnit) AS itemUnit,
+      warehouseId,MAX(warehouseCode) AS warehouseCode,MAX(warehouseName) AS warehouseName,
+      COUNT(*) AS reservationCount,COUNT(DISTINCT bookingId) AS bookingCount,
+      SUM(plannedQuantity) AS plannedQuantity,SUM(postedQuantity) AS postedQuantity,SUM(draftQuantity) AS draftQuantity,
+      SUM(CASE WHEN postedQuantity+0.000001>=plannedQuantity THEN 1 ELSE 0 END) AS fullyPostedReservations,
+      SUM(CASE WHEN postedQuantity+0.000001<plannedQuantity AND draftQuantity>0.000001 THEN 1 ELSE 0 END) AS draftReservations,
+      SUM(CASE WHEN postedQuantity+draftQuantity+0.000001<plannedQuantity THEN 1 ELSE 0 END) AS needsAllocationReservations
+    FROM facts
+    GROUP BY serviceCode,itemId,warehouseId
+    ORDER BY (SUM(plannedQuantity)-SUM(postedQuantity)) DESC,serviceCode,itemName,warehouseName
+    LIMIT 500
+  `).bind(organizationId,period.from,period.to,organizationId).all<RawRow>();
+
+  const rows:MaterialConsumptionControlRow[]=result.results.map(raw=>{
+    const plannedQuantity=Number(raw.plannedQuantity||0);
+    const postedQuantity=Number(raw.postedQuantity||0);
+    const draftQuantity=Number(raw.draftQuantity||0);
+    return {
+      serviceCode:String(raw.serviceCode||""),serviceTitle:String(raw.serviceTitle||raw.serviceCode||""),
+      itemId:Number(raw.itemId),itemSku:String(raw.itemSku||""),itemName:String(raw.itemName||""),itemUnit:String(raw.itemUnit||""),
+      warehouseId:Number(raw.warehouseId),warehouseCode:String(raw.warehouseCode||""),warehouseName:String(raw.warehouseName||""),
+      reservationCount:Number(raw.reservationCount||0),bookingCount:Number(raw.bookingCount||0),
+      plannedQuantity,postedQuantity,draftQuantity,
+      unpostedQuantity:Math.max(0,plannedQuantity-postedQuantity),
+      unallocatedQuantity:Math.max(0,plannedQuantity-postedQuantity-draftQuantity),
+      coveragePct:pct(postedQuantity,plannedQuantity),
+      fullyPostedReservations:Number(raw.fullyPostedReservations||0),
+      draftReservations:Number(raw.draftReservations||0),
+      needsAllocationReservations:Number(raw.needsAllocationReservations||0),
+    };
+  });
+
+  const reservationFacts=rows.reduce((sum,row)=>sum+row.reservationCount,0);
+  const fullyPosted=rows.reduce((sum,row)=>sum+row.fullyPostedReservations,0);
+  const withDraft=rows.reduce((sum,row)=>sum+row.draftReservations,0);
+  const needsAllocation=rows.reduce((sum,row)=>sum+row.needsAllocationReservations,0);
+  const completedBookings=await db.prepare(`
+    SELECT COUNT(DISTINCT r.booking_id) AS n
+    FROM inventory_reservation_movements r
+    JOIN business_documents appointment
+      ON appointment.id=r.appointment_document_id AND appointment.organization_id=r.organization_id
+     AND appointment.document_type='appointment' AND appointment.state='posted'
+    JOIN bookings b ON b.id=r.booking_id AND b.organization_id=r.organization_id
+    WHERE r.organization_id=? AND r.movement_type='reserve' AND b.status='completed'
+      AND substr(b.performed_at,1,10) BETWEEN ? AND ?
+      AND EXISTS (
+        SELECT 1 FROM inventory_reservation_movements rel
+        WHERE rel.organization_id=r.organization_id
+          AND rel.appointment_document_id=r.appointment_document_id
+          AND rel.requirement_id=r.requirement_id
+          AND rel.movement_type='release'
+          AND ABS(rel.quantity_delta+r.quantity_delta)<0.000001
+      )
+  `).bind(organizationId,period.from,period.to).first<{n:number}>();
+
+  const generatedAt=new Date().toISOString();
+  return {
+    period,generatedAt,actualAsOf:generatedAt,scope:"material_consumption_control" as const,
+    summary:{
+      completedBookings:Number(completedBookings?.n||0),reservationFacts,fullyPosted,withDraft,needsAllocation,
+      fullyPostedPct:reservationFacts?Math.round((fullyPosted/reservationFacts)*1000)/10:0,
+      rowCount:rows.length,
+    },
+    rows,
+  };
+}

--- a/lib/material-consumption-control-report.ts
+++ b/lib/material-consumption-control-report.ts
@@ -97,7 +97,6 @@ export async function buildMaterialConsumptionControlReport(
     FROM facts
     GROUP BY serviceCode,itemId,warehouseId
     ORDER BY (SUM(plannedQuantity)-SUM(postedQuantity)) DESC,serviceCode,itemName,warehouseName
-    LIMIT 500
   `).bind(organizationId,period.from,period.to,organizationId).all<RawRow>();
 
   const rows:MaterialConsumptionControlRow[]=result.results.map(raw=>{

--- a/tests/material-consumption-control-report.behavior.test.mjs
+++ b/tests/material-consumption-control-report.behavior.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker,seedStaffSession,withD1 } from "./helpers/d1.mjs";
+
+function dropInsertGuards(raw,table){
+  const rows=raw.prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=? AND upper(sql) LIKE '%BEFORE INSERT%'").all(table);
+  for(const row of rows){
+    const name=String(row.name).replaceAll('"','""');
+    raw.exec(`DROP TRIGGER "${name}"`);
+  }
+}
+
+async function report(db,cookie,from="2026-08-01",to="2026-08-31"){
+  return callWorker(new Request(`http://localhost/api/staff/reports/material-consumption-control?from=${from}&to=${to}`,{headers:{cookie}}),db);
+}
+
+async function seedBooking(db,{code,serviceCode,serviceTitle,performedAt}){
+  const result=await db.prepare(`INSERT INTO bookings
+    (organization_id,code,name,phone,phone_normalized,date_of_birth,service,service_code,equipment_id,
+     duration_minutes,desired_date,desired_time,patient_category,status,payment_amount,performed_at)
+    VALUES (1,?,?,? ,?,'1980-01-02',?,?,'ct',30,'2026-08-10','10:00','civilian','completed',0,?)`)
+    .bind(code,`Patient ${code}`,`+38050${code.slice(-6)}`,`38050${code.slice(-6)}`,serviceTitle,serviceCode,performedAt).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function appointment(db,{number,state="posted",occurredAt="2026-08-10T09:00:00"}){
+  const result=await db.prepare(`INSERT INTO business_documents
+    (organization_id,document_type,number,occurred_at,state,created_by,posted_by,posted_at)
+    VALUES (1,'appointment',?,?,?,?,?,?)`)
+    .bind(number,occurredAt,state,'control-test','control-test',occurredAt).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function requirement(db,{serviceCode,itemId,warehouseId,quantity}){
+  const result=await db.prepare(`INSERT INTO service_material_requirements
+    (organization_id,service_code,item_id,warehouse_id,quantity,active,created_by,updated_by)
+    VALUES (1,?,?,?,?,1,'control-test','control-test')`).bind(serviceCode,itemId,warehouseId,quantity).run();
+  return Number(result.meta.last_row_id);
+}
+
+async function reservePair(db,{appointmentDocumentId,bookingId,requirementId,serviceCode,itemId,warehouseId,quantity}){
+  const reserve=await db.prepare(`INSERT INTO inventory_reservation_movements
+    (organization_id,appointment_document_id,booking_id,requirement_id,service_code,item_id,warehouse_id,movement_type,quantity_delta,actor_email,occurred_at)
+    VALUES (1,?,?,?,?,?,?,'reserve',?,'control-test','2026-08-10T09:00:00')`)
+    .bind(appointmentDocumentId,bookingId,requirementId,serviceCode,itemId,warehouseId,quantity).run();
+  await db.prepare(`INSERT INTO inventory_reservation_movements
+    (organization_id,appointment_document_id,booking_id,requirement_id,service_code,item_id,warehouse_id,movement_type,quantity_delta,actor_email,occurred_at)
+    VALUES (1,?,?,?,?,?,?,'release',?,'control-test','2026-08-10T10:30:00')`)
+    .bind(appointmentDocumentId,bookingId,requirementId,serviceCode,itemId,warehouseId,-quantity).run();
+  return Number(reserve.meta.last_row_id);
+}
+
+async function writeoffLine(db,raw,{reservationId,bookingId,itemId,lotId,warehouse,quantity,state,number,occurredAt}){
+  const doc=await db.prepare(`INSERT INTO business_documents
+    (organization_id,document_type,number,occurred_at,state,created_by,posted_by,posted_at)
+    VALUES (1,'inventory_writeoff',?,?,?,?,?,?)`)
+    .bind(number,occurredAt,state,'control-test',state==='posted'?'control-test':'',state==='posted'?occurredAt:'').run();
+  const documentId=Number(doc.meta.last_row_id);
+  const line=await db.prepare(`INSERT INTO inventory_document_lines
+    (organization_id,document_id,line_no,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,
+     lot_number,expires_on,supplier,quantity,reason,booking_id,reservation_movement_id)
+    VALUES (1,?,1,?,?,?,?,?,'CONTROL-LOT','','',?,'control',?,?)`)
+    .bind(documentId,itemId,lotId,warehouse.id,warehouse.code,warehouse.name,quantity,bookingId,reservationId).run();
+  const lineId=Number(line.meta.last_row_id);
+  if(state==='posted'){
+    await db.prepare(`INSERT INTO inventory_movements
+      (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,occurred_at,document_id,document_line_id)
+      VALUES (1,?,?,?,?,?,'writeoff',?,'control','control-test',?,?,?)`)
+      .bind(itemId,lotId,warehouse.id,warehouse.code,warehouse.name,-quantity,occurredAt,documentId,lineId).run();
+  }
+  return {documentId,lineId};
+}
+
+test("material consumption control uses current Appointment plan and physical posted writeoff fact as of report time",async()=>{
+  await withD1(async(db,raw)=>{
+    dropInsertGuards(raw,"inventory_reservation_movements");
+    dropInsertGuards(raw,"inventory_document_lines");
+    dropInsertGuards(raw,"inventory_movements");
+
+    const admin=await seedStaffSession(db,{email:"control-admin@example.com",role:"admin",organizationId:1});
+    const registrar=await seedStaffSession(db,{email:"control-registrar@example.com",role:"registrar",organizationId:1});
+    const warehouse=raw.prepare("SELECT id,code,name FROM warehouses WHERE organization_id=1 AND is_default=1 LIMIT 1").get();
+    assert.ok(warehouse?.id);
+    const itemResult=await db.prepare(`INSERT INTO inventory_items
+      (organization_id,sku,name,category,unit,min_stock,active) VALUES (1,'CTRL-MAT','Контраст','other','мл',0,1)`).run();
+    const itemId=Number(itemResult.meta.last_row_id);
+    const lotResult=await db.prepare(`INSERT INTO inventory_lots
+      (organization_id,item_id,lot_number,expires_on,supplier) VALUES (1,?,'CONTROL-LOT','','')`).bind(itemId).run();
+    const lotId=Number(lotResult.meta.last_row_id);
+
+    const ct=await seedBooking(db,{code:"CTRL01",serviceCode:"ct-control",serviceTitle:"КТ контроль",performedAt:"2026-08-10T10:15:00"});
+    const ctRequirement=await requirement(db,{serviceCode:"ct-control",itemId,warehouseId:warehouse.id,quantity:3});
+    const staleAppointment=await appointment(db,{number:"A-OLD",state:"reversed"});
+    await reservePair(db,{appointmentDocumentId:staleAppointment,bookingId:ct,requirementId:ctRequirement,serviceCode:"ct-control",itemId,warehouseId:warehouse.id,quantity:3});
+    const currentAppointment=await appointment(db,{number:"A-CURRENT",state:"posted"});
+    const currentReserve=await reservePair(db,{appointmentDocumentId:currentAppointment,bookingId:ct,requirementId:ctRequirement,serviceCode:"ct-control",itemId,warehouseId:warehouse.id,quantity:3});
+
+    // Physical posting happens after the service-period boundary; the report still shows it because
+    // the period selects performed services and fact is the current posted ledger state.
+    await writeoffLine(db,raw,{reservationId:currentReserve,bookingId:ct,itemId,lotId,warehouse,quantity:2,state:"posted",number:"W-POSTED",occurredAt:"2026-09-05T12:00:00"});
+    await writeoffLine(db,raw,{reservationId:currentReserve,bookingId:ct,itemId,lotId,warehouse,quantity:1,state:"draft",number:"W-DRAFT",occurredAt:"2026-09-06T12:00:00"});
+
+    const xray=await seedBooking(db,{code:"CTRL02",serviceCode:"xray-control",serviceTitle:"Рентген контроль",performedAt:"2026-08-11T10:15:00"});
+    const xrayRequirement=await requirement(db,{serviceCode:"xray-control",itemId,warehouseId:warehouse.id,quantity:2});
+    const xrayAppointment=await appointment(db,{number:"A-XRAY",state:"posted",occurredAt:"2026-08-11T09:00:00"});
+    await reservePair(db,{appointmentDocumentId:xrayAppointment,bookingId:xray,requirementId:xrayRequirement,serviceCode:"xray-control",itemId,warehouseId:warehouse.id,quantity:2});
+
+    const response=await report(db,admin);assert.equal(response.status,200);
+    const body=await response.json();
+    assert.equal(body.scope,"material_consumption_control");
+    assert.deepEqual(body.period,{from:"2026-08-01",to:"2026-08-31"});
+    assert.equal(body.summary.completedBookings,2);
+    assert.equal(body.summary.reservationFacts,2,"reversed Appointment reserve must not double the plan");
+    assert.equal(body.summary.fullyPosted,0);
+    assert.equal(body.summary.withDraft,1);
+    assert.equal(body.summary.needsAllocation,1);
+    assert.equal(body.summary.rowCount,2);
+
+    const ctRow=body.rows.find(row=>row.serviceCode==="ct-control");assert.ok(ctRow);
+    assert.equal(ctRow.plannedQuantity,3);assert.equal(ctRow.postedQuantity,2);assert.equal(ctRow.draftQuantity,1);
+    assert.equal(ctRow.unpostedQuantity,1);assert.equal(ctRow.unallocatedQuantity,0);assert.equal(ctRow.coveragePct,66.7);
+    const xrayRow=body.rows.find(row=>row.serviceCode==="xray-control");assert.ok(xrayRow);
+    assert.equal(xrayRow.plannedQuantity,2);assert.equal(xrayRow.postedQuantity,0);assert.equal(xrayRow.draftQuantity,0);
+    assert.equal(xrayRow.unallocatedQuantity,2);assert.equal(xrayRow.coveragePct,0);
+
+    assert.equal((await report(db,registrar)).status,403);
+    assert.equal((await report(db,admin,"bad-date","2026-08-31")).status,400);
+    assert.equal((await report(db,admin,"2025-01-01","2026-08-31")).status,400);
+
+    raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Control Org 2','control-org-2',1)");
+    const admin2=await seedStaffSession(db,{email:"control-org2@example.com",role:"admin",organizationId:2});
+    const org2Response=await report(db,admin2);assert.equal(org2Response.status,200);
+    assert.equal((await org2Response.json()).summary.reservationFacts,0);
+
+    const auditRow=raw.prepare(`SELECT details_json AS details FROM security_audit_log
+      WHERE organization_id=1 AND actor_email='control-admin@example.com'
+        AND action='report_viewed' AND target_id='material_consumption_control'
+      ORDER BY id DESC LIMIT 1`).get();
+    assert.ok(auditRow);assert.equal(auditRow.details.includes("CTRL"),false);assert.equal(auditRow.details.includes("Patient"),false);
+  });
+});

--- a/tests/material-consumption-control-report.behavior.test.mjs
+++ b/tests/material-consumption-control-report.behavior.test.mjs
@@ -76,6 +76,9 @@ test("material consumption control uses current Appointment plan and physical po
     dropInsertGuards(raw,"inventory_reservation_movements");
     dropInsertGuards(raw,"inventory_document_lines");
     dropInsertGuards(raw,"inventory_movements");
+    // This is a read-model fixture: Appointment lifecycle integrity is covered separately.
+    // Here we need both historical reversed and current posted snapshots without synthesizing a reschedule.
+    raw.exec("DROP TRIGGER IF EXISTS appointment_document_integrity_insert");
 
     const admin=await seedStaffSession(db,{email:"control-admin@example.com",role:"admin",organizationId:1});
     const registrar=await seedStaffSession(db,{email:"control-registrar@example.com",role:"registrar",organizationId:1});

--- a/tests/material-consumption-control-report.behavior.test.mjs
+++ b/tests/material-consumption-control-report.behavior.test.mjs
@@ -64,9 +64,9 @@ async function writeoffLine(db,raw,{reservationId,bookingId,itemId,lotId,warehou
   const lineId=Number(line.meta.last_row_id);
   if(state==='posted'){
     await db.prepare(`INSERT INTO inventory_movements
-      (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,occurred_at,document_id,document_line_id)
-      VALUES (1,?,?,?,?,?,'writeoff',?,'control','control-test',?,?,?)`)
-      .bind(itemId,lotId,warehouse.id,warehouse.code,warehouse.name,-quantity,occurredAt,documentId,lineId).run();
+      (organization_id,item_id,lot_id,warehouse_id,warehouse_code,warehouse_name,movement_type,quantity_delta,reason,actor_email,document_id,document_line_id)
+      VALUES (1,?,?,?,?,?,'writeoff',?,'control','control-test',?,?)`)
+      .bind(itemId,lotId,warehouse.id,warehouse.code,warehouse.name,-quantity,documentId,lineId).run();
   }
   return {documentId,lineId};
 }


### PR DESCRIPTION
## Goal
Add an admin-only operational control report for historical planned service materials versus actual physical writeoff status.

## Semantics
- report period selects completed services by `bookings.performed_at`;
- plan comes only from the immutable `reserve` movement of the current same-tenant `posted` Appointment version;
- actual comes only from physical `inventory_movements` writeoff facts linked to that reservation;
- draft writeoff quantity is shown separately and is never treated as physical fact;
- actual/draft status is evaluated as of report generation, so a writeoff posted after the service-period boundary still updates the historical service's current consumption status;
- superseded/reversed Appointment reserves are excluded and cannot double the plan;
- quantities are not globally summed across incompatible units of measure.

## Scope
- add canonical read-only report builder;
- add admin-only, tenant-scoped staff API with <=366-day period validation and PHI-free audit;
- add report UI with plan / posted fact / draft / unposted / unallocated / coverage columns;
- add navigation from the material-margin report;
- add behavioral coverage for stale Appointment exclusion, delayed physical posting semantics, RBAC, tenant isolation and audit hygiene;
- no schema, migration, posting or production-deploy changes.

## Invariants
- inventory movements remain the sole physical stock ledger;
- current material rules never backfill historical plan;
- no heuristic allocation of unlinked writeoffs;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.