### PR TITLE
Resolve tenant context by membership capability

### DIFF
--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -50,6 +50,13 @@ export interface OrgContext<R extends AccessRole = StaffRole> {
   member: OrgMember<R>;
 }
 
+type MembershipContextRow = {
+  organizationId: number;
+  slug: string;
+  organizationName: string;
+  role: string;
+};
+
 async function resolveOrgContext<R extends AccessRole>(
   request: Request,
   db: D1Database,
@@ -58,19 +65,19 @@ async function resolveOrgContext<R extends AccessRole>(
   const identity = await requireStaff(request, db);
   if (!identity) return null;
 
-  let row = await db.prepare(
+  // One identity may belong to several organizations with different roles. Resolve
+  // the tenant only from server-verified active memberships whose role is valid for
+  // this capability context. Selecting the first tenant before checking its role
+  // would incorrectly deny a legitimate org2 radiologist merely because org1 has
+  // a management-only membership for the same identity.
+  const memberships = await db.prepare(
     `SELECT o.id AS organizationId, o.slug AS slug, o.name AS organizationName, m.role AS role
      FROM memberships m
      JOIN organizations o ON o.id = m.organization_id AND o.active = 1
      WHERE m.member_email = ? AND m.active = 1
-     ORDER BY o.id ASC
-     LIMIT 1`
-  ).bind(identity.email).first<{
-    organizationId: number;
-    slug: string;
-    organizationName: string;
-    role: string;
-  }>();
+     ORDER BY o.id ASC`
+  ).bind(identity.email).all<MembershipContextRow>();
+  let row = memberships.results.find((candidate) => allowedRoles.has(candidate.role as R)) || null;
 
   // Legacy bootstrap compatibility is allowed only for a genuinely empty
   // single-organization installation. Once any membership exists (or more than

--- a/tests/tenant-capability-resolution.behavior.test.mjs
+++ b/tests/tenant-capability-resolution.behavior.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  requireManagementOrgContext,
+  requireOrgContext,
+  requireSelfServiceOrgContext,
+  requireSystemOrgContext,
+} from "../lib/tenant.ts";
+import { seedStaffSession, withD1 } from "./helpers/d1.mjs";
+
+async function addOrganization(db, id, slug, name) {
+  await db.prepare(
+    "INSERT INTO organizations (id, slug, name, active) VALUES (?, ?, ?, 1)",
+  ).bind(id, slug, name).run();
+}
+
+async function addMembership(db, organizationId, email, role) {
+  await db.prepare(
+    "INSERT INTO memberships (organization_id, member_email, role, active) VALUES (?, ?, ?, 1)",
+  ).bind(organizationId, email, role).run();
+}
+
+function authenticatedRequest(cookie) {
+  return new Request("http://localhost/api/staff/context-test", {
+    headers: { cookie },
+  });
+}
+
+test("tenant context selects the first active membership allowed by each capability", async () => {
+  await withD1(async (db) => {
+    const email = "multi-capability@example.com";
+    const cookie = await seedStaffSession(db, {
+      email,
+      role: "department_head",
+      organizationId: 1,
+      displayName: "Multi Capability",
+    });
+    await addOrganization(db, 2, "medical-two", "Medical Two");
+    await addOrganization(db, 3, "system-three", "System Three");
+    await addMembership(db, 2, email, "radiologist");
+    await addMembership(db, 3, email, "organization_admin");
+
+    const request = authenticatedRequest(cookie);
+
+    const management = await requireManagementOrgContext(request, db);
+    assert.equal(management?.organizationId, 1);
+    assert.equal(management?.role, "department_head");
+
+    const medical = await requireOrgContext(request, db);
+    assert.equal(medical?.organizationId, 2);
+    assert.equal(medical?.role, "radiologist");
+
+    const system = await requireSystemOrgContext(request, db);
+    assert.equal(system?.organizationId, 3);
+    assert.equal(system?.role, "organization_admin");
+
+    const selfService = await requireSelfServiceOrgContext(request, db);
+    assert.equal(selfService?.organizationId, 1);
+    assert.equal(selfService?.role, "department_head");
+  });
+});
+
+test("capability resolution still denies when no active membership has an allowed role", async () => {
+  await withD1(async (db) => {
+    const email = "management-only@example.com";
+    const cookie = await seedStaffSession(db, {
+      email,
+      role: "department_head",
+      organizationId: 1,
+    });
+
+    const medical = await requireOrgContext(authenticatedRequest(cookie), db);
+    assert.equal(medical, null);
+  });
+});


### PR DESCRIPTION
Fix multi-organization capability resolution for shared staff identities.

- evaluate all active memberships from active organizations before choosing tenant context
- select the first server-verified membership whose role is allowed by the requested capability context
- preserve deterministic organization-id ordering without accepting organization ids from request bodies or query parameters
- keep deny-by-default behavior when no active membership has an allowed role
- preserve the genuine zero-membership single-org bootstrap path
- add D1 behavioral coverage proving one identity can resolve management org1, medical org2, and system org3 according to its membership roles

Production deploy is not part of this PR.