### PR TITLE
Require explicit tenant ownership for security audit

### DIFF
--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -2,7 +2,7 @@
 // подій; читає лише адміністратор. Записи скоупляться за організацією.
 
 export type AuditEvent = {
-  organizationId?: number; // за замовчуванням 1 (єдина організація)
+  organizationId: number;
   actorEmail: string;
   action: string;   // машинний код події, напр. "login", "booking_confirm"
   resource: string; // домен, напр. "auth", "booking", "settings", "staff"
@@ -62,13 +62,17 @@ export function auditLabel(action: string): string {
 }
 
 export async function logSecurityEvent(db: D1Database, event: AuditEvent): Promise<void> {
+  const organizationId = Number(event.organizationId);
+  if (!Number.isInteger(organizationId) || organizationId <= 0) {
+    throw new Error("security audit requires a valid organizationId");
+  }
   const details = JSON.stringify(event.details || {}).slice(0, 4000);
   await db.prepare(
     `INSERT INTO security_audit_log
        (organization_id, actor_email, action, resource, target_id, details_json)
      VALUES (?, ?, ?, ?, ?, ?)`
   ).bind(
-    event.organizationId || 1,
+    organizationId,
     String(event.actorEmail || "").slice(0, 254),
     event.action.slice(0, 80),
     event.resource.slice(0, 80),

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -32,6 +32,27 @@ test("logSecurityEvent writes org-scoped rows with all columns", async () => {
   assert.equal(bound.args[4], "42");         // target_id → string
 });
 
+test("security audit refuses missing or invalid tenant ownership instead of defaulting to org1", async () => {
+  const { logSecurityEvent } = await import("../lib/audit.ts");
+  let prepareCalls = 0;
+  const db = { prepare() { prepareCalls += 1; throw new Error("must not reach SQL"); } };
+
+  await assert.rejects(
+    () => logSecurityEvent(db, { actorEmail: "x@y.z", action: "login", resource: "auth" }),
+    /valid organizationId/,
+  );
+  await assert.rejects(
+    () => logSecurityEvent(db, { organizationId: 0, actorEmail: "x@y.z", action: "login", resource: "auth" }),
+    /valid organizationId/,
+  );
+  assert.equal(prepareCalls, 0, "invalid tenant ownership must fail before any audit INSERT");
+
+  const source = await read("lib/audit.ts");
+  assert.match(source, /organizationId: number/);
+  assert.doesNotMatch(source, /organizationId\?: number/);
+  assert.doesNotMatch(source, /event\.organizationId \|\| 1/);
+});
+
 test("migration 0023 creates the security_audit_log table and index", async () => {
   const sql = await read("drizzle/0023_security_audit_log.sql");
   assert.match(sql, /CREATE TABLE IF NOT EXISTS `security_audit_log`/);


### PR DESCRIPTION
Fail-closed tenant ownership for security audit events.

- make AuditEvent.organizationId required at the application type boundary
- reject missing, zero, negative, NaN, or non-integer organization ids before any SQL write
- remove the implicit `event.organizationId || 1` fallback that could silently attribute a caller bug to tenant 1
- keep `audit()` best-effort semantics: an invalid audit event cannot break the main operation, but it also cannot leak into another tenant
- add regression tests proving invalid tenant ownership never reaches the audit INSERT
- leave legacy DB column defaults/migrations unchanged for compatibility; application writes must be explicit

Production deploy is not part of this PR.