### PR TITLE
Apply BAS workspace structure and enterprise density

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,5 @@ jobs:
             exit "$status"
           fi
 
-      - name: Upload behavioral test diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr416-test-output
-          path: test-output.log
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Production release gate
         run: npm run test:production-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,14 @@ jobs:
             exit "$status"
           fi
 
+      - name: Upload behavioral test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr416-test-output
+          path: test-output.log
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Production release gate
         run: npm run test:production-gate

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,3 +23,4 @@
 @import "./styles/20-finance.css";
 @import "./styles/21-bas-shell.css";
 @import "./styles/22-shift-calendar.css";
+@import "./styles/23-bas-enterprise-density.css";

--- a/app/staff/directories/page.tsx
+++ b/app/staff/directories/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import StaffWorkspaceShell from "../workspace-shell";
+
+const directories=[
+  {name:"Обладнання",description:"Апарати, кабінети та технічні атрибути, що використовуються в записах і виконанні.",href:"/staff/equipment"},
+  {name:"Послуги",description:"Канонічний каталог послуг, тривалість, правила і матеріальні норми.",href:"/staff/services"},
+  {name:"Тарифи",description:"Ціни та правила оплати, які використовуються при формуванні замовлення і послуги.",href:"/staff/tariffs"},
+  {name:"Склади",description:"Місця зберігання для документів надходження, списання, переміщення й інвентаризації.",href:"/staff/warehouses"},
+  {name:"Контрагенти",description:"Постачальники та інші сторони господарських операцій.",href:"/staff/counterparties"},
+  {name:"Графік кабінетів",description:"Робочі інтервали, що визначають доступність запису.",href:"/staff/schedule"},
+  {name:"Графік змін персоналу",description:"Циклічні зміни, бригади та персональні корекції.",href:"/staff/shifts"},
+  {name:"Персонал і ролі",description:"Користувачі, ролі та права доступу в межах організації.",href:"/staff#staff-admin"},
+];
+
+export default function DirectoriesPage(){
+  return <StaffWorkspaceShell
+    active="directories"
+    title="Довідники"
+    description="Єдині master-data RadiologyOS: значення задаються один раз і повторно використовуються документами, регістрами та звітами."
+  >
+    <section className="financeSummary" aria-label="Принцип довідників">
+      <article><span>Єдине джерело</span><b>Master data</b><small>без копій у формах</small></article>
+      <article><span>Документи</span><b>Посилаються</b><small>на канонічні сутності</small></article>
+      <article><span>Tenant scope</span><b>Ізольовано</b><small>по організації</small></article>
+      <article><span>Історія</span><b>Стабільна</b><small>документи не переписуються заднім числом</small></article>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar"><div><b>Карта довідників</b><small>Змінюйте нормативно-довідкові дані тут, а не всередині кожного документа.</small></div></header>
+      <div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Довідник</th><th>Призначення</th><th/></tr></thead>
+        <tbody>{directories.map(item=><tr key={item.name}>
+          <td><b>{item.name}</b></td><td>{item.description}</td><td><Link className="excelButton" href={item.href}>Відкрити</Link></td>
+        </tr>)}</tbody>
+      </table></div>
+    </section>
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/documents/page.tsx
+++ b/app/staff/documents/page.tsx
@@ -61,6 +61,8 @@ export default function BusinessDocumentsPage(){
   const [detail,setDetail]=useState<Detail|null>(null);
   const [selectedId,setSelectedId]=useState<number|null>(null);
   const [query,setQuery]=useState("");
+  const [typeFilter,setTypeFilter]=useState("");
+  const [stateFilter,setStateFilter]=useState("");
   const [error,setError]=useState("");
   const [loadingDetail,setLoadingDetail]=useState(false);
 
@@ -73,7 +75,13 @@ export default function BusinessDocumentsPage(){
     }catch(e){setError(e instanceof Error?e.message:"Не вдалося завантажити журнал документів");}
   },[]);
 
-  useEffect(()=>{const timer=window.setTimeout(()=>{void load();},0);return()=>window.clearTimeout(timer);},[load]);
+  useEffect(()=>{
+    const params=new URLSearchParams(window.location.search);
+    setTypeFilter(params.get("type")||"");
+    setStateFilter(params.get("state")||"");
+    const timer=window.setTimeout(()=>{void load();},0);
+    return()=>window.clearTimeout(timer);
+  },[load]);
 
   async function openDocument(id:number){
     setSelectedId(id);setLoadingDetail(true);setError("");
@@ -89,39 +97,44 @@ export default function BusinessDocumentsPage(){
   const q=query.trim().toLowerCase();
   const rows=useMemo(()=>{
     const source=data?.documents||[];
-    if(!q)return source;
-    return source.filter((row)=>`${row.number} ${TYPE_UK[row.journalType]||row.journalType} ${row.bookingCode} ${row.patientName} ${row.subject} ${row.comment}`.toLowerCase().includes(q));
-  },[data,q]);
+    return source.filter((row)=>{
+      if(typeFilter&&row.journalType!==typeFilter)return false;
+      if(stateFilter&&row.state!==stateFilter)return false;
+      if(!q)return true;
+      return `${row.number} ${TYPE_UK[row.journalType]||row.journalType} ${row.bookingCode} ${row.patientName} ${row.subject} ${row.comment}`.toLowerCase().includes(q);
+    });
+  },[data,q,typeFilter,stateFilter]);
 
-  const totals=useMemo(()=>{
-    const source=data?.documents||[];
-    return {
-      all:source.length,
-      posted:source.filter(row=>row.state==="posted").length,
-      reversed:source.filter(row=>row.state==="reversed"||row.journalType==="service_correction").length,
-      types:new Set(source.map(row=>row.journalType)).size,
-    };
-  },[data]);
+  const totals=useMemo(()=>({
+    all:rows.length,
+    posted:rows.filter(row=>row.state==="posted").length,
+    reversed:rows.filter(row=>row.state==="reversed"||row.journalType==="service_correction").length,
+    types:new Set(rows.map(row=>row.journalType)).size,
+  }),[rows]);
 
   const movementGroups=detail?Object.entries(detail.movements).filter(([,items])=>items.length>0):[];
 
   return <StaffWorkspaceShell
-    active="finance"
+    active="documents"
     title="Журнал документів"
-    description="Єдиний BAS-журнал: документ, підстава, похідні документи, рухи по регістрах і друковані форми."
+    description="Єдиний BAS-журнал: реєстратор, підстава, похідні документи, рухи по регістрах і незмінні друковані форми."
   >
     <section className="financeSummary" aria-label="Підсумок журналу документів">
-      <article><span>Документів</span><b>{totals.all}</b><small>в одному журналі</small></article>
+      <article><span>Відібрано</span><b>{totals.all}</b><small>документів за поточним відбором</small></article>
       <article><span>Проведено</span><b>{totals.posted}</b><small>активних registrar-фактів</small></article>
       <article><span>Сторно / реверс</span><b>{totals.reversed}</b><small>історія не видаляється</small></article>
-      <article><span>Типів</span><b>{totals.types}</b><small>єдине business core</small></article>
+      <article><span>Типів</span><b>{totals.types}</b><small>у поточному відборі</small></article>
     </section>
 
     <section className="financeJournal">
       <header className="financeToolbar">
-        <div><b>Усі бізнес-документи</b><small>Сортування за датою документа. Журнал не створює нових даних — це read-model канонічних реєстраторів.</small></div>
-        <input value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пошук: НП, СТ, ОП, пацієнт, послуга…" aria-label="Пошук у журналі документів"/>
+        <div><b>Єдиний журнал реєстраторів</b><small>Документи не дублюються в журналі: він читає канонічні business_documents і пов’язані registrar-факти.</small></div>
+        <label><span>Тип документа</span><select value={typeFilter} onChange={e=>setTypeFilter(e.target.value)}><option value="">Усі типи</option>{Object.entries(TYPE_UK).map(([value,label])=><option key={value} value={value}>{label}</option>)}</select></label>
+        <label><span>Стан</span><select value={stateFilter} onChange={e=>setStateFilter(e.target.value)}><option value="">Усі стани</option>{Object.entries(STATE_UK).map(([value,label])=><option key={value} value={value}>{label}</option>)}</select></label>
+        <input value={query} onChange={e=>setQuery(e.target.value)} placeholder="Пошук: номер, пацієнт, послуга…" aria-label="Пошук у журналі документів"/>
+        <button type="button" onClick={()=>{setTypeFilter("");setStateFilter("");setQuery("");}}>Скинути</button>
         <button type="button" onClick={()=>void load()}>Оновити</button>
+        <a className="excelButton" href="/staff/registers">Регістри</a>
       </header>
       {error&&<p className="financeError">{error}</p>}
       {!data&&!error&&<p className="financeLoading">Завантаження журналу…</p>}
@@ -141,7 +154,7 @@ export default function BusinessDocumentsPage(){
     </section>
 
     {(loadingDetail||detail)&&<section className="financeJournal">
-      <header className="financeToolbar"><div><b>Структура підпорядкованості</b><small>{loadingDetail?"Завантаження…":detail?`${TYPE_UK[detail.document.journalType]||detail.document.journalType} ${detail.document.number}`:""}</small></div></header>
+      <header className="financeToolbar"><div><b>Ланцюжок документа</b><small>{loadingDetail?"Завантаження…":detail?`${TYPE_UK[detail.document.journalType]||detail.document.journalType} ${detail.document.number}`:""}</small></div><a className="excelButton" href="/staff/reports/registers">Обороти регістрів</a></header>
       {detail&&!loadingDetail&&<>
         <div className="financePrintDetails">
           <p><span>Документ</span><b>{detail.document.number}</b></p>

--- a/app/staff/documents/page.tsx
+++ b/app/staff/documents/page.tsx
@@ -76,10 +76,12 @@ export default function BusinessDocumentsPage(){
   },[]);
 
   useEffect(()=>{
-    const params=new URLSearchParams(window.location.search);
-    setTypeFilter(params.get("type")||"");
-    setStateFilter(params.get("state")||"");
-    const timer=window.setTimeout(()=>{void load();},0);
+    const timer=window.setTimeout(()=>{
+      const params=new URLSearchParams(window.location.search);
+      setTypeFilter(params.get("type")||"");
+      setStateFilter(params.get("state")||"");
+      void load();
+    },0);
     return()=>window.clearTimeout(timer);
   },[load]);
 

--- a/app/staff/registers/page.tsx
+++ b/app/staff/registers/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import StaffWorkspaceShell from "../workspace-shell";
+
+const registers=[
+  {name:"Гроші",description:"Оплати та повернення. Джерело — проведені фінансові документи й cash movements.",href:"/staff/finance",cta:"Відкрити фінанси"},
+  {name:"Взаєморозрахунки",description:"Сальдо пацієнтів і рухи боргу/кредиту без ручного перерахунку.",href:"/staff/finance",cta:"Відкрити сальдо"},
+  {name:"Дохід",description:"Нарахування за наданими послугами та сторно з immutable revenue movements.",href:"/staff/reports/registers",cta:"Обороти доходу"},
+  {name:"Надані послуги",description:"Факти service delivery і корекції, прив’язані до канонічних документів.",href:"/staff/finance/services",cta:"Журнал послуг"},
+  {name:"Склад",description:"Надходження, списання, переміщення й інвентаризаційні коригування по партіях і складах.",href:"/staff/inventory",cta:"Складські рухи"},
+  {name:"Навантаження обладнання",description:"Хвилини фактичного виконання та сторно по обладнанню.",href:"/staff/reports/registers",cta:"Обороти обладнання"},
+  {name:"Виробіток персоналу",description:"Фактичні виконання і сторно по працівниках без ручних KPI.",href:"/staff/reports/registers",cta:"Обороти персоналу"},
+  {name:"Матеріальні витрати",description:"Фактична собівартість із проведених списань і партійної вартості.",href:"/staff/reports/material-margin",cta:"Маржинальність"},
+];
+
+export default function RegistersPage(){
+  return <StaffWorkspaceShell
+    active="registers"
+    title="Регістри"
+    description="BAS-контур фактів: документ проводить рухи, регістр зберігає immutable стан, звіт лише читає ці факти."
+  >
+    <section className="financeSummary" aria-label="Принцип роботи регістрів">
+      <article><span>1. Документ</span><b>Реєстратор</b><small>канонічна бізнес-подія</small></article>
+      <article><span>2. Проведення</span><b>Рухи</b><small>атомарні зміни регістрів</small></article>
+      <article><span>3. Регістр</span><b>Факт</b><small>immutable історія</small></article>
+      <article><span>4. Звіт</span><b>Read model</b><small>без дублювання логіки</small></article>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div><b>Карта регістрів RadiologyOS</b><small>Це навігація до канонічних read-model. Вона не створює паралельних таблиць і не рахує показники в браузері.</small></div>
+        <Link className="excelButton" href="/staff/documents">Журнал документів</Link>
+        <Link className="excelButton" href="/staff/reports/registers">Обороти і залишки</Link>
+      </header>
+      <div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Регістр</th><th>Що зберігає</th><th>Робочий екран</th></tr></thead>
+        <tbody>{registers.map(item=><tr key={item.name}>
+          <td><b>{item.name}</b></td>
+          <td>{item.description}</td>
+          <td><Link className="excelButton" href={item.href}>{item.cta}</Link></td>
+        </tr>)}</tbody>
+      </table></div>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar"><div><b>Ключова перевага BAS-підходу</b><small>Суми, залишки та статуси не є окремими «цифрами на дашборді». Вони відтворюються з проведених документів і рухів, а сторно зберігає повну історію.</small></div></header>
+      <div className="financePrintDetails">
+        <p><span>Ланцюжок</span><b>Підстава → Документ → Проведення → Регістр → Звіт</b></p>
+        <p><span>Виправлення</span><b>Сторно / корекція замість видалення історії</b></p>
+        <p><span>Контроль</span><b>Tenant scope + D1 invariants + audit</b></p>
+      </div>
+    </section>
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import CommandPalette from "./command-palette";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "finance" | "counterparties" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks" | "inventory" | "purchases";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "finance" | "counterparties" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks" | "inventory" | "purchases" | "documents" | "registers" | "directories";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -32,11 +32,11 @@ const processRail: NavLink[] = [
 
 const quickRail:NavLink[]=[
   { label:"Пацієнти",href:"/staff/patients",section:"patients",icon:"👥" },
-  { label:"DICOM / PACS",href:"/staff/imaging",section:"imaging",icon:"🩻" },
+  { label:"Документи",href:"/staff/documents",section:"documents",icon:"▤" },
+  { label:"Регістри",href:"/staff/registers",section:"registers",icon:"≡" },
   { label:"Склад",href:"/staff/inventory",section:"inventory",icon:"▣" },
   { label:"Фінанси",href:"/staff/finance",section:"finance",icon:"₴" },
-  { label:"Звіти",href:"/staff/reports",section:"reports",icon:"▤" },
-  { label:"Налаштування",href:"/staff/settings",section:"settings",icon:"⚙" },
+  { label:"Звіти",href:"/staff/reports",section:"reports",icon:"⌁" },
 ];
 
 const businessModules:BusinessModule[]=[
@@ -48,15 +48,13 @@ const businessModules:BusinessModule[]=[
   ]},
   { key:"patients",label:"Пацієнти",items:[
     {label:"Картки пацієнтів",href:"/staff/patients"},
-    {label:"Чат із пацієнтами",href:"/staff/chat"},
-  ]},
-  { key:"registry",label:"Реєстратура",shortLabel:"Реєстратура",items:[
+    {label:"Замовлення пацієнтів",href:"/staff/documents?type=patient_order",hint:"Канонічні Patient Order у єдиному журналі документів"},
     {label:"Календар і записи",href:"/staff/appointments"},
     {label:"Прийом пацієнтів",href:"/staff/intake"},
-    {label:"Дошка досліджень",href:"/staff/board"},
-    {label:"Завдання",href:"/staff/tasks"},
+    {label:"Чат із пацієнтами",href:"/staff/chat"},
   ]},
   { key:"medicine",label:"Медицина",items:[
+    {label:"Дошка досліджень",href:"/staff/board"},
     {label:"DICOM / PACS",href:"/staff/imaging"},
     {label:"Протоколи",href:"/staff/protocols"},
     {label:"Видача результатів",href:"/staff/studies"},
@@ -65,29 +63,55 @@ const businessModules:BusinessModule[]=[
   ]},
   { key:"services",label:"Послуги",items:[
     {label:"Послуги кабінетів",href:"/staff/services"},
+    {label:"Надані послуги",href:"/staff/finance/services",hint:"Проведені та скориговані service-delivery документи"},
     {label:"Тарифи",href:"/staff/tariffs"},
-  ]},
-  { key:"finance",label:"Фінанси",items:[
-    {label:"Фінансові документи",href:"/staff/finance"},
-    {label:"Контрагенти",href:"/staff/counterparties"},
+    {label:"Матеріальні норми",href:"/staff/services",hint:"Норми матеріалів зберігаються у картці послуги"},
   ]},
   { key:"inventory",label:"Склад",items:[
-    {label:"Складський облік",href:"/staff/inventory",hint:"Залишки, надходження і списання"},
+    {label:"Залишки і номенклатура",href:"/staff/inventory",hint:"Залишки, партії, надходження і списання"},
+    {label:"Надходження / списання",href:"/staff/inventory"},
     {label:"Переміщення запасів",href:"/staff/inventory/transfers"},
     {label:"Інвентаризація",href:"/staff/inventory/counts",hint:"Фактичні залишки та контрольовані коригування"},
-    {label:"Фактичне списання",href:"/staff/inventory/material-consumption",hint:"Завершені послуги, резервації та вибір фактичних партій"},
+    {label:"Фактичне списання",href:"/staff/inventory/material-consumption",hint:"Резервації та вибір фактичних партій"},
     {label:"Склади",href:"/staff/warehouses"},
   ]},
   { key:"purchases",label:"Закупівлі",items:[
-    {label:"Кредиторка і оплати",href:"/staff/supplier-payables",hint:"Оцінка надходжень, борги та оплати постачальникам"},
+    {label:"Кредиторка і оплати",href:"/staff/supplier-payables",hint:"Борги та оплати постачальникам"},
     {label:"Постачальники",href:"/staff/counterparties",hint:"Довідник контрагентів"},
     {label:"Надходження на склад",href:"/staff/inventory",hint:"Документи оприбуткування"},
+  ]},
+  { key:"finance",label:"Фінанси",items:[
+    {label:"Фінансові документи",href:"/staff/finance"},
+    {label:"Каси і рахунки",href:"/staff/cash-accounts"},
+    {label:"Взаєморозрахунки",href:"/staff/finance"},
+    {label:"Дебіторська заборгованість",href:"/staff/reports/receivables"},
+    {label:"Контрагенти",href:"/staff/counterparties"},
+  ]},
+  { key:"documents",label:"Документи",items:[
+    {label:"Усі документи",href:"/staff/documents",hint:"Єдиний BAS-журнал усіх канонічних реєстраторів"},
+    {label:"Замовлення пацієнтів",href:"/staff/documents?type=patient_order"},
+    {label:"Записи",href:"/staff/documents?type=appointment"},
+    {label:"Надані послуги",href:"/staff/documents?type=service_delivery"},
+    {label:"Оплати",href:"/staff/documents?type=payment"},
+    {label:"Повернення",href:"/staff/documents?type=refund"},
+    {label:"Складські документи",href:"/staff/inventory"},
+  ]},
+  { key:"registers",label:"Регістри",items:[
+    {label:"Карта регістрів",href:"/staff/registers",hint:"Документ → рух → регістр → звіт"},
+    {label:"Обороти і залишки",href:"/staff/reports/registers"},
+    {label:"Гроші / взаєморозрахунки",href:"/staff/finance"},
+    {label:"Надані послуги",href:"/staff/finance/services"},
+    {label:"Складські рухи",href:"/staff/inventory"},
   ]},
   { key:"reports",label:"Звіти",items:[
     {label:"Звіти відділення",href:"/staff/reports"},
     {label:"Обороти регістрів",href:"/staff/reports/registers"},
+    {label:"Дебіторська заборгованість",href:"/staff/reports/receivables"},
+    {label:"Маржинальність послуг",href:"/staff/reports/material-margin"},
+    {label:"План / факт матеріалів",href:"/staff/reports/material-consumption-control"},
   ]},
   { key:"directories",label:"Довідники",items:[
+    {label:"Карта довідників",href:"/staff/directories"},
     {label:"Обладнання",href:"/staff/equipment"},
     {label:"Послуги",href:"/staff/services"},
     {label:"Тарифи",href:"/staff/tariffs"},
@@ -107,14 +131,13 @@ const businessModules:BusinessModule[]=[
 ];
 
 const moduleBySection:Record<WorkspaceSection,string>={
-  dashboard:"home",overview:"home",
-  patients:"patients",chat:"patients",
-  appointments:"registry",intake:"registry",board:"registry",tasks:"registry",
+  dashboard:"home",overview:"home",board:"home",tasks:"home",
+  patients:"patients",chat:"patients",appointments:"patients",intake:"patients",
   protocols:"medicine",imaging:"medicine",studies:"medicine",
   services:"services",tariffs:"services",
-  finance:"finance",counterparties:"finance",
+  finance:"finance",counterparties:"directories",
   inventory:"inventory",purchases:"purchases",
-  reports:"reports",
+  documents:"documents",registers:"registers",reports:"reports",directories:"directories",
   equipment:"directories",schedule:"directories",
   settings:"admin",organization:"admin",site:"admin",whatsapp:"admin",structure:"admin",audit:"admin",
 };
@@ -126,6 +149,7 @@ const sectionLabels:Record<WorkspaceSection,string>={
   appointments:"Календар записів",whatsapp:"WhatsApp",chat:"Чат з пацієнтами",schedule:"Графік кабінетів",
   equipment:"Обладнання",services:"Послуги",structure:"Структура відділення",audit:"Журнал дій",
   intake:"Прийом",board:"Дошка досліджень",tasks:"Завдання",inventory:"Склад",purchases:"Кредиторка постачальників",
+  documents:"Журнал документів",registers:"Регістри",directories:"Довідники",
 };
 
 function formatDateTime(value:Date) {
@@ -177,13 +201,13 @@ export default function StaffWorkspaceShell({
     window.location.assign("/staff/login");
   }
 
-  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board" || active === "tasks" || active === "inventory" || active === "finance" || active === "counterparties" || active === "purchases";
+  const wide = active === "dashboard" || active === "appointments" || active === "intake" || active === "board" || active === "tasks" || active === "inventory" || active === "finance" || active === "counterparties" || active === "purchases" || active === "documents" || active === "registers" || active === "directories";
   return <div className={`workspaceShell basWorkspaceShell${collapsed ? " workspaceCollapsed":""}${dark ? " themeDark":""}${wide ? " workspaceWide":""}`}>
     <CommandPalette />
     <aside className="workspaceSidebar">
       <Link className="workspaceBrand" href="/staff/dashboard" aria-label="RadiologyOS — головний пульт">
         <span className="workspaceBrandMark">R</span>
-        <span className="workspaceBrandCopy"><b>RadiologyOS</b><small>Бізнес-ядро + медицина</small></span>
+        <span className="workspaceBrandCopy"><b>RadiologyOS</b><small>Документи · регістри · медицина</small></span>
       </Link>
 
       <nav className="workspaceNavigation" aria-label="Робочий процес">
@@ -194,7 +218,7 @@ export default function StaffWorkspaceShell({
           aria-current={active === o.section ? "page":undefined}
           title={collapsed ? o.label:undefined} data-step={i + 1}
         ><span aria-hidden="true">{o.icon}</span><b>{o.label}</b></Link>)}
-        <p>Швидкий доступ</p>
+        <p>BAS-контур</p>
         {quickRail.map((o)=><Link
           key={o.href} href={o.href}
           className={`workspaceModuleLink${active === o.section ? " active":""}`}
@@ -230,7 +254,9 @@ export default function StaffWorkspaceShell({
             <span><b>{identity}</b><small>{staffRole || "Персонал відділення"}</small></span>
           </summary>
           <div>
-            <Link href="/staff/appointments">Календар і заявки</Link>
+            <Link href="/staff/documents">Документи</Link>
+            <Link href="/staff/registers">Регістри</Link>
+            <Link href="/staff/appointments">Календар і записи</Link>
             <Link href="/staff/finance">Фінанси</Link>
             <Link href="/staff/inventory">Склад</Link>
             <Link href="/staff/reports">Звіти відділення</Link>
@@ -269,9 +295,11 @@ export default function StaffWorkspaceShell({
             <p>{description}</p>
           </div>
           <div className="workspacePageActions">
-            {active === "reports"
-              ? <Link href="/staff/dashboard">На головний пульт</Link>
-              : <><Link href="/staff/dashboard">Головне</Link><Link className="primary" href="/staff/reports">Звіти</Link></>}
+            {active === "documents"
+              ? <><Link href="/staff/dashboard">Головне</Link><Link className="primary" href="/staff/registers">Регістри</Link></>
+              : active === "registers"
+                ? <><Link href="/staff/documents">Документи</Link><Link className="primary" href="/staff/reports/registers">Обороти</Link></>
+                : <><Link href="/staff/dashboard">Головне</Link><Link className="primary" href="/staff/documents">Документи</Link></>}
           </div>
         </header>
         {children}

--- a/app/styles/23-bas-enterprise-density.css
+++ b/app/styles/23-bas-enterprise-density.css
@@ -1,0 +1,428 @@
+/* ============================================================
+   RadiologyOS — BAS enterprise density layer.
+   Keeps RadiologyOS identity and clinical semantics, but applies a
+   compact BAS-like information density to every staff screen.
+   ============================================================ */
+
+.basWorkspaceShell{
+  --workspace-sidebar:224px;
+  --bas-topbar:48px;
+  --bas-modules:34px;
+  --bas-commands:38px;
+  --bas-control:30px;
+  --bas-row:32px;
+  --bas-radius:3px;
+  --bas-line:#cfd8d5;
+  --bas-line-soft:#e4e9e7;
+  --bas-bg:#eef1ef;
+  --bas-panel:#fff;
+  --bas-head:#f5f7f6;
+  --bas-text:#18322f;
+  --bas-muted:#677873;
+  --bas-accent:#0d5b50;
+  --fs-display:30px;
+  --fs-h1:20px;
+  --fs-h2:17px;
+  --fs-h3:14px;
+  --fs-lg:14px;
+  --fs-base:12px;
+  --fs-sm:11px;
+  --fs-xs:10px;
+  --r-xs:2px;
+  --r-sm:3px;
+  --r-md:4px;
+  --r-lg:5px;
+  --r-xl:6px;
+  --ws-radius-sm:3px;
+  --ws-radius-md:4px;
+  --ws-shadow-sm:0 1px 2px rgba(18,45,41,.05);
+  --ws-shadow-md:0 3px 10px rgba(18,45,41,.07);
+  background:var(--bas-bg);
+  font-size:12px;
+  line-height:1.35;
+}
+
+/* Left BAS rail: compact, persistent and scan-friendly. */
+.basWorkspaceShell .workspaceSidebar{
+  width:var(--workspace-sidebar);
+  background:linear-gradient(180deg,#164a43 0%,#123e39 100%);
+  border-right:1px solid #0d342f;
+  box-shadow:none;
+}
+.basWorkspaceShell .workspaceBrand{
+  height:var(--bas-topbar);
+  min-height:var(--bas-topbar);
+  gap:8px;
+  padding:0 11px;
+}
+.basWorkspaceShell .workspaceBrandMark{
+  width:28px;
+  height:28px;
+  flex-basis:28px;
+  border-radius:3px;
+  font-size:15px;
+  box-shadow:none;
+}
+.basWorkspaceShell .workspaceBrandMark::after{width:7px;height:7px;right:-2px;bottom:-2px}
+.basWorkspaceShell .workspaceBrandCopy b{font-family:var(--font-sans);font-size:13px;font-weight:800}
+.basWorkspaceShell .workspaceBrandCopy small{margin-top:1px;font-size:8px;letter-spacing:.045em}
+.basWorkspaceShell .workspaceNavigation{padding:7px 6px 8px}
+.basWorkspaceShell .workspaceNavigation>p,
+.basWorkspaceShell .workspaceSidebar .workspaceNavigation>p:nth-of-type(2){
+  margin:11px 7px 4px;
+  font-size:8px;
+  letter-spacing:.11em;
+}
+.basWorkspaceShell .workspaceModuleLink{
+  min-height:30px;
+  margin:1px 0;
+  padding:0 8px;
+  gap:7px;
+  border-radius:2px;
+  font-size:11px;
+  font-weight:650;
+}
+.basWorkspaceShell .workspaceModuleLink:hover{transform:none;background:rgba(255,255,255,.075)}
+.basWorkspaceShell .workspaceModuleLink.active{
+  background:#f7faf9;
+  color:#104e46;
+  box-shadow:inset 3px 0 0 #f0b24b;
+}
+.basWorkspaceShell .workspaceModuleLink.active::before{display:none}
+.basWorkspaceShell .workspaceModuleLink>span[aria-hidden="true"]{
+  width:15px;
+  height:15px;
+  flex-basis:15px;
+  -webkit-mask-size:15px 15px;
+  mask-size:15px 15px;
+}
+.basWorkspaceShell .workspaceNavigation .processStep+.processStep::before{left:15px;top:-2px;height:3px}
+.basWorkspaceShell .workspaceSidebarFoot{
+  min-height:42px;
+  margin:0;
+  padding:7px 10px;
+  gap:7px;
+}
+.basWorkspaceShell .workspaceSidebarFoot b{font-size:9.5px}
+.basWorkspaceShell .workspaceSidebarFoot small{margin-top:1px;font-size:8px}
+.basWorkspaceShell .systemPulse{width:7px;height:7px;flex-basis:7px;box-shadow:0 0 0 3px rgba(101,216,164,.12)}
+
+/* Main chrome: BAS-like stacked command area. */
+.basWorkspaceShell .workspaceMain{margin-left:var(--workspace-sidebar);background:var(--bas-bg)}
+.basWorkspaceShell .workspaceTopbar{
+  height:var(--bas-topbar);
+  min-height:var(--bas-topbar);
+  gap:10px;
+  padding:0 12px;
+  background:#fff;
+  border-bottom:1px solid var(--bas-line);
+  box-shadow:none;
+  backdrop-filter:none;
+}
+.basWorkspaceShell .workspaceTopbar::before{height:2px}
+.basWorkspaceShell .workspaceMenuButton{
+  width:30px;
+  height:30px;
+  border-radius:2px;
+  border-color:var(--bas-line);
+}
+.basWorkspaceShell .workspaceMenuButton span{width:14px;height:1.5px}
+.basWorkspaceShell .workspaceTopTitle b{font-size:11.5px}
+.basWorkspaceShell .workspaceTopTitle small{margin-top:1px;font-size:8.5px}
+.basWorkspaceShell .workspaceClock{gap:6px;padding-right:10px}
+.basWorkspaceShell .workspaceClock b{font-size:12px}
+.basWorkspaceShell .workspaceClock span{font-size:8.5px}
+.basWorkspaceShell .workspaceOnline{gap:5px;font-size:8.5px;letter-spacing:.035em}
+.basWorkspaceShell .workspaceOnline i{width:6px;height:6px;box-shadow:0 0 0 3px rgba(57,183,125,.12)}
+.basWorkspaceShell .workspaceProfile summary{min-width:164px;gap:7px;padding:3px 5px;border-radius:2px}
+.basWorkspaceShell .workspaceAvatar{width:28px;height:28px;flex-basis:28px;font-size:10px}
+.basWorkspaceShell .workspaceProfile b{font-size:9.5px}
+.basWorkspaceShell .workspaceProfile small{margin-top:1px;font-size:8px}
+.basWorkspaceShell .workspaceProfile>div{top:36px;width:198px;padding:4px;border-radius:3px;box-shadow:0 8px 22px rgba(18,61,58,.14)}
+.basWorkspaceShell .workspaceProfile>div a,.basWorkspaceShell .workspaceLogout{padding:7px 8px;border-radius:2px;font-size:10px}
+
+.basWorkspaceShell .workspaceBusinessBar{top:var(--bas-topbar);box-shadow:none;border-bottom:1px solid var(--bas-line)}
+.basWorkspaceShell .workspaceBusinessModules{
+  min-height:var(--bas-modules);
+  height:var(--bas-modules);
+  gap:0;
+  padding:0 10px;
+  border-bottom:1px solid var(--bas-line);
+  background:#f4f6f5;
+}
+.basWorkspaceShell .workspaceBusinessModules button{
+  min-height:var(--bas-modules);
+  height:var(--bas-modules);
+  padding:0 9px;
+  border-left:1px solid transparent;
+  border-right:1px solid transparent;
+  border-radius:0;
+  font-size:9.5px;
+  font-weight:700;
+}
+.basWorkspaceShell .workspaceBusinessModules button:hover{background:#e9efed}
+.basWorkspaceShell .workspaceBusinessModules button.selected{
+  background:#fff;
+  border-left-color:var(--bas-line);
+  border-right-color:var(--bas-line);
+  box-shadow:none;
+}
+.basWorkspaceShell .workspaceBusinessModules button.current::after{left:0;right:0;height:2px;border-radius:0;background:#e7a638}
+.basWorkspaceShell .workspaceBusinessModules button i{width:5px;height:5px;box-shadow:none}
+.basWorkspaceShell .workspaceBusinessCommands{
+  min-height:var(--bas-commands);
+  height:var(--bas-commands);
+  gap:8px;
+  padding:3px 12px;
+  border-bottom:1px solid var(--bas-line);
+}
+.basWorkspaceShell .workspaceBusinessContext{min-width:112px;padding-right:9px}
+.basWorkspaceShell .workspaceBusinessContext b{font-size:9.5px}
+.basWorkspaceShell .workspaceBusinessContext small{margin-top:0;font-size:7.5px}
+.basWorkspaceShell .workspaceBusinessLinks{gap:1px}
+.basWorkspaceShell .workspaceBusinessLinks a,
+.basWorkspaceShell .workspaceBusinessReturn{
+  min-height:27px;
+  height:27px;
+  padding:0 8px;
+  border-radius:2px;
+  font-size:9.5px;
+}
+
+/* Page canvas: less decoration, more usable data per viewport. */
+.basWorkspaceShell .workspacePage{
+  min-height:calc(100vh - var(--bas-topbar) - var(--bas-modules) - var(--bas-commands));
+  padding:10px 14px 28px;
+}
+.basWorkspaceShell .workspacePageHead,
+.basWorkspaceShell.workspaceWide .workspacePageHead{
+  max-width:none;
+  min-height:48px;
+  margin:0 0 8px;
+  padding:0 0 8px;
+  align-items:flex-end;
+  gap:14px;
+}
+.basWorkspaceShell .workspaceBreadcrumb{margin:0 0 3px!important;font-size:8.5px!important;letter-spacing:.035em;text-transform:none}
+.basWorkspaceShell .workspaceBreadcrumb span{margin:0 4px}
+.basWorkspaceShell .workspacePageHead h1{font-size:20px;line-height:1.15;font-weight:700;letter-spacing:-.012em}
+.basWorkspaceShell .workspacePageHead>div:first-child>p:last-child,
+.basWorkspaceShell .workspacePageHead>div>p:not(.workspaceBreadcrumb){
+  max-width:96ch;
+  margin:3px 0 0;
+  font-size:10px;
+  line-height:1.35;
+}
+.basWorkspaceShell .workspacePageActions{gap:4px}
+.basWorkspaceShell .workspacePageActions a,.basWorkspaceShell .workspacePageActions button{
+  min-height:var(--bas-control);
+  height:var(--bas-control);
+  padding:0 10px;
+  border-radius:2px;
+  font-size:9.5px;
+  font-weight:700;
+}
+
+/* Universal BAS form controls. */
+.basWorkspaceShell :where(input,select,textarea){
+  min-height:var(--bas-control);
+  border-radius:2px!important;
+  border-color:var(--bas-line)!important;
+  padding:5px 7px;
+  font-family:inherit;
+  font-size:10.5px;
+  line-height:1.2;
+  box-shadow:none!important;
+}
+.basWorkspaceShell textarea{min-height:62px}
+.basWorkspaceShell :where(input,select,textarea):focus{
+  outline:1px solid #4f8d84;
+  outline-offset:0;
+  border-color:#4f8d84!important;
+}
+.basWorkspaceShell :where(button,a)[class*="Btn"],
+.basWorkspaceShell :where(button,a)[class*="Button"],
+.basWorkspaceShell .excelButton{
+  min-height:28px;
+  border-radius:2px!important;
+  padding:0 8px;
+  font-size:9.5px;
+  box-shadow:none!important;
+}
+
+/* Universal BAS table geometry. */
+.basWorkspaceShell table{width:100%;border-collapse:collapse;border-spacing:0;font-size:10.5px}
+.basWorkspaceShell table thead th{
+  position:sticky;
+  top:0;
+  z-index:2;
+  height:28px;
+  padding:5px 7px;
+  background:#edf1ef;
+  border:1px solid var(--bas-line);
+  color:#344c48;
+  font-size:9px;
+  font-weight:750;
+  letter-spacing:.015em;
+  text-transform:none;
+  white-space:nowrap;
+}
+.basWorkspaceShell table tbody td{
+  min-height:var(--bas-row);
+  padding:5px 7px;
+  border:1px solid #dde4e1;
+  vertical-align:middle;
+}
+.basWorkspaceShell table tbody tr:nth-child(even){background:#fafbfa}
+.basWorkspaceShell table tbody tr:hover{background:#eef6f3}
+.basWorkspaceShell table td small{display:block;margin-top:1px;font-size:8.5px;line-height:1.25;color:var(--bas-muted)}
+.basWorkspaceShell table td b{font-size:10.5px}
+.basWorkspaceShell table td button,.basWorkspaceShell table td a{
+  min-height:25px;
+  padding:0 7px;
+  border-radius:2px;
+  font-size:9px;
+}
+
+/* Existing finance/report primitives become BAS journals everywhere. */
+.basWorkspaceShell .financeSummary{
+  max-width:none;
+  margin:0 0 7px;
+  gap:5px;
+}
+.basWorkspaceShell .financeSummary article,
+.basWorkspaceShell .reportStats article,
+.basWorkspaceShell .staffStats article{
+  min-height:68px;
+  padding:8px 10px;
+  border:1px solid var(--bas-line);
+  border-radius:2px;
+  box-shadow:none;
+  background:#fff;
+}
+.basWorkspaceShell .financeSummary article span,
+.basWorkspaceShell .reportStats article span,
+.basWorkspaceShell .staffStats article span{font-size:8.5px;letter-spacing:.025em}
+.basWorkspaceShell .financeSummary article b,
+.basWorkspaceShell .reportStats article b,
+.basWorkspaceShell .staffStats article b{margin-top:3px;font-size:16px;line-height:1.1}
+.basWorkspaceShell .financeSummary article small,
+.basWorkspaceShell .reportStats article small,
+.basWorkspaceShell .staffStats article small{margin-top:2px;font-size:8.5px;line-height:1.2}
+.basWorkspaceShell .financeJournal,
+.basWorkspaceShell .reportPanel,
+.basWorkspaceShell .reportBuilder,
+.basWorkspaceShell .equipmentAdmin,
+.basWorkspaceShell .staffAdmin,
+.basWorkspaceShell .bookingRow,
+.basWorkspaceShell .ds-card{
+  max-width:none;
+  margin-top:7px;
+  border:1px solid var(--bas-line);
+  border-radius:2px;
+  box-shadow:none;
+  background:#fff;
+}
+.basWorkspaceShell .financeToolbar,
+.basWorkspaceShell .staffTools{
+  min-height:40px;
+  gap:6px;
+  padding:5px 7px;
+  border-radius:0;
+  background:#f4f6f5;
+  color:var(--bas-text);
+  border-bottom:1px solid var(--bas-line);
+}
+.basWorkspaceShell .financeToolbar>div{min-width:180px;flex:1}
+.basWorkspaceShell .financeToolbar b{font-size:10.5px}
+.basWorkspaceShell .financeToolbar small{margin-top:1px;font-size:8.5px;line-height:1.2;color:var(--bas-muted)}
+.basWorkspaceShell .financeToolbar label span{margin-bottom:2px;font-size:8px}
+.basWorkspaceShell .financeTableWrap{border-radius:0;box-shadow:none}
+.basWorkspaceShell .financeTable{margin:0}
+.basWorkspaceShell .financePrintDetails{gap:4px;padding:6px}
+.basWorkspaceShell .financePrintDetails p{min-height:44px;margin:0;padding:7px 8px;border:1px solid var(--bas-line-soft);border-radius:2px}
+.basWorkspaceShell .financePrintDetails p span{font-size:8px}
+.basWorkspaceShell .financePrintDetails p b{margin-top:2px;font-size:10px}
+.basWorkspaceShell .financeState{padding:2px 5px;border-radius:2px;font-size:8.5px}
+.basWorkspaceShell .financeError,.basWorkspaceShell .financeLoading,.basWorkspaceShell .financeEmpty{margin:6px;padding:7px 8px;border-radius:2px;font-size:10px}
+
+/* Generic dashboard/card collections use the same dense rhythm. */
+.basWorkspaceShell .workspaceQuickGrid{
+  max-width:none;
+  margin:0 0 7px;
+  grid-template-columns:1.2fr repeat(3,1fr);
+  gap:5px;
+}
+.basWorkspaceShell .workspaceQuickGrid>a{
+  min-height:72px;
+  padding:9px 10px;
+  border-radius:2px;
+  box-shadow:none;
+}
+.basWorkspaceShell .workspaceQuickGrid>a:hover{transform:none;box-shadow:none}
+.basWorkspaceShell .workspaceQuickGrid a>b{margin-top:5px;font-size:10.5px}
+.basWorkspaceShell .workspaceQuickGrid a>small{margin-top:2px;font-size:8.5px}
+.basWorkspaceShell .workspaceTodayCard>strong{margin-top:5px;font-size:21px}
+.basWorkspaceShell .quickGlyph{width:22px;height:22px;border-radius:2px;font-size:12px}
+.basWorkspaceShell .ds-card{padding:9px}
+.basWorkspaceShell .ds-card.pad-lg{padding:11px}
+.basWorkspaceShell .ds-section-label{font-size:8.5px;letter-spacing:.04em}
+.basWorkspaceShell .ds-h1{font-size:20px}.basWorkspaceShell .ds-h2{font-size:17px}.basWorkspaceShell .ds-h3{font-size:14px}
+
+/* Dark theme keeps the same BAS geometry. */
+.basWorkspaceShell.themeDark{
+  --bas-bg:#11181c;
+  --bas-panel:#151f24;
+  --bas-head:#1a252a;
+  --bas-line:#334047;
+  --bas-line-soft:#29363c;
+  --bas-text:#d9e6e3;
+  --bas-muted:#8fa29e;
+}
+.basWorkspaceShell.themeDark .workspaceTopbar,
+.basWorkspaceShell.themeDark .workspaceBusinessCommands,
+.basWorkspaceShell.themeDark .financeJournal,
+.basWorkspaceShell.themeDark .reportPanel,
+.basWorkspaceShell.themeDark .reportBuilder,
+.basWorkspaceShell.themeDark .financeSummary article,
+.basWorkspaceShell.themeDark .reportStats article,
+.basWorkspaceShell.themeDark .staffStats article,
+.basWorkspaceShell.themeDark .ds-card{background:var(--bas-panel);border-color:var(--bas-line)}
+.basWorkspaceShell.themeDark .workspaceBusinessModules,
+.basWorkspaceShell.themeDark .financeToolbar,
+.basWorkspaceShell.themeDark .staffTools,
+.basWorkspaceShell.themeDark table thead th{background:var(--bas-head);border-color:var(--bas-line);color:#c5d5d1}
+.basWorkspaceShell.themeDark table tbody td{border-color:var(--bas-line-soft)}
+.basWorkspaceShell.themeDark table tbody tr:nth-child(even){background:#131d21}
+.basWorkspaceShell.themeDark table tbody tr:hover{background:#1a2a2d}
+
+/* Responsive: preserve information density on tablets, switch to drawer on phone. */
+@media(max-width:1180px){
+  .basWorkspaceShell{--workspace-sidebar:198px}
+  .basWorkspaceShell .workspaceNavigation{padding-left:4px;padding-right:4px}
+  .basWorkspaceShell .workspaceBusinessModules button{padding:0 7px;font-size:9px}
+  .basWorkspaceShell .workspaceBusinessLinks a{padding:0 6px;font-size:9px}
+}
+@media(max-width:820px){
+  .basWorkspaceShell{--workspace-sidebar:58px}
+  .basWorkspaceShell .workspaceBrand{padding:0 15px}
+  .basWorkspaceShell .workspaceBrandMark{width:28px;height:28px;flex-basis:28px}
+  .basWorkspaceShell .workspaceNavigation a{justify-content:center;padding:0}
+  .basWorkspaceShell .workspaceModuleLink>span[aria-hidden="true"]{width:16px;height:16px;flex-basis:16px}
+  .basWorkspaceShell .workspacePage{padding-left:9px;padding-right:9px}
+  .basWorkspaceShell .workspaceQuickGrid{grid-template-columns:1fr 1fr}
+}
+@media(max-width:560px){
+  .basWorkspaceShell{--workspace-sidebar:0px}
+  .basWorkspaceShell.workspaceCollapsed{--workspace-sidebar:224px}
+  .basWorkspaceShell.workspaceCollapsed .workspaceSidebar{width:224px}
+  .basWorkspaceShell .workspaceTopbar{padding:0 8px}
+  .basWorkspaceShell .workspaceBusinessBar{top:var(--bas-topbar)}
+  .basWorkspaceShell .workspaceBusinessModules{padding:0 5px}
+  .basWorkspaceShell .workspaceBusinessCommands{padding:3px 6px}
+  .basWorkspaceShell .workspacePage{padding:8px 6px 20px}
+  .basWorkspaceShell .workspacePageHead{align-items:flex-start;gap:6px}
+  .basWorkspaceShell .workspacePageHead h1{font-size:18px}
+  .basWorkspaceShell .financeSummary{grid-template-columns:1fr 1fr}
+  .basWorkspaceShell .workspaceQuickGrid{grid-template-columns:1fr}
+}

--- a/tests/bas-workspace-navigation.test.mjs
+++ b/tests/bas-workspace-navigation.test.mjs
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const shell=readFileSync("app/staff/workspace-shell.tsx","utf8");
+const documents=readFileSync("app/staff/documents/page.tsx","utf8");
+const registers=readFileSync("app/staff/registers/page.tsx","utf8");
+const directories=readFileSync("app/staff/directories/page.tsx","utf8");
+
+test("staff workspace exposes BAS documents and registers as first-class navigation",()=>{
+  assert.match(shell,/BAS-контур/);
+  assert.match(shell,/label:"Документи",href:"\/staff\/documents",section:"documents"/);
+  assert.match(shell,/label:"Регістри",href:"\/staff\/registers",section:"registers"/);
+  assert.match(shell,/key:"documents",label:"Документи"/);
+  assert.match(shell,/key:"registers",label:"Регістри"/);
+  assert.match(shell,/key:"directories",label:"Довідники"/);
+  assert.match(shell,/\/staff\/documents\?type=patient_order/);
+  assert.match(shell,/Документи · регістри · медицина/);
+});
+
+test("document journal supports canonical BAS filtering and lineage",()=>{
+  assert.match(documents,/active="documents"/);
+  assert.match(documents,/params\.get\("type"\)/);
+  assert.match(documents,/params\.get\("state"\)/);
+  assert.match(documents,/row\.journalType!==typeFilter/);
+  assert.match(documents,/row\.state!==stateFilter/);
+  assert.match(documents,/Єдиний журнал реєстраторів/);
+  assert.match(documents,/Ланцюжок документа/);
+  assert.match(documents,/← Підстава/);
+  assert.match(documents,/→ Похідний/);
+  assert.match(documents,/Рухів регістрів/);
+});
+
+test("register and directory landing pages are read-model maps, not duplicate stores",()=>{
+  assert.match(registers,/active="registers"/);
+  assert.match(registers,/Документ → Проведення → Регістр → Звіт/);
+  assert.match(registers,/не створює паралельних таблиць/);
+  assert.match(registers,/immutable історія/);
+  assert.match(directories,/active="directories"/);
+  assert.match(directories,/Єдині master-data RadiologyOS/);
+  assert.match(directories,/без копій у формах/);
+});

--- a/tests/bas-workspace-navigation.test.mjs
+++ b/tests/bas-workspace-navigation.test.mjs
@@ -6,6 +6,8 @@ const shell=readFileSync("app/staff/workspace-shell.tsx","utf8");
 const documents=readFileSync("app/staff/documents/page.tsx","utf8");
 const registers=readFileSync("app/staff/registers/page.tsx","utf8");
 const directories=readFileSync("app/staff/directories/page.tsx","utf8");
+const globals=readFileSync("app/globals.css","utf8");
+const density=readFileSync("app/styles/23-bas-enterprise-density.css","utf8");
 
 test("staff workspace exposes BAS documents and registers as first-class navigation",()=>{
   assert.match(shell,/BAS-контур/);
@@ -33,10 +35,24 @@ test("document journal supports canonical BAS filtering and lineage",()=>{
 
 test("register and directory landing pages are read-model maps, not duplicate stores",()=>{
   assert.match(registers,/active="registers"/);
-  assert.match(registers,/Документ → Проведення → Регістр → Звіт/);
+  assert.match(registers,/Підстава → Документ → Проведення → Регістр → Звіт/);
   assert.match(registers,/не створює паралельних таблиць/);
   assert.match(registers,/immutable історія/);
   assert.match(directories,/active="directories"/);
   assert.match(directories,/Єдині master-data RadiologyOS/);
   assert.match(directories,/без копій у формах/);
+});
+
+test("BAS density layer is global, last in cascade, and keeps compact enterprise geometry",()=>{
+  assert.match(globals,/22-shift-calendar\.css";\n@import "\.\/styles\/23-bas-enterprise-density\.css";/);
+  assert.match(density,/--workspace-sidebar:224px/);
+  assert.match(density,/--bas-topbar:48px/);
+  assert.match(density,/--bas-modules:34px/);
+  assert.match(density,/--bas-commands:38px/);
+  assert.match(density,/--bas-control:30px/);
+  assert.match(density,/--bas-row:32px/);
+  assert.match(density,/\.basWorkspaceShell table thead th/);
+  assert.match(density,/\.basWorkspaceShell table tbody td/);
+  assert.match(density,/\.basWorkspaceShell \.financeJournal/);
+  assert.match(density,/@media\(max-width:560px\)/);
 });

--- a/tests/intake.test.mjs
+++ b/tests/intake.test.mjs
@@ -68,8 +68,8 @@ test("intake board page is a two-pane queue + editable detail, wired into the sh
   assert.match(css, /\.intakeHistory\b/); // стилі identity-safe handoff секції
   assert.match(css, /\.intakeFacts\b/);   // сітка фактів
   const shell = await read("app/staff/workspace-shell.tsx");
-  // Intake remains reachable from the operational rail and belongs to the stable BAS Registry module.
+  // Intake remains reachable from the operational rail and belongs to the BAS Patients module.
   assert.match(shell, /label:"Прийом", href:"\/staff\/intake", section:"intake"/);
-  assert.match(shell, /key:"registry",label:"Реєстратура"/);
+  assert.match(shell, /key:"patients",label:"Пацієнти"/);
   assert.match(shell, /\{label:"Прийом пацієнтів",href:"\/staff\/intake"\}/);
 });


### PR DESCRIPTION
#416 — BAS Workspace: information architecture + enterprise density.

What changes:
- splits left navigation into clinical `Робочий процес` and accounting `BAS-контур`;
- makes `Документи`, `Регістри`, and `Довідники` first-class modules;
- exposes Patient Orders through the canonical unified business-document journal (`?type=patient_order`) instead of creating a duplicate store;
- keeps basis → derived-document → register movements visible in one journal;
- adds read-only register and directory landing maps that route to existing canonical screens;
- expands reports navigation to receivables, material margin, and material plan/fact control;
- applies BAS-like enterprise geometry to the complete staff workspace: compact 224px navigation rail, 48px topbar, 34px module strip, 38px command strip, 30px controls, ~32px table rows, compact page headers/cards/forms/tables, responsive drawer behavior and matching dark-theme geometry;
- loads the BAS density layer last so existing medical, inventory, finance, reporting and scheduling screens receive one consistent workspace rhythm without rewriting their business logic.

Safety / invariants:
- no schema or migration changes;
- no posting logic changes;
- no API contract changes;
- no new source of truth;
- no browser-authoritative IDs or amounts;
- no fake `Create on basis` action: command creation will only be added when a canonical server write-path is explicitly mapped;
- production deploy is not touched.