### PR TITLE
Єдиний стиль: Пацієнти (CRM) + Протоколи (крок 4)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -27,3 +27,4 @@
 @import "./styles/24-reports-minimal.css";
 @import "./styles/25-dashboard-journal.css";
 @import "./styles/26-intake-journal.css";
+@import "./styles/27-crm-protocol-journal.css";

--- a/app/styles/27-crm-protocol-journal.css
+++ b/app/styles/27-crm-protocol-journal.css
@@ -1,0 +1,39 @@
+/* ============================================================
+   RadiologyOS — Пацієнти (CRM) + Протоколи у єдиному журнальному стилі (крок 4).
+   Обидва екрани bespoke (щільнісний шар 23 їх не чіпає). Зводимо ключові
+   журнальні сигнали до системи: KPI-картки, сегментовані таби, картки черги
+   протоколів — тонкі рамки, щільний радіус, білий фон, зелений акцент.
+   Токени --rp-* із 24, --r-sm із 23. Функції/розмітку не чіпаємо.
+   ============================================================ */
+
+/* CRM — підсумкові показники → журнальні картки (без тонування, щільний радіус) */
+.basWorkspaceShell .crmStats article{
+  background:var(--rp-panel);
+  border-color:var(--rp-line);
+  border-radius:var(--r-sm,4px);
+  box-shadow:none;
+  padding:13px 14px;
+}
+.basWorkspaceShell .crmStats span{color:var(--rp-faint)}
+.basWorkspaceShell .crmStats b{font-size:22px;color:var(--rp-ink)}
+
+/* сегментовані таби (CRM + протоколи) → щільний радіус, тонка рамка; зелений active лишається */
+.basWorkspaceShell .crmSegmentTabs button,
+.basWorkspaceShell .protocolFilterTabs button{
+  border-color:var(--rp-line);
+  border-radius:var(--r-sm,4px);
+}
+.basWorkspaceShell .crmSegmentTabs button:hover,
+.basWorkspaceShell .protocolFilterTabs button:hover{border-color:var(--rp-faint)}
+
+/* картки черги протоколів → журнальна картка, без hover-стрибка й тіні */
+.basWorkspaceShell .protocolQueueItem{
+  border-color:var(--rp-line);
+  border-radius:var(--r-sm,4px);
+}
+.basWorkspaceShell .protocolQueueItem:hover{border-color:var(--rp-faint);transform:none}
+.basWorkspaceShell .protocolQueueItem.active{
+  border-color:var(--rp-accent);
+  box-shadow:none;
+  background:var(--rp-tint);
+}


### PR DESCRIPTION
## Навіщо

Крок 4 розкочення стилю Журналу документів. Пацієнти (CRM) і Протоколи — bespoke (щільнісний шар `23` їх не покриває), тож зводимо ключові журнальні сигнали до системи.

## Що зроблено

- **CRM-показники** (`.crmStats`) → журнальні картки: білий фон замість тонування, тонка рамка, щільний радіус, число 22px.
- **Сегментовані таби** (CRM + протоколи) → щільний радіус, тонка рамка; зелений `active` збережено.
- **Картки черги протоколів** (`.protocolQueueItem`) → журнальна картка: прибрано hover-стрибок і тінь активної (тонований фон замість тіні).

Новий шар `27-crm-protocol-journal.css`; токени `--rp-*` (світла/темна теми). Функції й розмітку не чіпано.

## Перевірки

- `919/919` тестів; `npm run build`, `lint` (0 errors) — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_