### PR TITLE
Add monitoring scope context to radiation dose summary

### DIFF
--- a/app/api/staff/personnel/radiation-dose-summary/route.ts
+++ b/app/api/staff/personnel/radiation-dose-summary/route.ts
@@ -18,6 +18,9 @@ type DoseSummaryRow = {
   displayName:string;
   positionTitle:string;
   departmentName:string | null;
+  monitoringScopeStatus:string | null;
+  monitoringScopeText:string | null;
+  monitoringScopeEffectiveDate:string | null;
   firstPeriodStart:string | null;
   lastPeriodEnd:string | null;
   measuredCount:number;
@@ -72,9 +75,29 @@ export async function GET(request: Request) {
               SUM(CASE WHEN measurement_status = 'measured' THEN hp3_msv ELSE 0 END) AS hp3_measured_subtotal
        FROM current_records
        GROUP BY personnel_id
+     ),
+     monitoring_scope_ranked AS (
+       SELECT r.personnel_id, r.scope_status, r.scope_text, r.effective_date,
+              ROW_NUMBER() OVER (
+                PARTITION BY r.personnel_id
+                ORDER BY r.effective_date DESC, r.created_at DESC, r.id DESC
+              ) AS rn
+       FROM personnel_radiation_monitoring_scope_records r
+       WHERE r.organization_id = ?
+         AND r.effective_date <= ?
+         AND NOT EXISTS (
+           SELECT 1 FROM personnel_radiation_monitoring_scope_records correction
+           WHERE correction.supersedes_id = r.id
+             AND correction.organization_id = r.organization_id
+             AND correction.personnel_id = r.personnel_id
+             AND correction.effective_date <= ?
+         )
      )
      SELECT p.id AS personnelId, p.display_name AS displayName,
             p.position_title AS positionTitle, d.name AS departmentName,
+            ms.scope_status AS monitoringScopeStatus,
+            ms.scope_text AS monitoringScopeText,
+            ms.effective_date AS monitoringScopeEffectiveDate,
             a.first_period_start AS firstPeriodStart,
             a.last_period_end AS lastPeriodEnd,
             COALESCE(a.measured_count, 0) AS measuredCount,
@@ -87,15 +110,21 @@ export async function GET(request: Request) {
      FROM personnel_records p
      LEFT JOIN departments d
        ON d.id = p.department_id AND d.organization_id = p.organization_id
+     LEFT JOIN monitoring_scope_ranked ms ON ms.personnel_id = p.id AND ms.rn = 1
      LEFT JOIN aggregated a ON a.personnel_id = p.id
      WHERE p.organization_id = ? AND p.active = 1
      ORDER BY p.last_name, p.first_name, p.patronymic, p.id`,
-  ).bind(ctx.organizationId, from, to, ctx.organizationId).all<DoseSummaryRow>();
+  ).bind(
+    ctx.organizationId, from, to,
+    ctx.organizationId, to, to,
+    ctx.organizationId,
+  ).all<DoseSummaryRow>();
 
   const records = rows.results.map((row) => {
     const recordCount = row.measuredCount + row.belowDetectionCount + row.missingCount + row.otherCount;
     return {
       ...row,
+      monitoringScopeState: row.monitoringScopeStatus || "unclassified",
       recordCount,
       hasNonMeasuredRecords: row.belowDetectionCount + row.missingCount + row.otherCount > 0,
       numericSubtotalAvailable: row.measuredCount > 0,
@@ -104,6 +133,9 @@ export async function GET(request: Request) {
 
   const personnelWithRecords = records.filter((record) => record.recordCount > 0).length;
   const personnelWithNonMeasuredRecords = records.filter((record) => record.hasNonMeasuredRecords).length;
+  const inScopeCount = records.filter((record) => record.monitoringScopeState === "in_scope").length;
+  const outOfScopeCount = records.filter((record) => record.monitoringScopeState === "out_of_scope").length;
+  const scopeReviewCount = records.length - inScopeCount - outOfScopeCount;
 
   await audit(db, {
     organizationId:ctx.organizationId,
@@ -116,12 +148,16 @@ export async function GET(request: Request) {
       personnelCount:records.length,
       personnelWithRecords,
       personnelWithNonMeasuredRecords,
+      inScopeCount,
+      outOfScopeCount,
+      scopeReviewCount,
     },
   });
 
   return Response.json({
     from,
     to,
+    scopeAsOf:to,
     rangeBasis:"period_end",
     subtotalBasis:"measured_only",
     records,
@@ -130,6 +166,9 @@ export async function GET(request: Request) {
       personnelWithRecords,
       personnelWithoutRecords:records.length - personnelWithRecords,
       personnelWithNonMeasuredRecords,
+      inScopeCount,
+      outOfScopeCount,
+      scopeReviewCount,
     },
   }, { headers:{ "cache-control":"no-store" } });
 }

--- a/app/staff/personnel/radiation-dose-summary/page.tsx
+++ b/app/staff/personnel/radiation-dose-summary/page.tsx
@@ -9,6 +9,10 @@ type DoseSummaryRecord = {
   displayName:string;
   positionTitle:string;
   departmentName:string | null;
+  monitoringScopeStatus:string | null;
+  monitoringScopeText:string | null;
+  monitoringScopeEffectiveDate:string | null;
+  monitoringScopeState:"in_scope" | "out_of_scope" | "other" | "unclassified";
   firstPeriodStart:string | null;
   lastPeriodEnd:string | null;
   measuredCount:number;
@@ -26,6 +30,7 @@ type DoseSummaryRecord = {
 type DoseSummaryResponse = {
   from?:string;
   to?:string;
+  scopeAsOf?:string;
   rangeBasis?:"period_end";
   subtotalBasis?:"measured_only";
   records?:DoseSummaryRecord[];
@@ -34,6 +39,9 @@ type DoseSummaryResponse = {
     personnelWithRecords:number;
     personnelWithoutRecords:number;
     personnelWithNonMeasuredRecords:number;
+    inScopeCount:number;
+    outOfScopeCount:number;
+    scopeReviewCount:number;
   };
   error?:string;
 };
@@ -61,15 +69,26 @@ function statusLines(record:DoseSummaryRecord) {
   return lines.length ? lines.join(" · ") : "Записів у вибраному інтервалі немає";
 }
 
+function scopeLabel(state:DoseSummaryRecord["monitoringScopeState"]) {
+  if (state === "in_scope") return "У контурі";
+  if (state === "out_of_scope") return "Поза контуром";
+  if (state === "other") return "Інший статус";
+  return "Не класифіковано";
+}
+
 export default function RadiationDoseSummaryPage() {
   const [from,setFrom] = useState("");
   const [to,setTo] = useState("");
+  const [scopeAsOf,setScopeAsOf] = useState("");
   const [records,setRecords] = useState<DoseSummaryRecord[]>([]);
   const [summary,setSummary] = useState({
     totalPersonnel:0,
     personnelWithRecords:0,
     personnelWithoutRecords:0,
     personnelWithNonMeasuredRecords:0,
+    inScopeCount:0,
+    outOfScopeCount:0,
+    scopeReviewCount:0,
   });
   const [loading,setLoading] = useState(true);
   const [error,setError] = useState("");
@@ -83,12 +102,16 @@ export default function RadiationDoseSummaryPage() {
       );
       const data = await response.json() as DoseSummaryResponse;
       if (!response.ok) throw new Error(data.error || "Не вдалося завантажити дозове зведення");
+      setScopeAsOf(data.scopeAsOf || nextTo);
       setRecords(data.records || []);
       setSummary(data.summary || {
         totalPersonnel:0,
         personnelWithRecords:0,
         personnelWithoutRecords:0,
         personnelWithNonMeasuredRecords:0,
+        inScopeCount:0,
+        outOfScopeCount:0,
+        scopeReviewCount:0,
       });
     } catch (value) {
       setError(value instanceof Error ? value.message : "Не вдалося завантажити дозове зведення");
@@ -118,8 +141,8 @@ export default function RadiationDoseSummaryPage() {
     <section className="financeSummary" aria-label="Дозове зведення">
       <article><span>Активний персонал</span><b>{summary.totalPersonnel}</b><small>кадрових карток</small></article>
       <article><span>Є дозиметричні записи</span><b>{summary.personnelWithRecords}</b><small>за period_end у діапазоні</small></article>
-      <article><span>Без записів</span><b>{summary.personnelWithoutRecords}</b><small>не означає нульову дозу</small></article>
-      <article><span>Є ненумеричні статуси</span><b>{summary.personnelWithNonMeasuredRecords}</b><small>below detection / missing / other</small></article>
+      <article><span>У контурі на кінець періоду</span><b>{summary.inScopeCount}</b><small>scope станом на {scopeAsOf || to || "—"}</small></article>
+      <article><span>Scope потребує уточнення</span><b>{summary.scopeReviewCount}</b><small>other / не класифіковано</small></article>
     </section>
 
     <section className="financeJournal">
@@ -140,16 +163,23 @@ export default function RadiationDoseSummaryPage() {
         Числовий subtotal нижче складається лише зі статусів `measured`. `below_detection` не є нульовою дозою, `missing` не означає нульове опромінення, а `other` не включається до subtotal без ручної інтерпретації первинного запису.
       </p>
       <p className="notice">
+        Контингент показується лише як організаційний контекст станом на кінець вибраного періоду. `out_of_scope`, `other` або відсутність класифікації не приховують і не обнуляють історичні дозиметричні записи чи measured subtotal. <Link href="/staff/personnel/radiation-monitoring-scope">Історія контингенту</Link>
+      </p>
+      <p className="notice">
         Це не розрахунок нормативної річної/ковзної дози, не юридичний висновок і не alert. Тут немає dose thresholds та автоматичного блокування PACS, КТ, рентген чи booking.
       </p>
     </section>
 
     <section className="financeJournal">
-      <header className="financeToolbar"><div><b>Активний персонал</b><small>Тільки unsuperseded append-only записи дозиметрії.</small></div></header>
+      <header className="financeToolbar"><div><b>Активний персонал</b><small>Тільки unsuperseded append-only записи дозиметрії; scope не фільтрує історичні дози.</small></div></header>
       {loading ? <p className="notice">Завантаження…</p> : <div className="financeTableWrap"><table className="financeTable">
-        <thead><tr><th>Працівник</th><th>Покритий записами період</th><th>Статуси записів</th><th>Hp(10) subtotal</th><th>Hp(0.07) subtotal</th><th>Hp(3) subtotal</th><th/></tr></thead>
+        <thead><tr><th>Працівник</th><th>Контингент</th><th>Покритий записами період</th><th>Статуси записів</th><th>Hp(10) subtotal</th><th>Hp(0.07) subtotal</th><th>Hp(3) subtotal</th><th/></tr></thead>
         <tbody>{records.map((record)=><tr key={record.personnelId}>
           <td><b>{record.displayName}</b><br/><small>{record.positionTitle}{record.departmentName?` · ${record.departmentName}`:""}</small></td>
+          <td>
+            <span className={`statusPill ${record.monitoringScopeState === "in_scope" ? "ok" : ""}`}>{scopeLabel(record.monitoringScopeState)}</span>
+            <br/><small>{record.monitoringScopeEffectiveDate || "Немає effective-dated запису"}{record.monitoringScopeText?` · ${record.monitoringScopeText}`:""}</small>
+          </td>
           <td>{record.firstPeriodStart && record.lastPeriodEnd ? <><b>{record.firstPeriodStart}</b> → <b>{record.lastPeriodEnd}</b></> : "—"}</td>
           <td>
             <span className={`statusPill ${record.recordCount && !record.hasNonMeasuredRecords?"ok":""}`}>

--- a/tests/personnel-radiation-dose-summary.test.mjs
+++ b/tests/personnel-radiation-dose-summary.test.mjs
@@ -46,11 +46,14 @@ function baselineDb() {
       ('p2', 1, 'Тест Два', 'Лаборант', 10, 1, 'Тест', 'Два'),
       ('p3', 2, 'Інший Tenant', 'Лікар', 20, 1, 'Інший', 'Tenant');
   `);
-  db.exec(fs.readFileSync("drizzle/0112_personnel_dosimetry.sql", "utf8"));
+  for (const migration of [
+    "drizzle/0112_personnel_dosimetry.sql",
+    "drizzle/0114_personnel_radiation_monitoring_scope.sql",
+  ]) db.exec(fs.readFileSync(migration, "utf8"));
   return db;
 }
 
-test("dose summary uses only current measured records and remains tenant scoped", () => {
+test("dose summary preserves measured history while adding effective-dated monitoring scope", () => {
   const db = baselineDb();
   db.exec(`
     INSERT INTO personnel_dosimetry_records
@@ -69,18 +72,38 @@ test("dose summary uses only current measured records and remains tenant scoped"
       ('d-below', 1, 'p1', '2026-02-01', '2026-02-28', 'below_detection', 0, 0, 0),
       ('d-missing', 1, 'p1', '2026-03-01', '2026-03-31', 'missing', 0, 0, 0),
       ('d-other', 1, 'p1', '2026-04-01', '2026-04-30', 'other', 9, 8, 7),
+      ('d-p2-measured', 1, 'p2', '2026-05-01', '2026-05-31', 'measured', 0.40, 0.50, 0.60),
       ('d-outside', 1, 'p1', '2025-12-01', '2025-12-31', 'measured', 99, 99, 99),
       ('d-other-tenant', 2, 'p3', '2026-01-01', '2026-01-31', 'measured', 100, 100, 100);
+
+    INSERT INTO personnel_radiation_monitoring_scope_records
+      (id, organization_id, personnel_id, effective_date, scope_status, scope_text)
+    VALUES
+      ('scope-p1-current', 1, 'p1', '2026-01-01', 'in_scope', 'Персональний дозиметричний контроль'),
+      ('scope-p2-out', 1, 'p2', '2026-01-01', 'out_of_scope', ''),
+      ('scope-other-tenant', 2, 'p3', '2026-01-01', 'in_scope', 'Інший tenant');
+
+    INSERT INTO personnel_radiation_monitoring_scope_records
+      (id, organization_id, personnel_id, effective_date, scope_status, scope_text, supersedes_id)
+    VALUES
+      ('scope-p1-future', 1, 'p1', '2027-01-01', 'out_of_scope', '', 'scope-p1-current');
   `);
 
-  const rows = db.prepare(summarySql()).all(1, "2026-01-01", "2026-12-31", 1);
-  assert.equal(rows.length, 2);
+  const sql = summarySql();
+  const rows2026 = db.prepare(sql).all(
+    1, "2026-01-01", "2026-12-31",
+    1, "2026-12-31", "2026-12-31",
+    1,
+  );
+  assert.equal(rows2026.length, 2);
 
-  const p1 = rows.find((row) => row.personnelId === "p1");
-  const p2 = rows.find((row) => row.personnelId === "p2");
+  const p1 = rows2026.find((row) => row.personnelId === "p1");
+  const p2 = rows2026.find((row) => row.personnelId === "p2");
   assert.ok(p1);
   assert.ok(p2);
 
+  assert.equal(p1.monitoringScopeStatus, "in_scope");
+  assert.equal(p1.monitoringScopeEffectiveDate, "2026-01-01");
   assert.equal(p1.measuredCount, 1);
   assert.equal(p1.belowDetectionCount, 1);
   assert.equal(p1.missingCount, 1);
@@ -91,32 +114,52 @@ test("dose summary uses only current measured records and remains tenant scoped"
   assert.equal(p1.firstPeriodStart, "2026-01-01");
   assert.equal(p1.lastPeriodEnd, "2026-04-30");
 
-  assert.equal(p2.measuredCount, 0);
-  assert.equal(p2.hp10MeasuredSubtotal, 0);
-  assert.equal(rows.some((row) => row.personnelId === "p3"), false);
+  assert.equal(p2.monitoringScopeStatus, "out_of_scope");
+  assert.equal(p2.measuredCount, 1);
+  assert.equal(p2.hp10MeasuredSubtotal, 0.40);
+  assert.equal(p2.hp007MeasuredSubtotal, 0.50);
+  assert.equal(p2.hp3MeasuredSubtotal, 0.60);
+  assert.equal(rows2026.some((row) => row.personnelId === "p3"), false);
+
+  const rows2027 = db.prepare(sql).all(
+    1, "2026-01-01", "2027-12-31",
+    1, "2027-12-31", "2027-12-31",
+    1,
+  );
+  const p1AfterFutureCorrection = rows2027.find((row) => row.personnelId === "p1");
+  assert.ok(p1AfterFutureCorrection);
+  assert.equal(p1AfterFutureCorrection.monitoringScopeStatus, "out_of_scope");
+  assert.equal(p1AfterFutureCorrection.hp10MeasuredSubtotal, 0.15);
 });
 
-test("dose summary endpoint is manager-only, read-only and measured-only", () => {
+test("dose summary endpoint is manager-only, read-only, measured-only and does not filter dose by scope", () => {
   assert.match(route, /role === "admin" \|\| role === "department_head"/);
   assert.match(route, /measurement_status = 'measured' THEN hp10_msv ELSE 0/);
   assert.match(route, /measurement_status = 'below_detection'/);
   assert.match(route, /measurement_status = 'missing'/);
   assert.match(route, /measurement_status = 'other'/);
-  assert.match(route, /NOT EXISTS/);
+  assert.match(route, /monitoring_scope_ranked/);
+  assert.match(route, /correction\.effective_date <= \?/);
+  assert.match(route, /ms\.scope_status AS monitoringScopeStatus/);
+  assert.match(route, /scopeAsOf:to/);
   assert.match(route, /r\.period_end >= \? AND r\.period_end <= \?/);
   assert.match(route, /p\.organization_id = \? AND p\.active = 1/);
   assert.match(route, /personnel_radiation_dose_summary_viewed/);
   assert.doesNotMatch(route, /export async function (POST|PUT|PATCH|DELETE)/);
   assert.doesNotMatch(route, /pacs_settings|imaging_studies|bookings/);
   assert.doesNotMatch(route, /hp10_measured_subtotal\s*[<>]=?\s*\d/);
+  assert.doesNotMatch(route, /WHERE[^`]*scope_status\s*=\s*['"]in_scope['"]/i);
 });
 
-test("dose summary UI never presents non-measured statuses as zero dose", () => {
+test("dose summary UI keeps historical dose visible regardless of monitoring scope", () => {
   assert.match(page, /below_detection` не є нульовою дозою/);
   assert.match(page, /missing` не означає нульове опромінення/);
   assert.match(page, /other` не включається до subtotal/);
   assert.match(page, /numericSubtotalAvailable/);
   assert.match(page, /available \? `\$\{String\(Number\(value \|\| 0\)\)\} mSv` : "—"/);
+  assert.match(page, /не приховують і не обнуляють історичні дозиметричні записи чи measured subtotal/);
+  assert.match(page, /scope не фільтрує історичні дози/);
+  assert.match(page, /Історія контингенту/);
   assert.match(page, /не розрахунок нормативної річної\/ковзної дози/);
   assert.match(page, /немає dose thresholds/);
   assert.match(directories, /Дозове зведення/);


### PR DESCRIPTION
## Що змінено
- додає effective-dated контекст «Контингент радіаційного контролю» до read-only дозового зведення
- scope визначається станом на `to` — кінець вибраного інтервалу
- future-effective correction не приховує поточний scope завчасно
- історичні дозиметричні записи та measured subtotal **не фільтруються за scope**
- працівник зі статусом `out_of_scope` продовжує показувати всі measured-дози за вибраний інтервал
- `other`/unclassified також не приховують і не обнуляють дозові дані
- числовий subtotal як і раніше складається тільки зі статусів `measured`; `below_detection`, `missing`, `other` не трактуються як нуль
- API повертає `scopeAsOf`, status/text/effectiveDate і агреговані scope counts
- audit отримує тільки лічильники scope, без scope text або дозових значень
- UI показує scope окремою колонкою та явно пояснює, що він не фільтрує історичні дози
- behavioral test виконує exact SQL у SQLite та перевіряє out-of-scope measured history і future-effective scope correction

## Важлива межа
Це read-only контекст. PR не додає dose thresholds, alerts, юридичний висновок чи operational enforcement і не блокує PACS, КТ, рентген або booking.

Production deploy не запускається.