### PR TITLE
Trigger approved production deploy

### DIFF
--- a/.github/workflows/dispatch-production-once.yml
+++ b/.github/workflows/dispatch-production-once.yml
@@ -1,0 +1,33 @@
+name: One-shot production deploy dispatcher
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    name: Dispatch approved production deploy
+    if: ${{ github.event.before == '0a23612aedb80ee135b1152bfebd26c72f8969dc' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify exact approved base
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ github.event.before }}" = "0a23612aedb80ee135b1152bfebd26c72f8969dc"
+
+      - name: Dispatch canonical manual deploy
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run deploy.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            --field confirmation=DEPLOY


### PR DESCRIPTION
One-shot exact-base dispatcher for the approved current `main` SHA `0a23612aedb80ee135b1152bfebd26c72f8969dc`. It adds no application code and only dispatches the canonical manual `deploy.yml` with `confirmation=DEPLOY` if `main` has not moved before merge. The dispatcher will be removed immediately after the production deploy completes.