### PR TITLE
Remove staff login account-enumeration oracle

### DIFF
--- a/app/api/staff/login/route.ts
+++ b/app/api/staff/login/route.ts
@@ -61,7 +61,10 @@ export async function POST(request: Request) {
   }
 
   const compromised = member ? isCompromisedPasswordHash(member.passwordHash) : false;
-  const ok = member && !compromised ? await verifyPassword(password, member.passwordHash) : false;
+  // Always run PBKDF2 after the limiter. For unknown or deliberately blocked
+  // accounts verifyPassword receives an empty hash and performs dummy KDF work,
+  // removing the large timing difference that would reveal account existence.
+  const ok = await verifyPassword(password, member && !compromised ? member.passwordHash : "");
   if (!member || !ok) {
     await recordIdentifierRateLimitFailure(
       db,
@@ -76,11 +79,7 @@ export async function POST(request: Request) {
       action: "login_failed", resource: "auth",
       details: { reason: compromised ? "compromised" : member ? "wrong_password" : "unknown_account" },
     });
-    return Response.json({
-      error: compromised
-        ? "Початковий PIN заблоковано. Зверніться до адміністратора для безпечної заміни."
-        : "Невірний номер телефону або PIN-код",
-    }, { status: 401 });
+    return Response.json({ error: "Невірний номер телефону або PIN-код" }, { status: 401 });
   }
 
   await clearIdentifierRateLimit(db, "staff-login-account", accountIdentifier);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,6 +11,14 @@
 const PBKDF2_ITERATIONS = 100000;
 const PBKDF2_KEYLEN = 32;
 
+// Missing accounts must still perform the same expensive KDF class as valid
+// accounts; otherwise remote callers can enumerate staff identifiers by timing
+// the login response. This salt is not a credential and never leaves the worker.
+const DUMMY_PASSWORD_SALT = new Uint8Array([
+  0x72, 0x61, 0x64, 0x69, 0x6f, 0x6c, 0x6f, 0x67,
+  0x79, 0x6f, 0x73, 0x2d, 0x61, 0x75, 0x74, 0x68,
+]);
+
 export const SESSION_COOKIE = "rid_session";
 export const SESSION_TTL_SECONDS = 60 * 60 * 12; // 12 hours
 
@@ -55,7 +63,10 @@ export async function hashPassword(password: string): Promise<string> {
 }
 
 export async function verifyPassword(password: string, encoded: string): Promise<boolean> {
-  if (!encoded) return false;
+  if (!encoded) {
+    await pbkdf2(password, DUMMY_PASSWORD_SALT, PBKDF2_ITERATIONS);
+    return false;
+  }
   const parts = encoded.split("$");
   if (parts.length !== 5 || parts[0] !== "pbkdf2" || parts[1] !== "sha256") return false;
   const iterations = Number(parts[2]);

--- a/tests/auth-hash.test.mjs
+++ b/tests/auth-hash.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
   hashPassword, verifyPassword, passwordHashNeedsUpgrade,
@@ -34,6 +35,12 @@ test("verifyPassword rejects malformed or empty hashes without throwing", async 
   assert.equal(await verifyPassword("x", "pbkdf2$sha256$999$c2FsdA==$ZGVyaXZlZA=="), false); // ітерацій < 1000
   assert.equal(await verifyPassword("x", "md5$sha256$100000$c2FsdA==$ZGVyaXZlZA=="), false); // не pbkdf2
   assert.equal(await verifyPassword("x", "pbkdf2$sha256$100000$@@@$@@@"), false); // невалідний base64
+});
+
+test("empty password hashes still burn the normal PBKDF2 work factor", async () => {
+  const source = await readFile(new URL("../lib/auth.ts", import.meta.url), "utf8");
+  assert.match(source, /const DUMMY_PASSWORD_SALT = new Uint8Array/);
+  assert.match(source, /if \(!encoded\) \{[\s\S]*await pbkdf2\(password, DUMMY_PASSWORD_SALT, PBKDF2_ITERATIONS\);[\s\S]*return false;/);
 });
 
 test("verifyPassword honours the iteration count stored in the hash", async () => {

--- a/tests/staff-login-account-rate-limit.test.mjs
+++ b/tests/staff-login-account-rate-limit.test.mjs
@@ -32,6 +32,14 @@ test("phone and email aliases share one known-account failure key", async () => 
   assert.doesNotMatch(login, /clearIdentifierRateLimit\([^\n]*loginIdentifier/);
 });
 
+test("unknown and blocked staff accounts do not expose an enumeration oracle", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+
+  assert.match(login, /const ok = await verifyPassword\(password, member && !compromised \? member\.passwordHash : ""\)/);
+  assert.match(login, /return Response\.json\(\{ error: "Невірний номер телефону або PIN-код" \}, \{ status: 401 \}\)/);
+  assert.doesNotMatch(login, /Початковий PIN заблоковано/);
+});
+
 test("account rate-limit keys are hashed and never stored as raw identifiers", async () => {
   const limiter = await read("lib/rate-limit.ts");
 


### PR DESCRIPTION
## Security finding
Staff login returned the same generic error for most failures, but unknown accounts skipped PBKDF2 entirely while known accounts performed a 100k-iteration verification. That creates a remotely observable timing difference. The deliberately blocked published bootstrap hash also returned a distinct client error, exposing account state directly.

## Fix
- empty password hashes now perform a dummy PBKDF2 operation with the normal work factor before returning false
- staff login always calls `verifyPassword` after rate-limit checks, including unknown/blocked accounts
- failed login responses are generic regardless of account existence or compromised-bootstrap state
- detailed failure reason remains in the internal security audit
- existing IP + canonical-account throttles remain unchanged

## Tests
- verify the empty-hash path burns PBKDF2 work
- verify login sends missing/blocked accounts through the same password-verification primitive
- verify the special compromised-account client message cannot regress
- retain the canonical-account rate-limit ordering tests

Production deploy is intentionally excluded.