### PR TITLE
Add read-only personnel radiation dose summary

### DIFF
--- a/app/api/staff/personnel/radiation-dose-summary/route.ts
+++ b/app/api/staff/personnel/radiation-dose-summary/route.ts
@@ -1,0 +1,135 @@
+import { audit } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import type { AccessRole } from "../../../../../lib/staff-auth";
+import { requireSelfServiceOrgContext } from "../../../../../lib/tenant";
+
+function canViewRadiationDoseSummary(role: AccessRole) {
+  return role === "admin" || role === "department_head";
+}
+
+function isIsoDate(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+type DoseSummaryRow = {
+  personnelId:string;
+  displayName:string;
+  positionTitle:string;
+  departmentName:string | null;
+  firstPeriodStart:string | null;
+  lastPeriodEnd:string | null;
+  measuredCount:number;
+  belowDetectionCount:number;
+  missingCount:number;
+  otherCount:number;
+  hp10MeasuredSubtotal:number;
+  hp007MeasuredSubtotal:number;
+  hp3MeasuredSubtotal:number;
+};
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error:"База тимчасово недоступна" }, { status:503 });
+
+  const ctx = await requireSelfServiceOrgContext(request, db);
+  if (!ctx || !canViewRadiationDoseSummary(ctx.member.role)) {
+    return Response.json({ error:"Доступ до дозового зведення персоналу заборонено" }, { status:403 });
+  }
+
+  const url = new URL(request.url);
+  const from = url.searchParams.get("from")?.trim() || "";
+  const to = url.searchParams.get("to")?.trim() || "";
+  if (!isIsoDate(from) || !isIsoDate(to) || to < from) {
+    return Response.json({ error:"Перевірте період зведення" }, { status:400 });
+  }
+
+  const rows = await db.prepare(
+    `WITH current_records AS (
+       SELECT r.personnel_id, r.period_start, r.period_end, r.measurement_status,
+              r.hp10_msv, r.hp007_msv, r.hp3_msv
+       FROM personnel_dosimetry_records r
+       WHERE r.organization_id = ?
+         AND r.period_end >= ? AND r.period_end <= ?
+         AND NOT EXISTS (
+           SELECT 1 FROM personnel_dosimetry_records correction
+           WHERE correction.supersedes_id = r.id
+             AND correction.organization_id = r.organization_id
+             AND correction.personnel_id = r.personnel_id
+         )
+     ),
+     aggregated AS (
+       SELECT personnel_id,
+              MIN(period_start) AS first_period_start,
+              MAX(period_end) AS last_period_end,
+              SUM(CASE WHEN measurement_status = 'measured' THEN 1 ELSE 0 END) AS measured_count,
+              SUM(CASE WHEN measurement_status = 'below_detection' THEN 1 ELSE 0 END) AS below_detection_count,
+              SUM(CASE WHEN measurement_status = 'missing' THEN 1 ELSE 0 END) AS missing_count,
+              SUM(CASE WHEN measurement_status = 'other' THEN 1 ELSE 0 END) AS other_count,
+              SUM(CASE WHEN measurement_status = 'measured' THEN hp10_msv ELSE 0 END) AS hp10_measured_subtotal,
+              SUM(CASE WHEN measurement_status = 'measured' THEN hp007_msv ELSE 0 END) AS hp007_measured_subtotal,
+              SUM(CASE WHEN measurement_status = 'measured' THEN hp3_msv ELSE 0 END) AS hp3_measured_subtotal
+       FROM current_records
+       GROUP BY personnel_id
+     )
+     SELECT p.id AS personnelId, p.display_name AS displayName,
+            p.position_title AS positionTitle, d.name AS departmentName,
+            a.first_period_start AS firstPeriodStart,
+            a.last_period_end AS lastPeriodEnd,
+            COALESCE(a.measured_count, 0) AS measuredCount,
+            COALESCE(a.below_detection_count, 0) AS belowDetectionCount,
+            COALESCE(a.missing_count, 0) AS missingCount,
+            COALESCE(a.other_count, 0) AS otherCount,
+            COALESCE(a.hp10_measured_subtotal, 0) AS hp10MeasuredSubtotal,
+            COALESCE(a.hp007_measured_subtotal, 0) AS hp007MeasuredSubtotal,
+            COALESCE(a.hp3_measured_subtotal, 0) AS hp3MeasuredSubtotal
+     FROM personnel_records p
+     LEFT JOIN departments d
+       ON d.id = p.department_id AND d.organization_id = p.organization_id
+     LEFT JOIN aggregated a ON a.personnel_id = p.id
+     WHERE p.organization_id = ? AND p.active = 1
+     ORDER BY p.last_name, p.first_name, p.patronymic, p.id`,
+  ).bind(ctx.organizationId, from, to, ctx.organizationId).all<DoseSummaryRow>();
+
+  const records = rows.results.map((row) => {
+    const recordCount = row.measuredCount + row.belowDetectionCount + row.missingCount + row.otherCount;
+    return {
+      ...row,
+      recordCount,
+      hasNonMeasuredRecords: row.belowDetectionCount + row.missingCount + row.otherCount > 0,
+      numericSubtotalAvailable: row.measuredCount > 0,
+    };
+  });
+
+  const personnelWithRecords = records.filter((record) => record.recordCount > 0).length;
+  const personnelWithNonMeasuredRecords = records.filter((record) => record.hasNonMeasuredRecords).length;
+
+  await audit(db, {
+    organizationId:ctx.organizationId,
+    actorEmail:ctx.member.email,
+    action:"personnel_radiation_dose_summary_viewed",
+    resource:"personnel_radiation_dose_summary",
+    details:{
+      from,
+      to,
+      personnelCount:records.length,
+      personnelWithRecords,
+      personnelWithNonMeasuredRecords,
+    },
+  });
+
+  return Response.json({
+    from,
+    to,
+    rangeBasis:"period_end",
+    subtotalBasis:"measured_only",
+    records,
+    summary:{
+      totalPersonnel:records.length,
+      personnelWithRecords,
+      personnelWithoutRecords:records.length - personnelWithRecords,
+      personnelWithNonMeasuredRecords,
+    },
+  }, { headers:{ "cache-control":"no-store" } });
+}

--- a/app/staff/directories/page.tsx
+++ b/app/staff/directories/page.tsx
@@ -7,6 +7,7 @@ const directories=[
   {name:"Допуск до ДІВ",description:"Append-only історія кадрових рішень щодо робіт з джерелами іонізуючого випромінювання.",href:"/staff/personnel/radiation-clearance"},
   {name:"Радіаційна безпека",description:"Навчання, перевірки знань та інструктажі з окремою історією сертифікатів і строків дії.",href:"/staff/personnel/radiation-training"},
   {name:"Індивідуальна дозиметрія",description:"Захищена append-only історія персонального дозиметричного контролю Hp(10), Hp(0.07) та Hp(3).",href:"/staff/personnel/dosimetry"},
+  {name:"Дозове зведення",description:"Read-only subtotal тільки виміряних Hp(10), Hp(0.07) та Hp(3) за період; ненумеричні статуси не трактуються як нуль.",href:"/staff/personnel/radiation-dose-summary"},
   {name:"Зведення ДІВ",description:"Read-only проекція допуску, навчання, перевірок знань і стану дозиметрії без автоматичного блокування роботи.",href:"/staff/personnel/radiation-compliance"},
   {name:"Політика ДІВ",description:"Append-only організаційні критерії review без прихованих нормативів, дозових лімітів або operational enforcement.",href:"/staff/personnel/radiation-review-policy"},
   {name:"Обладнання",description:"Апарати, кабінети та технічні атрибути, що використовуються в записах і виконанні.",href:"/staff/equipment"},

--- a/app/staff/personnel/radiation-dose-summary/page.tsx
+++ b/app/staff/personnel/radiation-dose-summary/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type DoseSummaryRecord = {
+  personnelId:string;
+  displayName:string;
+  positionTitle:string;
+  departmentName:string | null;
+  firstPeriodStart:string | null;
+  lastPeriodEnd:string | null;
+  measuredCount:number;
+  belowDetectionCount:number;
+  missingCount:number;
+  otherCount:number;
+  hp10MeasuredSubtotal:number;
+  hp007MeasuredSubtotal:number;
+  hp3MeasuredSubtotal:number;
+  recordCount:number;
+  hasNonMeasuredRecords:boolean;
+  numericSubtotalAvailable:boolean;
+};
+
+type DoseSummaryResponse = {
+  from?:string;
+  to?:string;
+  rangeBasis?:"period_end";
+  subtotalBasis?:"measured_only";
+  records?:DoseSummaryRecord[];
+  summary?:{
+    totalPersonnel:number;
+    personnelWithRecords:number;
+    personnelWithoutRecords:number;
+    personnelWithNonMeasuredRecords:number;
+  };
+  error?:string;
+};
+
+function localIsoDate() {
+  const now = new Date();
+  const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 10);
+}
+
+function yearStart(date:string) {
+  return `${date.slice(0, 4)}-01-01`;
+}
+
+function dose(value:number, available:boolean) {
+  return available ? `${String(Number(value || 0))} mSv` : "—";
+}
+
+function statusLines(record:DoseSummaryRecord) {
+  const lines:string[] = [];
+  if (record.measuredCount) lines.push(`measured: ${record.measuredCount}`);
+  if (record.belowDetectionCount) lines.push(`< межі визначення: ${record.belowDetectionCount}`);
+  if (record.missingCount) lines.push(`результат відсутній: ${record.missingCount}`);
+  if (record.otherCount) lines.push(`other: ${record.otherCount}`);
+  return lines.length ? lines.join(" · ") : "Записів у вибраному інтервалі немає";
+}
+
+export default function RadiationDoseSummaryPage() {
+  const [from,setFrom] = useState("");
+  const [to,setTo] = useState("");
+  const [records,setRecords] = useState<DoseSummaryRecord[]>([]);
+  const [summary,setSummary] = useState({
+    totalPersonnel:0,
+    personnelWithRecords:0,
+    personnelWithoutRecords:0,
+    personnelWithNonMeasuredRecords:0,
+  });
+  const [loading,setLoading] = useState(true);
+  const [error,setError] = useState("");
+
+  const load = useCallback(async(nextFrom:string,nextTo:string) => {
+    setLoading(true); setError("");
+    try {
+      const response = await fetch(
+        `/api/staff/personnel/radiation-dose-summary?from=${encodeURIComponent(nextFrom)}&to=${encodeURIComponent(nextTo)}`,
+        { cache:"no-store" },
+      );
+      const data = await response.json() as DoseSummaryResponse;
+      if (!response.ok) throw new Error(data.error || "Не вдалося завантажити дозове зведення");
+      setRecords(data.records || []);
+      setSummary(data.summary || {
+        totalPersonnel:0,
+        personnelWithRecords:0,
+        personnelWithoutRecords:0,
+        personnelWithNonMeasuredRecords:0,
+      });
+    } catch (value) {
+      setError(value instanceof Error ? value.message : "Не вдалося завантажити дозове зведення");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const today = localIsoDate();
+      const start = yearStart(today);
+      setFrom(start);
+      setTo(today);
+      void load(start, today);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  return <StaffWorkspaceShell
+    active="directories"
+    title="Індивідуальна дозиметрія · дозове зведення"
+    description="Read-only числовий subtotal виміряних Hp(10), Hp(0.07) та Hp(3) за вибраним інтервалом без нормативних порогів."
+  >
+    {error && <p className="errorBox">{error}</p>}
+
+    <section className="financeSummary" aria-label="Дозове зведення">
+      <article><span>Активний персонал</span><b>{summary.totalPersonnel}</b><small>кадрових карток</small></article>
+      <article><span>Є дозиметричні записи</span><b>{summary.personnelWithRecords}</b><small>за period_end у діапазоні</small></article>
+      <article><span>Без записів</span><b>{summary.personnelWithoutRecords}</b><small>не означає нульову дозу</small></article>
+      <article><span>Є ненумеричні статуси</span><b>{summary.personnelWithNonMeasuredRecords}</b><small>below detection / missing / other</small></article>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div>
+          <b>Період зведення</b>
+          <small>Запис включається за датою завершення дозиметричного періоду (`period_end`).</small>
+        </div>
+        <div className="shiftPlannerToolbar">
+          <input aria-label="Початок періоду" type="date" value={from} onChange={(event)=>setFrom(event.target.value)} />
+          <input aria-label="Кінець періоду" type="date" value={to} onChange={(event)=>setTo(event.target.value)} />
+          <button className="button secondary" type="button" disabled={!from || !to || loading} onClick={()=>void load(from,to)}>
+            {loading?"Оновлення…":"Оновити"}
+          </button>
+        </div>
+      </header>
+      <p className="notice">
+        Числовий subtotal нижче складається лише зі статусів `measured`. `below_detection` не є нульовою дозою, `missing` не означає нульове опромінення, а `other` не включається до subtotal без ручної інтерпретації первинного запису.
+      </p>
+      <p className="notice">
+        Це не розрахунок нормативної річної/ковзної дози, не юридичний висновок і не alert. Тут немає dose thresholds та автоматичного блокування PACS, КТ, рентген чи booking.
+      </p>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar"><div><b>Активний персонал</b><small>Тільки unsuperseded append-only записи дозиметрії.</small></div></header>
+      {loading ? <p className="notice">Завантаження…</p> : <div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Працівник</th><th>Покритий записами період</th><th>Статуси записів</th><th>Hp(10) subtotal</th><th>Hp(0.07) subtotal</th><th>Hp(3) subtotal</th><th/></tr></thead>
+        <tbody>{records.map((record)=><tr key={record.personnelId}>
+          <td><b>{record.displayName}</b><br/><small>{record.positionTitle}{record.departmentName?` · ${record.departmentName}`:""}</small></td>
+          <td>{record.firstPeriodStart && record.lastPeriodEnd ? <><b>{record.firstPeriodStart}</b> → <b>{record.lastPeriodEnd}</b></> : "—"}</td>
+          <td>
+            <span className={`statusPill ${record.recordCount && !record.hasNonMeasuredRecords?"ok":""}`}>
+              {record.recordCount ? `${record.recordCount} запис(ів)` : "Немає записів"}
+            </span>
+            <br/><small>{statusLines(record)}</small>
+            {record.hasNonMeasuredRecords && <><br/><small>Числовий subtotal не охоплює ненумеричні статуси.</small></>}
+          </td>
+          <td><b>{dose(record.hp10MeasuredSubtotal,record.numericSubtotalAvailable)}</b></td>
+          <td><b>{dose(record.hp007MeasuredSubtotal,record.numericSubtotalAvailable)}</b></td>
+          <td><b>{dose(record.hp3MeasuredSubtotal,record.numericSubtotalAvailable)}</b></td>
+          <td><Link href="/staff/personnel/dosimetry">Первинні записи</Link></td>
+        </tr>)}</tbody>
+      </table>{!records.length && <p className="notice">Активних кадрових карток немає.</p>}</div>}
+    </section>
+  </StaffWorkspaceShell>;
+}

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -62,6 +62,7 @@ export const AUDIT_LABELS: Record<string, string> = {
   personnel_radiation_training_recorded: "Додано запис навчання працівника з радіаційної безпеки",
   personnel_dosimetry_viewed: "Переглянуто індивідуальну дозиметрію працівника",
   personnel_dosimetry_recorded: "Додано результат індивідуальної дозиметрії працівника",
+  personnel_radiation_dose_summary_viewed: "Переглянуто дозове зведення індивідуальної дозиметрії",
   personnel_radiation_compliance_viewed: "Переглянуто зведення радіаційної безпеки персоналу",
   personnel_radiation_review_policy_viewed: "Переглянуто політику review радіаційної безпеки",
   personnel_radiation_review_policy_recorded: "Додано ревізію політики review радіаційної безпеки",

--- a/tests/personnel-radiation-dose-summary.test.mjs
+++ b/tests/personnel-radiation-dose-summary.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { DatabaseSync } from "node:sqlite";
+
+const route = fs.readFileSync("app/api/staff/personnel/radiation-dose-summary/route.ts", "utf8");
+const page = fs.readFileSync("app/staff/personnel/radiation-dose-summary/page.tsx", "utf8");
+const directories = fs.readFileSync("app/staff/directories/page.tsx", "utf8");
+const audit = fs.readFileSync("lib/audit.ts", "utf8");
+
+function summarySql() {
+  const match = route.match(/db\.prepare\(\s*`(WITH current_records[\s\S]*?ORDER BY p\.last_name, p\.first_name, p\.patronymic, p\.id)`\s*,?\s*\)\.bind/);
+  assert.ok(match, "dose summary SQL must remain extractable for behavioral coverage");
+  return match[1];
+}
+
+function baselineDb() {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE organizations (id INTEGER PRIMARY KEY);
+    CREATE TABLE departments (
+      id INTEGER PRIMARY KEY,
+      organization_id INTEGER NOT NULL,
+      name TEXT NOT NULL
+    );
+    CREATE TABLE personnel_records (
+      id TEXT PRIMARY KEY,
+      organization_id INTEGER NOT NULL,
+      display_name TEXT NOT NULL,
+      position_title TEXT NOT NULL,
+      department_id INTEGER,
+      active INTEGER NOT NULL DEFAULT 1,
+      last_name TEXT NOT NULL DEFAULT '',
+      first_name TEXT NOT NULL DEFAULT '',
+      patronymic TEXT NOT NULL DEFAULT ''
+    );
+    INSERT INTO organizations(id) VALUES (1), (2);
+    INSERT INTO departments(id, organization_id, name) VALUES
+      (10, 1, 'Рентгенологія'),
+      (20, 2, 'Інша');
+    INSERT INTO personnel_records
+      (id, organization_id, display_name, position_title, department_id, active, last_name, first_name)
+    VALUES
+      ('p1', 1, 'Тест Один', 'Лікар', 10, 1, 'Тест', 'Один'),
+      ('p2', 1, 'Тест Два', 'Лаборант', 10, 1, 'Тест', 'Два'),
+      ('p3', 2, 'Інший Tenant', 'Лікар', 20, 1, 'Інший', 'Tenant');
+  `);
+  db.exec(fs.readFileSync("drizzle/0112_personnel_dosimetry.sql", "utf8"));
+  return db;
+}
+
+test("dose summary uses only current measured records and remains tenant scoped", () => {
+  const db = baselineDb();
+  db.exec(`
+    INSERT INTO personnel_dosimetry_records
+      (id, organization_id, personnel_id, period_start, period_end, measurement_status, hp10_msv, hp007_msv, hp3_msv)
+    VALUES
+      ('d-old', 1, 'p1', '2026-01-01', '2026-01-31', 'measured', 0.10, 0.20, 0.30);
+
+    INSERT INTO personnel_dosimetry_records
+      (id, organization_id, personnel_id, period_start, period_end, measurement_status, hp10_msv, hp007_msv, hp3_msv, supersedes_id)
+    VALUES
+      ('d-corrected', 1, 'p1', '2026-01-01', '2026-01-31', 'measured', 0.15, 0.25, 0.35, 'd-old');
+
+    INSERT INTO personnel_dosimetry_records
+      (id, organization_id, personnel_id, period_start, period_end, measurement_status, hp10_msv, hp007_msv, hp3_msv)
+    VALUES
+      ('d-below', 1, 'p1', '2026-02-01', '2026-02-28', 'below_detection', 0, 0, 0),
+      ('d-missing', 1, 'p1', '2026-03-01', '2026-03-31', 'missing', 0, 0, 0),
+      ('d-other', 1, 'p1', '2026-04-01', '2026-04-30', 'other', 9, 8, 7),
+      ('d-outside', 1, 'p1', '2025-12-01', '2025-12-31', 'measured', 99, 99, 99),
+      ('d-other-tenant', 2, 'p3', '2026-01-01', '2026-01-31', 'measured', 100, 100, 100);
+  `);
+
+  const rows = db.prepare(summarySql()).all(1, "2026-01-01", "2026-12-31", 1);
+  assert.equal(rows.length, 2);
+
+  const p1 = rows.find((row) => row.personnelId === "p1");
+  const p2 = rows.find((row) => row.personnelId === "p2");
+  assert.ok(p1);
+  assert.ok(p2);
+
+  assert.equal(p1.measuredCount, 1);
+  assert.equal(p1.belowDetectionCount, 1);
+  assert.equal(p1.missingCount, 1);
+  assert.equal(p1.otherCount, 1);
+  assert.equal(p1.hp10MeasuredSubtotal, 0.15);
+  assert.equal(p1.hp007MeasuredSubtotal, 0.25);
+  assert.equal(p1.hp3MeasuredSubtotal, 0.35);
+  assert.equal(p1.firstPeriodStart, "2026-01-01");
+  assert.equal(p1.lastPeriodEnd, "2026-04-30");
+
+  assert.equal(p2.measuredCount, 0);
+  assert.equal(p2.hp10MeasuredSubtotal, 0);
+  assert.equal(rows.some((row) => row.personnelId === "p3"), false);
+});
+
+test("dose summary endpoint is manager-only, read-only and measured-only", () => {
+  assert.match(route, /role === "admin" \|\| role === "department_head"/);
+  assert.match(route, /measurement_status = 'measured' THEN hp10_msv ELSE 0/);
+  assert.match(route, /measurement_status = 'below_detection'/);
+  assert.match(route, /measurement_status = 'missing'/);
+  assert.match(route, /measurement_status = 'other'/);
+  assert.match(route, /NOT EXISTS/);
+  assert.match(route, /r\.period_end >= \? AND r\.period_end <= \?/);
+  assert.match(route, /p\.organization_id = \? AND p\.active = 1/);
+  assert.match(route, /personnel_radiation_dose_summary_viewed/);
+  assert.doesNotMatch(route, /export async function (POST|PUT|PATCH|DELETE)/);
+  assert.doesNotMatch(route, /pacs_settings|imaging_studies|bookings/);
+  assert.doesNotMatch(route, /hp10_measured_subtotal\s*[<>]=?\s*\d/);
+});
+
+test("dose summary UI never presents non-measured statuses as zero dose", () => {
+  assert.match(page, /below_detection` не є нульовою дозою/);
+  assert.match(page, /missing` не означає нульове опромінення/);
+  assert.match(page, /other` не включається до subtotal/);
+  assert.match(page, /numericSubtotalAvailable/);
+  assert.match(page, /available \? `\$\{String\(Number\(value \|\| 0\)\)\} mSv` : "—"/);
+  assert.match(page, /не розрахунок нормативної річної\/ковзної дози/);
+  assert.match(page, /немає dose thresholds/);
+  assert.match(directories, /Дозове зведення/);
+  assert.match(directories, /\/staff\/personnel\/radiation-dose-summary/);
+  assert.match(audit, /personnel_radiation_dose_summary_viewed/);
+});


### PR DESCRIPTION
## Що змінено
- додає manager-only GET `/api/staff/personnel/radiation-dose-summary`
- формує read-only зведення для активного персоналу за вибраним інтервалом, де включення запису визначається датою `period_end`
- використовує лише unsuperseded append-only записи дозиметрії та tenant scope
- числовий subtotal Hp(10), Hp(0.07), Hp(3) складається ТІЛЬКИ зі статусів `measured`
- `below_detection`, `missing` та `other` рахуються окремо і не додаються до subtotal як 0 mSv
- якщо measured-записів немає, UI показує `—`, а не 0 mSv
- `other` з числовими значеннями навмисно не входить у subtotal без ручної інтерпретації первинного запису
- UI показує кількість статусів та покритий наявними записами період
- додає audit event без копіювання дозових значень у audit details
- додає посилання з довідників
- behavioral test виконує exact SQL у SQLite та перевіряє correction/superseded handling, tenant isolation, range filtering і measured-only subtotal

## Важлива межа
Це не нормативний річний/ковзний dose calculation, не юридичний висновок і не alert. PR не містить dose thresholds і не блокує PACS, КТ, рентген, booking або інші operational flows.

Production deploy не запускається.