### PR TITLE
Canonicalize staff login account throttling

### DIFF
--- a/app/api/staff/login/route.ts
+++ b/app/api/staff/login/route.ts
@@ -35,20 +35,6 @@ export async function POST(request: Request) {
     return Response.json({ error: "Вкажіть номер телефону і PIN-код" }, { status: 400 });
   }
 
-  // Окремий hashed account bucket не дає обходити 6-значний PIN через
-  // distributed brute-force з багатьох IP. Невідомі акаунти лімітуються так само,
-  // тому відповідь не створює account-enumeration oracle.
-  const loginIdentifier = phone ? `phone:${phone}` : `email:${email}`;
-  if (await isIdentifierRateLimited(
-    db,
-    "staff-login-account",
-    loginIdentifier,
-    STAFF_LOGIN_LIMIT,
-    STAFF_LOGIN_WINDOW_MINUTES,
-  )) {
-    return Response.json({ error: "Забагато спроб входу. Спробуйте за 15 хвилин." }, { status: 429 });
-  }
-
   // Вхід за номером телефону (основний) або email (сумісність).
   const member = phone
     ? await db.prepare(
@@ -58,13 +44,29 @@ export async function POST(request: Request) {
         "SELECT email, display_name AS displayName, role, password_hash AS passwordHash FROM staff_members WHERE email = ? AND active = 1 LIMIT 1"
       ).bind(email).first<{ email: string; displayName: string; role: string; passwordHash: string }>();
 
+  // Known accounts are always throttled by one canonical account key, regardless
+  // of whether the caller supplied phone or email. Unknown identifiers still get
+  // their own hashed failure bucket, so raw phone/email values never reach
+  // request_limits and repeated guesses for a nonexistent identifier are bounded.
+  const submittedIdentifier = phone ? `phone:${phone}` : `email:${email}`;
+  const accountIdentifier = member ? `account:${member.email.toLowerCase()}` : submittedIdentifier;
+  if (await isIdentifierRateLimited(
+    db,
+    "staff-login-account",
+    accountIdentifier,
+    STAFF_LOGIN_LIMIT,
+    STAFF_LOGIN_WINDOW_MINUTES,
+  )) {
+    return Response.json({ error: "Забагато спроб входу. Спробуйте за 15 хвилин." }, { status: 429 });
+  }
+
   const compromised = member ? isCompromisedPasswordHash(member.passwordHash) : false;
   const ok = member && !compromised ? await verifyPassword(password, member.passwordHash) : false;
   if (!member || !ok) {
     await recordIdentifierRateLimitFailure(
       db,
       "staff-login-account",
-      loginIdentifier,
+      accountIdentifier,
       STAFF_LOGIN_LIMIT,
       STAFF_LOGIN_WINDOW_MINUTES,
     );
@@ -81,7 +83,7 @@ export async function POST(request: Request) {
     }, { status: 401 });
   }
 
-  await clearIdentifierRateLimit(db, "staff-login-account", loginIdentifier);
+  await clearIdentifierRateLimit(db, "staff-login-account", accountIdentifier);
 
   if (passwordHashNeedsUpgrade(member.passwordHash)) {
     await db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")

--- a/tests/staff-login-account-rate-limit.test.mjs
+++ b/tests/staff-login-account-rate-limit.test.mjs
@@ -4,21 +4,32 @@ import test from "node:test";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-test("staff login uses independent IP and account rate-limit buckets", async () => {
+test("staff login uses independent IP and canonical account rate-limit buckets", async () => {
   const login = await read("app/api/staff/login/route.ts");
 
   assert.match(login, /isRateLimited\(db, request, "staff-login"/);
-  assert.match(login, /isIdentifierRateLimited\([\s\S]*"staff-login-account"/);
-  assert.match(login, /recordIdentifierRateLimitFailure\([\s\S]*"staff-login-account"/);
-  assert.match(login, /clearIdentifierRateLimit\(db, "staff-login-account", loginIdentifier\)/);
-  assert.match(login, /phone:\$\{phone\}/);
-  assert.match(login, /email:\$\{email\}/);
+  assert.match(login, /const submittedIdentifier = phone \? `phone:\$\{phone\}` : `email:\$\{email\}`/);
+  assert.match(login, /const accountIdentifier = member \? `account:\$\{member\.email\.toLowerCase\(\)\}` : submittedIdentifier/);
+  assert.match(login, /isIdentifierRateLimited\([\s\S]*"staff-login-account"[\s\S]*accountIdentifier/);
+  assert.match(login, /recordIdentifierRateLimitFailure\([\s\S]*"staff-login-account"[\s\S]*accountIdentifier/);
+  assert.match(login, /clearIdentifierRateLimit\(db, "staff-login-account", accountIdentifier\)/);
 
+  const lookupIndex = login.indexOf("const member = phone");
   const checkIndex = login.indexOf("isIdentifierRateLimited(");
   const verifyIndex = login.indexOf("verifyPassword(password");
   const recordIndex = login.indexOf("recordIdentifierRateLimitFailure(");
+  assert.ok(lookupIndex >= 0 && lookupIndex < checkIndex, "known aliases must resolve to the member before account throttling");
   assert.ok(checkIndex >= 0 && checkIndex < verifyIndex, "account lockout must be checked before password verification");
   assert.ok(recordIndex > verifyIndex, "only failed credential verification should consume the account failure bucket");
+});
+
+test("phone and email aliases share one known-account failure key", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+
+  assert.match(login, /member \? `account:\$\{member\.email\.toLowerCase\(\)\}` : submittedIdentifier/);
+  assert.doesNotMatch(login, /isIdentifierRateLimited\([\s\S]*loginIdentifier/);
+  assert.doesNotMatch(login, /recordIdentifierRateLimitFailure\([\s\S]*loginIdentifier/);
+  assert.doesNotMatch(login, /clearIdentifierRateLimit\([^\n]*loginIdentifier/);
 });
 
 test("account rate-limit keys are hashed and never stored as raw identifiers", async () => {
@@ -33,11 +44,11 @@ test("account rate-limit keys are hashed and never stored as raw identifiers", a
   assert.doesNotMatch(limiter, /INSERT INTO request_limits[^\n]*identifier/i);
 });
 
-test("successful staff login clears only the account failure bucket", async () => {
+test("successful staff login clears the canonical account failure bucket", async () => {
   const login = await read("app/api/staff/login/route.ts");
-  const clearIndex = login.indexOf("clearIdentifierRateLimit(db, \"staff-login-account\", loginIdentifier)");
+  const clearIndex = login.indexOf("clearIdentifierRateLimit(db, \"staff-login-account\", accountIdentifier)");
   const successAuditIndex = login.indexOf('action: "login", resource: "auth"');
 
-  assert.ok(clearIndex >= 0, "successful login must clear accumulated account failures");
+  assert.ok(clearIndex >= 0, "successful login must clear accumulated canonical account failures");
   assert.ok(successAuditIndex > clearIndex, "account failures must be cleared on the verified-success path");
 });


### PR DESCRIPTION
## Security finding
The staff-login account limiter was keyed by the submitted login identifier. A known staff member with both phone and email therefore had two independent account buckets, allowing alias-based brute-force amplification and leaving one alias locked after a successful login through the other.

## Fix
- resolve the staff member before account-bucket lookup
- use one canonical `account:<member.email>` key for every known account
- keep a hashed submitted-identifier bucket for unknown accounts
- keep the independent IP limiter unchanged
- clear the canonical account bucket on successful authentication

## Tests
- assert phone/email aliases converge on the canonical known-account key
- assert account throttling remains before password verification
- assert failed verification records only the canonical account bucket
- assert successful login clears that bucket
- retain coverage that raw identifiers are not stored in `request_limits`

Production deploy is intentionally not part of this PR.