### PR TITLE
Retire legacy booking protocol write surface

### DIFF
--- a/app/api/staff/bookings/route.ts
+++ b/app/api/staff/bookings/route.ts
@@ -10,7 +10,6 @@ import { canTransition, isStudyState, stateLabel } from "../../../../lib/study-s
 import {
   canManageBookings,
   canManageFinance,
-  canManageProtocols,
   canAccessBooking,
   canWriteNotes,
   type StaffRole,
@@ -415,54 +414,14 @@ export async function PATCH(request: Request) {
     });
   }
 
+  // `protocols` is the only clinical source of truth. Keep recognizing the
+  // legacy booking payload so stale clients fail closed with a controlled
+  // response instead of reaching the D1 projection guard and surfacing a 500.
   if (typeof body.protocolStatus === "string" || typeof body.protocolNumber === "string") {
-    if (!canManageProtocols(member.role)) {
-      return Response.json({ error: "Протоколи може змінювати лише лікар або адміністратор" }, { status: 403 });
-    }
-    const protocolStatuses = new Set(["not_started", "in_progress", "ready", "issued"]);
-    const protocolStatus = String(body.protocolStatus || "");
-    const protocolNumber = String(body.protocolNumber || "").trim().slice(0, 80);
-    if (!protocolStatuses.has(protocolStatus)) {
-      return Response.json({ error: "Некоректний статус протоколу" }, { status: 400 });
-    }
-    if ((protocolStatus === "ready" || protocolStatus === "issued") && !protocolNumber) {
-      return Response.json({ error: "Для готового або виданого протоколу вкажіть його номер" }, { status: 400 });
-    }
-    const current = await db.prepare(
-      "SELECT protocol_status AS protocolStatus FROM bookings WHERE organization_id = ? AND id = ? LIMIT 1"
-    ).bind(ctx.organizationId, body.id).first<{ protocolStatus: string }>();
-    const protocolTransitions: Record<string, string[]> = {
-      not_started: ["in_progress"],
-      in_progress: ["ready"],
-      ready: ["issued"],
-      issued: [],
-    };
-    if (
-      current
-      && protocolStatus !== current.protocolStatus
-      && !(protocolTransitions[current.protocolStatus] || []).includes(protocolStatus)
-    ) {
-      return Response.json({ error: "Неможливо повернути протокол до попереднього статусу" }, { status: 409 });
-    }
-    const updated = await db.prepare(
-      `UPDATE bookings SET protocol_number = ?, protocol_status = ?,
-       protocol_updated_at = CURRENT_TIMESTAMP,
-       protocol_ready_at = CASE
-         WHEN ? IN ('ready','issued') AND protocol_ready_at = '' THEN CURRENT_TIMESTAMP
-         ELSE protocol_ready_at END,
-       protocol_issued_at = CASE
-         WHEN ? = 'issued' AND protocol_issued_at = '' THEN CURRENT_TIMESTAMP
-         ELSE protocol_issued_at END
-       WHERE organization_id = ? AND id = ?`
-    ).bind(protocolNumber, protocolStatus, protocolStatus, protocolStatus, ctx.organizationId, body.id).run();
-    if (!updated.meta.changes) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
-    await db.prepare(
-      "INSERT INTO booking_events (organization_id, booking_id, action, details, actor) VALUES (?, ?, 'protocol_updated', ?, ?)"
-    ).bind(ctx.organizationId, body.id, `${protocolStatus}${protocolNumber ? ` · ${protocolNumber}` : ""}`, member.email).run();
-    const protocolDates = await db.prepare(
-      "SELECT protocol_ready_at AS protocolReadyAt, protocol_issued_at AS protocolIssuedAt FROM bookings WHERE organization_id = ? AND id = ?"
-    ).bind(ctx.organizationId, body.id).first<{protocolReadyAt:string;protocolIssuedAt:string}>();
-    return Response.json({ ok: true, protocolNumber, protocolStatus, ...protocolDates });
+    return Response.json(
+      { error: "Статус і номер протоколу змінюються лише через редактор протоколів" },
+      { status: 409 },
+    );
   }
 
   if (

--- a/tests/protocol-lifecycle-consistency.behavior.test.mjs
+++ b/tests/protocol-lifecycle-consistency.behavior.test.mjs
@@ -143,3 +143,25 @@ test("lifecycle migrations protect projection and explicit signing semantics", a
     "the API must not append issue events independently of the actual D1 state transition",
   );
 });
+
+test("legacy bookings PATCH cannot mutate protocol projection or forge lifecycle events", async () => {
+  const route = await read("app/api/staff/bookings/route.ts");
+
+  assert.match(
+    route,
+    /typeof body\.protocolStatus === "string" \|\| typeof body\.protocolNumber === "string"/,
+    "legacy protocol payloads must be recognized and rejected explicitly",
+  );
+  assert.match(route, /Статус і номер протоколу змінюються лише через редактор протоколів/);
+  assert.match(route, /\{ status: 409 \}/);
+  assert.doesNotMatch(
+    route,
+    /UPDATE bookings SET protocol_number = \?, protocol_status = \?/,
+    "booking API must never write the protocol read-model directly",
+  );
+  assert.doesNotMatch(
+    route,
+    /'protocol_updated'/,
+    "booking API must never forge protocol lifecycle audit events",
+  );
+});


### PR DESCRIPTION
## Security finding
`PATCH /api/staff/bookings` still accepted `protocolStatus` / `protocolNumber` and attempted to write the legacy booking projection directly. D1 already protects the immutable protocol source-of-truth with `bookings_protocol_projection_guard`, so mismatched writes abort at the database layer and can surface as a 500. Matching/no-op writes could also manufacture a `protocol_updated` event outside the real clinical revision/signing lifecycle.

## Fix
- keep recognizing legacy protocol fields for compatibility
- fail closed with a controlled 409 before any protocol DB mutation
- remove the direct `bookings.protocol_*` write path
- remove booking-level `protocol_updated` audit/event creation
- leave the authoritative `/api/staff/protocols` + D1 signing/issuance lifecycle unchanged

## Tests
- assert legacy booking protocol payloads are explicitly rejected
- assert the bookings API contains no direct protocol projection UPDATE
- assert the bookings API cannot create `protocol_updated` lifecycle events
- retain D1 projection/signing/issuance consistency coverage

Production deploy is intentionally excluded.