### PR TITLE
Єдиний стиль: Прийом у журнальному вигляді (крок 3)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,3 +26,4 @@
 @import "./styles/23-bas-enterprise-density.css";
 @import "./styles/24-reports-minimal.css";
 @import "./styles/25-dashboard-journal.css";
+@import "./styles/26-intake-journal.css";

--- a/app/styles/26-intake-journal.css
+++ b/app/styles/26-intake-journal.css
@@ -1,0 +1,41 @@
+/* ============================================================
+   RadiologyOS — Прийом (/staff/intake) у єдиному журнальному стилі (крок 3).
+   /staff (реєстр) уже на щільнісному журнальному шарі (23). Прийом має власні
+   .intake* компоненти: світлі, але з великими радіусами (14/8px) і бірюзовим
+   акцентом (#0c7a85) замість зеленого. Зводимо до журнальної щільності —
+   тонкі рамки, щільний радіус, зелений акцент. Токени --rp-* із 24, --r-sm із 23.
+   Per-side border longhand, щоб не затерти кольорові статус-рейки карток.
+   ============================================================ */
+.basWorkspaceShell .intakeQueue,
+.basWorkspaceShell .intakeDetail{
+  border-color:var(--rp-line);
+  border-radius:var(--r-sm,4px);
+}
+.basWorkspaceShell .intakeQueueTop{border-bottom-color:var(--rp-line-soft)}
+.basWorkspaceShell .intakeQueueTop input{border-color:var(--rp-line);border-radius:var(--r-sm,4px)}
+.basWorkspaceShell .intakeQueueTop input:focus{outline:2px solid var(--rp-accent);outline-offset:-1px;border-color:var(--rp-accent)}
+
+/* сегментований перемикач — зелений акцент, щільний радіус */
+.basWorkspaceShell .intakeSeg{background:var(--rp-line-soft);border-radius:var(--r-sm,4px)}
+.basWorkspaceShell .intakeSeg button{color:var(--rp-muted);border-radius:calc(var(--r-sm,4px) - 1px)}
+.basWorkspaceShell .intakeSeg button.on{background:var(--rp-panel);color:var(--rp-accent);box-shadow:0 1px 2px rgba(0,0,0,.06)}
+
+/* «нова заявка» — зелений пунктир */
+.basWorkspaceShell .intakeNew{border-color:var(--rp-accent);background:var(--rp-tint);color:var(--rp-accent);border-radius:var(--r-sm,4px)}
+
+/* картки черги — тонка рамка, щільний радіус; лівий статус-акцент збережено */
+.basWorkspaceShell .intakeCard{
+  border-top-color:var(--rp-line-soft);
+  border-right-color:var(--rp-line-soft);
+  border-bottom-color:var(--rp-line-soft);
+  border-radius:var(--r-sm,4px);
+  background:var(--rp-panel);
+}
+.basWorkspaceShell .intakeCard:hover{background:var(--rp-head)}
+.basWorkspaceShell .intakeCard.active{
+  border-top-color:var(--rp-accent);
+  border-right-color:var(--rp-accent);
+  border-bottom-color:var(--rp-accent);
+  border-left-color:var(--rp-accent);
+  background:var(--rp-tint);
+}


### PR DESCRIPTION
## Навіщо

Крок 3 розкочення стилю Журналу документів. З'ясувалося, що **реєстр `/staff` уже** на спільному щільнісному журнальному шарі (тулбар, картки заявок, KPI — усе інheritує його через `23-bas-enterprise-density`), тож там нічого не треба. Робота — у **Прийомі** (`/staff/intake`), який має власні `.intake*` компоненти поза системою.

## Що зроблено

Прийом був світлий, але off-system: великі радіуси (14/8px) і бірюзовий акцент (`#0c7a85`) замість зеленого. Зведено до журнальної щільності:
- тонкі рамки (`--rp-line`), щільний радіус (`--r-sm`);
- зелений акцент (`--rp-accent`) у сегментах, кнопці «нова заявка», активній картці, фокусі пошуку;
- **збережено** лівий статус-акцент карток (нова/перенесена) — per-side border longhand, щоб shorthand не затер колір.

Новий шар `26-intake-journal.css`; токени `--rp-*` із кроку 1 (світла/темна теми).

## Перевірки

- `911/911` тестів; `npm run build`, `lint` (0 errors) — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_