### PR TITLE
Fail closed on over-limit protocol content

### DIFF
--- a/app/api/staff/ai/protocol-draft/route.ts
+++ b/app/api/staff/ai/protocol-draft/route.ts
@@ -1,5 +1,6 @@
 import { canAccessBooking, canManageProtocols } from "../../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../../lib/tenant";
+import { validateProtocolInputBounds } from "../../../../../lib/protocol-lifecycle";
 import { sanitizeDocument } from "../../../../../lib/protocols";
 import { generateProtocolDraft } from "../../../../../lib/ai";
 import { dbBinding } from "../../../../../lib/db";
@@ -24,8 +25,12 @@ export async function POST(request: Request) {
     return Response.json({ error: "Немає доступу до цього дослідження" }, { status: 403 });
   }
   // Draft from whatever is currently in the editor; force draft status so the
-  // ready/issued validation never blocks generating a suggestion.
-  const parsed = sanitizeDocument({ ...body, status: "draft" });
+  // ready/issued validation never blocks generating a suggestion. Reject input
+  // that would otherwise be silently clipped by the legacy normalizer.
+  const draftInput = { ...body, status: "draft" };
+  const bounds = validateProtocolInputBounds(draftInput);
+  if (!bounds.ok) return Response.json({ error: bounds.error }, { status: 400 });
+  const parsed = sanitizeDocument(draftInput);
   if (!parsed.ok) return Response.json({ error: parsed.error }, { status: 400 });
 
   let priorStudies = 0;

--- a/lib/protocol-lifecycle.ts
+++ b/lib/protocol-lifecycle.ts
@@ -1,5 +1,8 @@
 import {
   bookingProtocolStatus,
+  isProtocolTemplate,
+  PROTOCOL_LIMITS,
+  protocolTemplateByKey,
   sanitizeDocument,
   type ProtocolDocument,
   type ProtocolStatus as LegacyProtocolStatus,
@@ -7,6 +10,7 @@ import {
 
 export type ProtocolLifecycleStatus = LegacyProtocolStatus | "signed";
 export type ProtocolLifecycleDocument = Omit<ProtocolDocument, "status"> & { status: ProtocolLifecycleStatus };
+export type ProtocolInputBoundsValidation = { ok: true } | { ok: false; error: string };
 
 export const PROTOCOL_LIFECYCLE_STATUS_LABELS: Record<ProtocolLifecycleStatus, string> = {
   draft: "Чернетка",
@@ -19,6 +23,54 @@ export function isProtocolLifecycleStatus(value: string): value is ProtocolLifec
   return value === "draft" || value === "ready" || value === "signed" || value === "issued";
 }
 
+function normalizedInputText(value: unknown): string {
+  return String(value ?? "").replace(/\r\n/g, "\n").trim();
+}
+
+function protocolInputLengthError(value: unknown, max: number, label: string): string | null {
+  return normalizedInputText(value).length > max
+    ? `Поле «${label}» не може перевищувати ${max} символів`
+    : null;
+}
+
+// The legacy normalizer clips strings to its storage bounds. Clinical text must
+// never be silently shortened, so every user-controlled persisted field is
+// checked first and the request fails closed if any value is over the limit.
+export function validateProtocolInputBounds(input: unknown): ProtocolInputBoundsValidation {
+  if (!input || typeof input !== "object") return { ok: false, error: "Некоректні дані протоколу" };
+  const raw = input as Record<string, unknown>;
+  const templateKey = String(raw.templateKey || "generic");
+  if (!isProtocolTemplate(templateKey)) return { ok: false, error: "Невідомий шаблон протоколу" };
+
+  const topLevelChecks: Array<[unknown, number, string]> = [
+    [raw.method, PROTOCOL_LIMITS.method, "Методика"],
+    [raw.findings, PROTOCOL_LIMITS.narrative, "Опис"],
+    [raw.conclusion, PROTOCOL_LIMITS.narrative, "Висновок"],
+    [raw.recommendations, PROTOCOL_LIMITS.narrative, "Рекомендації"],
+    [raw.number, PROTOCOL_LIMITS.number, "Номер протоколу"],
+  ];
+  for (const [value, max, label] of topLevelChecks) {
+    const error = protocolInputLengthError(value, max, label);
+    if (error) return { ok: false, error };
+  }
+
+  const incomingSections = raw.sections && typeof raw.sections === "object" && !Array.isArray(raw.sections)
+    ? raw.sections as Record<string, unknown>
+    : {};
+  const template = protocolTemplateByKey(templateKey);
+  for (const section of template.sections) {
+    const incoming = incomingSections[section.key];
+    const source = incoming && typeof incoming === "object" && !Array.isArray(incoming)
+      ? incoming as Record<string, unknown>
+      : {};
+    for (const field of section.fields) {
+      const error = protocolInputLengthError(source[field.key], PROTOCOL_LIMITS.field, field.label);
+      if (error) return { ok: false, error };
+    }
+  }
+  return { ok: true };
+}
+
 export function sanitizeLifecycleDocument(
   input: unknown,
 ): { ok: true; document: ProtocolLifecycleDocument } | { ok: false; error: string } {
@@ -27,7 +79,10 @@ export function sanitizeLifecycleDocument(
   const requestedStatus = String(raw.status || "draft");
   if (!isProtocolLifecycleStatus(requestedStatus)) return { ok: false, error: "Некоректний статус протоколу" };
 
-  // The existing document sanitizer already owns all field bounds and the
+  const bounds = validateProtocolInputBounds(raw);
+  if (!bounds.ok) return bounds;
+
+  // The existing document sanitizer owns field normalization and the
   // number/conclusion requirements for finalized documents. Validate `signed`
   // with the same strictness as `ready`, then restore the lifecycle status.
   const parsed = sanitizeDocument({

--- a/tests/protocol-input-bounds.behavior.test.mjs
+++ b/tests/protocol-input-bounds.behavior.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addBooking(db, email) {
+  const result = await db.prepare(
+    `INSERT INTO bookings
+      (organization_id, code, name, phone, phone_normalized, service, service_code, equipment_id,
+       desired_date, desired_time, assigned_radiologist_email, performed_at)
+     VALUES (1, 'BOUNDS-001', 'Bounds Patient', '+380501112233', '380501112233',
+       'КТ органів грудної клітки', '408', 'ct', '2026-08-15', '10:00', ?, '2026-08-15T10:20:00')`
+  ).bind(email).run();
+  return Number(result.meta.last_row_id);
+}
+
+function protocolPayload(bookingId, overrides = {}) {
+  return {
+    bookingId,
+    baseVersion: 0,
+    templateKey: "generic",
+    method: "КТ без внутрішньовенного контрастування",
+    sections: { findings: { description: "Опис без патологічних змін." } },
+    findings: "Легенева тканина без свіжих вогнищевих змін.",
+    conclusion: "КТ-ознаки без гострої патології.",
+    recommendations: "",
+    number: `CT-${bookingId}`,
+    status: "ready",
+    ...overrides,
+  };
+}
+
+test("protocol endpoints reject over-limit clinical text instead of silently truncating it", async () => {
+  await withD1(async (db) => {
+    const email = "bounds@example.com";
+    const cookie = await seedStaffSession(db, { email, role: "radiologist", displayName: "Bounds Doctor" });
+    const bookingId = await addBooking(db, email);
+
+    const overlongConclusion = await callWorker(
+      jsonRequest(
+        "/api/staff/protocols",
+        protocolPayload(bookingId, { conclusion: "X".repeat(6001) }),
+        { method: "PUT", headers: { cookie } },
+      ),
+      db,
+    );
+    assert.equal(overlongConclusion.status, 400);
+    assert.match(JSON.stringify(await overlongConclusion.json()), /Висновок.*6000/);
+
+    const overlongSection = await callWorker(
+      jsonRequest(
+        "/api/staff/protocols",
+        protocolPayload(bookingId, {
+          sections: { findings: { description: "Y".repeat(2001) } },
+        }),
+        { method: "PUT", headers: { cookie } },
+      ),
+      db,
+    );
+    assert.equal(overlongSection.status, 400);
+    assert.match(JSON.stringify(await overlongSection.json()), /Опис дослідження.*2000/);
+
+    const overlongAiDraft = await callWorker(
+      jsonRequest(
+        "/api/staff/ai/protocol-draft",
+        protocolPayload(bookingId, { findings: "Z".repeat(6001), status: "draft" }),
+        { method: "POST", headers: { cookie } },
+      ),
+      db,
+    );
+    assert.equal(overlongAiDraft.status, 400);
+    assert.match(JSON.stringify(await overlongAiDraft.json()), /Опис.*6000/);
+
+    const protocolCount = await db.prepare(
+      "SELECT COUNT(*) AS count FROM protocols WHERE organization_id=1 AND booking_id=?"
+    ).bind(bookingId).first();
+    assert.equal(Number(protocolCount.count), 0, "rejected content must never be partially persisted");
+
+    const revisionCount = await db.prepare(
+      "SELECT COUNT(*) AS count FROM protocol_revisions WHERE organization_id=1 AND booking_id=?"
+    ).bind(bookingId).first();
+    assert.equal(Number(revisionCount.count), 0, "rejected content must not create medical revisions");
+
+    const aiEventCount = await db.prepare(
+      `SELECT COUNT(*) AS count FROM booking_events
+       WHERE organization_id=1 AND booking_id=? AND action='ai_draft_generated'`
+    ).bind(bookingId).first();
+    assert.equal(Number(aiEventCount.count), 0, "rejected AI input must not create a generated-draft event");
+  });
+});


### PR DESCRIPTION
## Defect
Protocol normalization silently clipped over-limit medical text with `.slice(...)`. A long conclusion, findings block, recommendation, method, protocol number, or structured field could therefore be partially persisted without telling the radiologist.

## Fix
- validate all persisted protocol text against existing `PROTOCOL_LIMITS` before normalization;
- return `400` instead of truncating clinical content;
- apply the same guard to AI protocol-draft input;
- preserve existing normalization, lifecycle, tenant and signing behavior.

## Regression coverage
- over-limit conclusion is rejected and not persisted;
- over-limit structured protocol field is rejected and not persisted;
- over-limit AI-draft input is rejected before generation/event logging;
- no protocol or revision row is created after rejected input.

Production deploy is intentionally not part of this PR.