### PR TITLE
Rate limit staff login by account and IP

### DIFF
--- a/app/api/staff/login/route.ts
+++ b/app/api/staff/login/route.ts
@@ -7,15 +7,23 @@ import {
   SESSION_TTL_SECONDS,
   verifyPassword,
 } from "../../../../lib/auth";
-import { isRateLimited } from "../../../../lib/rate-limit";
+import {
+  clearIdentifierRateLimit,
+  isIdentifierRateLimited,
+  isRateLimited,
+  recordIdentifierRateLimitFailure,
+} from "../../../../lib/rate-limit";
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
 
+const STAFF_LOGIN_LIMIT = 10;
+const STAFF_LOGIN_WINDOW_MINUTES = 15;
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
-  if (await isRateLimited(db, request, "staff-login", 10, 15)) {
+  if (await isRateLimited(db, request, "staff-login", STAFF_LOGIN_LIMIT, STAFF_LOGIN_WINDOW_MINUTES)) {
     return Response.json({ error: "Забагато спроб входу. Спробуйте за 15 хвилин." }, { status: 429 });
   }
 
@@ -25,6 +33,20 @@ export async function POST(request: Request) {
   const password = String(body.password || "");
   if ((!phone && !email) || !password) {
     return Response.json({ error: "Вкажіть номер телефону і PIN-код" }, { status: 400 });
+  }
+
+  // Окремий hashed account bucket не дає обходити 6-значний PIN через
+  // distributed brute-force з багатьох IP. Невідомі акаунти лімітуються так само,
+  // тому відповідь не створює account-enumeration oracle.
+  const loginIdentifier = phone ? `phone:${phone}` : `email:${email}`;
+  if (await isIdentifierRateLimited(
+    db,
+    "staff-login-account",
+    loginIdentifier,
+    STAFF_LOGIN_LIMIT,
+    STAFF_LOGIN_WINDOW_MINUTES,
+  )) {
+    return Response.json({ error: "Забагато спроб входу. Спробуйте за 15 хвилин." }, { status: 429 });
   }
 
   // Вхід за номером телефону (основний) або email (сумісність).
@@ -39,6 +61,13 @@ export async function POST(request: Request) {
   const compromised = member ? isCompromisedPasswordHash(member.passwordHash) : false;
   const ok = member && !compromised ? await verifyPassword(password, member.passwordHash) : false;
   if (!member || !ok) {
+    await recordIdentifierRateLimitFailure(
+      db,
+      "staff-login-account",
+      loginIdentifier,
+      STAFF_LOGIN_LIMIT,
+      STAFF_LOGIN_WINDOW_MINUTES,
+    );
     await audit(db, {
       organizationId: 1,
       actorEmail: member?.email || phone || email || "невідомо",
@@ -51,6 +80,8 @@ export async function POST(request: Request) {
         : "Невірний номер телефону або PIN-код",
     }, { status: 401 });
   }
+
+  await clearIdentifierRateLimit(db, "staff-login-account", loginIdentifier);
 
   if (passwordHashNeedsUpgrade(member.passwordHash)) {
     await db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,23 +1,25 @@
 type Database = D1Database;
 
+async function digestKey(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest)).map(byte => byte.toString(16).padStart(2, "0")).join("");
+}
+
 async function fingerprint(request: Request, scope: string) {
   // Лише cf-connecting-ip (за Cloudflare встановлюється завжди й не
   // підробляється клієнтом). Без нього — єдиний спільний кошик, а не
   // клієнтський проксі-заголовок, який дозволяв би обхід ліміту через підміну.
   const source = request.headers.get("cf-connecting-ip") || "no-ip";
-  const bytes = new TextEncoder().encode(`${scope}:${source.trim()}`);
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest)).map(byte => byte.toString(16).padStart(2, "0")).join("");
+  return digestKey(`${scope}:${source.trim()}`);
 }
 
-export async function isRateLimited(
-  db: Database,
-  request: Request,
-  scope: string,
-  limit: number,
-  windowMinutes: number,
-) {
-  const key = await fingerprint(request, scope);
+async function identifierFingerprint(scope: string, identifier: string) {
+  // Ідентифікатор акаунта ніколи не зберігається у request_limits у відкритому вигляді.
+  return digestKey(`${scope}:identifier:${identifier.trim().toLowerCase()}`);
+}
+
+async function incrementLimit(db: Database, key: string, limit: number, windowMinutes: number) {
   const now = Math.floor(Date.now() / 1000);
   const cutoff = now - windowMinutes * 60;
   await db.prepare(
@@ -34,4 +36,52 @@ export async function isRateLimited(
       .bind(now - 86400).run();
   }
   return (row?.attempts || 0) > limit;
+}
+
+export async function isRateLimited(
+  db: Database,
+  request: Request,
+  scope: string,
+  limit: number,
+  windowMinutes: number,
+) {
+  return incrementLimit(db, await fingerprint(request, scope), limit, windowMinutes);
+}
+
+export async function isIdentifierRateLimited(
+  db: Database,
+  scope: string,
+  identifier: string,
+  limit: number,
+  windowMinutes: number,
+) {
+  if (!identifier.trim()) return false;
+  const key = await identifierFingerprint(scope, identifier);
+  const now = Math.floor(Date.now() / 1000);
+  const cutoff = now - windowMinutes * 60;
+  const row = await db.prepare(
+    "SELECT attempts, window_started_at AS windowStartedAt FROM request_limits WHERE key = ?"
+  ).bind(key).first<{ attempts: number; windowStartedAt: number }>();
+  return Boolean(row && row.windowStartedAt >= cutoff && row.attempts >= limit);
+}
+
+export async function recordIdentifierRateLimitFailure(
+  db: Database,
+  scope: string,
+  identifier: string,
+  limit: number,
+  windowMinutes: number,
+) {
+  if (!identifier.trim()) return false;
+  return incrementLimit(db, await identifierFingerprint(scope, identifier), limit, windowMinutes);
+}
+
+export async function clearIdentifierRateLimit(
+  db: Database,
+  scope: string,
+  identifier: string,
+) {
+  if (!identifier.trim()) return;
+  await db.prepare("DELETE FROM request_limits WHERE key = ?")
+    .bind(await identifierFingerprint(scope, identifier)).run();
 }

--- a/tests/staff-login-account-rate-limit.test.mjs
+++ b/tests/staff-login-account-rate-limit.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("staff login uses independent IP and account rate-limit buckets", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+
+  assert.match(login, /isRateLimited\(db, request, "staff-login"/);
+  assert.match(login, /isIdentifierRateLimited\([\s\S]*"staff-login-account"/);
+  assert.match(login, /recordIdentifierRateLimitFailure\([\s\S]*"staff-login-account"/);
+  assert.match(login, /clearIdentifierRateLimit\(db, "staff-login-account", loginIdentifier\)/);
+  assert.match(login, /phone:\$\{phone\}/);
+  assert.match(login, /email:\$\{email\}/);
+
+  const checkIndex = login.indexOf("isIdentifierRateLimited(");
+  const verifyIndex = login.indexOf("verifyPassword(password");
+  const recordIndex = login.indexOf("recordIdentifierRateLimitFailure(");
+  assert.ok(checkIndex >= 0 && checkIndex < verifyIndex, "account lockout must be checked before password verification");
+  assert.ok(recordIndex > verifyIndex, "only failed credential verification should consume the account failure bucket");
+});
+
+test("account rate-limit keys are hashed and never stored as raw identifiers", async () => {
+  const limiter = await read("lib/rate-limit.ts");
+
+  assert.match(limiter, /identifierFingerprint/);
+  assert.match(limiter, /digestKey\(`\$\{scope\}:identifier:\$\{identifier\.trim\(\)\.toLowerCase\(\)\}`\)/);
+  assert.match(limiter, /crypto\.subtle\.digest\("SHA-256"/);
+  assert.match(limiter, /export async function isIdentifierRateLimited/);
+  assert.match(limiter, /export async function recordIdentifierRateLimitFailure/);
+  assert.match(limiter, /export async function clearIdentifierRateLimit/);
+  assert.doesNotMatch(limiter, /INSERT INTO request_limits[^\n]*identifier/i);
+});
+
+test("successful staff login clears only the account failure bucket", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+  const clearIndex = login.indexOf("clearIdentifierRateLimit(db, \"staff-login-account\", loginIdentifier)");
+  const successAuditIndex = login.indexOf('action: "login", resource: "auth"');
+
+  assert.ok(clearIndex >= 0, "successful login must clear accumulated account failures");
+  assert.ok(successAuditIndex > clearIndex, "account failures must be cleared on the verified-success path");
+});


### PR DESCRIPTION
## Defect
Staff login throttling was scoped only to `cf-connecting-ip`. With intentionally supported 6-digit staff PINs, an attacker could distribute guesses for one account across many source IPs and avoid the per-IP bucket. The same IP-only design also means shared hospital NAT traffic shares one coarse bucket.

## Fix
- preserve the existing Cloudflare-IP login limiter unchanged;
- add an independent account-scoped failure limiter keyed only by SHA-256 of the normalized phone/email identifier;
- check account lockout before password verification;
- consume the account bucket only after failed credential verification, including unknown/compromised accounts;
- clear accumulated account failures after a verified successful login;
- keep unknown and real identifiers on the same response path to avoid an account-enumeration oracle;
- store no raw phone/email value in `request_limits`.

## Regression coverage
- proves staff login uses independent IP and account buckets;
- proves account lockout is checked before password verification;
- proves only failed verification consumes the account failure bucket;
- proves successful login clears the account failure bucket;
- proves account rate-limit keys are SHA-256-derived rather than raw identifiers.

No D1 schema/posting changes. Production deploy is intentionally not part of this PR.