### PR TITLE
Add CSV export for material consumption control report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,13 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload PR 413 test failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr413-test-output
+          path: test-output.log
+          retention-days: 1
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload PR 413 test failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr413-test-output
-          path: test-output.log
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate

--- a/app/api/staff/reports/material-consumption-control/export/route.ts
+++ b/app/api/staff/reports/material-consumption-control/export/route.ts
@@ -1,0 +1,48 @@
+import { audit } from "../../../../../../lib/audit";
+import { dbBinding } from "../../../../../../lib/db";
+import { buildMaterialConsumptionControlCsv } from "../../../../../../lib/material-consumption-control-csv";
+import {
+  buildMaterialConsumptionControlReport,normalizeMaterialConsumptionControlPeriod,
+} from "../../../../../../lib/material-consumption-control-report";
+import { canViewReports } from "../../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../../lib/tenant";
+
+function kyivToday(){
+  return new Intl.DateTimeFormat("en-CA",{timeZone:"Europe/Kyiv",year:"numeric",month:"2-digit",day:"2-digit"}).format(new Date());
+}
+function safeFilenameDate(value:string){return /^\d{4}-\d{2}-\d{2}$/.test(value)?value:"date";}
+
+export async function GET(request:Request){
+  const db=dbBinding();
+  if(!db)return Response.json({error:"База тимчасово недоступна"},{status:503});
+  const ctx=await requireOrgContext(request,db);
+  if(!ctx)return Response.json({error:"Доступ лише для персоналу"},{status:403});
+  if(!canViewReports(ctx.member.role))return Response.json({error:"Експорт контролю матеріалів доступний лише адміністратору"},{status:403});
+
+  const today=kyivToday();
+  const defaults={from:`${today.slice(0,7)}-01`,to:today};
+  try{
+    const url=new URL(request.url);
+    const period=normalizeMaterialConsumptionControlPeriod(url.searchParams.get("from"),url.searchParams.get("to"),defaults);
+    const report=await buildMaterialConsumptionControlReport(db,ctx.organizationId,period);
+    const csv=buildMaterialConsumptionControlCsv(report);
+    await audit(db,{
+      organizationId:ctx.organizationId,
+      actorEmail:ctx.member.email,
+      action:"report_exported",
+      resource:"report",
+      targetId:"material_consumption_control",
+      details:{from:period.from,to:period.to,rows:report.rows.length,reservationFacts:report.summary.reservationFacts,scope:report.scope,format:"csv"},
+    });
+    return new Response(csv,{headers:{
+      "content-type":"text/csv; charset=utf-8",
+      "content-disposition":`attachment; filename="material-consumption-control-${safeFilenameDate(period.from)}-${safeFilenameDate(period.to)}.csv"`,
+      "cache-control":"private, no-store",
+    }});
+  }catch(error){
+    if(error instanceof Error&&error.message==="report_period_too_large"){
+      return Response.json({error:"Період звіту не може перевищувати 366 днів"},{status:400});
+    }
+    return Response.json({error:"Некоректний період звіту"},{status:400});
+  }
+}

--- a/app/staff/reports/material-consumption-control/page.tsx
+++ b/app/staff/reports/material-consumption-control/page.tsx
@@ -31,6 +31,7 @@ export default function MaterialConsumptionControlPage(){
   const [data,setData]=useState<Report|null>(null);
   const [loading,setLoading]=useState(true);
   const [error,setError]=useState("");
+  const exportUrl=`/api/staff/reports/material-consumption-control/export?${new URLSearchParams({from,to}).toString()}`;
 
   async function load(){
     setLoading(true);setError("");
@@ -57,6 +58,7 @@ export default function MaterialConsumptionControlPage(){
         <label><span>Від</span><input type="date" value={from} onChange={e=>setFrom(e.target.value)}/></label>
         <label><span>До</span><input type="date" value={to} onChange={e=>setTo(e.target.value)}/></label>
         <button type="button" disabled={loading} onClick={()=>void load()}>{loading?"Формування…":"Сформувати"}</button>
+        <a className="excelButton" href={exportUrl}>CSV</a>
         <a className="excelButton" href="/staff/reports/material-margin">Маржинальність</a>
         <a className="excelButton" href="/staff/inventory/material-consumption">Робочий список</a>
         <a className="excelButton" href="/staff/reports">Звіти</a>

--- a/lib/material-consumption-control-csv.ts
+++ b/lib/material-consumption-control-csv.ts
@@ -1,0 +1,35 @@
+import type { buildMaterialConsumptionControlReport } from "./material-consumption-control-report.ts";
+
+type Report=Awaited<ReturnType<typeof buildMaterialConsumptionControlReport>>;
+
+function safeValue(value:unknown){
+  if(typeof value==="number"&&Number.isFinite(value))return `"${value}"`;
+  let text=value===null||value===undefined?"":String(value);
+  if(/^[\s]*[=+\-@]/.test(text)||/^[\t\r]/.test(text))text=`'${text}`;
+  return `"${text.replaceAll('"','""')}"`;
+}
+function line(...values:unknown[]){return values.map(safeValue).join(",");}
+
+export function buildMaterialConsumptionControlCsv(report:Report){
+  const rows:Array<Array<unknown>>=[
+    ["RadiologyOS — матеріали: план / факт списання"],
+    ["Період виконання послуг",report.period.from,report.period.to],
+    ["Стан списань на",report.actualAsOf],
+    [],
+    ["Підсумок"],
+    ["Виконані заявки",report.summary.completedBookings],
+    ["Планові позиції",report.summary.reservationFacts],
+    ["Повністю списано",report.summary.fullyPosted],
+    ["Є draft",report.summary.withDraft],
+    ["Потрібне розподілення",report.summary.needsAllocation],
+    ["Повністю списано, %",report.summary.fullyPostedPct],
+    [],
+    ["Код послуги","Послуга","SKU","Матеріал","Од.","Код складу","Склад","Планових позицій","Заявок","План","Факт posted","Draft","Не проведено","Не розподілено","Покриття, %"],
+    ...report.rows.map(row=>[
+      row.serviceCode,row.serviceTitle,row.itemSku,row.itemName,row.itemUnit,row.warehouseCode,row.warehouseName,
+      row.reservationCount,row.bookingCount,row.plannedQuantity,row.postedQuantity,row.draftQuantity,
+      row.unpostedQuantity,row.unallocatedQuantity,row.coveragePct,
+    ]),
+  ];
+  return "\uFEFF"+rows.map(row=>line(...row)).join("\r\n");
+}

--- a/tests/material-consumption-control-csv.behavior.test.mjs
+++ b/tests/material-consumption-control-csv.behavior.test.mjs
@@ -15,7 +15,7 @@ test("material consumption control CSV preserves numeric facts and neutralizes s
     ],
   });
   assert.ok(csv.startsWith("\uFEFF"));
-  assert.ok(csv.includes('"Планових позицій","2"'));
+  assert.ok(csv.includes('"Планові позиції","2"'));
   assert.ok(csv.includes('"ct-control","КТ контроль","CTRL","Контраст"'));
   assert.ok(csv.includes('"\'=SUM(A1:A2)","\'+unsafe service","\'@unsafe-sku","\'-unsafe material"'));
   assert.ok(csv.includes('"\'=WH","\'+unsafe warehouse"'));

--- a/tests/material-consumption-control-csv.behavior.test.mjs
+++ b/tests/material-consumption-control-csv.behavior.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildMaterialConsumptionControlCsv } from "../lib/material-consumption-control-csv.ts";
+
+test("material consumption control CSV preserves numeric facts and neutralizes spreadsheet formulas",()=>{
+  const csv=buildMaterialConsumptionControlCsv({
+    period:{from:"2026-08-01",to:"2026-08-31"},
+    generatedAt:"2026-08-19T18:00:00.000Z",
+    actualAsOf:"2026-08-19T18:00:00.000Z",
+    scope:"material_consumption_control",
+    summary:{completedBookings:2,reservationFacts:2,fullyPosted:0,withDraft:1,needsAllocation:1,fullyPostedPct:0,rowCount:2},
+    rows:[
+      {serviceCode:"ct-control",serviceTitle:"КТ контроль",itemId:1,itemSku:"CTRL",itemName:"Контраст",itemUnit:"мл",warehouseId:1,warehouseCode:"MAIN",warehouseName:"Основний",reservationCount:1,bookingCount:1,plannedQuantity:3,postedQuantity:2,draftQuantity:1,unpostedQuantity:1,unallocatedQuantity:0,coveragePct:66.7,fullyPostedReservations:0,draftReservations:1,needsAllocationReservations:0},
+      {serviceCode:"=SUM(A1:A2)",serviceTitle:"+unsafe service",itemId:2,itemSku:"@unsafe-sku",itemName:"-unsafe material",itemUnit:"шт",warehouseId:2,warehouseCode:"=WH",warehouseName:"+unsafe warehouse",reservationCount:1,bookingCount:1,plannedQuantity:2,postedQuantity:0,draftQuantity:0,unpostedQuantity:2,unallocatedQuantity:2,coveragePct:0,fullyPostedReservations:0,draftReservations:0,needsAllocationReservations:1},
+    ],
+  });
+  assert.ok(csv.startsWith("\uFEFF"));
+  assert.ok(csv.includes('"Планових позицій","2"'));
+  assert.ok(csv.includes('"ct-control","КТ контроль","CTRL","Контраст"'));
+  assert.ok(csv.includes('"\'=SUM(A1:A2)","\'+unsafe service","\'@unsafe-sku","\'-unsafe material"'));
+  assert.ok(csv.includes('"\'=WH","\'+unsafe warehouse"'));
+  assert.ok(csv.includes('"66.7"'),"numeric coverage must remain numeric for spreadsheet analysis");
+  assert.ok(!csv.includes('"\'66.7"'));
+});


### PR DESCRIPTION
## Goal
Export the material consumption plan/fact control report from #412 as spreadsheet-safe CSV without duplicating its business semantics.

## Scope
- add a CSV renderer over the canonical `buildMaterialConsumptionControlReport` result;
- add admin-only, tenant-scoped `/api/staff/reports/material-consumption-control/export`;
- reuse the same service-period normalization and report builder as the JSON report;
- preserve the explicit `actualAsOf` meaning for current posted/draft consumption state;
- emit UTF-8 BOM, attachment headers and `private, no-store`;
- preserve numeric facts while neutralizing spreadsheet formulas in all text fields;
- record a PHI-free `report_exported` audit event;
- add a CSV action to the existing plan/fact report UI;
- add focused behavioral coverage;
- no schema, migration, posting or production-deploy changes.

## Invariants
- CSV and JSON values come from the same canonical report builder;
- inventory movements remain the sole physical fact source;
- export never accepts tenant identity or report facts from the browser;
- stale Appointment reservations remain excluded by #411/#412 semantics;
- merge only after exact-head CI + CodeQL are green; production remains manual-only.