### PR TITLE
Audit profile security changes across active tenants

### DIFF
--- a/app/api/staff/profile/route.ts
+++ b/app/api/staff/profile/route.ts
@@ -9,6 +9,44 @@ function clean(value: unknown, max = 120) {
   return String(value || "").trim().replace(/\s+/g, " ").slice(0, max);
 }
 
+type AuditOrganizationRow = { organizationId: number };
+
+async function profileSecurityAuditOrganizationIds(
+  db: D1Database,
+  memberEmail: string,
+  fallbackOrganizationId: number,
+): Promise<number[]> {
+  const linked = await db.prepare(
+    `SELECT DISTINCT m.organization_id AS organizationId
+     FROM memberships m
+     JOIN organizations o ON o.id = m.organization_id
+     WHERE m.member_email = ? AND m.active = 1 AND o.active = 1
+     ORDER BY m.organization_id`
+  ).bind(memberEmail).all<AuditOrganizationRow>();
+  const ids = linked.results
+    .map((row) => Number(row.organizationId))
+    .filter((id) => Number.isInteger(id) && id > 0);
+  if (ids.length > 0) return ids;
+
+  // Self-service normally requires an active membership. The only safe fallback
+  // is the legacy bootstrap state where memberships have never existed at all and
+  // the resolved context is the sole active organization. Never attribute a
+  // detached/disabled identity to an arbitrary tenant.
+  const membershipCount = await db.prepare("SELECT COUNT(*) AS n FROM memberships").first<{ n: number }>();
+  if (Number(membershipCount?.n || 0) !== 0) return [];
+
+  const activeOrganizations = await db.prepare(
+    "SELECT id AS organizationId FROM organizations WHERE active = 1 ORDER BY id LIMIT 2"
+  ).all<AuditOrganizationRow>();
+  if (activeOrganizations.results.length !== 1) return [];
+  const organizationId = Number(activeOrganizations.results[0]?.organizationId);
+  return Number.isInteger(organizationId)
+    && organizationId > 0
+    && organizationId === fallbackOrganizationId
+    ? [organizationId]
+    : [];
+}
+
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
@@ -120,14 +158,19 @@ export async function PATCH(request: Request) {
     await db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(staff.email).run();
   }
 
-  await audit(db, {
-    organizationId: ctx.organizationId,
-    actorEmail: staff.email,
-    action: securityChange ? "profile_security_update" : "profile_update",
-    resource: "staff",
-    targetId: staff.email,
-    details: { phoneChanged, pinChanged: wantsPinChange },
-  });
+  const auditOrganizationIds = securityChange
+    ? await profileSecurityAuditOrganizationIds(db, staff.email, ctx.organizationId)
+    : [ctx.organizationId];
+  for (const organizationId of auditOrganizationIds) {
+    await audit(db, {
+      organizationId,
+      actorEmail: staff.email,
+      action: securityChange ? "profile_security_update" : "profile_update",
+      resource: "staff",
+      targetId: staff.email,
+      details: { phoneChanged, pinChanged: wantsPinChange },
+    });
+  }
 
   return Response.json({ ok: true, signedOut: securityChange });
 }

--- a/tests/staff-profile-phone-security.behavior.test.mjs
+++ b/tests/staff-profile-phone-security.behavior.test.mjs
@@ -5,6 +5,18 @@ import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.
 const TEST_PASSWORD_HASH = "pbkdf2$sha256$100000$bWVtYmVyc2hpcC10ZXN0IQ==$2/9vE4JQ+7or+3sxZDWVYBEZFHg+JGSjVqOivgvaoPs=";
 const TEST_PIN = "123456";
 
+async function addOrganizationTwo(db) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (2, 'profile-security-two', 'Profile Security Two', 1)",
+  ).run();
+}
+
+async function addMembership(db, email, organizationId = 2) {
+  await db.prepare(
+    "INSERT INTO memberships (organization_id, member_email, role, active) VALUES (?, ?, 'radiologist', 1)",
+  ).bind(organizationId, email).run();
+}
+
 async function seedProfileIdentity(db, {
   email = "profile-phone@phone.local",
   phone = "380501112233",
@@ -27,9 +39,11 @@ function profilePatch(body, cookie) {
   });
 }
 
-test("changing the staff login phone requires the current PIN before mutating identity", async () => {
+test("changing the staff login phone requires the current PIN and audits every active tenant", async () => {
   await withD1(async (db) => {
     const { cookie, email, phone: oldPhone } = await seedProfileIdentity(db);
+    await addOrganizationTwo(db);
+    await addMembership(db, email);
     const newPhone = "380501112244";
 
     const denied = await callWorker(profilePatch({ phone: newPhone }, cookie), db);
@@ -63,22 +77,26 @@ test("changing the staff login phone requires the current PIN before mutating id
       `SELECT organization_id AS organizationId, details_json AS detailsJson
        FROM security_audit_log
        WHERE actor_email = ? AND action = 'profile_security_update'
-       ORDER BY id DESC LIMIT 1`,
-    ).bind(email).first();
-    assert.equal(securityAudit.organizationId, 1);
-    assert.deepEqual(JSON.parse(securityAudit.detailsJson), {
-      phoneChanged: true,
-      pinChanged: false,
-    });
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(securityAudit.results.map((row) => row.organizationId), [1, 2]);
+    for (const row of securityAudit.results) {
+      assert.deepEqual(JSON.parse(row.detailsJson), {
+        phoneChanged: true,
+        pinChanged: false,
+      });
+    }
   });
 });
 
-test("saving the unchanged login phone does not require PIN or revoke the session", async () => {
+test("ordinary profile save stays scoped to the current tenant and keeps the session", async () => {
   await withD1(async (db) => {
     const { cookie, email, phone } = await seedProfileIdentity(db, {
       email: "profile-same-phone@phone.local",
       phone: "380501112255",
     });
+    await addOrganizationTwo(db);
+    await addMembership(db, email);
 
     const response = await callWorker(profilePatch({ phone, firstName: "Марія" }, cookie), db);
     assert.equal(response.status, 200);
@@ -94,5 +112,13 @@ test("saving the unchanged login phone does not require PIN or revoke the sessio
       "SELECT COUNT(*) AS n FROM staff_sessions WHERE email = ?",
     ).bind(email).first();
     assert.equal(sessions.n, 1);
+
+    const profileAudit = await db.prepare(
+      `SELECT organization_id AS organizationId
+       FROM security_audit_log
+       WHERE actor_email = ? AND action = 'profile_update'
+       ORDER BY organization_id`,
+    ).bind(email).all();
+    assert.deepEqual(profileAudit.results.map((auditRow) => auditRow.organizationId), [1]);
   });
 });


### PR DESCRIPTION
Tenant-audit hardening for global staff identity security changes.

- fan out `profile_security_update` to every active organization membership the identity can enter
- keep ordinary `profile_update` scoped to the current tenant context
- preserve only the genuine zero-membership single-org bootstrap fallback
- never attribute detached or disabled identities to an arbitrary tenant
- add D1 behavioral coverage for multi-org security fan-out and ordinary-profile tenant scoping

Production deploy is not part of this PR.