### PR TITLE
Revoke staff sessions when final membership is disabled

### DIFF
--- a/app/api/staff/members/route.ts
+++ b/app/api/staff/members/route.ts
@@ -91,8 +91,11 @@ export async function POST(request: Request) {
       "SELECT role, active FROM memberships WHERE organization_id = ? AND member_email = ? LIMIT 1"
     ).bind(ctx.organizationId, email).first<{ role:string; active:number }>(),
     db.prepare(
-      "SELECT 1 AS ok FROM memberships WHERE member_email = ? AND organization_id <> ? LIMIT 1"
-    ).bind(email, ctx.organizationId).first<{ ok:number }>(),
+      `SELECT active FROM memberships
+       WHERE member_email = ? AND organization_id <> ?
+       ORDER BY active DESC
+       LIMIT 1`
+    ).bind(email, ctx.organizationId).first<{ active:number }>(),
   ]);
   if (!identity && !password) {
     return Response.json({ error: "Для нового працівника потрібно задати PIN-код" }, { status: 400 });
@@ -103,6 +106,7 @@ export async function POST(request: Request) {
   }
 
   const sharedIdentity = Boolean(identity && otherMembership);
+  const hasOtherActiveMembership = Number(otherMembership?.active) === 1;
   if (sharedIdentity && identity) {
     const sameProfile =
       String(identity.phone || "") === phone &&
@@ -147,10 +151,10 @@ export async function POST(request: Request) {
     ).bind(ctx.organizationId, email, role, active),
   );
 
-  // Membership deactivation is an account-security boundary. Revoke all current
-  // sessions immediately so an already issued (or stolen) token cannot become
-  // usable again merely because this membership is re-enabled before it expires.
-  if (existing && existing.active === 1 && active === 0) {
+  // Identity sessions are shared across tenants. Revoke them only when this
+  // deactivation removes the member's final active organization access; otherwise
+  // preserve sessions that are still legitimately needed by another organization.
+  if (existing && existing.active === 1 && active === 0 && !hasOtherActiveMembership) {
     statements.push(db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(email));
   }
 

--- a/app/api/staff/members/route.ts
+++ b/app/api/staff/members/route.ts
@@ -147,6 +147,13 @@ export async function POST(request: Request) {
     ).bind(ctx.organizationId, email, role, active),
   );
 
+  // Membership deactivation is an account-security boundary. Revoke all current
+  // sessions immediately so an already issued (or stolen) token cannot become
+  // usable again merely because this membership is re-enabled before it expires.
+  if (existing && existing.active === 1 && active === 0) {
+    statements.push(db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(email));
+  }
+
   if (password) {
     statements.push(
       db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")

--- a/tests/staff-auth.test.mjs
+++ b/tests/staff-auth.test.mjs
@@ -50,9 +50,10 @@ test("login and logout endpoints verify credentials, rate-limit and manage the c
   assert.match(logout, /clearedSessionCookie\(/);
 });
 
-test("disabling a staff membership revokes existing sessions", async () => {
+test("disabling the final active staff membership revokes existing sessions", async () => {
   const members = await read("app/api/staff/members/route.ts");
-  assert.match(members, /existing && existing\.active === 1 && active === 0/);
+  assert.match(members, /existing && existing\.active === 1 && active === 0 && !hasOtherActiveMembership/);
+  assert.match(members, /ORDER BY active DESC/);
   assert.match(members, /DELETE FROM staff_sessions WHERE email = \?/);
 });
 

--- a/tests/staff-auth.test.mjs
+++ b/tests/staff-auth.test.mjs
@@ -50,6 +50,12 @@ test("login and logout endpoints verify credentials, rate-limit and manage the c
   assert.match(logout, /clearedSessionCookie\(/);
 });
 
+test("disabling a staff membership revokes existing sessions", async () => {
+  const members = await read("app/api/staff/members/route.ts");
+  assert.match(members, /existing && existing\.active === 1 && active === 0/);
+  assert.match(members, /DELETE FROM staff_sessions WHERE email = \?/);
+});
+
 test("no ChatGPT sign-in remains anywhere in the app", async () => {
   for (const file of [
     "app/page.tsx", "app/layout.tsx", "app/robots.ts", "app/sitemap.ts",

--- a/tests/staff-session-revocation.behavior.test.mjs
+++ b/tests/staff-session-revocation.behavior.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+test("disabling the final active membership revokes that identity's sessions", async () => {
+  await withD1(async (db) => {
+    const phone = "380502225566";
+    const email = `${phone}@phone.local`;
+    await seedStaffSession(db, {
+      email,
+      role: "radiologist",
+      displayName: "Останній Працівник Іванович",
+      organizationId: 1,
+    });
+    await db.prepare(
+      `UPDATE staff_members SET
+         phone = ?, display_name = 'Останній Працівник Іванович',
+         last_name = 'Останній', first_name = 'Працівник', patronymic = 'Іванович',
+         contact_email = 'last@example.com', military_rank = 'капітан',
+         position_title = 'лікар-рентгенолог'
+       WHERE email = ?`,
+    ).bind(phone, email).run();
+
+    const adminCookie = await seedStaffSession(db, {
+      email: "final-membership-admin@example.com",
+      role: "admin",
+      organizationId: 1,
+    });
+
+    const response = await callWorker(jsonRequest(
+      "/api/staff/members",
+      {
+        phone: `+${phone}`,
+        lastName: "Останній",
+        firstName: "Працівник",
+        patronymic: "Іванович",
+        contactEmail: "last@example.com",
+        militaryRank: "капітан",
+        positionTitle: "лікар-рентгенолог",
+        role: "radiologist",
+        active: false,
+      },
+      { headers: { cookie: adminCookie } },
+    ), db);
+    assert.equal(response.status, 201);
+
+    const membership = await db.prepare(
+      "SELECT active FROM memberships WHERE organization_id = 1 AND member_email = ?",
+    ).bind(email).first();
+    assert.equal(membership.active, 0);
+
+    const victimSessions = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(victimSessions.n, 0);
+
+    const adminSessions = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = 'final-membership-admin@example.com'",
+    ).first();
+    assert.equal(adminSessions.n, 1);
+  });
+});


### PR DESCRIPTION
Security hardening for the staff membership lifecycle.

- revoke identity-level staff sessions when an active membership is disabled and no other active organization membership remains
- preserve sessions when the same identity still has legitimate access to another organization
- prevents a token from becoming usable again after final-membership reactivation within the original session lifetime
- adds source regression coverage plus D1 behavioral coverage for both multi-tenant preservation and final-membership revocation

Production deploy is not part of this PR.