### PR TITLE
Tenant-scope staff logout audit events

### DIFF
--- a/app/api/staff/logout/route.ts
+++ b/app/api/staff/logout/route.ts
@@ -3,12 +3,53 @@ import { clearedSessionCookie, readCookie, SESSION_COOKIE } from "../../../../li
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
 
+type AuditOrganizationRow = { organizationId: number };
+
+async function logoutAuditOrganizationIds(db: D1Database, memberEmail: string): Promise<number[]> {
+  const linked = await db.prepare(
+    `SELECT DISTINCT m.organization_id AS organizationId
+     FROM memberships m
+     JOIN organizations o ON o.id = m.organization_id
+     WHERE m.member_email = ? AND m.active = 1 AND o.active = 1
+     ORDER BY m.organization_id`
+  ).bind(memberEmail).all<AuditOrganizationRow>();
+  const ids = linked.results
+    .map((row) => Number(row.organizationId))
+    .filter((id) => Number.isInteger(id) && id > 0);
+  if (ids.length > 0) return ids;
+
+  // The only safe fallback is the legacy bootstrap state where memberships have
+  // never been created at all. A detached or disabled identity must not be
+  // attributed to an arbitrary organization merely because one active tenant
+  // happens to remain.
+  const membershipCount = await db.prepare("SELECT COUNT(*) AS n FROM memberships").first<{ n: number }>();
+  if (Number(membershipCount?.n || 0) !== 0) return [];
+
+  const activeOrganizations = await db.prepare(
+    "SELECT id AS organizationId FROM organizations WHERE active = 1 ORDER BY id LIMIT 2"
+  ).all<AuditOrganizationRow>();
+  if (activeOrganizations.results.length !== 1) return [];
+  const organizationId = Number(activeOrganizations.results[0]?.organizationId);
+  return Number.isInteger(organizationId) && organizationId > 0 ? [organizationId] : [];
+}
+
 export async function POST(request: Request) {
   const db = dbBinding();
   if (db) {
-    // Резолвимо співробітника до знищення сесії, щоб журнал знав, хто вийшов.
+    // Resolve the identity before destroying its global session. Logout invalidates
+    // that identity-level token for every tenant it could enter, so each active
+    // membership receives its own tenant-scoped security event.
     const member = await requireStaff(request, db).catch(() => null);
-    if (member) await audit(db, { organizationId: 1, actorEmail: member.email, action: "logout", resource: "auth" });
+    if (member) {
+      for (const organizationId of await logoutAuditOrganizationIds(db, member.email)) {
+        await audit(db, {
+          organizationId,
+          actorEmail: member.email,
+          action: "logout",
+          resource: "auth",
+        });
+      }
+    }
     await destroySession(db, readCookie(request, SESSION_COOKIE));
   }
   return Response.json({ ok: true }, { headers: { "set-cookie": clearedSessionCookie(), "cache-control": "no-store" } });

--- a/tests/staff-logout-audit-tenant.behavior.test.mjs
+++ b/tests/staff-logout-audit-tenant.behavior.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'logout-audit-two', 'Logout Audit Two', 1)",
+  ).run();
+}
+
+function logoutRequest(cookie) {
+  return new Request("http://localhost/api/staff/logout", {
+    method: "POST",
+    headers: { cookie },
+  });
+}
+
+test("org2-only staff logout audit stays out of org1 and destroys the session", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const email = "logout-org2@phone.local";
+    const cookie = await seedStaffSession(db, {
+      email,
+      role: "radiologist",
+      organizationId: 2,
+    });
+
+    const response = await callWorker(logoutRequest(cookie), db);
+    assert.equal(response.status, 200);
+
+    const rows = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'logout'
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(rows.results.map((row) => row.organizationId), [2]);
+
+    const sessions = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(sessions.n, 0);
+  });
+});
+
+test("multi-org identity logout is audited to every active tenant membership", async () => {
+  await withD1(async (db) => {
+    await addOrganizationTwo(db);
+    const email = "logout-multi@phone.local";
+    const cookie = await seedStaffSession(db, {
+      email,
+      role: "radiologist",
+      organizationId: 1,
+    });
+    await db.prepare(
+      "INSERT INTO memberships (organization_id, member_email, role, active) VALUES (2, ?, 'radiologist', 1)",
+    ).bind(email).run();
+
+    const response = await callWorker(logoutRequest(cookie), db);
+    assert.equal(response.status, 200);
+
+    const rows = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'logout'
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(rows.results.map((row) => row.organizationId), [1, 2]);
+  });
+});


### PR DESCRIPTION
Tenant-isolation hardening for staff logout audit events.

- remove hardcoded organization_id=1 from staff logout
- audit identity-global logout to every active organization membership the session could enter
- retain single-org fallback only for the genuine legacy zero-membership bootstrap state
- never attribute detached/disabled identities to an arbitrary tenant
- add D1 behavioral coverage for org2-only isolation, multi-org visibility, and session destruction

Production deploy is not part of this PR.