### PR TITLE
Make radiation compliance overview monitoring-scope aware

### DIFF
--- a/app/api/staff/personnel/radiation-compliance/route.ts
+++ b/app/api/staff/personnel/radiation-compliance/route.ts
@@ -3,10 +3,12 @@ import { dbBinding } from "../../../../../lib/db";
 import {
   classifyDosimetry,
   classifyRadiationClearance,
+  classifyRadiationMonitoringScope,
   classifyRadiationTraining,
   mergeRadiationReviewReasons,
   radiationPolicyReviewReasons,
   radiationReviewReasons,
+  radiationScopeReviewReasons,
   type RadiationReviewPolicy,
 } from "../../../../../lib/personnel-radiation-compliance";
 import type { AccessRole } from "../../../../../lib/staff-auth";
@@ -39,6 +41,10 @@ type RawComplianceRow = {
   displayName: string;
   positionTitle: string;
   departmentName: string | null;
+  monitoringScopeStatus: string | null;
+  monitoringScopeEffectiveDate: string | null;
+  monitoringScopeText: string | null;
+  monitoringScopeBasisTitle: string | null;
   clearanceDecisionCode: string | null;
   clearanceEffectiveDate: string | null;
   clearanceValidUntil: string | null;
@@ -102,7 +108,25 @@ export async function GET(request: Request) {
   } : null;
 
   const rows = await db.prepare(
-    `WITH clearance_ranked AS (
+    `WITH monitoring_scope_ranked AS (
+       SELECT r.personnel_id, r.scope_status, r.effective_date,
+              r.scope_text, r.basis_title,
+              ROW_NUMBER() OVER (
+                PARTITION BY r.personnel_id
+                ORDER BY r.effective_date DESC, r.created_at DESC, r.id DESC
+              ) AS rn
+       FROM personnel_radiation_monitoring_scope_records r
+       WHERE r.organization_id = ?
+         AND r.effective_date <= ?
+         AND NOT EXISTS (
+           SELECT 1 FROM personnel_radiation_monitoring_scope_records correction
+           WHERE correction.supersedes_id = r.id
+             AND correction.organization_id = r.organization_id
+             AND correction.personnel_id = r.personnel_id
+             AND correction.effective_date <= ?
+         )
+     ),
+     clearance_ranked AS (
        SELECT r.personnel_id, r.decision_code, r.effective_date, r.valid_until,
               r.document_number,
               ROW_NUMBER() OVER (
@@ -174,6 +198,10 @@ export async function GET(request: Request) {
      )
      SELECT p.id AS personnelId, p.display_name AS displayName,
             p.position_title AS positionTitle, d.name AS departmentName,
+            ms.scope_status AS monitoringScopeStatus,
+            ms.effective_date AS monitoringScopeEffectiveDate,
+            ms.scope_text AS monitoringScopeText,
+            ms.basis_title AS monitoringScopeBasisTitle,
             c.decision_code AS clearanceDecisionCode,
             c.effective_date AS clearanceEffectiveDate,
             c.valid_until AS clearanceValidUntil,
@@ -193,6 +221,7 @@ export async function GET(request: Request) {
      FROM personnel_records p
      LEFT JOIN departments d
        ON d.id = p.department_id AND d.organization_id = p.organization_id
+     LEFT JOIN monitoring_scope_ranked ms ON ms.personnel_id = p.id AND ms.rn = 1
      LEFT JOIN clearance_ranked c ON c.personnel_id = p.id AND c.rn = 1
      LEFT JOIN training_ranked t ON t.personnel_id = p.id AND t.rn = 1
      LEFT JOIN knowledge_ranked k ON k.personnel_id = p.id AND k.rn = 1
@@ -200,6 +229,7 @@ export async function GET(request: Request) {
      WHERE p.organization_id = ? AND p.active = 1
      ORDER BY p.last_name, p.first_name, p.patronymic, p.id`,
   ).bind(
+    ctx.organizationId, asOf, asOf,
     ctx.organizationId, asOf,
     ctx.organizationId, asOf,
     ctx.organizationId, asOf,
@@ -208,6 +238,9 @@ export async function GET(request: Request) {
   ).all<RawComplianceRow>();
 
   const records = rows.results.map((row) => {
+    const monitoringScopeState = classifyRadiationMonitoringScope(
+      row.monitoringScopeStatus ? { scopeStatus:row.monitoringScopeStatus } : null,
+    );
     const clearanceRecord = row.clearanceDecisionCode ? {
       decisionCode: row.clearanceDecisionCode,
       validUntil: row.clearanceValidUntil,
@@ -228,37 +261,55 @@ export async function GET(request: Request) {
     const trainingState = classifyRadiationTraining(trainingRecord, asOf);
     const knowledgeCheckState = classifyRadiationTraining(knowledgeRecord, asOf);
     const dosimetryState = classifyDosimetry(dosimetryRecord);
-    const baseReviewReasons = radiationReviewReasons({
+    const scopeReviewReasons = radiationScopeReviewReasons(monitoringScopeState);
+
+    const baseReviewReasons = monitoringScopeState === "in_scope" ? radiationReviewReasons({
       clearance: clearanceState,
       training: trainingState,
       knowledgeCheck: knowledgeCheckState,
       dosimetry: dosimetryState,
-    });
-    const policyReviewReasons = radiationPolicyReviewReasons({
+    }) : [];
+    const policyReviewReasons = monitoringScopeState === "in_scope" ? radiationPolicyReviewReasons({
       policy,
       asOf,
       clearanceValidUntil:row.clearanceValidUntil,
       trainingDate:row.trainingDate,
       knowledgeDate:row.knowledgeDate,
       dosimetryPeriodEnd:row.dosimetryPeriodEnd,
-    });
-    const reviewReasons = mergeRadiationReviewReasons(baseReviewReasons, policyReviewReasons);
+    }) : [];
+    const reviewReasons = mergeRadiationReviewReasons(
+      scopeReviewReasons,
+      baseReviewReasons,
+      policyReviewReasons,
+    );
+    const summaryState = monitoringScopeState === "out_of_scope"
+      ? "out_of_scope"
+      : reviewReasons.length ? "review" : "recorded";
 
     return {
       ...row,
+      monitoringScopeState,
       clearanceState,
       trainingState,
       knowledgeCheckState,
       dosimetryState,
+      scopeReviewReasons,
       baseReviewReasons,
       policyReviewReasons,
       reviewReasons,
-      summaryState: reviewReasons.length ? "review" : "recorded",
+      summaryState,
     };
   });
 
+  const inScopeCount = records.filter((record) => record.monitoringScopeState === "in_scope").length;
+  const outOfScopeCount = records.filter((record) => record.monitoringScopeState === "out_of_scope").length;
+  const scopeReviewCount = records.filter(
+    (record) => record.monitoringScopeState === "review" || record.monitoringScopeState === "unclassified",
+  ).length;
   const reviewCount = records.filter((record) => record.summaryState === "review").length;
+  const recordedCount = records.filter((record) => record.summaryState === "recorded").length;
   const policyReviewCount = records.filter((record) => record.policyReviewReasons.length > 0).length;
+
   await audit(db, {
     organizationId: ctx.organizationId,
     actorEmail: ctx.member.email,
@@ -267,6 +318,9 @@ export async function GET(request: Request) {
     details: {
       asOf,
       recordCount: records.length,
+      inScopeCount,
+      outOfScopeCount,
+      scopeReviewCount,
       reviewCount,
       policyId: policy?.id || "",
       policyReviewCount,
@@ -280,8 +334,11 @@ export async function GET(request: Request) {
       records,
       summary: {
         total: records.length,
+        inScopeCount,
+        outOfScopeCount,
+        scopeReviewCount,
         reviewCount,
-        recordedCount: records.length - reviewCount,
+        recordedCount,
         policyReviewCount,
       },
     },

--- a/app/staff/personnel/radiation-compliance/page.tsx
+++ b/app/staff/personnel/radiation-compliance/page.tsx
@@ -21,6 +21,11 @@ type ComplianceRecord = {
   displayName:string;
   positionTitle:string;
   departmentName:string | null;
+  monitoringScopeStatus:string | null;
+  monitoringScopeEffectiveDate:string | null;
+  monitoringScopeText:string | null;
+  monitoringScopeBasisTitle:string | null;
+  monitoringScopeState:"in_scope" | "out_of_scope" | "review" | "unclassified";
   clearanceState:string;
   clearanceEffectiveDate:string | null;
   clearanceValidUntil:string | null;
@@ -37,18 +42,39 @@ type ComplianceRecord = {
   dosimetryPeriodStart:string | null;
   dosimetryPeriodEnd:string | null;
   dosimetryReportNumber:string | null;
+  scopeReviewReasons:string[];
   baseReviewReasons:string[];
   policyReviewReasons:string[];
   reviewReasons:string[];
-  summaryState:"recorded" | "review";
+  summaryState:"recorded" | "review" | "out_of_scope";
+};
+
+type ComplianceSummary = {
+  total:number;
+  inScopeCount:number;
+  outOfScopeCount:number;
+  scopeReviewCount:number;
+  reviewCount:number;
+  recordedCount:number;
+  policyReviewCount:number;
 };
 
 type ComplianceResponse = {
   asOf?:string;
   policy?:AppliedPolicy | null;
   records?:ComplianceRecord[];
-  summary?:{total:number;reviewCount:number;recordedCount:number;policyReviewCount:number};
+  summary?:ComplianceSummary;
   error?:string;
+};
+
+const EMPTY_SUMMARY:ComplianceSummary = {
+  total:0,
+  inScopeCount:0,
+  outOfScopeCount:0,
+  scopeReviewCount:0,
+  reviewCount:0,
+  recordedCount:0,
+  policyReviewCount:0,
 };
 
 function localIsoDate(){
@@ -85,6 +111,12 @@ const DOSIMETRY_LABELS:Record<string,string>={
   review:"Перевірити",
   missing:"Немає запису",
 };
+const SCOPE_LABELS:Record<ComplianceRecord["monitoringScopeState"],string>={
+  in_scope:"У контурі",
+  out_of_scope:"Поза контуром",
+  review:"Уточнити",
+  unclassified:"Не визначено",
+};
 
 function goodState(kind:"clearance"|"training"|"dosimetry",state:string){
   if(kind==="clearance") return state==="authorized";
@@ -97,11 +129,26 @@ function Status({kind,state}:{kind:"clearance"|"training"|"dosimetry";state:stri
   return <span className={`statusPill ${goodState(kind,state)?"ok":""}`}>{labels[state] || state}</span>;
 }
 
+function ScopeStatus({record}:{record:ComplianceRecord}){
+  const good=record.monitoringScopeState==="in_scope";
+  return <>
+    <span className={`statusPill ${good?"ok":""}`}>{SCOPE_LABELS[record.monitoringScopeState]}</span>
+    {record.monitoringScopeEffectiveDate && <><br/><small>з {record.monitoringScopeEffectiveDate}</small></>}
+    {record.monitoringScopeText && <><br/><small>{record.monitoringScopeText}</small></>}
+    {record.monitoringScopeBasisTitle && <><br/><small>{record.monitoringScopeBasisTitle}</small></>}
+    <br/><Link href="/staff/personnel/radiation-monitoring-scope">Історія scope</Link>
+  </>;
+}
+
+function NotEvaluated({scope}:{scope:ComplianceRecord["monitoringScopeState"]}){
+  return <><span className="statusPill">Не оцінюється</span><br/><small>{scope==="out_of_scope"?"Працівник поза організаційним контуром":"Спочатку уточніть контур радіаційного контролю"}</small></>;
+}
+
 export default function RadiationCompliancePage(){
   const [asOf,setAsOf]=useState("");
   const [policy,setPolicy]=useState<AppliedPolicy | null>(null);
   const [records,setRecords]=useState<ComplianceRecord[]>([]);
-  const [summary,setSummary]=useState({total:0,reviewCount:0,recordedCount:0,policyReviewCount:0});
+  const [summary,setSummary]=useState<ComplianceSummary>(EMPTY_SUMMARY);
   const [loading,setLoading]=useState(true);
   const [error,setError]=useState("");
 
@@ -113,7 +160,7 @@ export default function RadiationCompliancePage(){
       if(!response.ok) throw new Error(data.error || "Не вдалося завантажити зведення");
       setPolicy(data.policy || null);
       setRecords(data.records || []);
-      setSummary(data.summary || {total:0,reviewCount:0,recordedCount:0,policyReviewCount:0});
+      setSummary(data.summary || EMPTY_SUMMARY);
     }catch(value){
       setError(value instanceof Error?value.message:"Не вдалося завантажити зведення");
     }finally{ setLoading(false); }
@@ -131,43 +178,56 @@ export default function RadiationCompliancePage(){
   return <StaffWorkspaceShell
     active="directories"
     title="Радіаційна безпека · зведення"
-    description="Read-only проекція кадрових фактів: допуск до ДІВ, навчання, перевірка знань та останній стан індивідуальної дозиметрії."
+    description="Read-only проекція організаційного scope, допуску до ДІВ, навчання, перевірки знань та останнього стану індивідуальної дозиметрії."
   >
     {error && <p className="errorBox">{error}</p>}
 
     <section className="financeSummary" aria-label="Стан даних радіаційної безпеки">
-      <article><span>Активний персонал</span><b>{summary.total}</b><small>у кадровому довіднику</small></article>
-      <article><span>Без очевидних зауважень</span><b>{summary.recordedCount}</b><small>за наявними даними</small></article>
-      <article><span>Потребує перевірки</span><b>{summary.reviewCount}</b><small>не означає автоматичну заборону</small></article>
-      <article><span>За policy-критеріями</span><b>{summary.policyReviewCount}</b><small>інформаційний review, не alert</small></article>
+      <article><span>Активний персонал</span><b>{summary.total}</b><small>усі картки показані для backfill</small></article>
+      <article><span>У контурі</span><b>{summary.inScopeCount}</b><small>оцінюються safety-реєстри</small></article>
+      <article><span>Потребує перевірки</span><b>{summary.reviewCount}</b><small>включно з невизначеним scope</small></article>
+      <article><span>Поза контуром</span><b>{summary.outOfScopeCount}</b><small>окремий нейтральний стан</small></article>
     </section>
 
     <section className="financeJournal">
       <header className="financeToolbar">
-        <div><b>Дата зрізу</b><small>Майбутні кадрові записи й майбутні policy revisions не включаються.</small></div>
+        <div><b>Дата зрізу</b><small>Майбутні scope-записи, кадрові записи й policy revisions не включаються.</small></div>
         <div className="shiftPlannerToolbar">
           <input aria-label="Дата зрізу" type="date" value={asOf} onChange={(event)=>setAsOf(event.target.value)} />
           <button className="button secondary" type="button" disabled={!asOf || loading} onClick={()=>void load(asOf)}>{loading?"Оновлення…":"Оновити"}</button>
         </div>
       </header>
+      <p className="notice">
+        Safety-оцінка допуску, навчання, перевірки знань і дозиметрії виконується лише для працівників зі статусом `in_scope`. `out_of_scope` — це тільки організаційна класифікація RadiologyOS, не юридичне чи медичне звільнення від вимог. Невизначений або `other` scope не генерує фальшивих «відсутній допуск/дозиметрія» — спочатку потрібно уточнити контур.
+      </p>
       <p className="notice">Це інформаційне зведення, а не автоматичне рішення про допуск до роботи. Воно не застосовує дозові пороги, не створює alerts і не блокує PACS, КТ, рентген або запис пацієнтів.</p>
       {policy ? <p className="notice">
-        Застосована policy revision від <b>{policy.effectiveFrom}</b>: {policy.enabled?"увімкнена":"вимкнена"}. {policy.sourceTitle || "Джерело не вказано"}. {policy.requireClearanceValidUntil?"Строк дії допуску — критерій review. ":""}{policyCriterion(policy.trainingMaxAgeDays,"Навчання")} · {policyCriterion(policy.knowledgeCheckMaxAgeDays,"Перевірка знань")} · {policyCriterion(policy.dosimetryMaxAgeDays,"Дозиметрія")}. <Link href="/staff/personnel/radiation-review-policy">Історія політики</Link>
-      </p> : <p className="notice">Станом на {asOf || "обрану дату"} policy revision ще не набула чинності. Застосовуються лише базові детерміновані safety-signals. <Link href="/staff/personnel/radiation-review-policy">Політика ДІВ</Link></p>}
+        Застосована policy revision від <b>{policy.effectiveFrom}</b>: {policy.enabled?"увімкнена":"вимкнена"}. {policy.sourceTitle || "Джерело не вказано"}. {policy.requireClearanceValidUntil?"Строк дії допуску — критерій review. ":""}{policyCriterion(policy.trainingMaxAgeDays,"Навчання")} · {policyCriterion(policy.knowledgeCheckMaxAgeDays,"Перевірка знань")} · {policyCriterion(policy.dosimetryMaxAgeDays,"Дозиметрія")}. Policy застосовується лише до `in_scope`. <Link href="/staff/personnel/radiation-review-policy">Історія політики</Link>
+      </p> : <p className="notice">Станом на {asOf || "обрану дату"} policy revision ще не набула чинності. Для `in_scope` застосовуються лише базові детерміновані safety-signals. <Link href="/staff/personnel/radiation-review-policy">Політика ДІВ</Link></p>}
+      <p className="notice">Scope потребує уточнення: <b>{summary.scopeReviewCount}</b>. Policy-review серед `in_scope`: <b>{summary.policyReviewCount}</b>. Без очевидних зауважень серед `in_scope`: <b>{summary.recordedCount}</b>.</p>
     </section>
 
     <section className="financeJournal">
-      <header className="financeToolbar"><div><b>Активний персонал</b><small>Показані останні несуперечливі append-only записи станом на обрану дату.</small></div></header>
+      <header className="financeToolbar"><div><b>Активний персонал</b><small>Показані всі активні картки для безпечного backfill організаційного scope.</small></div></header>
       {loading ? <p className="notice">Завантаження…</p> : <div className="financeTableWrap"><table className="financeTable">
-        <thead><tr><th>Працівник</th><th>Допуск до ДІВ</th><th>Навчання</th><th>Перевірка знань</th><th>Дозиметрія</th><th>Зведення</th></tr></thead>
-        <tbody>{records.map((record)=><tr key={record.personnelId}>
-          <td><b>{record.displayName}</b><br/><small>{record.positionTitle}{record.departmentName?` · ${record.departmentName}`:""}</small></td>
-          <td><Status kind="clearance" state={record.clearanceState}/><br/><small>{record.clearanceEffectiveDate || "—"}{record.clearanceValidUntil?` → ${record.clearanceValidUntil}`:""}{record.clearanceDocumentNumber?` · № ${record.clearanceDocumentNumber}`:""}</small><br/><Link href="/staff/personnel/radiation-clearance">Історія</Link></td>
-          <td><Status kind="training" state={record.trainingState}/><br/><small>{record.trainingDate || "—"}{record.trainingValidUntil?` → ${record.trainingValidUntil}`:""}{record.trainingCourseTitle?` · ${record.trainingCourseTitle}`:""}</small><br/><Link href="/staff/personnel/radiation-training">Історія</Link></td>
-          <td><Status kind="training" state={record.knowledgeCheckState}/><br/><small>{record.knowledgeDate || "—"}{record.knowledgeValidUntil?` → ${record.knowledgeValidUntil}`:""}{record.knowledgeCourseTitle?` · ${record.knowledgeCourseTitle}`:""}</small></td>
-          <td><Status kind="dosimetry" state={record.dosimetryState}/><br/><small>{record.dosimetryPeriodStart && record.dosimetryPeriodEnd?`${record.dosimetryPeriodStart} → ${record.dosimetryPeriodEnd}`:"—"}{record.dosimetryReportNumber?` · звіт № ${record.dosimetryReportNumber}`:""}</small><br/><Link href="/staff/personnel/dosimetry">Історія</Link></td>
-          <td>{record.reviewReasons.length ? <><span className="statusPill">Потребує перевірки</span><br/><small>{record.reviewReasons.join("; ")}</small>{record.policyReviewReasons.length>0 && <><br/><small><b>Policy review:</b> {record.policyReviewReasons.join("; ")}</small></>}</> : <><span className="statusPill ok">Без очевидних зауважень</span><br/><small>Лише за даними реєстрів і налаштованих review-критеріїв, без enforcement.</small></>}</td>
-        </tr>)}</tbody>
+        <thead><tr><th>Працівник</th><th>Контур</th><th>Допуск до ДІВ</th><th>Навчання</th><th>Перевірка знань</th><th>Дозиметрія</th><th>Зведення</th></tr></thead>
+        <tbody>{records.map((record)=>{
+          const evaluate=record.monitoringScopeState==="in_scope";
+          return <tr key={record.personnelId}>
+            <td><b>{record.displayName}</b><br/><small>{record.positionTitle}{record.departmentName?` · ${record.departmentName}`:""}</small></td>
+            <td><ScopeStatus record={record}/></td>
+            <td>{evaluate ? <><Status kind="clearance" state={record.clearanceState}/><br/><small>{record.clearanceEffectiveDate || "—"}{record.clearanceValidUntil?` → ${record.clearanceValidUntil}`:""}{record.clearanceDocumentNumber?` · № ${record.clearanceDocumentNumber}`:""}</small><br/><Link href="/staff/personnel/radiation-clearance">Історія</Link></> : <NotEvaluated scope={record.monitoringScopeState}/>}</td>
+            <td>{evaluate ? <><Status kind="training" state={record.trainingState}/><br/><small>{record.trainingDate || "—"}{record.trainingValidUntil?` → ${record.trainingValidUntil}`:""}{record.trainingCourseTitle?` · ${record.trainingCourseTitle}`:""}</small><br/><Link href="/staff/personnel/radiation-training">Історія</Link></> : <NotEvaluated scope={record.monitoringScopeState}/>}</td>
+            <td>{evaluate ? <><Status kind="training" state={record.knowledgeCheckState}/><br/><small>{record.knowledgeDate || "—"}{record.knowledgeValidUntil?` → ${record.knowledgeValidUntil}`:""}{record.knowledgeCourseTitle?` · ${record.knowledgeCourseTitle}`:""}</small></> : <NotEvaluated scope={record.monitoringScopeState}/>}</td>
+            <td>{evaluate ? <><Status kind="dosimetry" state={record.dosimetryState}/><br/><small>{record.dosimetryPeriodStart && record.dosimetryPeriodEnd?`${record.dosimetryPeriodStart} → ${record.dosimetryPeriodEnd}`:"—"}{record.dosimetryReportNumber?` · звіт № ${record.dosimetryReportNumber}`:""}</small><br/><Link href="/staff/personnel/dosimetry">Історія</Link></> : <NotEvaluated scope={record.monitoringScopeState}/>}</td>
+            <td>{record.summaryState==="out_of_scope"
+              ? <><span className="statusPill">Поза контуром</span><br/><small>Safety-реєстри тут не оцінюються. Це не юридичне звільнення.</small></>
+              : record.reviewReasons.length
+                ? <><span className="statusPill">Потребує перевірки</span><br/><small>{record.reviewReasons.join("; ")}</small>{record.policyReviewReasons.length>0 && <><br/><small><b>Policy review:</b> {record.policyReviewReasons.join("; ")}</small></>}</>
+                : <><span className="statusPill ok">Без очевидних зауважень</span><br/><small>Лише для `in_scope`, за даними реєстрів і review-критеріїв, без enforcement.</small></>}
+            </td>
+          </tr>;
+        })}</tbody>
       </table>{!records.length && <p className="notice">Активних кадрових карток немає.</p>}</div>}
     </section>
   </StaffWorkspaceShell>;

--- a/lib/personnel-radiation-compliance.ts
+++ b/lib/personnel-radiation-compliance.ts
@@ -22,6 +22,12 @@ export type DosimetryState =
   | "review"
   | "missing";
 
+export type RadiationMonitoringScopeState =
+  | "in_scope"
+  | "out_of_scope"
+  | "review"
+  | "unclassified";
+
 export type RadiationReviewPolicy = {
   id:string;
   effectiveFrom:string;
@@ -33,6 +39,21 @@ export type RadiationReviewPolicy = {
   sourceTitle:string;
   sourceReference:string;
 };
+
+export function classifyRadiationMonitoringScope(
+  record: { scopeStatus?: string | null } | null,
+): RadiationMonitoringScopeState {
+  if (!record) return "unclassified";
+  if (record.scopeStatus === "in_scope") return "in_scope";
+  if (record.scopeStatus === "out_of_scope") return "out_of_scope";
+  return "review";
+}
+
+export function radiationScopeReviewReasons(scope: RadiationMonitoringScopeState): string[] {
+  if (scope === "unclassified") return ["Не визначено контур радіаційного контролю"];
+  if (scope === "review") return ["Організаційний контур радіаційного контролю потребує уточнення"];
+  return [];
+}
 
 export function classifyRadiationClearance(
   record: { decisionCode?: string | null; validUntil?: string | null } | null,

--- a/tests/personnel-radiation-compliance.test.mjs
+++ b/tests/personnel-radiation-compliance.test.mjs
@@ -10,7 +10,7 @@ const directories = fs.readFileSync("app/staff/directories/page.tsx", "utf8");
 const audit = fs.readFileSync("lib/audit.ts", "utf8");
 
 function projectionSql() {
-  const match = route.match(/db\.prepare\(\s*`(WITH clearance_ranked[\s\S]*?ORDER BY p\.last_name, p\.first_name, p\.patronymic, p\.id)`\s*,?\s*\)\.bind/);
+  const match = route.match(/db\.prepare\(\s*`(WITH monitoring_scope_ranked[\s\S]*?ORDER BY p\.last_name, p\.first_name, p\.patronymic, p\.id)`\s*,?\s*\)\.bind/);
   assert.ok(match, "projection SQL must remain extractable for behavioral coverage");
   return match[1];
 }
@@ -19,6 +19,17 @@ function effectivePolicySql() {
   const match = route.match(/rawPolicy = await db\.prepare\(\s*`(SELECT r\.id,[\s\S]*?LIMIT 1)`\s*,?\s*\)\.bind/);
   assert.ok(match, "effective policy SQL must remain extractable for behavioral coverage");
   return match[1];
+}
+
+function projectionRows(db, asOf) {
+  return db.prepare(projectionSql()).all(
+    1, asOf, asOf,
+    1, asOf,
+    1, asOf,
+    1, asOf,
+    1, asOf,
+    1,
+  );
 }
 
 function baselineDb() {
@@ -48,7 +59,9 @@ function baselineDb() {
       (id, organization_id, display_name, position_title, department_id, active, last_name, first_name)
     VALUES
       ('p1', 1, 'Тест Один', 'Лікар', 10, 1, 'Тест', 'Один'),
-      ('p2', 1, 'Тест Неактивний', 'Лікар', 10, 0, 'Тест', 'Неактивний'),
+      ('p2', 1, 'Тест Два', 'Адміністратор', 10, 1, 'Тест', 'Два'),
+      ('p4', 1, 'Тест Чотири', 'Працівник', 10, 1, 'Тест', 'Чотири'),
+      ('p5', 1, 'Тест Пʼять', 'Працівник', 10, 1, 'Тест', 'Пʼять'),
       ('p3', 2, 'Інший Tenant', 'Лікар', 20, 1, 'Інший', 'Tenant');
   `);
   for (const migration of [
@@ -56,14 +69,23 @@ function baselineDb() {
     "drizzle/0111_personnel_radiation_training.sql",
     "drizzle/0112_personnel_dosimetry.sql",
     "drizzle/0113_personnel_radiation_review_policy.sql",
+    "drizzle/0114_personnel_radiation_monitoring_scope.sql",
   ]) db.exec(fs.readFileSync(migration, "utf8"));
   return db;
 }
 
-test("compliance projection selects current unsuperseded tenant-scoped facts", () => {
+test("compliance projection selects monitoring scope and current tenant-scoped safety facts", () => {
   const db = baselineDb();
 
   db.exec(`
+    INSERT INTO personnel_radiation_monitoring_scope_records
+      (id, organization_id, personnel_id, effective_date, scope_status, scope_text, note)
+    VALUES
+      ('scope-p1', 1, 'p1', '2026-01-01', 'in_scope', 'КТ', ''),
+      ('scope-p2', 1, 'p2', '2026-01-01', 'out_of_scope', '', ''),
+      ('scope-p5', 1, 'p5', '2026-01-01', 'other', '', 'Потребує уточнення'),
+      ('scope-p3', 2, 'p3', '2026-01-01', 'in_scope', 'КТ', '');
+
     INSERT INTO personnel_radiation_clearance_records
       (id, organization_id, personnel_id, effective_date, decision_code, scope_text, valid_until)
     VALUES ('c-old', 1, 'p1', '2026-01-10', 'authorized', 'КТ', '2026-12-31');
@@ -89,14 +111,43 @@ test("compliance projection selects current unsuperseded tenant-scoped facts", (
       ('d-other-tenant', 2, 'p3', '2026-06-01', '2026-06-30', 'measured', 1, 0, 0);
   `);
 
-  const asOf = "2026-08-21";
-  const rows = db.prepare(projectionSql()).all(1, asOf, 1, asOf, 1, asOf, 1, asOf, 1);
-  assert.equal(rows.length, 1);
-  assert.equal(rows[0].personnelId, "p1");
-  assert.equal(rows[0].clearanceDecisionCode, "revoked");
-  assert.equal(rows[0].trainingResultCode, "completed");
-  assert.equal(rows[0].knowledgeResultCode, "failed");
-  assert.equal(rows[0].dosimetryMeasurementStatus, "measured");
+  const rows = projectionRows(db, "2026-08-21");
+  assert.equal(rows.length, 4);
+
+  const p1 = rows.find((row) => row.personnelId === "p1");
+  const p2 = rows.find((row) => row.personnelId === "p2");
+  const p4 = rows.find((row) => row.personnelId === "p4");
+  const p5 = rows.find((row) => row.personnelId === "p5");
+  assert.equal(p1.monitoringScopeStatus, "in_scope");
+  assert.equal(p1.clearanceDecisionCode, "revoked");
+  assert.equal(p1.trainingResultCode, "completed");
+  assert.equal(p1.knowledgeResultCode, "failed");
+  assert.equal(p1.dosimetryMeasurementStatus, "measured");
+  assert.equal(p2.monitoringScopeStatus, "out_of_scope");
+  assert.equal(p2.clearanceDecisionCode, null);
+  assert.equal(p4.monitoringScopeStatus, null);
+  assert.equal(p5.monitoringScopeStatus, "other");
+  assert.equal(rows.some((row) => row.personnelId === "p3"), false);
+});
+
+test("future scope correction does not erase current scope before its effective date", () => {
+  const db = baselineDb();
+  db.exec(`
+    INSERT INTO personnel_radiation_monitoring_scope_records
+      (id, organization_id, personnel_id, effective_date, scope_status, scope_text)
+    VALUES ('scope-current', 1, 'p1', '2026-01-01', 'in_scope', 'КТ');
+    INSERT INTO personnel_radiation_monitoring_scope_records
+      (id, organization_id, personnel_id, effective_date, scope_status, supersedes_id)
+    VALUES ('scope-future-correction', 1, 'p1', '2027-01-01', 'out_of_scope', 'scope-current');
+  `);
+
+  const before = projectionRows(db, "2026-08-21").find((row) => row.personnelId === "p1");
+  assert.equal(before.monitoringScopeStatus, "in_scope");
+  assert.equal(before.monitoringScopeEffectiveDate, "2026-01-01");
+
+  const after = projectionRows(db, "2027-01-02").find((row) => row.personnelId === "p1");
+  assert.equal(after.monitoringScopeStatus, "out_of_scope");
+  assert.equal(after.monitoringScopeEffectiveDate, "2027-01-01");
 });
 
 test("effective policy selection keeps current revision until future successor takes effect", () => {
@@ -125,44 +176,48 @@ test("effective policy selection keeps current revision until future successor t
   assert.doesNotMatch(sql, /supersedes_id|NOT EXISTS/i);
 });
 
-test("projection endpoint is read-only, manager-only and does not duplicate dose values", () => {
+test("scope helper prevents false safety review outside explicit in-scope population", () => {
+  assert.match(helper, /RadiationMonitoringScopeState/);
+  assert.match(helper, /classifyRadiationMonitoringScope/);
+  assert.match(helper, /scopeStatus === "in_scope"/);
+  assert.match(helper, /scopeStatus === "out_of_scope"/);
+  assert.match(helper, /return "unclassified"/);
+  assert.match(helper, /Не визначено контур радіаційного контролю/);
+  assert.match(helper, /Організаційний контур радіаційного контролю потребує уточнення/);
+  assert.match(route, /monitoringScopeState === "in_scope" \? radiationReviewReasons/);
+  assert.match(route, /monitoringScopeState === "in_scope" \? radiationPolicyReviewReasons/);
+  assert.match(route, /monitoringScopeState === "out_of_scope"[\s\S]*?"out_of_scope"/);
+});
+
+test("projection endpoint remains read-only, tenant-scoped and has no operational enforcement", () => {
   assert.match(route, /role === "admin" \|\| role === "department_head"/);
-  assert.match(route, /personnel_radiation_compliance_viewed/);
+  assert.match(route, /WITH monitoring_scope_ranked AS/);
+  assert.match(route, /correction\.effective_date <= \?/);
+  assert.match(route, /LEFT JOIN monitoring_scope_ranked ms/);
   assert.match(route, /p\.organization_id = \? AND p\.active = 1/);
   assert.match(route, /effective_from <= \?/);
-  assert.match(route, /ORDER BY r\.effective_from DESC, r\.created_at DESC, r\.id DESC/);
   assert.match(route, /radiationPolicyReviewReasons/);
-  assert.match(route, /policyReviewCount/);
-  assert.match(route, /training_kind = 'radiation_safety'/);
-  assert.match(route, /training_kind = 'knowledge_check'/);
-  assert.match(route, /period_end <= \?/);
+  assert.match(route, /scopeReviewCount/);
+  assert.match(route, /outOfScopeCount/);
+  assert.match(route, /personnel_radiation_compliance_viewed/);
   assert.doesNotMatch(route, /export async function (POST|PUT|PATCH|DELETE)/);
   assert.doesNotMatch(route, /hp10_msv|hp007_msv|hp3_msv/);
-  assert.doesNotMatch(route, /pacs_settings|imaging_studies|bookings/);
+  assert.doesNotMatch(route, /pacs_settings|imaging_studies|bookings|work_lock|access_denied/);
 });
 
-test("policy review helper adds configured age reasons without legal compliance claims", () => {
-  assert.match(helper, /radiationPolicyReviewReasons/);
-  assert.match(helper, /age > policy\.trainingMaxAgeDays/);
-  assert.match(helper, /age > policy\.knowledgeCheckMaxAgeDays/);
-  assert.match(helper, /age > policy\.dosimetryMaxAgeDays/);
-  assert.match(helper, /немає запису перевірки знань/);
-  assert.match(helper, /mergeRadiationReviewReasons/);
-  assert.match(helper, /authorized_unknown_expiry/);
-  assert.match(helper, /Останній дозиметричний результат відсутній/);
-  assert.doesNotMatch(helper, /compliant|noncompliant|doseLimit|annualLimit/i);
-});
-
-test("overview UI exposes applied policy but remains informational", () => {
-  assert.match(page, /майбутні policy revisions не включаються/);
-  assert.match(page, /не автоматичне рішення про допуск до роботи/);
+test("overview UI shows scope separately and masks safety statuses outside in-scope", () => {
+  assert.match(page, /monitoringScopeState/);
+  assert.match(page, /У контурі/);
+  assert.match(page, /Поза контуром/);
+  assert.match(page, /Не визначено/);
+  assert.match(page, /const evaluate=record\.monitoringScopeState==="in_scope"/);
+  assert.match(page, /Не оцінюється/);
+  assert.match(page, /не генерує фальшивих «відсутній допуск\/дозиметрія»/);
+  assert.match(page, /це тільки організаційна класифікація RadiologyOS/);
+  assert.match(page, /не юридичне чи медичне звільнення/);
   assert.match(page, /не створює alerts/);
   assert.match(page, /не блокує PACS, КТ, рентген або запис пацієнтів/);
-  assert.match(page, /Застосована policy revision/);
-  assert.match(page, /policyReviewCount/);
-  assert.match(page, /Історія політики/);
-  assert.match(page, /Без очевидних зауважень/);
+  assert.match(page, /\/staff\/personnel\/radiation-monitoring-scope/);
   assert.match(directories, /Зведення ДІВ/);
-  assert.match(directories, /\/staff\/personnel\/radiation-compliance/);
   assert.match(audit, /personnel_radiation_compliance_viewed/);
 });


### PR DESCRIPTION
## Що змінено
- підключає append-only «Контингент радіаційного контролю» до read-only «Зведення ДІВ»
- effective-dated scope selection: береться останній запис станом на `asOf`; майбутні записи не впливають на поточний зріз
- correction/supersedes check є date-aware: майбутнє виправлення не приховує сьогоднішній scope завчасно
- `in_scope`: виконується звичайна оцінка допуску, навчання, перевірки знань, дозиметрії та policy criteria
- `out_of_scope`: окремий нейтральний стан; safety-реєстри не оцінюються і не генеруються фальшиві missing-причини
- `other` та unclassified: тільки причина уточнити організаційний scope; safety missing-причини до визначення scope не генеруються
- `out_of_scope` не називається compliant і не трактується як юридичне/медичне звільнення
- UI продовжує показувати весь активний персонал для безпечного backfill, але маскує safety-колонки як «Не оцінюється» поза `in_scope`
- додає окремі summary counts: in-scope, out-of-scope, scope review, policy review
- audit містить лише агреговані counts і policy ID, без scope text
- behavioral tests виконують exact SQL і перевіряють in/out/other/unclassified, tenant isolation та future-effective correction

## Важлива межа
PR залишається read-only. Він не створює alerts, не застосовує dose thresholds і не блокує PACS, КТ, рентген, booking чи інші operational flows.

Production deploy не запускається.