### PR TITLE
Єдиний стиль: Пульт — KPI-смуга у журнальних картках (крок 2)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,3 +25,4 @@
 @import "./styles/22-shift-calendar.css";
 @import "./styles/23-bas-enterprise-density.css";
 @import "./styles/24-reports-minimal.css";
+@import "./styles/25-dashboard-journal.css";

--- a/app/styles/25-dashboard-journal.css
+++ b/app/styles/25-dashboard-journal.css
@@ -1,0 +1,38 @@
+/* ============================================================
+   RadiologyOS — Пульт у єдиному журнальному стилі (крок 2).
+   KPI-смуга дня (.dashMcItem) отримує той самий картковий вигляд, що й
+   .financeSummary у Журналі документів: підпис малими капітелями зверху,
+   помітне число знизу, тонка рамка, щільний радіус. Колір-семантику
+   (червоний/оранж/зелений/синій/фіолет) збережено тонким лівим акцентом,
+   клік-навігацію — теж. Токени --rp-* визначені в 24 на .basWorkspaceShell
+   (світла й темна теми), тож перевикористовуємо їх тут.
+   Per-side longhand навмисно: щоб не затерти border-left-color кольорових
+   класів shorthand-ом.
+   ============================================================ */
+.basWorkspaceShell .dashMcItem{
+  background:var(--rp-panel);
+  border-top-color:var(--rp-line);
+  border-right-color:var(--rp-line);
+  border-bottom-color:var(--rp-line);
+  border-left-width:3px;
+  border-radius:var(--r-sm,4px);
+  padding:13px 15px;
+  gap:6px;
+  flex-direction:column-reverse; /* підпис зверху, число знизу — як у журналі */
+  align-items:flex-start;
+  box-shadow:none;
+}
+.basWorkspaceShell .dashMcItem:hover{
+  border-top-color:var(--rp-faint);
+  border-right-color:var(--rp-faint);
+  border-bottom-color:var(--rp-faint);
+  transform:none;
+}
+.basWorkspaceShell .dashMcItem>b{
+  font-size:22px;font-weight:750;letter-spacing:-.4px;line-height:1;
+  color:var(--rp-ink);font-variant-numeric:tabular-nums;
+}
+.basWorkspaceShell .dashMcItem>span{
+  font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.05em;
+  color:var(--rp-faint);
+}


### PR DESCRIPTION
## Навіщо

Крок 2 розкочення стилю Журналу документів. Верхня KPI-смуга Пульта отримує той самий картковий вигляд, що й показники в Документах/Звітах — помірно, без ламання робочих фіч.

## Що зроблено

- `.dashMcItem` (нові заявки / контраст / сьогодні / протокол / оплата) → журнальний картковий стиль: підпис малими капітелями **зверху**, помітне число знизу, тонка рамка, щільний радіус.
- **Збережено**: колір-семантику — тонким лівим акцентом (3px); клік-навігацію/фільтри.
- **Не чіпано**: черга «Робота зараз», розклад на сьогодні, швидкі «Прибув / Не зʼявився», позначка «Прострочено» — усі функції на місці.
- Новий шар `25-dashboard-journal.css` (вантажиться останнім); токени `--rp-*` перевикористано з кроку 1 (світла/темна теми). Per-side border longhand — щоб shorthand не затер колір лівого акценту.

## Перевірки

- `903/903` тестів; `npm run build`, `lint` (0 errors) — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_