### PR TITLE
Staff personal cabinet: phone login, birth date and self-service security

### DIFF
--- a/app/api/staff/profile/route.ts
+++ b/app/api/staff/profile/route.ts
@@ -9,7 +9,35 @@ function clean(value: unknown, max = 120) {
   return String(value || "").trim().replace(/\s+/g, " ").slice(0, max);
 }
 
+function validBirthDate(value: string) {
+  if (value === "") return true;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) return false;
+  return value <= new Date().toISOString().slice(0, 10);
+}
+
 type AuditOrganizationRow = { organizationId: number };
+
+type CurrentIdentity = {
+  email: string;
+  phone: string | null;
+  passwordHash: string;
+  lastName: string;
+  firstName: string;
+  patronymic: string;
+  contactEmail: string;
+};
+
+type PersonnelLink = {
+  id: string;
+  dateOfBirth: string;
+};
 
 async function profileSecurityAuditOrganizationIds(
   db: D1Database,
@@ -28,10 +56,6 @@ async function profileSecurityAuditOrganizationIds(
     .filter((id) => Number.isInteger(id) && id > 0);
   if (ids.length > 0) return ids;
 
-  // Self-service normally requires an active membership. The only safe fallback
-  // is the legacy bootstrap state where memberships have never existed at all and
-  // the resolved context is the sole active organization. Never attribute a
-  // detached/disabled identity to an arbitrary tenant.
   const membershipCount = await db.prepare("SELECT COUNT(*) AS n FROM memberships").first<{ n: number }>();
   if (Number(membershipCount?.n || 0) !== 0) return [];
 
@@ -55,14 +79,34 @@ export async function GET(request: Request) {
   const staff = ctx.member;
 
   const profile = await db.prepare(
-    `SELECT email, phone, display_name AS displayName, last_name AS lastName,
-       first_name AS firstName, patronymic, contact_email AS contactEmail,
-       military_rank AS militaryRank, position_title AS positionTitle, active
-     FROM staff_members WHERE email = ? AND active = 1 LIMIT 1`
-  ).bind(staff.email).first<Record<string, unknown>>();
+    `SELECT s.email, s.phone, s.display_name AS displayName,
+       COALESCE(NULLIF(p.last_name, ''), s.last_name) AS lastName,
+       COALESCE(NULLIF(p.first_name, ''), s.first_name) AS firstName,
+       COALESCE(NULLIF(p.patronymic, ''), s.patronymic) AS patronymic,
+       s.contact_email AS contactEmail,
+       COALESCE(NULLIF(p.military_rank, ''), s.military_rank) AS militaryRank,
+       COALESCE(NULLIF(p.position_title, ''), s.position_title) AS positionTitle,
+       COALESCE(p.date_of_birth, '') AS dateOfBirth,
+       p.id AS personnelId,
+       COALESCE(d.name, '') AS departmentName,
+       s.active
+     FROM staff_members s
+     LEFT JOIN personnel_records p
+       ON p.organization_id = ? AND p.account_email = s.email AND p.active = 1
+     LEFT JOIN departments d
+       ON d.id = p.department_id AND d.organization_id = p.organization_id
+     WHERE s.email = ? AND s.active = 1
+     LIMIT 1`
+  ).bind(ctx.organizationId, staff.email).first<Record<string, unknown>>();
 
   if (!profile) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
-  return Response.json({ profile: { ...profile, role: ctx.role } });
+  return Response.json({
+    profile: {
+      ...profile,
+      role: ctx.role,
+      hasPersonnelRecord: Boolean(profile.personnelId),
+    },
+  }, { headers: { "cache-control": "no-store" } });
 }
 
 export async function PATCH(request: Request) {
@@ -78,16 +122,25 @@ export async function PATCH(request: Request) {
     lastName?: string;
     patronymic?: string;
     contactEmail?: string;
-    militaryRank?: string;
-    positionTitle?: string;
+    dateOfBirth?: string;
     currentPin?: string;
     newPin?: string;
   };
 
-  const current = await db.prepare(
-    `SELECT email, phone, password_hash AS passwordHash FROM staff_members
-     WHERE email = ? AND active = 1 LIMIT 1`
-  ).bind(staff.email).first<{ email: string; phone: string | null; passwordHash: string }>();
+  const [current, personnel] = await Promise.all([
+    db.prepare(
+      `SELECT email, phone, password_hash AS passwordHash,
+         last_name AS lastName, first_name AS firstName, patronymic,
+         contact_email AS contactEmail
+       FROM staff_members WHERE email = ? AND active = 1 LIMIT 1`
+    ).bind(staff.email).first<CurrentIdentity>(),
+    db.prepare(
+      `SELECT id, date_of_birth AS dateOfBirth
+       FROM personnel_records
+       WHERE organization_id = ? AND account_email = ? AND active = 1
+       LIMIT 1`
+    ).bind(ctx.organizationId, staff.email).first<PersonnelLink>(),
+  ]);
   if (!current) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
 
   const phone = body.phone == null ? null : normalizeUkrainianPhone(body.phone);
@@ -98,10 +151,16 @@ export async function PATCH(request: Request) {
   const lastName = body.lastName == null ? null : clean(body.lastName, 60);
   const patronymic = body.patronymic == null ? null : clean(body.patronymic, 60);
   const contactEmail = body.contactEmail == null ? null : clean(body.contactEmail, 254).toLowerCase();
-  const militaryRank = body.militaryRank == null ? null : clean(body.militaryRank, 80);
-  const positionTitle = body.positionTitle == null ? null : clean(body.positionTitle, 120);
+  const dateOfBirth = body.dateOfBirth == null ? null : clean(body.dateOfBirth, 10);
+
   if (contactEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactEmail)) {
     return Response.json({ error: "Перевірте e-mail" }, { status: 400 });
+  }
+  if (dateOfBirth !== null && !validBirthDate(dateOfBirth)) {
+    return Response.json({ error: "Перевірте дату народження" }, { status: 400 });
+  }
+  if (dateOfBirth !== null && !personnel) {
+    return Response.json({ error: "Кадрова картка не прив’язана до цього облікового запису" }, { status: 409 });
   }
 
   if (phone) {
@@ -117,10 +176,6 @@ export async function PATCH(request: Request) {
     if (problem) return Response.json({ error: problem }, { status: 400 });
   }
 
-  // Phone is the primary login identifier. Changing it is therefore a credential
-  // boundary just like changing the PIN: a stolen session must not be enough to
-  // re-bind the account to an attacker's number. Require the current PIN for any
-  // real phone change, then revoke every identity-level session after success.
   const securityChange = wantsPinChange || phoneChanged;
   if (securityChange) {
     if (!body.currentPin || !(await verifyPassword(body.currentPin, current.passwordHash))) {
@@ -128,35 +183,59 @@ export async function PATCH(request: Request) {
     }
   }
 
-  const existingProfile = await db.prepare(
-    `SELECT last_name AS lastName, first_name AS firstName, patronymic
-     FROM staff_members WHERE email = ? LIMIT 1`
-  ).bind(staff.email).first<{ lastName: string; firstName: string; patronymic: string }>();
-  const finalLastName = lastName ?? existingProfile?.lastName ?? "";
-  const finalFirstName = firstName ?? existingProfile?.firstName ?? "";
-  const finalPatronymic = patronymic ?? existingProfile?.patronymic ?? "";
+  const finalLastName = lastName ?? current.lastName ?? "";
+  const finalFirstName = firstName ?? current.firstName ?? "";
+  const finalPatronymic = patronymic ?? current.patronymic ?? "";
   const displayName = [finalLastName, finalFirstName, finalPatronymic].filter(Boolean).join(" ").slice(0, 180);
+  const nameChanged = finalLastName !== current.lastName
+    || finalFirstName !== current.firstName
+    || finalPatronymic !== current.patronymic;
+  const contactEmailChanged = contactEmail !== null && contactEmail !== current.contactEmail;
+  const dateOfBirthChanged = dateOfBirth !== null && dateOfBirth !== (personnel?.dateOfBirth || "");
 
-  await db.prepare(
-    `UPDATE staff_members SET
-       phone = COALESCE(?, phone),
-       last_name = COALESCE(?, last_name),
-       first_name = COALESCE(?, first_name),
-       patronymic = COALESCE(?, patronymic),
-       contact_email = COALESCE(?, contact_email),
-       military_rank = COALESCE(?, military_rank),
-       position_title = COALESCE(?, position_title),
-       display_name = CASE WHEN ? <> '' THEN ? ELSE display_name END
-     WHERE email = ?`
-  ).bind(phone, lastName, firstName, patronymic, contactEmail, militaryRank, positionTitle, displayName, displayName, staff.email).run();
+  const statements = [
+    db.prepare(
+      `UPDATE staff_members SET
+         phone = COALESCE(?, phone),
+         last_name = COALESCE(?, last_name),
+         first_name = COALESCE(?, first_name),
+         patronymic = COALESCE(?, patronymic),
+         contact_email = COALESCE(?, contact_email),
+         display_name = CASE WHEN ? <> '' THEN ? ELSE display_name END
+       WHERE email = ?`
+    ).bind(phone, lastName, firstName, patronymic, contactEmail, displayName, displayName, staff.email),
+  ];
+
+  if (personnel) {
+    statements.push(
+      db.prepare(
+        `UPDATE personnel_records SET
+           last_name = COALESCE(?, last_name),
+           first_name = COALESCE(?, first_name),
+           patronymic = COALESCE(?, patronymic),
+           display_name = CASE WHEN ? <> '' THEN ? ELSE display_name END,
+           personal_phone = COALESCE(?, personal_phone),
+           alternate_email = COALESCE(?, alternate_email),
+           date_of_birth = COALESCE(?, date_of_birth),
+           updated_by = ?, updated_at = CURRENT_TIMESTAMP
+         WHERE id = ? AND organization_id = ?`
+      ).bind(
+        lastName, firstName, patronymic, displayName, displayName,
+        phone, contactEmail, dateOfBirth, staff.email, personnel.id, ctx.organizationId,
+      ),
+    );
+  }
 
   if (wantsPinChange) {
-    await db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")
-      .bind(await hashPassword(body.newPin || ""), staff.email).run();
+    statements.push(
+      db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")
+        .bind(await hashPassword(body.newPin || ""), staff.email),
+    );
   }
   if (securityChange) {
-    await db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(staff.email).run();
+    statements.push(db.prepare("DELETE FROM staff_sessions WHERE email = ?").bind(staff.email));
   }
+  await db.batch(statements);
 
   const auditOrganizationIds = securityChange
     ? await profileSecurityAuditOrganizationIds(db, staff.email, ctx.organizationId)
@@ -168,7 +247,14 @@ export async function PATCH(request: Request) {
       action: securityChange ? "profile_security_update" : "profile_update",
       resource: "staff",
       targetId: staff.email,
-      details: { phoneChanged, pinChanged: wantsPinChange },
+      details: {
+        phoneChanged,
+        pinChanged: wantsPinChange,
+        dateOfBirthChanged,
+        nameChanged,
+        contactEmailChanged,
+        personnelLinked: Boolean(personnel),
+      },
     });
   }
 

--- a/app/api/staff/profile/route.ts
+++ b/app/api/staff/profile/route.ts
@@ -240,6 +240,19 @@ export async function PATCH(request: Request) {
   const auditOrganizationIds = securityChange
     ? await profileSecurityAuditOrganizationIds(db, staff.email, ctx.organizationId)
     : [ctx.organizationId];
+  const auditDetails = securityChange
+    ? {
+        phoneChanged,
+        pinChanged: wantsPinChange,
+      }
+    : {
+        phoneChanged,
+        pinChanged: wantsPinChange,
+        dateOfBirthChanged,
+        nameChanged,
+        contactEmailChanged,
+        personnelLinked: Boolean(personnel),
+      };
   for (const organizationId of auditOrganizationIds) {
     await audit(db, {
       organizationId,
@@ -247,14 +260,7 @@ export async function PATCH(request: Request) {
       action: securityChange ? "profile_security_update" : "profile_update",
       resource: "staff",
       targetId: staff.email,
-      details: {
-        phoneChanged,
-        pinChanged: wantsPinChange,
-        dateOfBirthChanged,
-        nameChanged,
-        contactEmailChanged,
-        personnelLinked: Boolean(personnel),
-      },
+      details: auditDetails,
     });
   }
 

--- a/app/staff/profile/page.tsx
+++ b/app/staff/profile/page.tsx
@@ -5,8 +5,21 @@ import StaffWorkspaceShell from "../workspace-shell";
 import { roleLabelUk } from "../../../lib/labels";
 
 type Profile = {
-  email:string; phone:string; displayName:string; lastName:string; firstName:string; patronymic:string;
-  contactEmail:string; militaryRank:string; positionTitle:string; role:string; active:number;
+  email:string;
+  phone:string;
+  displayName:string;
+  lastName:string;
+  firstName:string;
+  patronymic:string;
+  contactEmail:string;
+  militaryRank:string;
+  positionTitle:string;
+  departmentName:string;
+  dateOfBirth:string;
+  personnelId:string | null;
+  hasPersonnelRecord:boolean;
+  role:string;
+  active:number;
 };
 
 export default function StaffProfilePage() {
@@ -45,33 +58,50 @@ export default function StaffProfilePage() {
     return () => { cancelled = true; };
   },[]);
 
-  async function saveProfile(event:FormEvent<HTMLFormElement>) {
+  async function patchProfile(payload:Record<string, unknown>) {
+    setSaving(true); setError(""); setSuccess("");
+    try {
+      const response = await fetch("/api/staff/profile", {
+        method:"PATCH",
+        headers:{ "content-type":"application/json" },
+        body:JSON.stringify(payload),
+      });
+      const data = await response.json().catch(()=>({})) as { error?:string; signedOut?:boolean };
+      if (!response.ok) throw new Error(data.error || "Не вдалося зберегти профіль");
+      if (data.signedOut) {
+        window.location.assign("/staff/login?returnTo=%2Fstaff%2Fprofile&changed=1");
+        return false;
+      }
+      await load();
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося зберегти профіль");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function savePersonal(event:FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const form = new FormData(event.currentTarget);
-    setSaving(true); setError(""); setSuccess("");
-    const response = await fetch("/api/staff/profile", {
-      method:"PATCH",
-      headers:{ "content-type":"application/json" },
-      body:JSON.stringify({
-        phone:String(form.get("phone") || ""),
-        currentPin:String(form.get("currentPin") || ""),
-        lastName:String(form.get("lastName") || ""),
-        firstName:String(form.get("firstName") || ""),
-        patronymic:String(form.get("patronymic") || ""),
-        contactEmail:String(form.get("contactEmail") || ""),
-        militaryRank:String(form.get("militaryRank") || ""),
-        positionTitle:String(form.get("positionTitle") || ""),
-      }),
+    const payload:Record<string, unknown> = {
+      lastName:String(form.get("lastName") || ""),
+      firstName:String(form.get("firstName") || ""),
+      patronymic:String(form.get("patronymic") || ""),
+      contactEmail:String(form.get("contactEmail") || ""),
+    };
+    if (profile?.hasPersonnelRecord) payload.dateOfBirth = String(form.get("dateOfBirth") || "");
+    if (await patchProfile(payload)) setSuccess("Особисті дані оновлено");
+  }
+
+  async function changePhone(event:FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    await patchProfile({
+      phone:String(form.get("phone") || ""),
+      currentPin:String(form.get("currentPin") || ""),
     });
-    const data = await response.json().catch(()=>({})) as { error?:string; signedOut?:boolean };
-    setSaving(false);
-    if (!response.ok) { setError(data.error || "Не вдалося зберегти профіль"); return; }
-    if (data.signedOut) {
-      window.location.assign("/staff/login?returnTo=%2Fstaff%2Fprofile&changed=1");
-      return;
-    }
-    setSuccess("Профіль оновлено");
-    await load();
   }
 
   async function changePin(event:FormEvent<HTMLFormElement>) {
@@ -81,51 +111,45 @@ export default function StaffProfilePage() {
     const newPin = String(form.get("newPin") || "");
     const confirmPin = String(form.get("confirmPin") || "");
     if (newPin !== confirmPin) { setError("Новий PIN і підтвердження не збігаються"); return; }
-    setSaving(true); setError(""); setSuccess("");
-    const response = await fetch("/api/staff/profile", {
-      method:"PATCH",
-      headers:{ "content-type":"application/json" },
-      body:JSON.stringify({ currentPin, newPin }),
-    });
-    const data = await response.json().catch(()=>({})) as { error?:string; signedOut?:boolean };
-    setSaving(false);
-    if (!response.ok) { setError(data.error || "Не вдалося змінити PIN"); return; }
-    if (data.signedOut) {
-      window.location.assign("/staff/login?returnTo=%2Fstaff%2Fprofile&changed=1");
-      return;
-    }
-    setSuccess("PIN-код змінено");
-    event.currentTarget.reset();
+    await patchProfile({ currentPin, newPin });
   }
 
   return <StaffWorkspaceShell
-    active="organization"
-    title="Мій профіль"
-    description="Контактні дані, посада та безпека робочого облікового запису."
+    active="overview"
+    title="Особистий кабінет персоналу"
+    description="Ваші особисті дані, логін за номером телефону та безпека облікового запису."
     staffName={profile?.displayName}
     staffRole={roleLabelUk(profile?.role)}
   >
-    {error && <p className="notice bad">{error}</p>}
-    {success && <p className="notice good">{success}</p>}
+    {error && <p className="notice bad" role="alert">{error}</p>}
+    {success && <p className="notice good" role="status">{success}</p>}
     {!profile ? <p className="dashLoading">Завантаження…</p> : <div className="orgProfile">
       <section className="orgProfileCard">
-        <h3>Профіль працівника</h3>
-        <form onSubmit={saveProfile} className="formGrid">
-          <label>Прізвище<input name="lastName" defaultValue={profile.lastName || ""}/></label>
-          <label>Ім’я<input name="firstName" defaultValue={profile.firstName || ""}/></label>
+        <h3>Особисті дані</h3>
+        <p className="orgProfileHint">Ці дані належать тільки вашому профілю. Посада, роль і підрозділ змінюються керівництвом.</p>
+        <form onSubmit={savePersonal} className="formGrid">
+          <label>Прізвище<input name="lastName" defaultValue={profile.lastName || ""} required/></label>
+          <label>Ім’я<input name="firstName" defaultValue={profile.firstName || ""} required/></label>
           <label>По батькові<input name="patronymic" defaultValue={profile.patronymic || ""}/></label>
-          <label>Телефон<input name="phone" inputMode="tel" defaultValue={profile.phone || ""}/></label>
-          <label>Поточний PIN для зміни телефону<input name="currentPin" type="password" inputMode="numeric" autoComplete="current-password" placeholder="Потрібен лише якщо змінюєте телефон"/></label>
+          <label>Дата народження<input name="dateOfBirth" type="date" defaultValue={profile.dateOfBirth || ""} disabled={!profile.hasPersonnelRecord}/></label>
           <label>Контактний e-mail<input name="contactEmail" type="email" defaultValue={profile.contactEmail || ""}/></label>
-          <label>Військове звання<input name="militaryRank" defaultValue={profile.militaryRank || ""}/></label>
-          <label>Посада<input name="positionTitle" defaultValue={profile.positionTitle || ""}/></label>
-          <div><small>Роль у системі: <b>{roleLabelUk(profile.role)}</b>. Зміна номера входу потребує поточного PIN і завершить усі активні сеанси.</small></div>
-          <div><button className="button" type="submit" disabled={saving}>{saving ? "Зберігаємо…":"Зберегти профіль"}</button></div>
+          {!profile.hasPersonnelRecord && <div className="notice warning">Дата народження зберігається у кадровій картці. Адміністратор має спочатку прив’язати вашу картку персоналу до облікового запису.</div>}
+          <div><button className="button" type="submit" disabled={saving}>{saving ? "Зберігаємо…":"Зберегти особисті дані"}</button></div>
         </form>
       </section>
 
       <section className="orgProfileCard">
-        <h3>Змінити PIN-код</h3>
+        <h3>Логін: номер телефону</h3>
+        <p className="orgProfileHint">Для входу до RadiologyOS використовується ваш номер телефону. Зміна логіна потребує поточного PIN і завершить усі активні сеанси.</p>
+        <form onSubmit={changePhone} className="formGrid">
+          <label>Телефон / логін<input name="phone" inputMode="tel" autoComplete="username" defaultValue={profile.phone || ""} required/></label>
+          <label>Поточний PIN<input name="currentPin" type="password" inputMode="numeric" autoComplete="current-password" required/></label>
+          <div><button className="button" type="submit" disabled={saving}>{saving ? "Змінюємо…":"Змінити логін"}</button></div>
+        </form>
+      </section>
+
+      <section className="orgProfileCard">
+        <h3>Пароль / PIN-код</h3>
         <p className="orgProfileHint">Після зміни PIN усі активні сеанси буде завершено. Увійдіть знову вже з новим кодом.</p>
         <form onSubmit={changePin} className="formGrid">
           <label>Поточний PIN<input name="currentPin" type="password" inputMode="numeric" autoComplete="current-password" required/></label>
@@ -133,6 +157,17 @@ export default function StaffProfilePage() {
           <label>Повторіть новий PIN<input name="confirmPin" type="password" inputMode="numeric" autoComplete="new-password" minLength={6} required/></label>
           <div><button className="button" type="submit" disabled={saving}>{saving ? "Змінюємо…":"Змінити PIN"}</button></div>
         </form>
+      </section>
+
+      <section className="orgProfileCard">
+        <h3>Службові дані</h3>
+        <div className="formGrid">
+          <label>Посада<input value={profile.positionTitle || ""} readOnly/></label>
+          <label>Військове звання<input value={profile.militaryRank || ""} readOnly/></label>
+          <label>Підрозділ<input value={profile.departmentName || ""} readOnly/></label>
+          <label>Роль у системі<input value={roleLabelUk(profile.role)} readOnly/></label>
+        </div>
+        <p className="orgProfileHint">Службові повноваження не можна змінити з особистого кабінету.</p>
       </section>
     </div>}
   </StaffWorkspaceShell>;

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -254,6 +254,7 @@ export default function StaffWorkspaceShell({
             <span><b>{identity}</b><small>{staffRole || "Персонал відділення"}</small></span>
           </summary>
           <div>
+            <Link href="/staff/profile">Особистий кабінет</Link>
             <Link href="/staff/documents">Документи</Link>
             <Link href="/staff/registers">Регістри</Link>
             <Link href="/staff/appointments">Календар і записи</Link>

--- a/tests/staff-profile-membership-context.behavior.test.mjs
+++ b/tests/staff-profile-membership-context.behavior.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFile } from "node:fs/promises";
 import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
 async function setMembershipRole(db, email, role, organizationId = 1) {
@@ -13,6 +14,32 @@ async function getProfile(db, cookie) {
     jsonRequest("/api/staff/profile", undefined, { method:"GET", headers:{ cookie } }),
     db,
   );
+}
+
+async function linkPersonnel(db, email, overrides = {}) {
+  const value = {
+    id:`personnel-${email}`,
+    organizationId:1,
+    lastName:"Профільний",
+    firstName:"Працівник",
+    patronymic:"Тестович",
+    displayName:"Профільний Працівник Тестович",
+    dateOfBirth:"1985-01-02",
+    militaryRank:"Сержант",
+    positionTitle:"Рентгенолаборант",
+    ...overrides,
+  };
+  await db.prepare(
+    `INSERT INTO personnel_records
+      (id, organization_id, account_email, last_name, first_name, patronymic,
+       display_name, date_of_birth, military_rank, position_title,
+       personal_phone, alternate_email, active, created_by, updated_by)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', '', 1, 'test', 'test')`
+  ).bind(
+    value.id, value.organizationId, email, value.lastName, value.firstName, value.patronymic,
+    value.displayName, value.dateOfBirth, value.militaryRank, value.positionTitle,
+  ).run();
+  return value;
 }
 
 test("self-profile returns the active tenant membership role, not the legacy global identity role", async () => {
@@ -39,26 +66,29 @@ test("self-profile returns the active tenant membership role, not the legacy glo
   });
 });
 
-test("system and management roles can update only their own shared profile through the neutral context", async () => {
+test("self-service updates personal data and date of birth but never self-promotes position or role", async () => {
   await withD1(async (db) => {
     const email = "profile-update@example.com";
     const cookie = await seedStaffSession(db, { email, role:"admin", displayName:"Before" });
     await setMembershipRole(db, email, "organization_admin");
-    // Phone is the primary login identifier. Keep it unchanged in this ordinary
-    // profile-edit regression; rebinding it is a separate security operation that
-    // requires the current PIN and revokes sessions.
-    await db.prepare("UPDATE staff_members SET phone = ? WHERE email = ?")
-      .bind("380501234567", email).run();
+    await db.prepare(
+      `UPDATE staff_members SET phone = ?, position_title = ?, military_rank = ? WHERE email = ?`
+    ).bind("380501234567", "Системний адміністратор", "Сержант", email).run();
+    await linkPersonnel(db, email, {
+      positionTitle:"Системний адміністратор",
+      militaryRank:"Сержант",
+    });
 
     const response = await callWorker(
       jsonRequest("/api/staff/profile", {
         lastName:"Системний",
         firstName:"Адміністратор",
         patronymic:"Тестович",
-        phone:"+380501234567",
         contactEmail:"self@example.com",
-        militaryRank:"",
-        positionTitle:"Системний адміністратор",
+        dateOfBirth:"1986-03-04",
+        positionTitle:"Самопризначений начальник",
+        militaryRank:"Полковник",
+        role:"admin",
       }, { method:"PATCH", headers:{ cookie } }),
       db,
     );
@@ -66,19 +96,35 @@ test("system and management roles can update only their own shared profile throu
 
     const stored = await db.prepare(
       `SELECT display_name AS displayName, phone, contact_email AS contactEmail,
-        position_title AS positionTitle, role
+        position_title AS positionTitle, military_rank AS militaryRank, role
        FROM staff_members WHERE email = ?`
     ).bind(email).first();
     assert.equal(stored.displayName, "Системний Адміністратор Тестович");
     assert.equal(stored.phone, "380501234567");
     assert.equal(stored.contactEmail, "self@example.com");
     assert.equal(stored.positionTitle, "Системний адміністратор");
+    assert.equal(stored.militaryRank, "Сержант");
     assert.equal(stored.role, "admin", "self-service must never rewrite the legacy global authorization role");
+
+    const personnel = await db.prepare(
+      `SELECT display_name AS displayName, date_of_birth AS dateOfBirth,
+        alternate_email AS alternateEmail, position_title AS positionTitle,
+        military_rank AS militaryRank
+       FROM personnel_records WHERE organization_id = 1 AND account_email = ?`
+    ).bind(email).first();
+    assert.equal(personnel.displayName, "Системний Адміністратор Тестович");
+    assert.equal(personnel.dateOfBirth, "1986-03-04");
+    assert.equal(personnel.alternateEmail, "self@example.com");
+    assert.equal(personnel.positionTitle, "Системний адміністратор");
+    assert.equal(personnel.militaryRank, "Сержант");
 
     const after = await getProfile(db, cookie);
     assert.equal(after.status, 200);
     const body = await after.json();
     assert.equal(body.profile.role, "organization_admin");
+    assert.equal(body.profile.dateOfBirth, "1986-03-04");
+    assert.equal(body.profile.hasPersonnelRecord, true);
+    assert.equal(body.profile.positionTitle, "Системний адміністратор");
 
     const audit = await db.prepare(
       `SELECT organization_id AS organizationId, action, details_json AS detailsJson
@@ -87,19 +133,53 @@ test("system and management roles can update only their own shared profile throu
     ).bind(email).first();
     assert.equal(audit.organizationId, 1);
     assert.equal(audit.action, "profile_update");
-    assert.doesNotMatch(String(audit.detailsJson), /Системний|self@example|380501234567/);
+    assert.match(String(audit.detailsJson), /dateOfBirthChanged/);
+    assert.doesNotMatch(String(audit.detailsJson), /1986-03-04|Системний|self@example|380501234567/);
   });
 });
 
-test("profile route uses the neutral membership context and never trusts staff_members.role for the response", async () => {
-  const { readFile } = await import("node:fs/promises");
+test("date of birth cannot be written without a linked personnel card", async () => {
+  await withD1(async (db) => {
+    const email = "profile-unlinked@example.com";
+    const cookie = await seedStaffSession(db, { email, role:"radiographer", displayName:"Unlinked" });
+
+    const response = await callWorker(
+      jsonRequest("/api/staff/profile", { dateOfBirth:"1990-05-06" }, { method:"PATCH", headers:{ cookie } }),
+      db,
+    );
+    assert.equal(response.status, 409);
+    assert.match(String((await response.json()).error), /Кадрова картка/);
+  });
+});
+
+test("profile route uses tenant-scoped personnel data and excludes privileged self-service fields", async () => {
   const route = await readFile(new URL("../app/api/staff/profile/route.ts", import.meta.url), "utf8");
   const tenant = await readFile(new URL("../lib/tenant.ts", import.meta.url), "utf8");
 
   assert.match(route, /requireSelfServiceOrgContext\(request, db\)/);
-  assert.match(route, /profile: \{ \.\.\.profile, role: ctx\.role \}/);
-  assert.doesNotMatch(route, /position_title AS positionTitle,[\s\S]*role, active/);
+  assert.match(route, /p\.organization_id = \?/);
+  assert.match(route, /p\.account_email = s\.email/);
+  assert.match(route, /date_of_birth AS dateOfBirth/);
+  assert.match(route, /personal_phone = COALESCE/);
+  assert.match(route, /date_of_birth = COALESCE/);
+  assert.match(route, /profile:[\s\S]*role: ctx\.role/);
+  assert.doesNotMatch(route, /body\.positionTitle/);
+  assert.doesNotMatch(route, /body\.militaryRank/);
+  assert.doesNotMatch(route, /body\.role/);
   assert.match(tenant, /SELF_SERVICE_ROLES/);
   assert.match(tenant, /requireSelfServiceOrgContext/);
   assert.match(tenant, /resolveOrgContext\(request, db, SELF_SERVICE_ROLES\)/);
+});
+
+test("personal cabinet exposes phone login, birth date and password controls from the profile menu", async () => {
+  const [page, shell] = await Promise.all([
+    readFile(new URL("../app/staff/profile/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../app/staff/workspace-shell.tsx", import.meta.url), "utf8"),
+  ]);
+  assert.match(page, /Особистий кабінет персоналу/);
+  assert.match(page, /Логін: номер телефону/);
+  assert.match(page, /name="dateOfBirth" type="date"/);
+  assert.match(page, /Пароль \/ PIN-код/);
+  assert.match(page, /Службові повноваження не можна змінити/);
+  assert.match(shell, /href="\/staff\/profile">Особистий кабінет/);
 });


### PR DESCRIPTION
## Що змінено
- особистий кабінет персоналу доступний з меню профілю;
- логін явно оформлено як номер телефону;
- дата народження читається/змінюється через tenant-scoped `personnel_records`;
- ім’я/контактні дані синхронізуються з прив’язаною кадровою карткою;
- зміна телефону або PIN вимагає поточного PIN і завершує всі активні сесії;
- посада, військове звання та роль у self-service більше не змінюються;
- додані behavioral/source тести на tenant scope, DOB, privilege boundaries та UI.

Без production deploy. Нова міграція не потрібна: використані вже наявні поля `staff_members.phone/password_hash` і `personnel_records.date_of_birth`.