### PR TITLE
Tenant-scope staff login audit events

### DIFF
--- a/app/api/staff/login/route.ts
+++ b/app/api/staff/login/route.ts
@@ -26,6 +26,74 @@ type TenantAccessState = {
   activeOrgCount: number;
 };
 
+type AuditOrganizationRow = { organizationId: number };
+
+async function authAuditOrganizationIds(
+  db: D1Database,
+  memberEmail: string | null,
+  { activeOnly, allowSingleOrgFallback }: { activeOnly: boolean; allowSingleOrgFallback: boolean },
+): Promise<number[]> {
+  if (memberEmail) {
+    const activeClause = activeOnly ? "AND m.active = 1 AND o.active = 1" : "";
+    const linked = await db.prepare(
+      `SELECT DISTINCT m.organization_id AS organizationId
+       FROM memberships m
+       JOIN organizations o ON o.id = m.organization_id
+       WHERE m.member_email = ? ${activeClause}
+       ORDER BY m.organization_id`
+    ).bind(memberEmail).all<AuditOrganizationRow>();
+    const ids = linked.results
+      .map((row) => Number(row.organizationId))
+      .filter((id) => Number.isInteger(id) && id > 0);
+    if (ids.length > 0) return ids;
+  }
+
+  // Unknown identifiers have no tenant identity. In a true single-org deployment
+  // the sole active organization is the only meaningful audit owner; in multi-org
+  // installations we deliberately avoid attributing the guess to an arbitrary
+  // tenant. The same fallback supports the legacy empty-membership bootstrap.
+  if (!allowSingleOrgFallback) return [];
+  const activeOrganizations = await db.prepare(
+    "SELECT id AS organizationId FROM organizations WHERE active = 1 ORDER BY id LIMIT 2"
+  ).all<AuditOrganizationRow>();
+  if (activeOrganizations.results.length !== 1) return [];
+  const organizationId = Number(activeOrganizations.results[0]?.organizationId);
+  return Number.isInteger(organizationId) && organizationId > 0 ? [organizationId] : [];
+}
+
+async function auditAuthEvent(
+  db: D1Database,
+  {
+    memberEmail,
+    actorEmail,
+    action,
+    details,
+    activeOnly = false,
+    allowSingleOrgFallback = false,
+  }: {
+    memberEmail: string | null;
+    actorEmail: string;
+    action: "login" | "login_failed";
+    details: Record<string, unknown>;
+    activeOnly?: boolean;
+    allowSingleOrgFallback?: boolean;
+  },
+): Promise<void> {
+  const organizationIds = await authAuditOrganizationIds(db, memberEmail, {
+    activeOnly,
+    allowSingleOrgFallback,
+  });
+  for (const organizationId of organizationIds) {
+    await audit(db, {
+      organizationId,
+      actorEmail,
+      action,
+      resource: "auth",
+      details,
+    });
+  }
+}
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "Сервіс тимчасово недоступний" }, { status: 503 });
@@ -108,10 +176,11 @@ export async function POST(request: Request) {
         STAFF_LOGIN_WINDOW_MINUTES,
       );
     }
-    await audit(db, {
-      organizationId: 1,
+    await auditAuthEvent(db, {
+      memberEmail: member?.email || null,
       actorEmail: member?.email || phone || email || "невідомо",
-      action: "login_failed", resource: "auth",
+      action: "login_failed",
+      allowSingleOrgFallback: !member || Number(accessState?.membershipCount) === 0,
       details: {
         reason: compromised
           ? "compromised"
@@ -132,9 +201,13 @@ export async function POST(request: Request) {
       .bind(await hashPassword(password), member.email).run();
   }
 
-  await audit(db, {
-    organizationId: 1, actorEmail: member.email,
-    action: "login", resource: "auth", details: { via: phone ? "phone" : "email" },
+  await auditAuthEvent(db, {
+    memberEmail: member.email,
+    actorEmail: member.email,
+    action: "login",
+    activeOnly: true,
+    allowSingleOrgFallback: Number(accessState?.membershipCount) === 0,
+    details: { via: phone ? "phone" : "email" },
   });
   const rawToken = await createSession(db, member.email);
   return Response.json(

--- a/tests/staff-login-account-rate-limit.test.mjs
+++ b/tests/staff-login-account-rate-limit.test.mjs
@@ -55,8 +55,13 @@ test("account rate-limit keys are hashed and never stored as raw identifiers", a
 test("successful staff login clears the canonical account failure bucket", async () => {
   const login = await read("app/api/staff/login/route.ts");
   const clearIndex = login.indexOf("clearIdentifierRateLimit(db, \"staff-login-account\", accountIdentifier)");
-  const successAuditIndex = login.indexOf('action: "login", resource: "auth"');
+  const successAuditIndex = login.indexOf('action: "login",');
 
   assert.ok(clearIndex >= 0, "successful login must clear accumulated canonical account failures");
-  assert.ok(successAuditIndex > clearIndex, "account failures must be cleared on the verified-success path");
+  assert.ok(successAuditIndex > clearIndex, "account failures must be cleared on the verified-success path before login audit");
+  assert.match(
+    login,
+    /async function auditAuthEvent[\s\S]*resource: "auth"/,
+    "tenant-aware auth audit helper must keep login events in the auth resource",
+  );
 });

--- a/tests/staff-login-audit-tenant.behavior.test.mjs
+++ b/tests/staff-login-audit-tenant.behavior.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const TEST_PASSWORD_HASH = "pbkdf2$sha256$100000$bWVtYmVyc2hpcC10ZXN0IQ==$2/9vE4JQ+7or+3sxZDWVYBEZFHg+JGSjVqOivgvaoPs=";
+
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'login-audit-two', 'Login Audit Two', 1)",
+  ).run();
+}
+
+async function seedLoginIdentity(db, { phone, organizationId = 2 }) {
+  const email = `${phone}@phone.local`;
+  await seedStaffSession(db, {
+    email,
+    role: "radiologist",
+    displayName: "Аудит Працівник",
+    organizationId,
+  });
+  await db.prepare(
+    "UPDATE staff_members SET phone = ?, password_hash = ? WHERE email = ?",
+  ).bind(phone, TEST_PASSWORD_HASH, email).run();
+  await db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(email).run();
+  return email;
+}
+
+test("org2 staff login success and failure audit only to org2", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380502225533";
+    const email = await seedLoginIdentity(db, { phone });
+
+    const failed = await callWorker(jsonRequest(
+      "/api/staff/login",
+      { phone: `+${phone}`, password: "654321" },
+      { ip: "203.0.113.53" },
+    ), db);
+    assert.equal(failed.status, 401);
+
+    const failedRows = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'login_failed'
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(failedRows.results.map((row) => row.organizationId), [2]);
+
+    const success = await callWorker(jsonRequest(
+      "/api/staff/login",
+      { phone: `+${phone}`, password: "123456" },
+      { ip: "203.0.113.54" },
+    ), db);
+    assert.equal(success.status, 200);
+
+    const successRows = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'login'
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(successRows.results.map((row) => row.organizationId), [2]);
+
+    const leakedToOrg1 = await db.prepare(
+      "SELECT COUNT(*) AS n FROM security_audit_log WHERE organization_id = 1 AND actor_email = ? AND resource = 'auth'",
+    ).bind(email).first();
+    assert.equal(leakedToOrg1.n, 0);
+  });
+});
+
+test("multi-org identity login is visible to every active organization it can enter", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380502225532";
+    const email = await seedLoginIdentity(db, { phone, organizationId: 1 });
+    await db.prepare(
+      "INSERT INTO memberships (organization_id, member_email, role, active) VALUES (2, ?, 'radiologist', 1)",
+    ).bind(email).run();
+
+    const success = await callWorker(jsonRequest(
+      "/api/staff/login",
+      { phone: `+${phone}`, password: "123456" },
+      { ip: "203.0.113.55" },
+    ), db);
+    assert.equal(success.status, 200);
+
+    const rows = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'login'
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(rows.results.map((row) => row.organizationId), [1, 2]);
+  });
+});
+
+test("unknown login guess is not attributed to an arbitrary tenant in multi-org mode", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const phone = "380502225531";
+
+    const failed = await callWorker(jsonRequest(
+      "/api/staff/login",
+      { phone: `+${phone}`, password: "123456" },
+      { ip: "203.0.113.56" },
+    ), db);
+    assert.equal(failed.status, 401);
+
+    const rows = await db.prepare(
+      "SELECT organization_id AS organizationId FROM security_audit_log WHERE actor_email = ? AND action = 'login_failed'",
+    ).bind(phone).all();
+    assert.deepEqual(rows.results, []);
+  });
+});

--- a/tests/staff-login-audit-tenant.test.mjs
+++ b/tests/staff-login-audit-tenant.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("staff login audit derives tenant ownership instead of hardcoding org1", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+
+  assert.match(login, /async function authAuditOrganizationIds/);
+  assert.match(login, /FROM memberships m[\s\S]*JOIN organizations o ON o\.id = m\.organization_id/);
+  assert.match(login, /activeOnly \? "AND m\.active = 1 AND o\.active = 1" : ""/);
+  assert.match(login, /SELECT id AS organizationId FROM organizations WHERE active = 1 ORDER BY id LIMIT 2/);
+  assert.match(login, /await auditAuthEvent\(db/);
+  assert.doesNotMatch(login, /organizationId:\s*1/);
+});
+
+test("unknown multi-org login is not assigned to a fallback tenant", async () => {
+  const login = await read("app/api/staff/login/route.ts");
+  assert.match(login, /if \(activeOrganizations\.results\.length !== 1\) return \[\]/);
+  assert.match(login, /allowSingleOrgFallback: !member \|\| Number\(accessState\?\.membershipCount\) === 0/);
+});


### PR DESCRIPTION
Tenant-isolation hardening for staff authentication audit events.

- remove hardcoded organization_id=1 from login/login_failed audit writes
- successful login is audited to every active organization membership the identity can enter
- failed login for a known identity is audited only to organizations already linked to that identity, including inactive memberships where the attempt remains security-relevant
- unknown identifiers fall back to the sole active organization only in true single-org mode; multi-org guesses are not attributed to an arbitrary tenant
- preserve the legacy empty-membership single-org bootstrap audit path
- add D1 behavioral tests for org2 isolation, multi-org visibility and unknown multi-org guesses, plus source regression coverage

Production deploy is not part of this PR.