### PR TITLE
Block staff login without active tenant membership

### DIFF
--- a/app/api/staff/login/route.ts
+++ b/app/api/staff/login/route.ts
@@ -20,6 +20,12 @@ import { audit } from "../../../../lib/audit";
 const STAFF_LOGIN_LIMIT = 10;
 const STAFF_LOGIN_WINDOW_MINUTES = 15;
 
+type TenantAccessState = {
+  activeMembershipCount: number;
+  membershipCount: number;
+  activeOrgCount: number;
+};
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
@@ -60,24 +66,61 @@ export async function POST(request: Request) {
     return Response.json({ error: "Забагато спроб входу. Спробуйте за 15 хвилин." }, { status: 429 });
   }
 
+  // Authentication is identity-level, but a session must only be issued when the
+  // identity still has usable tenant access. Otherwise a user whose final
+  // membership was disabled could immediately log in again and keep a fresh token
+  // that would become usable if the membership were re-enabled before expiry.
+  // Preserve the legacy bootstrap path only for a genuinely empty, single-org
+  // installation, matching resolveOrgContext() exactly.
+  const accessState = member
+    ? await db.prepare(
+        `SELECT
+           (SELECT COUNT(*)
+              FROM memberships m
+              JOIN organizations o ON o.id = m.organization_id AND o.active = 1
+             WHERE m.member_email = ? AND m.active = 1) AS activeMembershipCount,
+           (SELECT COUNT(*) FROM memberships) AS membershipCount,
+           (SELECT COUNT(*) FROM organizations WHERE active = 1) AS activeOrgCount`
+      ).bind(member.email).first<TenantAccessState>()
+    : null;
+  const hasTenantAccess = Boolean(
+    member && accessState && (
+      Number(accessState.activeMembershipCount) > 0 ||
+      (Number(accessState.membershipCount) === 0 && Number(accessState.activeOrgCount) === 1)
+    )
+  );
+
   const compromised = member ? isCompromisedPasswordHash(member.passwordHash) : false;
   // Always run PBKDF2 after the limiter. For unknown or deliberately blocked
   // accounts verifyPassword receives an empty hash and performs dummy KDF work,
   // removing the large timing difference that would reveal account existence.
   const ok = await verifyPassword(password, member && !compromised ? member.passwordHash : "");
-  if (!member || !ok) {
-    await recordIdentifierRateLimitFailure(
-      db,
-      "staff-login-account",
-      accountIdentifier,
-      STAFF_LOGIN_LIMIT,
-      STAFF_LOGIN_WINDOW_MINUTES,
-    );
+  if (!member || !ok || !hasTenantAccess) {
+    // A correct credential for a membership-disabled identity is an authorization
+    // denial, not a credential failure, so it must not consume the account's
+    // password-failure bucket. The response stays identical to prevent enumeration.
+    if (!member || !ok) {
+      await recordIdentifierRateLimitFailure(
+        db,
+        "staff-login-account",
+        accountIdentifier,
+        STAFF_LOGIN_LIMIT,
+        STAFF_LOGIN_WINDOW_MINUTES,
+      );
+    }
     await audit(db, {
       organizationId: 1,
       actorEmail: member?.email || phone || email || "невідомо",
       action: "login_failed", resource: "auth",
-      details: { reason: compromised ? "compromised" : member ? "wrong_password" : "unknown_account" },
+      details: {
+        reason: compromised
+          ? "compromised"
+          : member && ok && !hasTenantAccess
+            ? "no_active_membership"
+            : member
+              ? "wrong_password"
+              : "unknown_account",
+      },
     });
     return Response.json({ error: "Невірний номер телефону або PIN-код" }, { status: 401 });
   }

--- a/tests/staff-login-membership.behavior.test.mjs
+++ b/tests/staff-login-membership.behavior.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const TEST_PASSWORD_HASH = "pbkdf2$sha256$100000$bWVtYmVyc2hpcC10ZXN0IQ==$2/9vE4JQ+7or+3sxZDWVYBEZFHg+JGSjVqOivgvaoPs=";
+
+test("staff login refuses a valid PIN when no active tenant membership remains", async () => {
+  await withD1(async (db) => {
+    const phone = "380502225544";
+    const email = `${phone}@phone.local`;
+    await seedStaffSession(db, {
+      email,
+      role: "radiologist",
+      displayName: "Деактивований Працівник",
+      organizationId: 1,
+    });
+    await db.prepare(
+      "UPDATE staff_members SET phone = ?, password_hash = ? WHERE email = ?",
+    ).bind(phone, TEST_PASSWORD_HASH, email).run();
+    await db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(email).run();
+    await db.prepare(
+      "UPDATE memberships SET active = 0 WHERE organization_id = 1 AND member_email = ?",
+    ).bind(email).run();
+
+    const denied = await callWorker(jsonRequest(
+      "/api/staff/login",
+      { phone: `+${phone}`, password: "123456" },
+      { ip: "203.0.113.44" },
+    ), db);
+    assert.equal(denied.status, 401);
+    assert.equal(denied.headers.get("set-cookie"), null);
+    assert.equal((await denied.json()).error, "Невірний номер телефону або PIN-код");
+
+    const disabledSessions = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(disabledSessions.n, 0);
+
+    await db.prepare(
+      "UPDATE memberships SET active = 1 WHERE organization_id = 1 AND member_email = ?",
+    ).bind(email).run();
+
+    const allowed = await callWorker(jsonRequest(
+      "/api/staff/login",
+      { phone: `+${phone}`, password: "123456" },
+      { ip: "203.0.113.45" },
+    ), db);
+    assert.equal(allowed.status, 200);
+    assert.match(allowed.headers.get("set-cookie") || "", /rid_session=/);
+
+    const activeSessions = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(activeSessions.n, 1);
+  });
+});

--- a/tests/staff-login-membership.test.mjs
+++ b/tests/staff-login-membership.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("staff login issues sessions only to identities with active tenant access", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+
+  assert.match(login, /FROM memberships m[\s\S]*JOIN organizations o ON o\.id = m\.organization_id AND o\.active = 1/);
+  assert.match(login, /m\.member_email = \? AND m\.active = 1/);
+  assert.match(login, /const hasTenantAccess = Boolean/);
+  assert.match(login, /!member \|\| !ok \|\| !hasTenantAccess/);
+  assert.match(login, /no_active_membership/);
+
+  const accessCheck = login.indexOf("const hasTenantAccess = Boolean");
+  const sessionIssue = login.indexOf("createSession(db, member.email)");
+  assert.ok(accessCheck >= 0 && sessionIssue > accessCheck, "tenant access must be checked before a staff session is issued");
+});
+
+test("membership-disabled login is not counted as a wrong-PIN failure", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+  assert.match(login, /if \(!member \|\| !ok\) \{[\s\S]*recordIdentifierRateLimitFailure/);
+  assert.doesNotMatch(login, /if \(!member \|\| !ok \|\| !hasTenantAccess\) \{\s*await recordIdentifierRateLimitFailure/);
+});


### PR DESCRIPTION
Security hardening for staff authentication after membership deactivation.

- require at least one active membership in an active organization before issuing a staff session
- preserve the existing legacy bootstrap rule only for a genuinely empty single-organization installation
- keep the generic 401 response so membership state is not exposed
- do not consume the wrong-PIN account failure bucket when the supplied credential is correct but tenant authorization is disabled
- add source regression coverage and D1 behavioral coverage for disabled -> denied/no session and reactivated -> allowed/session

Production deploy is not part of this PR.