### PR TITLE
Єдиний стиль: Звіти на спільних журнальних компонентах (крок 1)

### DIFF
--- a/app/staff/reports/page.tsx
+++ b/app/staff/reports/page.tsx
@@ -211,7 +211,7 @@ export default function ReportsPage() {
         {error && <p className="staffError" role="alert">{error}</p>}
         {data && <div className="reportPreview">
           <div className="reportPreviewHead"><b>Попередній перегляд</b><span>{data.previewTotal} рядків · показано до 100</span></div>
-          <div className="reportTableScroll"><table><thead><tr>{data.columns.map((item)=><th key={item.key}>{item.label}</th>)}</tr></thead>
+          <div className="financeTableWrap"><table className="financeTable"><thead><tr>{data.columns.map((item)=><th key={item.key}>{item.label}</th>)}</tr></thead>
             <tbody>{data.preview.length === 0 ? <tr><td colSpan={Math.max(1,data.columns.length)}>Даних за обраними фільтрами немає.</td></tr> :
               data.preview.map((row,index)=><tr key={index}>{data.columns.map((item)=><td key={item.key}>{formatCell(row[item.key],item)}</td>)}</tr>)}
             </tbody></table></div>
@@ -219,7 +219,7 @@ export default function ReportsPage() {
       </section>
 
       {data && <div className="reportContent">
-        <section className="reportStats" aria-label="Ключові показники">
+        <section className="financeSummary" aria-label="Ключові показники">
           <article><span>Записів</span><b>{data.summary.total}</b><small>{data.summary.cancelled} скасовано</small></article>
           <article><span>Фактично виконано</span><b>{data.summary.performed}</b><small>{data.summary.regions} анатомічних ділянок</small></article>
           <article><span>Протоколи готові</span><b>{data.summary.protocolsReady}</b><small>{data.summary.awaitingProtocol} очікують</small></article>

--- a/app/styles/24-reports-minimal.css
+++ b/app/styles/24-reports-minimal.css
@@ -73,29 +73,17 @@
 .basWorkspaceShell .columnChecks label:has(input:checked){background:var(--rp-tint);border-color:transparent;color:var(--rp-accent)}
 .basWorkspaceShell .columnChecks input{width:13px;height:13px;accent-color:var(--rp-accent)}
 
-/* попередній перегляд — чиста таблиця */
-.basWorkspaceShell .reportPreview{border:1px solid var(--rp-line);border-radius:10px;margin-top:16px;overflow:hidden;background:var(--rp-panel)}
-.basWorkspaceShell .reportPreviewHead{background:var(--rp-panel);border-bottom:1px solid var(--rp-line-soft)}
+/* попередній перегляд — заголовок над спільною журнальною таблицею
+   (.financeTableWrap / .financeTable дають єдиний вигляд із Журналом документів) */
+.basWorkspaceShell .reportPreview{border:0;background:transparent;margin-top:16px}
+.basWorkspaceShell .reportPreviewHead{background:transparent;padding:0 0 10px;border-bottom:0}
 .basWorkspaceShell .reportPreviewHead span{color:var(--rp-faint)}
-.basWorkspaceShell .reportTableScroll th{
-  background:var(--rp-head);color:var(--rp-faint);text-transform:uppercase;
-  font-size:11px;font-weight:800;letter-spacing:.04em;border-bottom:1px solid var(--rp-line);
-}
-.basWorkspaceShell .reportTableScroll td{color:var(--rp-ink);border-bottom-color:var(--rp-line-soft)}
-.basWorkspaceShell .reportTableScroll tr:nth-child(even) td{background:transparent}
 
-/* KPI — одна hairline-смуга замість важких карток */
-.basWorkspaceShell .reportStats{
-  grid-template-columns:repeat(6,1fr);gap:0;margin-top:16px;
-  border:1px solid var(--rp-line);border-radius:10px;overflow:hidden;background:var(--rp-panel);
-}
-.basWorkspaceShell .reportStats article{
-  border:0;border-right:1px solid var(--rp-line-soft);border-radius:0;padding:15px 16px;min-height:0;box-shadow:none;background:transparent;
-}
-.basWorkspaceShell .reportStats article:last-child{border-right:0}
-.basWorkspaceShell .reportStats article span{font-size:11px;letter-spacing:.03em;color:var(--rp-faint)}
-.basWorkspaceShell .reportStats article b{font-family:var(--font-sans);font-size:23px;margin:8px 0 3px;font-weight:750;letter-spacing:-.5px;line-height:1;color:var(--rp-ink)}
-.basWorkspaceShell .reportStats article small{font-size:11px;color:var(--rp-faint)}
+/* KPI та таблиця беруть спільний журнальний стиль (.financeSummary/.financeTable),
+   тож бespоke-правила тут не потрібні — єдина дизайн-система.
+   Звіти мають 6 показників (журнал — 4), тож даємо адаптивну сітку,
+   щоб усі стали рівно в один ряд у тому самому картковому стилі. */
+.basWorkspaceShell .reportContent .financeSummary{grid-template-columns:repeat(auto-fit,minmax(148px,1fr))}
 
 /* панелі */
 .basWorkspaceShell .reportPanel{border:1px solid var(--rp-line);border-radius:10px;background:var(--rp-panel);padding:17px 18px;box-shadow:none}


### PR DESCRIPTION
## Навіщо

Обрано напрям — стиль **Журналу документів** зробити єдиним по всьому staff-застосунку. Це крок 1: приводимо екран **Звіти** до тих самих спільних компонентів, щоб не було двох джерел правди.

## Що зроблено

- KPI-показники Звітів → канонічний `.financeSummary` (ті самі картки, що в Журналі документів). Оскільки показників 6 (а в журналі 4) — адаптивна `auto-fit` сітка, щоб стали рівно в один ряд.
- Прев’ю Звітів → спільні `.financeTableWrap` / `.financeTable` (єдиний вигляд таблиці зі статус-стилем журналу).
- Прибрано зайві bespoke-правила KPI/таблиці з `24-reports-minimal.css` — одне джерело стилю.
- Компактні таби реєстрів, світлі фільтри й чіпи-колонки Звітів збережено.

## Далі (наступні кроки розкочення)

Пульт, реєстр `/staff`, Пацієнти, Протоколи, Imaging — кожен окремим PR+деплоєм, щоб безпечно.

## Перевірки

- `903/903` тестів; `npm run build`, `lint` (0 errors) — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_