### PR TITLE
Add read-only radiation safety review queue

### DIFF
--- a/app/staff/directories/page.tsx
+++ b/app/staff/directories/page.tsx
@@ -10,6 +10,7 @@ const directories=[
   {name:"Контингент радіаційного контролю",description:"Явний append-only організаційний scope персоналу для радіаційного review без автоматичної правової категоризації.",href:"/staff/personnel/radiation-monitoring-scope"},
   {name:"Дозове зведення",description:"Read-only subtotal тільки виміряних Hp(10), Hp(0.07) та Hp(3) за період; ненумеричні статуси не трактуються як нуль.",href:"/staff/personnel/radiation-dose-summary"},
   {name:"Зведення ДІВ",description:"Read-only проекція допуску, навчання, перевірок знань і стану дозиметрії без автоматичного блокування роботи.",href:"/staff/personnel/radiation-compliance"},
+  {name:"Черга review ДІВ",description:"Read-only робочий список детермінованих review-причин зі зведення ДІВ без alerts, дозових порогів або operational enforcement.",href:"/staff/personnel/radiation-review-queue"},
   {name:"Політика ДІВ",description:"Append-only організаційні критерії review без прихованих нормативів, дозових лімітів або operational enforcement.",href:"/staff/personnel/radiation-review-policy"},
   {name:"Обладнання",description:"Апарати, кабінети та технічні атрибути, що використовуються в записах і виконанні.",href:"/staff/equipment"},
   {name:"Послуги",description:"Канонічний каталог послуг, тривалість, правила і матеріальні норми.",href:"/staff/services"},

--- a/app/staff/personnel/radiation-review-queue/page.tsx
+++ b/app/staff/personnel/radiation-review-queue/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type ReviewRecord = {
+  personnelId:string;
+  displayName:string;
+  positionTitle:string;
+  departmentName:string | null;
+  monitoringScopeState:string;
+  monitoringScopeEffectiveDate:string | null;
+  monitoringScopeText:string | null;
+  clearanceState:string;
+  trainingState:string;
+  knowledgeCheckState:string;
+  dosimetryState:string;
+  scopeReviewReasons:string[];
+  baseReviewReasons:string[];
+  policyReviewReasons:string[];
+  reviewReasons:string[];
+  summaryState:"recorded" | "review" | "out_of_scope";
+};
+
+type ComplianceResponse = {
+  asOf?:string;
+  policy?:{ id:string; effectiveFrom:string; enabled:boolean; sourceTitle:string } | null;
+  records?:ReviewRecord[];
+  error?:string;
+};
+
+type QueueFilter = "all" | "scope" | "base" | "policy";
+
+function localIsoDate() {
+  const now = new Date();
+  const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 10);
+}
+
+function reasonCount(record:ReviewRecord, filter:QueueFilter) {
+  if (filter === "scope") return record.scopeReviewReasons.length;
+  if (filter === "base") return record.baseReviewReasons.length;
+  if (filter === "policy") return record.policyReviewReasons.length;
+  return record.reviewReasons.length;
+}
+
+function reasons(record:ReviewRecord, filter:QueueFilter) {
+  if (filter === "scope") return record.scopeReviewReasons;
+  if (filter === "base") return record.baseReviewReasons;
+  if (filter === "policy") return record.policyReviewReasons;
+  return record.reviewReasons;
+}
+
+export default function RadiationReviewQueuePage() {
+  const [asOf,setAsOf] = useState("");
+  const [records,setRecords] = useState<ReviewRecord[]>([]);
+  const [policy,setPolicy] = useState<ComplianceResponse["policy"]>(null);
+  const [filter,setFilter] = useState<QueueFilter>("all");
+  const [loading,setLoading] = useState(true);
+  const [error,setError] = useState("");
+
+  const load = useCallback(async(date:string) => {
+    setLoading(true); setError("");
+    try {
+      const response = await fetch(
+        `/api/staff/personnel/radiation-compliance?asOf=${encodeURIComponent(date)}`,
+        { cache:"no-store" },
+      );
+      const data = await response.json() as ComplianceResponse;
+      if (!response.ok) throw new Error(data.error || "Не вдалося завантажити чергу review");
+      setRecords((data.records || []).filter((record) => record.summaryState === "review"));
+      setPolicy(data.policy || null);
+    } catch (value) {
+      setError(value instanceof Error ? value.message : "Не вдалося завантажити чергу review");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const today = localIsoDate();
+      setAsOf(today);
+      void load(today);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const queue = useMemo(
+    () => records.filter((record) => reasonCount(record, filter) > 0),
+    [records, filter],
+  );
+  const scopeCount = useMemo(() => records.filter((record) => record.scopeReviewReasons.length > 0).length, [records]);
+  const baseCount = useMemo(() => records.filter((record) => record.baseReviewReasons.length > 0).length, [records]);
+  const policyCount = useMemo(() => records.filter((record) => record.policyReviewReasons.length > 0).length, [records]);
+
+  return <StaffWorkspaceShell
+    active="directories"
+    title="Радіаційна безпека · черга review"
+    description="Read-only робочий список персоналу, для якого зведення ДІВ уже має детерміновані причини ручної перевірки."
+  >
+    {error && <p className="errorBox">{error}</p>}
+
+    <section className="financeSummary" aria-label="Черга review радіаційної безпеки">
+      <article><span>У черзі</span><b>{records.length}</b><small>summaryState = review</small></article>
+      <article><span>Scope</span><b>{scopeCount}</b><small>контингент потребує уточнення</small></article>
+      <article><span>Базові причини</span><b>{baseCount}</b><small>допуск / навчання / знання / дозиметрія</small></article>
+      <article><span>Policy review</span><b>{policyCount}</b><small>лише налаштовані review-критерії</small></article>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar">
+        <div><b>Дата зрізу</b><small>Черга будується з того самого read-only «Зведення ДІВ».</small></div>
+        <div className="shiftPlannerToolbar">
+          <input aria-label="Дата зрізу" type="date" value={asOf} onChange={(event)=>setAsOf(event.target.value)} />
+          <button className="button secondary" type="button" disabled={!asOf || loading} onClick={()=>void load(asOf)}>{loading?"Оновлення…":"Оновити"}</button>
+        </div>
+      </header>
+      <div className="shiftPlannerToolbar" aria-label="Фільтр причин review">
+        <button className={`button ${filter === "all" ? "primary" : "secondary"}`} type="button" onClick={()=>setFilter("all")}>Усі review</button>
+        <button className={`button ${filter === "scope" ? "primary" : "secondary"}`} type="button" onClick={()=>setFilter("scope")}>Scope</button>
+        <button className={`button ${filter === "base" ? "primary" : "secondary"}`} type="button" onClick={()=>setFilter("base")}>Базові</button>
+        <button className={`button ${filter === "policy" ? "primary" : "secondary"}`} type="button" onClick={()=>setFilter("policy")}>Policy</button>
+      </div>
+      <p className="notice">
+        Це не alert, не юридичний висновок і не operational gate. Черга нічого не блокує, не змінює кадрові записи і не застосовує дозові пороги. `out_of_scope` сюди не потрапляє автоматично, бо має окремий нейтральний стан у зведенні.
+      </p>
+      <p className="notice">
+        {policy ? <>Policy revision від <b>{policy.effectiveFrom}</b> ({policy.enabled?"увімкнена":"вимкнена"}) · {policy.sourceTitle || "джерело не вказано"}. </> : <>Effective policy на цю дату не знайдена. </>}
+        <Link href="/staff/personnel/radiation-compliance">Повне зведення ДІВ</Link> · <Link href="/staff/personnel/radiation-review-policy">Політика ДІВ</Link>
+      </p>
+    </section>
+
+    <section className="financeJournal">
+      <header className="financeToolbar"><div><b>Потребує ручної перевірки</b><small>{queue.length} запис(ів) у поточному фільтрі.</small></div></header>
+      {loading ? <p className="notice">Завантаження…</p> : <div className="financeTableWrap"><table className="financeTable">
+        <thead><tr><th>Працівник</th><th>Контингент</th><th>Причини review</th><th>Джерело причини</th><th/></tr></thead>
+        <tbody>{queue.map((record)=>{
+          const selectedReasons = reasons(record, filter);
+          const sources = [
+            record.scopeReviewReasons.length ? "scope" : "",
+            record.baseReviewReasons.length ? "базові реєстри" : "",
+            record.policyReviewReasons.length ? "policy" : "",
+          ].filter(Boolean).join(" · ");
+          return <tr key={record.personnelId}>
+            <td><b>{record.displayName}</b><br/><small>{record.positionTitle}{record.departmentName?` · ${record.departmentName}`:""}</small></td>
+            <td><span className="statusPill">{record.monitoringScopeState}</span><br/><small>{record.monitoringScopeEffectiveDate || "—"}{record.monitoringScopeText?` · ${record.monitoringScopeText}`:""}</small></td>
+            <td><b>{selectedReasons.length}</b><br/><small>{selectedReasons.join("; ")}</small></td>
+            <td><small>{filter === "all" ? sources : filter}</small></td>
+            <td><Link href="/staff/personnel/radiation-compliance">Перевірити у зведенні</Link></td>
+          </tr>;
+        })}</tbody>
+      </table>{!queue.length && <p className="notice">Для поточного фільтра review-причин немає.</p>}</div>}
+    </section>
+  </StaffWorkspaceShell>;
+}

--- a/tests/personnel-radiation-review-queue.test.mjs
+++ b/tests/personnel-radiation-review-queue.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const page = fs.readFileSync("app/staff/personnel/radiation-review-queue/page.tsx", "utf8");
+const complianceRoute = fs.readFileSync("app/api/staff/personnel/radiation-compliance/route.ts", "utf8");
+const directories = fs.readFileSync("app/staff/directories/page.tsx", "utf8");
+
+test("radiation review queue reuses the canonical compliance projection", () => {
+  assert.match(page, /\/api\/staff\/personnel\/radiation-compliance\?asOf=/);
+  assert.match(page, /record\.summaryState === "review"/);
+  assert.match(page, /scopeReviewReasons/);
+  assert.match(page, /baseReviewReasons/);
+  assert.match(page, /policyReviewReasons/);
+  assert.match(page, /reviewReasons/);
+  assert.doesNotMatch(page, /\/api\/staff\/personnel\/radiation-review-queue/);
+  assert.doesNotMatch(page, /method:\s*["'](?:POST|PUT|PATCH|DELETE)["']/);
+});
+
+test("queue exposes reason filters without turning neutral scope into an alert", () => {
+  assert.match(page, /type QueueFilter = "all" \| "scope" \| "base" \| "policy"/);
+  assert.match(page, /filter === "scope"/);
+  assert.match(page, /filter === "base"/);
+  assert.match(page, /filter === "policy"/);
+  assert.match(page, /`out_of_scope` сюди не потрапляє автоматично/);
+  assert.match(page, /Це не alert, не юридичний висновок і не operational gate/);
+  assert.match(page, /не застосовує дозові пороги/);
+  assert.doesNotMatch(page, /закрити review|підтвердити порушення|заблокувати роботу/i);
+});
+
+test("canonical compliance endpoint remains manager-only and read-only", () => {
+  assert.match(complianceRoute, /role === "admin" \|\| role === "department_head"/);
+  assert.match(complianceRoute, /personnel_radiation_compliance_viewed/);
+  assert.match(complianceRoute, /summaryState = monitoringScopeState === "out_of_scope"/);
+  assert.match(complianceRoute, /scopeReviewReasons/);
+  assert.match(complianceRoute, /policyReviewReasons/);
+  assert.doesNotMatch(complianceRoute, /export async function (POST|PUT|PATCH|DELETE)/);
+  assert.doesNotMatch(complianceRoute, /pacs_settings|imaging_studies|bookings/);
+});
+
+test("review queue is discoverable from staff directories", () => {
+  assert.match(directories, /Черга review ДІВ/);
+  assert.match(directories, /\/staff\/personnel\/radiation-review-queue/);
+  assert.match(directories, /без alerts, дозових порогів або operational enforcement/);
+});


### PR DESCRIPTION
## Що змінено
- додає `/staff/personnel/radiation-review-queue` як read-only робочий список
- не створює нового backend або другого набору правил: сторінка використовує канонічний `/api/staff/personnel/radiation-compliance`
- у чергу потрапляють тільки записи з `summaryState === "review"`
- `out_of_scope` має окремий нейтральний стан і автоматично в чергу не потрапляє
- фільтри: усі review / scope / базові реєстрові причини / policy criteria
- показує personnel, monitoring scope, конкретні review-причини та джерело причини
- дата зрізу така сама effective-dated, як у «Зведенні ДІВ»
- додає посилання з довідників
- regression tests фіксують reuse канонічного compliance endpoint, read-only характер, neutral out-of-scope і відсутність mutation flow

## Важлива межа
Це не alert/notification system, не юридичний висновок і не operational gate. Немає dose thresholds, автоматичного закриття review або блокування PACS, КТ, рентген чи booking.

Production deploy не запускається.