### PR TITLE
Protect staff login phone changes

### DIFF
--- a/app/api/staff/profile/route.ts
+++ b/app/api/staff/profile/route.ts
@@ -47,13 +47,14 @@ export async function PATCH(request: Request) {
   };
 
   const current = await db.prepare(
-    `SELECT email, password_hash AS passwordHash FROM staff_members
+    `SELECT email, phone, password_hash AS passwordHash FROM staff_members
      WHERE email = ? AND active = 1 LIMIT 1`
-  ).bind(staff.email).first<{ email: string; passwordHash: string }>();
+  ).bind(staff.email).first<{ email: string; phone: string | null; passwordHash: string }>();
   if (!current) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
 
   const phone = body.phone == null ? null : normalizeUkrainianPhone(body.phone);
   if (body.phone != null && !phone) return Response.json({ error: "Перевірте номер телефону" }, { status: 400 });
+  const phoneChanged = body.phone != null && phone !== (current.phone || "");
 
   const firstName = body.firstName == null ? null : clean(body.firstName, 60);
   const lastName = body.lastName == null ? null : clean(body.lastName, 60);
@@ -76,6 +77,14 @@ export async function PATCH(request: Request) {
   if (wantsPinChange) {
     const problem = passwordProblem(body.newPin || "");
     if (problem) return Response.json({ error: problem }, { status: 400 });
+  }
+
+  // Phone is the primary login identifier. Changing it is therefore a credential
+  // boundary just like changing the PIN: a stolen session must not be enough to
+  // re-bind the account to an attacker's number. Require the current PIN for any
+  // real phone change, then revoke every identity-level session after success.
+  const securityChange = wantsPinChange || phoneChanged;
+  if (securityChange) {
     if (!body.currentPin || !(await verifyPassword(body.currentPin, current.passwordHash))) {
       return Response.json({ error: "Поточний PIN-код невірний" }, { status: 401 });
     }
@@ -106,17 +115,19 @@ export async function PATCH(request: Request) {
   if (wantsPinChange) {
     await db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")
       .bind(await hashPassword(body.newPin || ""), staff.email).run();
+  }
+  if (securityChange) {
     await db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(staff.email).run();
   }
 
   await audit(db, {
     organizationId: ctx.organizationId,
     actorEmail: staff.email,
-    action: wantsPinChange ? "profile_security_update" : "profile_update",
+    action: securityChange ? "profile_security_update" : "profile_update",
     resource: "staff",
     targetId: staff.email,
-    details: { phoneChanged: body.phone != null, pinChanged: wantsPinChange },
+    details: { phoneChanged, pinChanged: wantsPinChange },
   });
 
-  return Response.json({ ok: true, signedOut: wantsPinChange });
+  return Response.json({ ok: true, signedOut: securityChange });
 }

--- a/app/staff/profile/page.tsx
+++ b/app/staff/profile/page.tsx
@@ -54,6 +54,7 @@ export default function StaffProfilePage() {
       headers:{ "content-type":"application/json" },
       body:JSON.stringify({
         phone:String(form.get("phone") || ""),
+        currentPin:String(form.get("currentPin") || ""),
         lastName:String(form.get("lastName") || ""),
         firstName:String(form.get("firstName") || ""),
         patronymic:String(form.get("patronymic") || ""),
@@ -62,9 +63,13 @@ export default function StaffProfilePage() {
         positionTitle:String(form.get("positionTitle") || ""),
       }),
     });
-    const data = await response.json().catch(()=>({})) as { error?:string };
+    const data = await response.json().catch(()=>({})) as { error?:string; signedOut?:boolean };
     setSaving(false);
     if (!response.ok) { setError(data.error || "Не вдалося зберегти профіль"); return; }
+    if (data.signedOut) {
+      window.location.assign("/staff/login?returnTo=%2Fstaff%2Fprofile&changed=1");
+      return;
+    }
     setSuccess("Профіль оновлено");
     await load();
   }
@@ -110,10 +115,11 @@ export default function StaffProfilePage() {
           <label>Ім’я<input name="firstName" defaultValue={profile.firstName || ""}/></label>
           <label>По батькові<input name="patronymic" defaultValue={profile.patronymic || ""}/></label>
           <label>Телефон<input name="phone" inputMode="tel" defaultValue={profile.phone || ""}/></label>
+          <label>Поточний PIN для зміни телефону<input name="currentPin" type="password" inputMode="numeric" autoComplete="current-password" placeholder="Потрібен лише якщо змінюєте телефон"/></label>
           <label>Контактний e-mail<input name="contactEmail" type="email" defaultValue={profile.contactEmail || ""}/></label>
           <label>Військове звання<input name="militaryRank" defaultValue={profile.militaryRank || ""}/></label>
           <label>Посада<input name="positionTitle" defaultValue={profile.positionTitle || ""}/></label>
-          <div><small>Роль у системі: <b>{roleLabelUk(profile.role)}</b></small></div>
+          <div><small>Роль у системі: <b>{roleLabelUk(profile.role)}</b>. Зміна номера входу потребує поточного PIN і завершить усі активні сеанси.</small></div>
           <div><button className="button" type="submit" disabled={saving}>{saving ? "Зберігаємо…":"Зберегти профіль"}</button></div>
         </form>
       </section>

--- a/tests/staff-profile-membership-context.behavior.test.mjs
+++ b/tests/staff-profile-membership-context.behavior.test.mjs
@@ -44,6 +44,11 @@ test("system and management roles can update only their own shared profile throu
     const email = "profile-update@example.com";
     const cookie = await seedStaffSession(db, { email, role:"admin", displayName:"Before" });
     await setMembershipRole(db, email, "organization_admin");
+    // Phone is the primary login identifier. Keep it unchanged in this ordinary
+    // profile-edit regression; rebinding it is a separate security operation that
+    // requires the current PIN and revokes sessions.
+    await db.prepare("UPDATE staff_members SET phone = ? WHERE email = ?")
+      .bind("380501234567", email).run();
 
     const response = await callWorker(
       jsonRequest("/api/staff/profile", {

--- a/tests/staff-profile-phone-security.behavior.test.mjs
+++ b/tests/staff-profile-phone-security.behavior.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+const TEST_PASSWORD_HASH = "pbkdf2$sha256$100000$bWVtYmVyc2hpcC10ZXN0IQ==$2/9vE4JQ+7or+3sxZDWVYBEZFHg+JGSjVqOivgvaoPs=";
+const TEST_PIN = "123456";
+
+async function seedProfileIdentity(db, {
+  email = "profile-phone@phone.local",
+  phone = "380501112233",
+} = {}) {
+  const cookie = await seedStaffSession(db, {
+    email,
+    role: "radiologist",
+    organizationId: 1,
+  });
+  await db.prepare(
+    "UPDATE staff_members SET phone = ?, password_hash = ? WHERE email = ?",
+  ).bind(phone, TEST_PASSWORD_HASH, email).run();
+  return { cookie, email, phone };
+}
+
+function profilePatch(body, cookie) {
+  return jsonRequest("/api/staff/profile", body, {
+    method: "PATCH",
+    headers: { cookie },
+  });
+}
+
+test("changing the staff login phone requires the current PIN before mutating identity", async () => {
+  await withD1(async (db) => {
+    const { cookie, email, phone: oldPhone } = await seedProfileIdentity(db);
+    const newPhone = "380501112244";
+
+    const denied = await callWorker(profilePatch({ phone: newPhone }, cookie), db);
+    assert.equal(denied.status, 401);
+
+    const afterDenied = await db.prepare(
+      "SELECT phone FROM staff_members WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(afterDenied.phone, oldPhone);
+
+    const sessionsAfterDenied = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(sessionsAfterDenied.n, 1);
+
+    const allowed = await callWorker(profilePatch({ phone: newPhone, currentPin: TEST_PIN }, cookie), db);
+    assert.equal(allowed.status, 200);
+    assert.deepEqual(await allowed.json(), { ok: true, signedOut: true });
+
+    const afterAllowed = await db.prepare(
+      "SELECT phone FROM staff_members WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(afterAllowed.phone, newPhone);
+
+    const sessionsAfterAllowed = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(sessionsAfterAllowed.n, 0);
+
+    const securityAudit = await db.prepare(
+      `SELECT organization_id AS organizationId, details_json AS detailsJson
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'profile_security_update'
+       ORDER BY id DESC LIMIT 1`,
+    ).bind(email).first();
+    assert.equal(securityAudit.organizationId, 1);
+    assert.deepEqual(JSON.parse(securityAudit.detailsJson), {
+      phoneChanged: true,
+      pinChanged: false,
+    });
+  });
+});
+
+test("saving the unchanged login phone does not require PIN or revoke the session", async () => {
+  await withD1(async (db) => {
+    const { cookie, email, phone } = await seedProfileIdentity(db, {
+      email: "profile-same-phone@phone.local",
+      phone: "380501112255",
+    });
+
+    const response = await callWorker(profilePatch({ phone, firstName: "Марія" }, cookie), db);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, signedOut: false });
+
+    const row = await db.prepare(
+      "SELECT phone, first_name AS firstName FROM staff_members WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(row.phone, phone);
+    assert.equal(row.firstName, "Марія");
+
+    const sessions = await db.prepare(
+      "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
+    ).bind(email).first();
+    assert.equal(sessions.n, 1);
+  });
+});


### PR DESCRIPTION
Harden self-service changes to the staff login identifier.

- treat a real change of `staff_members.phone` as an account-security boundary because phone is the primary login identifier
- require the current PIN before rebinding the login phone
- revoke all identity-level staff sessions after a successful phone or PIN change
- return `signedOut: true` for either security change and redirect the profile UI back to login
- keep ordinary profile saves frictionless when the submitted phone is unchanged
- mark phone changes as `profile_security_update` and record `phoneChanged` / `pinChanged`
- add D1 behavioral coverage proving missing PIN cannot mutate the phone, correct PIN revokes sessions, and unchanged phone does not force logout

Production deploy is not part of this PR.