### PR TITLE
Personnel assignments, work schedules and personnel-keyed duty roster

### DIFF
--- a/app/api/staff/personnel/route.ts
+++ b/app/api/staff/personnel/route.ts
@@ -4,6 +4,8 @@ import { requireSelfServiceOrgContext } from "../../../../lib/tenant";
 import type { AccessRole } from "../../../../lib/staff-auth";
 
 const EMPLOYMENT_KINDS = new Set(["unspecified", "military", "civilian", "contractor", "other"]);
+const ASSIGNMENT_KINDS = new Set(["primary", "acting", "secondary", "temporary", "other"]);
+const SCHEDULE_KINDS = new Set(["five_day", "six_day", "shift", "individual", "other"]);
 
 function canManagePersonnel(role: AccessRole) {
   return role === "admin" || role === "department_head";
@@ -11,6 +13,10 @@ function canManagePersonnel(role: AccessRole) {
 
 function clean(value: unknown, max = 160) {
   return String(value ?? "").trim().replace(/\s+/g, " ").slice(0, max);
+}
+
+function cleanMultiline(value: unknown, max = 4000) {
+  return String(value ?? "").trim().replace(/\r\n/g, "\n").slice(0, max);
 }
 
 function cleanEmail(value: unknown) {
@@ -22,11 +28,49 @@ function validEmail(value: string) {
 }
 
 function validDate(value: string) {
-  return !value || /^\d{4}-\d{2}-\d{2}$/.test(value);
+  if (!value) return true;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day;
+}
+
+function validRequiredDate(value: string) {
+  return Boolean(value) && validDate(value);
+}
+
+function validTime(value: string) {
+  return value === "" || /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+}
+
+function parseDepartmentId(value: unknown) {
+  if (value == null || value === "") return null;
+  const result = Number(value);
+  return Number.isInteger(result) && result > 0 ? result : NaN;
+}
+
+function minutesOfDay(value: string) {
+  const [hours, minutes] = value.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+function workingMinutes(start: string, end: string, breakStart: string, breakEnd: string) {
+  let finish = minutesOfDay(end);
+  const begin = minutesOfDay(start);
+  if (finish <= begin) finish += 1440;
+  let result = finish - begin;
+  if (breakStart && breakEnd) {
+    let breakFinish = minutesOfDay(breakEnd);
+    const breakBegin = minutesOfDay(breakStart);
+    if (breakFinish <= breakBegin) breakFinish += 1440;
+    result -= Math.max(0, breakFinish - breakBegin);
+  }
+  return Math.max(0, result);
 }
 
 type PersonnelInput = {
   id?: string;
+  action?: string;
   accountEmail?: string | null;
   staffNumber?: string;
   employmentKind?: string;
@@ -48,14 +92,47 @@ type PersonnelInput = {
   active?: boolean;
 };
 
+type AssignmentInput = {
+  action?: string;
+  assignmentId?: string;
+  personnelId?: string;
+  departmentId?: number | string | null;
+  positionTitle?: string;
+  assignmentKind?: string;
+  duties?: string;
+  startsOn?: string;
+  endsOn?: string;
+  orderReference?: string;
+};
+
+type WorkScheduleDayInput = {
+  weekday?: number;
+  isWorking?: boolean;
+  startTime?: string;
+  endTime?: string;
+  breakStart?: string;
+  breakEnd?: string;
+};
+
+type WorkScheduleInput = {
+  action?: string;
+  scheduleId?: string;
+  personnelId?: string;
+  name?: string;
+  scheduleKind?: string;
+  validFrom?: string;
+  validTo?: string;
+  note?: string;
+  active?: boolean;
+  days?: WorkScheduleDayInput[];
+};
+
 function parseInput(body: PersonnelInput) {
   const lastName = clean(body.lastName, 80);
   const firstName = clean(body.firstName, 80);
   const patronymic = clean(body.patronymic, 80);
   const displayName = [lastName, firstName, patronymic].filter(Boolean).join(" ").slice(0, 240);
   const employmentKind = clean(body.employmentKind || "unspecified", 24);
-  const departmentNumber = body.departmentId == null || body.departmentId === "" ? null : Number(body.departmentId);
-  const departmentId = departmentNumber == null ? null : (Number.isInteger(departmentNumber) && departmentNumber > 0 ? departmentNumber : NaN);
   return {
     accountEmail: cleanEmail(body.accountEmail || "") || null,
     staffNumber: clean(body.staffNumber, 40),
@@ -67,7 +144,7 @@ function parseInput(body: PersonnelInput) {
     dateOfBirth: clean(body.dateOfBirth, 10),
     militaryRank: clean(body.militaryRank, 100),
     positionTitle: clean(body.positionTitle, 160),
-    departmentId,
+    departmentId: parseDepartmentId(body.departmentId),
     workPhone: clean(body.workPhone, 40),
     personalPhone: clean(body.personalPhone, 40),
     workEmail: cleanEmail(body.workEmail),
@@ -80,6 +157,22 @@ function parseInput(body: PersonnelInput) {
   };
 }
 
+async function personnelInOrganization(db: D1Database, organizationId: number, personnelId: string) {
+  return db.prepare(
+    `SELECT id, position_title AS positionTitle, department_id AS departmentId
+     FROM personnel_records WHERE id = ? AND organization_id = ? LIMIT 1`,
+  ).bind(personnelId, organizationId).first<{ id:string; positionTitle:string; departmentId:number | null }>();
+}
+
+async function validateDepartment(db: D1Database, organizationId: number, departmentId: number | null) {
+  if (departmentId == null) return "";
+  if (!Number.isInteger(departmentId)) return "Некоректний підрозділ";
+  const department = await db.prepare(
+    "SELECT id FROM departments WHERE id = ? AND organization_id = ? AND active = 1 LIMIT 1",
+  ).bind(departmentId, organizationId).first();
+  return department ? "" : "Підрозділ не належить цій організації або неактивний";
+}
+
 async function validateReferences(
   db: D1Database,
   organizationId: number,
@@ -87,13 +180,8 @@ async function validateReferences(
   accountEmail: string | null,
   currentId?: string,
 ) {
-  if (departmentId != null) {
-    if (!Number.isInteger(departmentId)) return "Некоректний підрозділ";
-    const department = await db.prepare(
-      "SELECT id FROM departments WHERE id = ? AND organization_id = ? AND active = 1 LIMIT 1",
-    ).bind(departmentId, organizationId).first();
-    if (!department) return "Підрозділ не належить цій організації або неактивний";
-  }
+  const departmentProblem = await validateDepartment(db, organizationId, departmentId);
+  if (departmentProblem) return departmentProblem;
   if (accountEmail) {
     const membership = await db.prepare(
       "SELECT id FROM memberships WHERE organization_id = ? AND member_email = ? LIMIT 1",
@@ -125,13 +213,219 @@ async function requirePersonnelManager(request: Request, db: D1Database) {
   return ctx;
 }
 
+async function saveAssignment(request: Request, db: D1Database, ctx: Awaited<ReturnType<typeof requirePersonnelManager>>) {
+  if (!ctx) return Response.json({ error:"Доступ до кадрового довідника заборонено" }, { status:403 });
+  const body = await request.json().catch(() => ({})) as AssignmentInput;
+  const personnelId = clean(body.personnelId, 120);
+  const assignmentId = clean(body.assignmentId, 160);
+  const departmentId = parseDepartmentId(body.departmentId);
+  const positionTitle = clean(body.positionTitle, 160);
+  const assignmentKind = clean(body.assignmentKind || "primary", 24);
+  const duties = cleanMultiline(body.duties, 4000);
+  const startsOn = clean(body.startsOn, 10);
+  const endsOn = clean(body.endsOn, 10);
+  const orderReference = clean(body.orderReference, 240);
+
+  if (!personnelId || !positionTitle || !ASSIGNMENT_KINDS.has(assignmentKind)) {
+    return Response.json({ error:"Вкажіть працівника, посаду та тип призначення" }, { status:400 });
+  }
+  if (!validDate(startsOn) || !validDate(endsOn) || (startsOn && endsOn && endsOn < startsOn)) {
+    return Response.json({ error:"Перевірте дати призначення" }, { status:400 });
+  }
+  const personnel = await personnelInOrganization(db, ctx.organizationId, personnelId);
+  if (!personnel) return Response.json({ error:"Працівника не знайдено" }, { status:404 });
+  const departmentProblem = await validateDepartment(db, ctx.organizationId, departmentId);
+  if (departmentProblem) return Response.json({ error:departmentProblem }, { status:409 });
+
+  let id = assignmentId;
+  try {
+    if (assignmentId) {
+      const existing = await db.prepare(
+        "SELECT id FROM personnel_assignments WHERE id = ? AND organization_id = ? AND personnel_id = ? LIMIT 1",
+      ).bind(assignmentId, ctx.organizationId, personnelId).first();
+      if (!existing) return Response.json({ error:"Призначення не знайдено" }, { status:404 });
+      await db.prepare(
+        `UPDATE personnel_assignments SET department_id = ?, position_title = ?, assignment_kind = ?,
+           duties = ?, starts_on = ?, ends_on = ?, order_reference = ?,
+           updated_by = ?, updated_at = CURRENT_TIMESTAMP
+         WHERE id = ? AND organization_id = ? AND personnel_id = ?`,
+      ).bind(
+        departmentId, positionTitle, assignmentKind, duties, startsOn, endsOn, orderReference,
+        ctx.member.email, assignmentId, ctx.organizationId, personnelId,
+      ).run();
+    } else {
+      id = `assignment-${crypto.randomUUID()}`;
+      await db.prepare(
+        `INSERT INTO personnel_assignments
+         (id, organization_id, personnel_id, department_id, position_title, assignment_kind,
+          duties, starts_on, ends_on, order_reference, created_by, updated_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        id, ctx.organizationId, personnelId, departmentId, positionTitle, assignmentKind,
+        duties, startsOn, endsOn, orderReference, ctx.member.email, ctx.member.email,
+      ).run();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/personnel_assignment_scope/i.test(message)) {
+      return Response.json({ error:"Призначення не належить цій організації" }, { status:409 });
+    }
+    if (/personnel_assignments_current_primary_idx|UNIQUE constraint failed: personnel_assignments\.organization_id, personnel_assignments\.personnel_id/i.test(message)) {
+      return Response.json({ error:"У працівника вже є чинне основне призначення. Відредагуйте його або вкажіть дату завершення." }, { status:409 });
+    }
+    throw error;
+  }
+
+  if (assignmentKind === "primary" && !endsOn) {
+    await db.prepare(
+      `UPDATE personnel_records SET position_title = ?, department_id = ?,
+         updated_by = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE id = ? AND organization_id = ?`,
+    ).bind(positionTitle, departmentId, ctx.member.email, personnelId, ctx.organizationId).run();
+  }
+
+  await audit(db, {
+    organizationId:ctx.organizationId,
+    actorEmail:ctx.member.email,
+    action:assignmentId ? "personnel_assignment_updated" : "personnel_assignment_created",
+    resource:"personnel_assignment",
+    targetId:personnelId,
+    details:{ assignmentId:id, assignmentKind, departmentId, hasEndDate:Boolean(endsOn) },
+  });
+  return Response.json({ ok:true, id }, { status:assignmentId ? 200 : 201 });
+}
+
+function parseScheduleDays(value: unknown) {
+  if (!Array.isArray(value) || value.length !== 7) return { error:"Графік має містити всі 7 днів тижня", days:[] as Required<WorkScheduleDayInput>[] };
+  const seen = new Set<number>();
+  const days:Required<WorkScheduleDayInput>[] = [];
+  for (const item of value as WorkScheduleDayInput[]) {
+    const weekday = Number(item.weekday);
+    if (!Number.isInteger(weekday) || weekday < 1 || weekday > 7 || seen.has(weekday)) {
+      return { error:"У графіку дублюються або відсутні дні тижня", days:[] as Required<WorkScheduleDayInput>[] };
+    }
+    seen.add(weekday);
+    const isWorking = Boolean(item.isWorking);
+    const startTime = clean(item.startTime, 5);
+    const endTime = clean(item.endTime, 5);
+    const breakStart = clean(item.breakStart, 5);
+    const breakEnd = clean(item.breakEnd, 5);
+    if (![startTime, endTime, breakStart, breakEnd].every(validTime)) {
+      return { error:"Перевірте час у графіку роботи", days:[] as Required<WorkScheduleDayInput>[] };
+    }
+    if (isWorking && (!startTime || !endTime)) {
+      return { error:"Для робочого дня вкажіть початок і завершення роботи", days:[] as Required<WorkScheduleDayInput>[] };
+    }
+    if (!isWorking && (startTime || endTime || breakStart || breakEnd)) {
+      return { error:"Для вихідного дня час має бути порожнім", days:[] as Required<WorkScheduleDayInput>[] };
+    }
+    if ((breakStart && !breakEnd) || (!breakStart && breakEnd)) {
+      return { error:"Перерву потрібно вказати повністю", days:[] as Required<WorkScheduleDayInput>[] };
+    }
+    days.push({ weekday, isWorking, startTime, endTime, breakStart, breakEnd });
+  }
+  days.sort((a,b) => a.weekday - b.weekday);
+  return { error:"", days };
+}
+
+async function saveWorkSchedule(request: Request, db: D1Database, ctx: Awaited<ReturnType<typeof requirePersonnelManager>>) {
+  if (!ctx) return Response.json({ error:"Доступ до кадрового довідника заборонено" }, { status:403 });
+  const body = await request.json().catch(() => ({})) as WorkScheduleInput;
+  const personnelId = clean(body.personnelId, 120);
+  const scheduleId = clean(body.scheduleId, 160);
+  const name = clean(body.name, 160);
+  const scheduleKind = clean(body.scheduleKind || "individual", 24);
+  const validFrom = clean(body.validFrom, 10);
+  const validTo = clean(body.validTo, 10);
+  const note = cleanMultiline(body.note, 1000);
+  const active = body.active === false ? 0 : 1;
+  const parsedDays = parseScheduleDays(body.days);
+
+  if (!personnelId || !name || !SCHEDULE_KINDS.has(scheduleKind) || !validRequiredDate(validFrom)) {
+    return Response.json({ error:"Вкажіть працівника, назву, тип і дату початку дії графіка" }, { status:400 });
+  }
+  if (!validDate(validTo) || (validTo && validTo < validFrom)) {
+    return Response.json({ error:"Перевірте строк дії графіка" }, { status:400 });
+  }
+  if (parsedDays.error) return Response.json({ error:parsedDays.error }, { status:400 });
+  const personnel = await personnelInOrganization(db, ctx.organizationId, personnelId);
+  if (!personnel) return Response.json({ error:"Працівника не знайдено" }, { status:404 });
+
+  const weeklyMinutes = parsedDays.days.reduce((sum, day) => {
+    if (!day.isWorking) return sum;
+    return sum + workingMinutes(day.startTime, day.endTime, day.breakStart, day.breakEnd);
+  }, 0);
+  if (weeklyMinutes > 10080) return Response.json({ error:"Некоректна тривалість робочого тижня" }, { status:400 });
+
+  let id = scheduleId;
+  if (scheduleId) {
+    const existing = await db.prepare(
+      "SELECT id FROM personnel_work_schedules WHERE id = ? AND organization_id = ? AND personnel_id = ? LIMIT 1",
+    ).bind(scheduleId, ctx.organizationId, personnelId).first();
+    if (!existing) return Response.json({ error:"Графік роботи не знайдено" }, { status:404 });
+  } else {
+    id = `work-schedule-${crypto.randomUUID()}`;
+  }
+
+  const statements = [];
+  if (scheduleId) {
+    statements.push(db.prepare(
+      `UPDATE personnel_work_schedules SET name = ?, schedule_kind = ?, valid_from = ?, valid_to = ?,
+         weekly_minutes = ?, note = ?, active = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE id = ? AND organization_id = ? AND personnel_id = ?`,
+    ).bind(name, scheduleKind, validFrom, validTo, weeklyMinutes, note, active, ctx.member.email, id, ctx.organizationId, personnelId));
+    statements.push(db.prepare(
+      "DELETE FROM personnel_work_schedule_days WHERE schedule_id = ? AND organization_id = ?",
+    ).bind(id, ctx.organizationId));
+  } else {
+    statements.push(db.prepare(
+      `INSERT INTO personnel_work_schedules
+       (id, organization_id, personnel_id, name, schedule_kind, valid_from, valid_to,
+        weekly_minutes, note, active, created_by, updated_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(id, ctx.organizationId, personnelId, name, scheduleKind, validFrom, validTo,
+      weeklyMinutes, note, active, ctx.member.email, ctx.member.email));
+  }
+  for (const day of parsedDays.days) {
+    statements.push(db.prepare(
+      `INSERT INTO personnel_work_schedule_days
+       (schedule_id, organization_id, weekday, is_working, start_time, end_time, break_start, break_end)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(id, ctx.organizationId, day.weekday, day.isWorking ? 1 : 0,
+      day.startTime, day.endTime, day.breakStart, day.breakEnd));
+  }
+
+  try {
+    await db.batch(statements);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/personnel_work_schedule_(scope|day_scope)/i.test(message)) {
+      return Response.json({ error:"Графік роботи не належить цій організації" }, { status:409 });
+    }
+    if (/personnel_work_schedules_current_idx|UNIQUE constraint failed: personnel_work_schedules\.organization_id, personnel_work_schedules\.personnel_id/i.test(message)) {
+      return Response.json({ error:"У працівника вже є чинний графік без дати завершення. Відредагуйте його або завершіть попередній." }, { status:409 });
+    }
+    throw error;
+  }
+
+  await audit(db, {
+    organizationId:ctx.organizationId,
+    actorEmail:ctx.member.email,
+    action:scheduleId ? "personnel_work_schedule_updated" : "personnel_work_schedule_created",
+    resource:"personnel_work_schedule",
+    targetId:personnelId,
+    details:{ scheduleId:id, scheduleKind, weeklyMinutes, active:Boolean(active), hasEndDate:Boolean(validTo) },
+  });
+  return Response.json({ ok:true, id, weeklyMinutes }, { status:scheduleId ? 200 : 201 });
+}
+
 export async function GET(request: Request) {
   const db = dbBinding();
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requirePersonnelManager(request, db);
   if (!ctx) return Response.json({ error: "Доступ до кадрового довідника заборонено" }, { status: 403 });
 
-  const [records, departments, accounts] = await Promise.all([
+  const [records, departments, accounts, structure, assignments, workSchedules, workScheduleDays] = await Promise.all([
     db.prepare(
       `SELECT p.id, p.account_email AS accountEmail, p.staff_number AS staffNumber,
          p.employment_kind AS employmentKind, p.last_name AS lastName,
@@ -143,7 +437,21 @@ export async function GET(request: Request) {
          p.alternate_email AS alternateEmail, p.region, p.city,
          p.address_line AS addressLine, p.postal_code AS postalCode,
          p.photo_storage_key AS photoStorageKey, p.active,
-         p.created_at AS createdAt, p.updated_at AS updatedAt
+         p.created_at AS createdAt, p.updated_at AS updatedAt,
+         (SELECT v.decision_code FROM personnel_vlk_records v
+          WHERE v.organization_id = p.organization_id AND v.personnel_id = p.id
+            AND NOT EXISTS (
+              SELECT 1 FROM personnel_vlk_records correction
+              WHERE correction.supersedes_id = v.id
+            )
+          ORDER BY v.examination_date DESC, v.created_at DESC, v.id DESC LIMIT 1) AS vlkDecisionCode,
+         (SELECT v.valid_until FROM personnel_vlk_records v
+          WHERE v.organization_id = p.organization_id AND v.personnel_id = p.id
+            AND NOT EXISTS (
+              SELECT 1 FROM personnel_vlk_records correction
+              WHERE correction.supersedes_id = v.id
+            )
+          ORDER BY v.examination_date DESC, v.created_at DESC, v.id DESC LIMIT 1) AS vlkValidUntil
        FROM personnel_records p
        LEFT JOIN departments d
          ON d.id = p.department_id AND d.organization_id = p.organization_id
@@ -163,6 +471,54 @@ export async function GET(request: Request) {
        WHERE m.organization_id = ?
        ORDER BY m.active DESC, s.display_name, m.member_email`,
     ).bind(ctx.organizationId).all(),
+    db.prepare(
+      `SELECT d.id AS departmentId, d.name AS departmentName,
+         ds.parent_department_id AS parentDepartmentId, parent.name AS parentDepartmentName,
+         COALESCE(ds.unit_type, 'unit') AS unitType
+       FROM departments d
+       LEFT JOIN department_structure ds
+         ON ds.organization_id = d.organization_id AND ds.department_id = d.id
+       LEFT JOIN departments parent
+         ON parent.organization_id = d.organization_id AND parent.id = ds.parent_department_id
+       WHERE d.organization_id = ? AND d.active = 1
+       ORDER BY COALESCE(parent.name, d.name), ds.parent_department_id IS NOT NULL, d.name`,
+    ).bind(ctx.organizationId).all(),
+    db.prepare(
+      `SELECT a.id, a.personnel_id AS personnelId, a.department_id AS departmentId,
+         d.name AS departmentName, ds.parent_department_id AS parentDepartmentId,
+         parent.name AS parentDepartmentName, a.position_title AS positionTitle,
+         a.assignment_kind AS assignmentKind, a.duties, a.starts_on AS startsOn,
+         a.ends_on AS endsOn, a.order_reference AS orderReference,
+         a.created_at AS createdAt, a.updated_at AS updatedAt
+       FROM personnel_assignments a
+       LEFT JOIN departments d
+         ON d.id = a.department_id AND d.organization_id = a.organization_id
+       LEFT JOIN department_structure ds
+         ON ds.department_id = a.department_id AND ds.organization_id = a.organization_id
+       LEFT JOIN departments parent
+         ON parent.id = ds.parent_department_id AND parent.organization_id = a.organization_id
+       WHERE a.organization_id = ?
+       ORDER BY a.personnel_id, CASE WHEN a.ends_on = '' THEN 0 ELSE 1 END,
+         CASE a.assignment_kind WHEN 'primary' THEN 0 WHEN 'acting' THEN 1 ELSE 2 END,
+         a.starts_on DESC, a.created_at DESC`,
+    ).bind(ctx.organizationId).all(),
+    db.prepare(
+      `SELECT id, personnel_id AS personnelId, name, schedule_kind AS scheduleKind,
+         valid_from AS validFrom, valid_to AS validTo, weekly_minutes AS weeklyMinutes,
+         note, active, created_at AS createdAt, updated_at AS updatedAt
+       FROM personnel_work_schedules
+       WHERE organization_id = ?
+       ORDER BY personnel_id, active DESC, valid_to = '' DESC, valid_from DESC, created_at DESC`,
+    ).bind(ctx.organizationId).all(),
+    db.prepare(
+      `SELECT d.schedule_id AS scheduleId, d.weekday, d.is_working AS isWorking,
+         d.start_time AS startTime, d.end_time AS endTime,
+         d.break_start AS breakStart, d.break_end AS breakEnd
+       FROM personnel_work_schedule_days d
+       JOIN personnel_work_schedules s ON s.id = d.schedule_id
+       WHERE d.organization_id = ? AND s.organization_id = ?
+       ORDER BY d.schedule_id, d.weekday`,
+    ).bind(ctx.organizationId, ctx.organizationId).all(),
   ]);
 
   await audit(db, {
@@ -174,7 +530,15 @@ export async function GET(request: Request) {
   });
 
   return Response.json(
-    { records: records.results, departments: departments.results, accounts: accounts.results },
+    {
+      records: records.results,
+      departments: departments.results,
+      accounts: accounts.results,
+      departmentStructure: structure.results,
+      assignments: assignments.results,
+      workSchedules: workSchedules.results,
+      workScheduleDays: workScheduleDays.results,
+    },
     { headers: { "cache-control": "no-store" } },
   );
 }
@@ -184,6 +548,11 @@ export async function POST(request: Request) {
   if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
   const ctx = await requirePersonnelManager(request, db);
   if (!ctx) return Response.json({ error: "Доступ до кадрового довідника заборонено" }, { status: 403 });
+
+  const probe = await request.clone().json().catch(() => ({})) as { action?:string };
+  const action = clean(probe.action, 40);
+  if (action === "assignment") return saveAssignment(request, db, ctx);
+  if (action === "work_schedule") return saveWorkSchedule(request, db, ctx);
 
   const body = await request.json().catch(() => ({})) as PersonnelInput;
   const input = parseInput(body);
@@ -207,6 +576,17 @@ export async function POST(request: Request) {
     input.militaryRank, input.positionTitle, input.departmentId, input.workPhone, input.personalPhone,
     input.workEmail, input.alternateEmail, input.region, input.city, input.addressLine, input.postalCode,
     input.active, ctx.member.email, ctx.member.email,
+  ).run();
+
+  const assignmentId = `assignment-${crypto.randomUUID()}`;
+  await db.prepare(
+    `INSERT INTO personnel_assignments
+     (id, organization_id, personnel_id, department_id, position_title, assignment_kind,
+      duties, starts_on, ends_on, order_reference, created_by, updated_by)
+     VALUES (?, ?, ?, ?, ?, 'primary', '', ?, '', '', ?, ?)`,
+  ).bind(
+    assignmentId, ctx.organizationId, id, input.departmentId, input.positionTitle,
+    new Date().toISOString().slice(0, 10), ctx.member.email, ctx.member.email,
   ).run();
 
   await audit(db, {

--- a/app/api/staff/shifts/route.ts
+++ b/app/api/staff/shifts/route.ts
@@ -17,21 +17,25 @@ import {
 } from "../../../../lib/shift-calendar";
 
 type PersonRow = {
+  personnelId:string;
   email:string;
+  accountEmail:string | null;
   displayName:string;
   role:string;
   positionTitle:string;
   militaryRank:string;
+  departmentName:string;
 };
 
 type AssignmentRow = {
+  personnelId:string;
   staffEmail:string;
   presetCode:string;
   teamIndex:number;
   anchorDate:string;
 };
 
-type OverrideRow = ShiftOverride & { id:number };
+type OverrideRow = ShiftOverride & { id:number; personnelId:string };
 
 function clean(value:unknown, max=160) {
   return String(value || "").trim().replace(/\s+/g, " ").slice(0, max);
@@ -50,69 +54,97 @@ function currentMonth() {
   return new Date().toISOString().slice(0, 7);
 }
 
-async function staffRows(db:D1Database, organizationId:number, email:string | null) {
-  const sql = `SELECT s.email, s.display_name AS displayName, m.role AS role,
-      COALESCE(s.position_title, '') AS positionTitle,
-      COALESCE(s.military_rank, '') AS militaryRank
-    FROM memberships m
-    JOIN staff_members s ON s.email = m.member_email AND s.active = 1
-    WHERE m.organization_id = ? AND m.active = 1${email ? " AND s.email = ?" : ""}
-    ORDER BY s.position_title, s.display_name, s.email`;
-  return email
-    ? db.prepare(sql).bind(organizationId, email).all<PersonRow>()
+async function personnelRows(db:D1Database, organizationId:number, accountEmail:string | null) {
+  const sql = `SELECT p.id AS personnelId,
+      COALESCE(p.account_email, '') AS email,
+      p.account_email AS accountEmail,
+      p.display_name AS displayName,
+      COALESCE(m.role, '') AS role,
+      COALESCE(p.position_title, '') AS positionTitle,
+      COALESCE(p.military_rank, '') AS militaryRank,
+      COALESCE(d.name, '') AS departmentName
+    FROM personnel_records p
+    LEFT JOIN memberships m
+      ON m.organization_id = p.organization_id
+     AND m.member_email = p.account_email
+     AND m.active = 1
+    LEFT JOIN departments d
+      ON d.organization_id = p.organization_id
+     AND d.id = p.department_id
+    WHERE p.organization_id = ? AND p.active = 1${accountEmail ? " AND p.account_email = ?" : ""}
+    ORDER BY p.position_title, p.display_name, p.id`;
+  return accountEmail
+    ? db.prepare(sql).bind(organizationId, accountEmail).all<PersonRow>()
     : db.prepare(sql).bind(organizationId).all<PersonRow>();
 }
 
-async function assignmentRows(db:D1Database, organizationId:number, email:string | null) {
-  const sql = `SELECT staff_email AS staffEmail, preset_code AS presetCode,
-      team_index AS teamIndex, anchor_date AS anchorDate
-    FROM staff_shift_assignments
-    WHERE organization_id = ?${email ? " AND staff_email = ?" : ""}
-    ORDER BY staff_email`;
-  return email
-    ? db.prepare(sql).bind(organizationId, email).all<AssignmentRow>()
+async function assignmentRows(db:D1Database, organizationId:number, personnelId:string | null) {
+  const sql = `SELECT a.personnel_id AS personnelId,
+      COALESCE(p.account_email, '') AS staffEmail,
+      a.preset_code AS presetCode, a.team_index AS teamIndex, a.anchor_date AS anchorDate
+    FROM personnel_shift_assignments a
+    JOIN personnel_records p
+      ON p.organization_id = a.organization_id AND p.id = a.personnel_id
+    WHERE a.organization_id = ?${personnelId ? " AND a.personnel_id = ?" : ""}
+    ORDER BY p.display_name, a.personnel_id`;
+  return personnelId
+    ? db.prepare(sql).bind(organizationId, personnelId).all<AssignmentRow>()
     : db.prepare(sql).bind(organizationId).all<AssignmentRow>();
 }
 
-async function overrideRows(db:D1Database, organizationId:number, month:string, email:string | null) {
-  const sql = `SELECT id, staff_email AS staffEmail, shift_date AS shiftDate, kind,
-      label, start_time AS startTime, end_time AS endTime, note
-    FROM staff_shift_overrides
-    WHERE organization_id = ? AND shift_date LIKE ?${email ? " AND staff_email = ?" : ""}
-    ORDER BY shift_date, staff_email`;
-  return email
-    ? db.prepare(sql).bind(organizationId, `${month}-%`, email).all<OverrideRow>()
+async function overrideRows(db:D1Database, organizationId:number, month:string, personnelId:string | null) {
+  const sql = `SELECT o.id, o.personnel_id AS personnelId,
+      COALESCE(p.account_email, '') AS staffEmail,
+      o.shift_date AS shiftDate, o.kind, o.label,
+      o.start_time AS startTime, o.end_time AS endTime, o.note
+    FROM personnel_shift_overrides o
+    JOIN personnel_records p
+      ON p.organization_id = o.organization_id AND p.id = o.personnel_id
+    WHERE o.organization_id = ? AND o.shift_date LIKE ?${personnelId ? " AND o.personnel_id = ?" : ""}
+    ORDER BY o.shift_date, p.display_name, o.personnel_id`;
+  return personnelId
+    ? db.prepare(sql).bind(organizationId, `${month}-%`, personnelId).all<OverrideRow>()
     : db.prepare(sql).bind(organizationId, `${month}-%`).all<OverrideRow>();
 }
 
-function buildCsv(
-  month:string,
-  people:PersonRow[],
-  assignments:AssignmentRow[],
-  overrides:OverrideRow[],
-) {
+function buildCsv(month:string, people:PersonRow[], assignments:AssignmentRow[], overrides:OverrideRow[]) {
   const dates = datesForMonth(month);
-  const assignmentByEmail = new Map(assignments.map((row) => [row.staffEmail, row]));
-  const overrideByKey = new Map(overrides.map((row) => [`${row.staffEmail}:${row.shiftDate}`, row]));
+  const assignmentByPersonnel = new Map(assignments.map((row) => [row.personnelId, row]));
+  const overrideByKey = new Map(overrides.map((row) => [`${row.personnelId}:${row.shiftDate}`, row]));
   const header = ["Працівник", "Посада", "Графік", "Бригада", ...dates.map((date) => date.slice(-2))];
   const rows = people.map((person) => {
-    const assignment = assignmentByEmail.get(person.email);
+    const assignment = assignmentByPersonnel.get(person.personnelId);
     const preset = assignment ? shiftPreset(assignment.presetCode) : null;
     const dayCells = dates.map((date) => {
-      const override = overrideByKey.get(`${person.email}:${date}`);
+      const override = overrideByKey.get(`${person.personnelId}:${date}`);
       if (override) return shiftCellText(resolvedOverride(override));
       if (!assignment) return "";
       return shiftCellText(resolvePresetShift(assignment.presetCode, assignment.teamIndex, assignment.anchorDate, date));
     });
-    return [
-      person.displayName || person.email,
-      person.positionTitle,
-      preset?.name || "",
-      assignment ? String(assignment.teamIndex) : "",
-      ...dayCells,
-    ];
+    return [person.displayName || person.email || person.personnelId, person.positionTitle, preset?.name || "",
+      assignment ? String(assignment.teamIndex) : "", ...dayCells];
   });
   return "\ufeff" + [header, ...rows].map((row) => row.map(csvCell).join(";")).join("\r\n");
+}
+
+async function requestedPersonnel(
+  db:D1Database,
+  organizationId:number,
+  body:Record<string, unknown>,
+) {
+  const personnelId = clean(body.personnelId, 160);
+  const legacyEmail = clean(body.staffEmail, 254).toLowerCase();
+  if (!personnelId && !legacyEmail) return null;
+  if (personnelId) {
+    return db.prepare(
+      `SELECT id AS personnelId, account_email AS accountEmail
+       FROM personnel_records WHERE organization_id = ? AND id = ? AND active = 1 LIMIT 1`,
+    ).bind(organizationId, personnelId).first<{ personnelId:string; accountEmail:string | null }>();
+  }
+  return db.prepare(
+    `SELECT id AS personnelId, account_email AS accountEmail
+     FROM personnel_records WHERE organization_id = ? AND account_email = ? AND active = 1 LIMIT 1`,
+  ).bind(organizationId, legacyEmail).first<{ personnelId:string; accountEmail:string | null }>();
 }
 
 export async function GET(request:Request) {
@@ -125,13 +157,13 @@ export async function GET(request:Request) {
   const month = url.searchParams.get("month") || currentMonth();
   if (!isMonthKey(month)) return Response.json({ error:"Некоректний місяць" }, { status:400 });
   const canManage = canViewManagementSummary(ctx.member.role);
-  const ownOnly = canManage ? null : ctx.member.email;
-  const [peopleResult, assignmentsResult, overridesResult] = await Promise.all([
-    staffRows(db, ctx.organizationId, ownOnly),
-    assignmentRows(db, ctx.organizationId, ownOnly),
-    overrideRows(db, ctx.organizationId, month, ownOnly),
-  ]);
+  const peopleResult = await personnelRows(db, ctx.organizationId, canManage ? null : ctx.member.email);
   const people = peopleResult.results as PersonRow[];
+  const ownPersonnelId = canManage ? null : (people[0]?.personnelId || null);
+  const [assignmentsResult, overridesResult] = await Promise.all([
+    assignmentRows(db, ctx.organizationId, ownPersonnelId),
+    overrideRows(db, ctx.organizationId, month, ownPersonnelId),
+  ]);
   const assignments = assignmentsResult.results as AssignmentRow[];
   const overrides = overridesResult.results as OverrideRow[];
 
@@ -140,7 +172,7 @@ export async function GET(request:Request) {
     actorEmail:ctx.member.email,
     action:"staff_shift_calendar_viewed",
     resource:"staff_shift_calendar",
-    details:{ month, scope:canManage ? "organization" : "self" },
+    details:{ month, scope:canManage ? "organization" : "self", personnelLinked:Boolean(canManage || ownPersonnelId) },
   });
 
   if (url.searchParams.get("format") === "csv") {
@@ -155,14 +187,8 @@ export async function GET(request:Request) {
   }
 
   return Response.json({
-    month,
-    canManage,
-    staff:ctx.member,
-    people,
-    assignments,
-    overrides,
-    presets:CALENDAR6_PRESETS,
-    overrideKinds:SHIFT_OVERRIDE_KINDS,
+    month, canManage, staff:ctx.member, people, assignments, overrides,
+    personnelLinked:canManage || Boolean(ownPersonnelId), presets:CALENDAR6_PRESETS, overrideKinds:SHIFT_OVERRIDE_KINDS,
   }, { headers:{ "cache-control":"no-store" } });
 }
 
@@ -175,15 +201,9 @@ export async function POST(request:Request) {
   }
   const body = await request.json().catch(() => ({})) as Record<string, unknown>;
   const action = clean(body.action, 40);
-  const staffEmail = clean(body.staffEmail, 254).toLowerCase();
-  if (!staffEmail) return Response.json({ error:"Оберіть працівника" }, { status:400 });
-
-  const member = await db.prepare(
-    `SELECT 1 AS ok FROM memberships m
-     JOIN staff_members s ON s.email = m.member_email AND s.active = 1
-     WHERE m.organization_id = ? AND m.member_email = ? AND m.active = 1 LIMIT 1`
-  ).bind(ctx.organizationId, staffEmail).first<{ ok:number }>();
-  if (!member) return Response.json({ error:"Працівника не знайдено в цій організації" }, { status:404 });
+  const personnel = await requestedPersonnel(db, ctx.organizationId, body);
+  if (!personnel) return Response.json({ error:"Працівника не знайдено в кадровому довіднику цієї організації" }, { status:404 });
+  const personnelId = personnel.personnelId;
 
   if (action === "assignment") {
     const presetCode = clean(body.presetCode, 40);
@@ -194,42 +214,33 @@ export async function POST(request:Request) {
       return Response.json({ error:"Перевірте тип графіка, бригаду та опорну дату" }, { status:400 });
     }
     await db.prepare(
-      `INSERT INTO staff_shift_assignments
-        (organization_id, staff_email, preset_code, team_index, anchor_date, created_by, updated_by)
+      `INSERT INTO personnel_shift_assignments
+        (organization_id, personnel_id, preset_code, team_index, anchor_date, created_by, updated_by)
        VALUES (?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(organization_id, staff_email) DO UPDATE SET
+       ON CONFLICT(organization_id, personnel_id) DO UPDATE SET
          preset_code=excluded.preset_code,
          team_index=excluded.team_index,
          anchor_date=excluded.anchor_date,
          updated_by=excluded.updated_by,
-         updated_at=CURRENT_TIMESTAMP`
-    ).bind(
-      ctx.organizationId, staffEmail, presetCode, teamIndex, anchorDate,
-      ctx.member.email, ctx.member.email,
-    ).run();
+         updated_at=CURRENT_TIMESTAMP`,
+    ).bind(ctx.organizationId, personnelId, presetCode, teamIndex, anchorDate, ctx.member.email, ctx.member.email).run();
     await audit(db, {
-      organizationId:ctx.organizationId,
-      actorEmail:ctx.member.email,
-      action:"staff_shift_assignment_saved",
-      resource:"staff_shift_calendar",
-      targetId:staffEmail,
+      organizationId:ctx.organizationId, actorEmail:ctx.member.email,
+      action:"staff_shift_assignment_saved", resource:"staff_shift_calendar", targetId:personnelId,
       details:{ presetCode, teamIndex, anchorDate },
     });
-    return Response.json({ ok:true });
+    return Response.json({ ok:true, personnelId });
   }
 
   if (action === "clear_assignment") {
     await db.prepare(
-      "DELETE FROM staff_shift_assignments WHERE organization_id = ? AND staff_email = ?"
-    ).bind(ctx.organizationId, staffEmail).run();
+      "DELETE FROM personnel_shift_assignments WHERE organization_id = ? AND personnel_id = ?",
+    ).bind(ctx.organizationId, personnelId).run();
     await audit(db, {
-      organizationId:ctx.organizationId,
-      actorEmail:ctx.member.email,
-      action:"staff_shift_assignment_cleared",
-      resource:"staff_shift_calendar",
-      targetId:staffEmail,
+      organizationId:ctx.organizationId, actorEmail:ctx.member.email,
+      action:"staff_shift_assignment_cleared", resource:"staff_shift_calendar", targetId:personnelId,
     });
-    return Response.json({ ok:true });
+    return Response.json({ ok:true, personnelId });
   }
 
   if (action === "override") {
@@ -244,51 +255,38 @@ export async function POST(request:Request) {
       return Response.json({ error:"Перевірте дату, тип і час персональної зміни" }, { status:400 });
     }
     const assignment = await db.prepare(
-      "SELECT 1 AS ok FROM staff_shift_assignments WHERE organization_id = ? AND staff_email = ? LIMIT 1"
-    ).bind(ctx.organizationId, staffEmail).first<{ ok:number }>();
-    if (!assignment) return Response.json({ error:"Спочатку призначте працівнику базовий графік" }, { status:409 });
+      "SELECT 1 AS ok FROM personnel_shift_assignments WHERE organization_id = ? AND personnel_id = ? LIMIT 1",
+    ).bind(ctx.organizationId, personnelId).first<{ ok:number }>();
+    if (!assignment) return Response.json({ error:"Спочатку призначте працівнику базовий графік чергувань" }, { status:409 });
     await db.prepare(
-      `INSERT INTO staff_shift_overrides
-        (organization_id, staff_email, shift_date, kind, label, start_time, end_time, note, created_by, updated_by)
+      `INSERT INTO personnel_shift_overrides
+        (organization_id, personnel_id, shift_date, kind, label, start_time, end_time, note, created_by, updated_by)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(organization_id, staff_email, shift_date) DO UPDATE SET
-         kind=excluded.kind,
-         label=excluded.label,
-         start_time=excluded.start_time,
-         end_time=excluded.end_time,
-         note=excluded.note,
-         updated_by=excluded.updated_by,
-         updated_at=CURRENT_TIMESTAMP`
-    ).bind(
-      ctx.organizationId, staffEmail, shiftDate, kind, label, startTime, endTime, note,
-      ctx.member.email, ctx.member.email,
-    ).run();
+       ON CONFLICT(organization_id, personnel_id, shift_date) DO UPDATE SET
+         kind=excluded.kind, label=excluded.label, start_time=excluded.start_time,
+         end_time=excluded.end_time, note=excluded.note,
+         updated_by=excluded.updated_by, updated_at=CURRENT_TIMESTAMP`,
+    ).bind(ctx.organizationId, personnelId, shiftDate, kind, label, startTime, endTime, note, ctx.member.email, ctx.member.email).run();
     await audit(db, {
-      organizationId:ctx.organizationId,
-      actorEmail:ctx.member.email,
-      action:"staff_shift_override_saved",
-      resource:"staff_shift_calendar",
-      targetId:staffEmail,
+      organizationId:ctx.organizationId, actorEmail:ctx.member.email,
+      action:"staff_shift_override_saved", resource:"staff_shift_calendar", targetId:personnelId,
       details:{ shiftDate, kind },
     });
-    return Response.json({ ok:true });
+    return Response.json({ ok:true, personnelId });
   }
 
   if (action === "clear_override") {
     const shiftDate = clean(body.shiftDate, 10);
     if (!isIsoDate(shiftDate)) return Response.json({ error:"Некоректна дата" }, { status:400 });
     await db.prepare(
-      "DELETE FROM staff_shift_overrides WHERE organization_id = ? AND staff_email = ? AND shift_date = ?"
-    ).bind(ctx.organizationId, staffEmail, shiftDate).run();
+      "DELETE FROM personnel_shift_overrides WHERE organization_id = ? AND personnel_id = ? AND shift_date = ?",
+    ).bind(ctx.organizationId, personnelId, shiftDate).run();
     await audit(db, {
-      organizationId:ctx.organizationId,
-      actorEmail:ctx.member.email,
-      action:"staff_shift_override_cleared",
-      resource:"staff_shift_calendar",
-      targetId:staffEmail,
+      organizationId:ctx.organizationId, actorEmail:ctx.member.email,
+      action:"staff_shift_override_cleared", resource:"staff_shift_calendar", targetId:personnelId,
       details:{ shiftDate },
     });
-    return Response.json({ ok:true });
+    return Response.json({ ok:true, personnelId });
   }
 
   return Response.json({ error:"Невідома дія" }, { status:400 });

--- a/app/staff/personnel/page.tsx
+++ b/app/staff/personnel/page.tsx
@@ -10,11 +10,37 @@ type PersonnelRecord = {
   militaryRank:string; positionTitle:string; departmentId:number | null; departmentName:string | null;
   workPhone:string; personalPhone:string; workEmail:string; alternateEmail:string;
   region:string; city:string; addressLine:string; postalCode:string; photoStorageKey:string;
-  active:number; createdAt:string; updatedAt:string;
+  active:number; createdAt:string; updatedAt:string; vlkDecisionCode:string | null; vlkValidUntil:string | null;
 };
 type Department = { id:number; name:string; active:number };
 type Account = { email:string; displayName:string; phone:string; role:string; active:number };
-type ApiData = { records:PersonnelRecord[]; departments:Department[]; accounts:Account[]; error?:string };
+type DepartmentStructure = {
+  departmentId:number; departmentName:string; parentDepartmentId:number | null;
+  parentDepartmentName:string | null; unitType:string;
+};
+type Assignment = {
+  id:string; personnelId:string; departmentId:number | null; departmentName:string | null;
+  parentDepartmentId:number | null; parentDepartmentName:string | null; positionTitle:string;
+  assignmentKind:string; duties:string; startsOn:string; endsOn:string; orderReference:string;
+  createdAt:string; updatedAt:string;
+};
+type WorkSchedule = {
+  id:string; personnelId:string; name:string; scheduleKind:string; validFrom:string; validTo:string;
+  weeklyMinutes:number; note:string; active:number; createdAt:string; updatedAt:string;
+};
+type WorkScheduleDay = {
+  scheduleId:string; weekday:number; isWorking:number; startTime:string; endTime:string;
+  breakStart:string; breakEnd:string;
+};
+type ApiData = {
+  records:PersonnelRecord[]; departments:Department[]; accounts:Account[];
+  departmentStructure:DepartmentStructure[]; assignments:Assignment[];
+  workSchedules:WorkSchedule[]; workScheduleDays:WorkScheduleDay[]; error?:string;
+};
+
+type DayDraft = {
+  weekday:number; isWorking:boolean; startTime:string; endTime:string; breakStart:string; breakEnd:string;
+};
 
 const EMPLOYMENT = [
   ["unspecified", "Не визначено"],
@@ -23,22 +49,31 @@ const EMPLOYMENT = [
   ["contractor", "Сумісник / контрактний"],
   ["other", "Інше"],
 ] as const;
+const ASSIGNMENT_KINDS = [
+  ["primary", "Основна посада"], ["acting", "Тимчасове виконання обов’язків"],
+  ["secondary", "Додаткова посада / суміщення"], ["temporary", "Тимчасове призначення"], ["other", "Інше"],
+] as const;
+const SCHEDULE_KINDS = [
+  ["five_day", "П’ятиденний"], ["six_day", "Шестиденний"], ["shift", "Змінний"],
+  ["individual", "Індивідуальний"], ["other", "Інший"],
+] as const;
+const WEEKDAYS = ["Понеділок", "Вівторок", "Середа", "Четвер", "П’ятниця", "Субота", "Неділя"];
 const POSITIONS = [
-  "Начальник відділення променевої діагностики",
-  "Лікар-рентгенолог",
-  "Рентгенолаборант",
-  "Молодша медична сестра",
-  "Начальник ПРК",
-  "Рентгенолаборант ПРК",
-  "Водій ПРК",
-  "Начальник кабінету УЗД",
-  "Лікар ультразвукової діагностики",
+  "Начальник відділення променевої діагностики", "Лікар-рентгенолог", "Рентгенолаборант",
+  "Молодша медична сестра", "Начальник ПРК", "ТВО начальника ПРК", "Рентгенолаборант ПРК",
+  "Водій-електрик ПРК", "Начальник кабінету УЗД", "Лікар ультразвукової діагностики",
 ];
 const RANKS = [
   "Цивільний персонал", "Солдат", "Старший солдат", "Молодший сержант", "Сержант",
   "Старший сержант", "Головний сержант", "Штаб-сержант", "Молодший лейтенант",
   "Лейтенант", "Старший лейтенант", "Капітан", "Майор", "Підполковник", "Полковник",
 ];
+
+function emptyWeek():DayDraft[] {
+  return Array.from({ length:7 }, (_, index) => ({
+    weekday:index + 1, isWorking:false, startTime:"", endTime:"", breakStart:"", breakEnd:"",
+  }));
+}
 
 function initials(record:PersonnelRecord) {
   return `${record.firstName?.[0] || ""}${record.lastName?.[0] || ""}`.toUpperCase() || "?";
@@ -48,9 +83,27 @@ function employmentLabel(value:string) {
   return EMPLOYMENT.find(([key]) => key === value)?.[1] || value || "Не визначено";
 }
 
+function assignmentKindLabel(value:string) {
+  return ASSIGNMENT_KINDS.find(([key]) => key === value)?.[1] || value;
+}
+
+function scheduleKindLabel(value:string) {
+  return SCHEDULE_KINDS.find(([key]) => key === value)?.[1] || value;
+}
+
+function vlkLabel(value:string | null) {
+  return ({ fit:"Придатний", temporarily_unfit:"Тимчасово непридатний", unfit:"Непридатний", other:"Інше рішення" } as Record<string,string>)[value || ""] || "Немає запису";
+}
+
+function hoursLabel(minutes:number) {
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest ? `${hours} год ${rest} хв` : `${hours} год`;
+}
+
 export default function PersonnelPage() {
   const [data, setData] = useState<ApiData | null>(null);
-  const [selectedId, setSelectedId] = useState<string>("");
+  const [selectedId, setSelectedId] = useState("");
   const [creating, setCreating] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -58,6 +111,11 @@ export default function PersonnelPage() {
   const [notice, setNotice] = useState("");
   const [query, setQuery] = useState("");
   const [departmentFilter, setDepartmentFilter] = useState("all");
+  const [assignmentEditor, setAssignmentEditor] = useState<Assignment | null>(null);
+  const [showAssignmentForm, setShowAssignmentForm] = useState(false);
+  const [scheduleEditor, setScheduleEditor] = useState<WorkSchedule | null>(null);
+  const [scheduleDays, setScheduleDays] = useState<DayDraft[]>(emptyWeek);
+  const [showScheduleForm, setShowScheduleForm] = useState(false);
 
   const load = useCallback(async (preferredId?:string) => {
     setLoading(true); setError("");
@@ -65,16 +123,16 @@ export default function PersonnelPage() {
       const response = await fetch("/api/staff/personnel", { cache:"no-store" });
       const body = await response.json().catch(() => ({})) as Partial<ApiData>;
       if (!response.ok) throw new Error(body.error || "Не вдалося завантажити персонал");
-      const next = {
-        records: body.records || [], departments: body.departments || [], accounts: body.accounts || [],
-      } as ApiData;
+      const next:ApiData = {
+        records:body.records || [], departments:body.departments || [], accounts:body.accounts || [],
+        departmentStructure:body.departmentStructure || [], assignments:body.assignments || [],
+        workSchedules:body.workSchedules || [], workScheduleDays:body.workScheduleDays || [],
+      };
       setData(next);
       if (preferredId && next.records.some((record) => record.id === preferredId)) setSelectedId(preferredId);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не вдалося завантажити персонал");
-    } finally {
-      setLoading(false);
-    }
+    } finally { setLoading(false); }
   }, []);
 
   useEffect(() => {
@@ -82,10 +140,14 @@ export default function PersonnelPage() {
     return () => window.clearTimeout(timer);
   }, [load]);
 
-  const selected = useMemo(
-    () => data?.records.find((record) => record.id === selectedId) || null,
-    [data, selectedId],
+  const selected = useMemo(() => data?.records.find((record) => record.id === selectedId) || null, [data, selectedId]);
+  const selectedAssignments = useMemo(
+    () => (data?.assignments || []).filter((row) => row.personnelId === selectedId), [data, selectedId],
   );
+  const selectedSchedules = useMemo(
+    () => (data?.workSchedules || []).filter((row) => row.personnelId === selectedId), [data, selectedId],
+  );
+  const currentSchedule = selectedSchedules.find((row) => row.active && !row.validTo) || selectedSchedules[0] || null;
   const linkedAccounts = useMemo(
     () => new Set((data?.records || []).filter((record) => record.id !== selectedId && record.accountEmail).map((record) => record.accountEmail as string)),
     [data, selectedId],
@@ -102,130 +164,217 @@ export default function PersonnelPage() {
 
   function startCreate() {
     setCreating(true); setSelectedId(""); setNotice(""); setError("");
+    setShowAssignmentForm(false); setShowScheduleForm(false);
   }
   function startEdit(id:string) {
     setCreating(false); setSelectedId(id); setNotice(""); setError("");
+    setShowAssignmentForm(false); setShowScheduleForm(false); setAssignmentEditor(null); setScheduleEditor(null);
   }
   function closeEditor() {
-    setCreating(false); setSelectedId(""); setError("");
+    setCreating(false); setSelectedId(""); setError(""); setShowAssignmentForm(false); setShowScheduleForm(false);
   }
 
   async function save(event:FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const form = new FormData(event.currentTarget);
     const payload = {
-      id: selected?.id,
-      accountEmail: String(form.get("accountEmail") || "") || null,
-      staffNumber: String(form.get("staffNumber") || ""),
-      employmentKind: String(form.get("employmentKind") || "unspecified"),
-      lastName: String(form.get("lastName") || ""),
-      firstName: String(form.get("firstName") || ""),
-      patronymic: String(form.get("patronymic") || ""),
-      dateOfBirth: String(form.get("dateOfBirth") || ""),
-      militaryRank: String(form.get("militaryRank") || ""),
-      positionTitle: String(form.get("positionTitle") || ""),
-      departmentId: String(form.get("departmentId") || "") || null,
-      workPhone: String(form.get("workPhone") || ""),
-      personalPhone: String(form.get("personalPhone") || ""),
-      workEmail: String(form.get("workEmail") || ""),
-      alternateEmail: String(form.get("alternateEmail") || ""),
-      region: String(form.get("region") || ""),
-      city: String(form.get("city") || ""),
-      addressLine: String(form.get("addressLine") || ""),
-      postalCode: String(form.get("postalCode") || ""),
-      active: form.get("active") === "on",
+      id:selected?.id, accountEmail:String(form.get("accountEmail") || "") || null,
+      staffNumber:String(form.get("staffNumber") || ""), employmentKind:String(form.get("employmentKind") || "unspecified"),
+      lastName:String(form.get("lastName") || ""), firstName:String(form.get("firstName") || ""), patronymic:String(form.get("patronymic") || ""),
+      dateOfBirth:String(form.get("dateOfBirth") || ""), militaryRank:String(form.get("militaryRank") || ""),
+      positionTitle:String(form.get("positionTitle") || ""), departmentId:String(form.get("departmentId") || "") || null,
+      workPhone:String(form.get("workPhone") || ""), personalPhone:String(form.get("personalPhone") || ""),
+      workEmail:String(form.get("workEmail") || ""), alternateEmail:String(form.get("alternateEmail") || ""),
+      region:String(form.get("region") || ""), city:String(form.get("city") || ""), addressLine:String(form.get("addressLine") || ""),
+      postalCode:String(form.get("postalCode") || ""), active:form.get("active") === "on",
     };
     setSaving(true); setError(""); setNotice("");
     try {
       const response = await fetch("/api/staff/personnel", {
-        method: selected ? "PATCH" : "POST",
-        headers: { "content-type":"application/json" },
-        body: JSON.stringify(payload),
+        method:selected ? "PATCH" : "POST", headers:{ "content-type":"application/json" }, body:JSON.stringify(payload),
       });
       const body = await response.json().catch(() => ({})) as { ok?:boolean; id?:string; error?:string };
       if (!response.ok || !body.ok || !body.id) throw new Error(body.error || "Не вдалося зберегти картку");
-      await load(body.id);
-      setCreating(false);
-      setSelectedId(body.id);
+      await load(body.id); setCreating(false); setSelectedId(body.id);
       setNotice(selected ? "Картку працівника оновлено." : "Працівника додано до кадрового довідника.");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Не вдалося зберегти картку");
-    } finally {
-      setSaving(false);
-    }
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося зберегти картку"); }
+    finally { setSaving(false); }
+  }
+
+  async function saveAssignment(event:FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selected) return;
+    const form = new FormData(event.currentTarget);
+    const payload = {
+      action:"assignment", assignmentId:assignmentEditor?.id, personnelId:selected.id,
+      departmentId:String(form.get("assignmentDepartmentId") || "") || null,
+      positionTitle:String(form.get("assignmentPositionTitle") || ""),
+      assignmentKind:String(form.get("assignmentKind") || "primary"), duties:String(form.get("duties") || ""),
+      startsOn:String(form.get("startsOn") || ""), endsOn:String(form.get("endsOn") || ""),
+      orderReference:String(form.get("orderReference") || ""),
+    };
+    setSaving(true); setError(""); setNotice("");
+    try {
+      const response = await fetch("/api/staff/personnel", { method:"POST", headers:{"content-type":"application/json"}, body:JSON.stringify(payload) });
+      const body = await response.json().catch(() => ({})) as {ok?:boolean;error?:string};
+      if (!response.ok || !body.ok) throw new Error(body.error || "Не вдалося зберегти призначення");
+      await load(selected.id); setShowAssignmentForm(false); setAssignmentEditor(null);
+      setNotice("Призначення та посадові обов’язки збережено.");
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося зберегти призначення"); }
+    finally { setSaving(false); }
+  }
+
+  function editAssignment(row:Assignment) { setAssignmentEditor(row); setShowAssignmentForm(true); setNotice(""); setError(""); }
+  function newAssignment() { setAssignmentEditor(null); setShowAssignmentForm(true); setNotice(""); setError(""); }
+
+  function loadScheduleDraft(schedule:WorkSchedule | null) {
+    setScheduleEditor(schedule);
+    if (!schedule) { setScheduleDays(emptyWeek()); return; }
+    const byWeekday = new Map((data?.workScheduleDays || []).filter((row) => row.scheduleId === schedule.id).map((row) => [row.weekday, row]));
+    setScheduleDays(Array.from({length:7}, (_, index) => {
+      const row = byWeekday.get(index + 1);
+      return { weekday:index + 1, isWorking:Boolean(row?.isWorking), startTime:row?.startTime || "", endTime:row?.endTime || "", breakStart:row?.breakStart || "", breakEnd:row?.breakEnd || "" };
+    }));
+  }
+  function editSchedule(schedule:WorkSchedule) { loadScheduleDraft(schedule); setShowScheduleForm(true); setNotice(""); setError(""); }
+  function newSchedule() { loadScheduleDraft(null); setShowScheduleForm(true); setNotice(""); setError(""); }
+  function updateDay(weekday:number, patch:Partial<DayDraft>) {
+    setScheduleDays((current) => current.map((day) => day.weekday === weekday ? {...day, ...patch} : day));
+  }
+
+  async function saveSchedule(event:FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selected) return;
+    const form = new FormData(event.currentTarget);
+    const payload = {
+      action:"work_schedule", scheduleId:scheduleEditor?.id, personnelId:selected.id,
+      name:String(form.get("scheduleName") || ""), scheduleKind:String(form.get("scheduleKind") || "individual"),
+      validFrom:String(form.get("validFrom") || ""), validTo:String(form.get("validTo") || ""),
+      note:String(form.get("scheduleNote") || ""), active:form.get("scheduleActive") === "on", days:scheduleDays,
+    };
+    setSaving(true); setError(""); setNotice("");
+    try {
+      const response = await fetch("/api/staff/personnel", {method:"POST", headers:{"content-type":"application/json"}, body:JSON.stringify(payload)});
+      const body = await response.json().catch(() => ({})) as {ok?:boolean;error?:string;weeklyMinutes?:number};
+      if (!response.ok || !body.ok) throw new Error(body.error || "Не вдалося зберегти графік роботи");
+      await load(selected.id); setShowScheduleForm(false); setScheduleEditor(null);
+      setNotice(`Графік роботи збережено${typeof body.weeklyMinutes === "number" ? ` · ${hoursLabel(body.weeklyMinutes)} на тиждень` : ""}.`);
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося зберегти графік роботи"); }
+    finally { setSaving(false); }
   }
 
   const editorRecord = selected;
   const showEditor = creating || Boolean(editorRecord);
+  const hierarchyLabel = (departmentId:number | null, departmentName?:string | null) => {
+    if (!departmentId) return departmentName || "Підрозділ не вказано";
+    const structure = data?.departmentStructure.find((row) => row.departmentId === departmentId);
+    return structure?.parentDepartmentName ? `${structure.parentDepartmentName} → ${structure.departmentName}` : (structure?.departmentName || departmentName || "Підрозділ не вказано");
+  };
 
-  return <StaffWorkspaceShell
-    active="directories"
-    title="Персонал"
-    description="Кадровий довідник працівників. Картка працівника відокремлена від облікового запису RadiologyOS."
-  >
+  return <StaffWorkspaceShell active="directories" title="Персонал" description="Єдина кадрова картка працівника: особа, призначення, підрозділи, посадові обов’язки, графік роботи та кадрові допуски.">
     <section className="financeSummary" aria-label="Стан кадрового довідника">
       <article><span>Працівники</span><b>{data?.records.filter((record) => record.active).length || 0}</b><small>активні картки</small></article>
-      <article><span>Підрозділи</span><b>{data?.departments.length || 0}</b><small>доступні у структурі</small></article>
+      <article><span>Структура</span><b>{data?.departments.length || 0}</b><small>відділення й підрозділи</small></article>
       <article><span>З акаунтом</span><b>{data?.records.filter((record) => record.accountEmail).length || 0}</b><small>мають вхід у RadiologyOS</small></article>
-      <article><span>Графіки</span><b>Calendar6</b><small><Link href="/staff/shifts">відкрити графік змін</Link></small></article>
+      <article><span>Чергування</span><b>Calendar6</b><small><Link href="/staff/shifts">окремий графік змін</Link></small></article>
     </section>
 
     {notice && <p className="notice success" role="status">{notice}</p>}
     {error && <p className="notice error" role="alert">{error}</p>}
 
     <section className="financeJournal">
-      <header className="financeToolbar">
-        <div><b>Зведений реєстр персоналу</b><small>ПІБ, підрозділ, посада й робочі контакти. ВЛК, ДІВ, навчання та документи підключаються наступними кадровими блоками.</small></div>
-        <div className="shiftPlannerActions"><button className="button primary" type="button" onClick={startCreate}>+ Додати працівника</button></div>
-      </header>
+      <header className="financeToolbar"><div><b>Зведений реєстр персоналу</b><small>Одна людина має одну кадрову картку та може мати кілька призначень. ВЛК, ДІВ, навчання й дозиметрія вже ведуться за тим самим personnelId.</small></div><div className="shiftPlannerActions"><button className="button primary" type="button" onClick={startCreate}>+ Додати працівника</button></div></header>
       <div className="shiftPlannerToolbar">
         <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Пошук за ПІБ, посадою, телефоном…" aria-label="Пошук персоналу" />
-        <select value={departmentFilter} onChange={(event) => setDepartmentFilter(event.target.value)} aria-label="Фільтр підрозділу">
-          <option value="all">Усі підрозділи</option>
-          {(data?.departments || []).map((department) => <option key={department.id} value={department.id}>{department.name}</option>)}
-        </select>
+        <select value={departmentFilter} onChange={(event) => setDepartmentFilter(event.target.value)} aria-label="Фільтр підрозділу"><option value="all">Усі підрозділи</option>{(data?.departments || []).map((department) => <option key={department.id} value={department.id}>{department.name}</option>)}</select>
       </div>
       {loading ? <p className="notice">Завантаження персоналу…</p> : <div className="financeTableWrap"><table className="financeTable">
-        <thead><tr><th>Працівник</th><th>Підрозділ / посада</th><th>Службові дані</th><th>Контакти</th><th>Статус</th><th/></tr></thead>
+        <thead><tr><th>Працівник</th><th>Підрозділ / основна посада</th><th>Службові дані</th><th>ВЛК</th><th>Статус</th><th/></tr></thead>
         <tbody>{filtered.map((record) => <tr key={record.id}>
           <td><div style={{display:"flex",alignItems:"center",gap:8}}><span className="statusPill">{initials(record)}</span><div><b>{record.displayName}</b><br/><small>{record.staffNumber ? `Таб. № ${record.staffNumber}` : employmentLabel(record.employmentKind)}</small></div></div></td>
-          <td><b>{record.departmentName || "Підрозділ не вказано"}</b><br/><small>{record.positionTitle}</small></td>
-          <td>{record.militaryRank || "—"}<br/><small>{record.dateOfBirth || "Дата народження не вказана"}</small></td>
-          <td>
-            {record.workPhone ? <><a href={`tel:${record.workPhone}`}>{record.workPhone}</a><br/></> : null}
-            {record.workEmail ? <a href={`mailto:${record.workEmail}`}>{record.workEmail}</a> : (!record.workPhone ? "—" : null)}
-          </td>
+          <td><b>{hierarchyLabel(record.departmentId, record.departmentName)}</b><br/><small>{record.positionTitle || "Посаду не вказано"}</small></td>
+          <td>{record.militaryRank || "—"}<br/><small>{record.accountEmail ? "Є обліковий запис" : "Без облікового запису"}</small></td>
+          <td><b>{vlkLabel(record.vlkDecisionCode)}</b><br/><small>{record.vlkValidUntil ? `до ${record.vlkValidUntil}` : "—"}</small></td>
           <td><span className={`statusPill ${record.active ? "ok" : ""}`}>{record.active ? "Працює" : "Архів"}</span></td>
           <td><button className="button secondary" type="button" onClick={() => startEdit(record.id)}>Картка</button></td>
         </tr>)}</tbody>
       </table>{!filtered.length && <p className="notice">Працівників за цим фільтром немає.</p>}</div>}
     </section>
 
-    {showEditor && <section className="financeJournal">
-      <header className="financeToolbar"><div><b>{editorRecord ? `Картка · ${editorRecord.displayName}` : "Новий працівник"}</b><small>Контактні та кадрові дані не змінюють логін/PIN працівника.</small></div><button className="button secondary" type="button" onClick={closeEditor}>Закрити</button></header>
-      <form key={editorRecord?.id || "new"} className="formGrid" onSubmit={save}>
-        <label>Прізвище<input name="lastName" defaultValue={editorRecord?.lastName || ""} required /></label>
-        <label>Ім’я<input name="firstName" defaultValue={editorRecord?.firstName || ""} required /></label>
-        <label>По батькові<input name="patronymic" defaultValue={editorRecord?.patronymic || ""} /></label>
-        <label>Дата народження<input name="dateOfBirth" type="date" defaultValue={editorRecord?.dateOfBirth || ""} /></label>
-        <label>Табельний / службовий №<input name="staffNumber" defaultValue={editorRecord?.staffNumber || ""} /></label>
-        <label>Категорія персоналу<select name="employmentKind" defaultValue={editorRecord?.employmentKind || "unspecified"}>{EMPLOYMENT.map(([value,label]) => <option key={value} value={value}>{label}</option>)}</select></label>
-        <label>Підрозділ<select name="departmentId" defaultValue={editorRecord?.departmentId || ""}><option value="">Не вказано</option>{(data?.departments || []).map((department) => <option key={department.id} value={department.id}>{department.name}</option>)}</select></label>
-        <label>Посада<input name="positionTitle" list="personnel-position-options" defaultValue={editorRecord?.positionTitle || ""} required /><datalist id="personnel-position-options">{POSITIONS.map((value) => <option key={value} value={value}/>)}</datalist></label>
-        <label>Військове звання<input name="militaryRank" list="personnel-rank-options" defaultValue={editorRecord?.militaryRank || ""} /><datalist id="personnel-rank-options">{RANKS.map((value) => <option key={value} value={value}/>)}</datalist></label>
-        <label>Обліковий запис RadiologyOS<select name="accountEmail" defaultValue={editorRecord?.accountEmail || ""}><option value="">Без облікового запису</option>{(data?.accounts || []).map((account) => <option key={account.email} value={account.email} disabled={linkedAccounts.has(account.email)}>{account.displayName || account.phone || account.email}{linkedAccounts.has(account.email) ? " · вже пов’язаний" : ""}</option>)}</select></label>
-        <label>Робочий телефон<input name="workPhone" inputMode="tel" defaultValue={editorRecord?.workPhone || ""} /></label>
-        <label>Особистий телефон<input name="personalPhone" inputMode="tel" defaultValue={editorRecord?.personalPhone || ""} /></label>
-        <label>Робочий e-mail<input name="workEmail" type="email" defaultValue={editorRecord?.workEmail || ""} /></label>
-        <label>Додатковий e-mail<input name="alternateEmail" type="email" defaultValue={editorRecord?.alternateEmail || ""} /></label>
-        <label>Область<input name="region" defaultValue={editorRecord?.region || ""} /></label>
-        <label>Населений пункт<input name="city" defaultValue={editorRecord?.city || ""} /></label>
-        <label>Адреса<input name="addressLine" defaultValue={editorRecord?.addressLine || ""} placeholder="Вулиця, будинок, квартира" /></label>
-        <label>Поштовий індекс<input name="postalCode" inputMode="numeric" defaultValue={editorRecord?.postalCode || ""} /></label>
-        <label><span>Статус</span><span><input name="active" type="checkbox" defaultChecked={editorRecord ? Boolean(editorRecord.active) : true} /> Активний працівник</span></label>
-        <div><button className="button primary" type="submit" disabled={saving}>{saving ? "Зберігаємо…" : "Зберегти картку"}</button></div>
-      </form>
-      <p className="notice">Фото, дипломи, сертифікати, ВЛК, допуск до ДІВ і навчання будуть окремими захищеними вкладками цієї ж картки — без зберігання файлів у D1.</p>
-    </section>}
+    {showEditor && <>
+      <section className="financeJournal">
+        <header className="financeToolbar"><div><b>{editorRecord ? `Картка · ${editorRecord.displayName}` : "Новий працівник"}</b><small>Особистість працівника зберігається окремо від логіна. Посади та графіки нижче мають власну історію.</small></div><button className="button secondary" type="button" onClick={closeEditor}>Закрити</button></header>
+        <form key={editorRecord?.id || "new"} className="formGrid" onSubmit={save}>
+          <label>Прізвище<input name="lastName" defaultValue={editorRecord?.lastName || ""} required /></label>
+          <label>Ім’я<input name="firstName" defaultValue={editorRecord?.firstName || ""} required /></label>
+          <label>По батькові<input name="patronymic" defaultValue={editorRecord?.patronymic || ""} /></label>
+          <label>Дата народження<input name="dateOfBirth" type="date" defaultValue={editorRecord?.dateOfBirth || ""} /></label>
+          <label>Табельний / службовий №<input name="staffNumber" defaultValue={editorRecord?.staffNumber || ""} /></label>
+          <label>Категорія персоналу<select name="employmentKind" defaultValue={editorRecord?.employmentKind || "unspecified"}>{EMPLOYMENT.map(([value,label]) => <option key={value} value={value}>{label}</option>)}</select></label>
+          <label>Основний підрозділ<select name="departmentId" defaultValue={editorRecord?.departmentId || ""}><option value="">Не вказано</option>{(data?.departments || []).map((department) => <option key={department.id} value={department.id}>{hierarchyLabel(department.id, department.name)}</option>)}</select></label>
+          <label>Основна посада<input name="positionTitle" list="personnel-position-options" defaultValue={editorRecord?.positionTitle || ""} required /><datalist id="personnel-position-options">{POSITIONS.map((value) => <option key={value} value={value}/>)}</datalist></label>
+          <label>Військове звання<input name="militaryRank" list="personnel-rank-options" defaultValue={editorRecord?.militaryRank || ""} /><datalist id="personnel-rank-options">{RANKS.map((value) => <option key={value} value={value}/>)}</datalist></label>
+          <label>Обліковий запис RadiologyOS<select name="accountEmail" defaultValue={editorRecord?.accountEmail || ""}><option value="">Без облікового запису</option>{(data?.accounts || []).map((account) => <option key={account.email} value={account.email} disabled={linkedAccounts.has(account.email)}>{account.displayName || account.phone || account.email}{linkedAccounts.has(account.email) ? " · вже пов’язаний" : ""}</option>)}</select></label>
+          <label>Робочий телефон<input name="workPhone" inputMode="tel" defaultValue={editorRecord?.workPhone || ""} /></label>
+          <label>Особистий телефон<input name="personalPhone" inputMode="tel" defaultValue={editorRecord?.personalPhone || ""} /></label>
+          <label>Робочий e-mail<input name="workEmail" type="email" defaultValue={editorRecord?.workEmail || ""} /></label>
+          <label>Додатковий e-mail<input name="alternateEmail" type="email" defaultValue={editorRecord?.alternateEmail || ""} /></label>
+          <label>Область<input name="region" defaultValue={editorRecord?.region || ""} /></label>
+          <label>Населений пункт<input name="city" defaultValue={editorRecord?.city || ""} /></label>
+          <label>Адреса<input name="addressLine" defaultValue={editorRecord?.addressLine || ""} placeholder="Вулиця, будинок, квартира" /></label>
+          <label>Поштовий індекс<input name="postalCode" inputMode="numeric" defaultValue={editorRecord?.postalCode || ""} /></label>
+          <label><span>Статус</span><span><input name="active" type="checkbox" defaultChecked={editorRecord ? Boolean(editorRecord.active) : true} /> Активний працівник</span></label>
+          <div><button className="button primary" type="submit" disabled={saving}>{saving ? "Зберігаємо…" : "Зберегти картку"}</button></div>
+        </form>
+      </section>
+
+      {editorRecord && <>
+        <section className="financeJournal">
+          <header className="financeToolbar"><div><b>Призначення і посадові обов’язки</b><small>Основна, додаткова або тимчасово виконувана посада з датами та підставою. Працівник не дублюється.</small></div><button className="button primary" type="button" onClick={newAssignment}>+ Призначення</button></header>
+          <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Посада</th><th>Структура</th><th>Період</th><th>Обов’язки / підстава</th><th/></tr></thead><tbody>
+            {selectedAssignments.map((row) => <tr key={row.id}><td><b>{row.positionTitle}</b><br/><small>{assignmentKindLabel(row.assignmentKind)}</small></td><td>{row.parentDepartmentName ? `${row.parentDepartmentName} → ` : ""}{row.departmentName || "Без підрозділу"}</td><td>{row.startsOn || "—"} → {row.endsOn || "дотепер"}</td><td><small>{row.duties || "Обов’язки не внесено"}{row.orderReference ? ` · ${row.orderReference}` : ""}</small></td><td><button className="button secondary" type="button" onClick={() => editAssignment(row)}>Змінити</button></td></tr>)}
+          </tbody></table>{!selectedAssignments.length && <p className="notice">Призначень ще немає.</p>}</div>
+          {showAssignmentForm && <form key={assignmentEditor?.id || "new-assignment"} className="formGrid" onSubmit={saveAssignment}>
+            <label>Тип призначення<select name="assignmentKind" defaultValue={assignmentEditor?.assignmentKind || "secondary"}>{ASSIGNMENT_KINDS.map(([value,label]) => <option key={value} value={value}>{label}</option>)}</select></label>
+            <label>Підрозділ<select name="assignmentDepartmentId" defaultValue={assignmentEditor?.departmentId || editorRecord.departmentId || ""}><option value="">Не вказано</option>{(data?.departments || []).map((department) => <option key={department.id} value={department.id}>{hierarchyLabel(department.id, department.name)}</option>)}</select></label>
+            <label>Посада<input name="assignmentPositionTitle" list="personnel-position-options" defaultValue={assignmentEditor?.positionTitle || ""} required /></label>
+            <label>Початок<input name="startsOn" type="date" defaultValue={assignmentEditor?.startsOn || ""} /></label>
+            <label>Завершення<input name="endsOn" type="date" defaultValue={assignmentEditor?.endsOn || ""} /></label>
+            <label>Наказ / підстава<input name="orderReference" defaultValue={assignmentEditor?.orderReference || ""} placeholder="№, дата або коротка підстава" /></label>
+            <label style={{gridColumn:"1 / -1"}}>Посадові обов’язки<textarea name="duties" rows={5} defaultValue={assignmentEditor?.duties || ""} placeholder="Функції та відповідальність за цією посадою" /></label>
+            <div className="shiftPlannerActions"><button className="button primary" disabled={saving} type="submit">{saving ? "Зберігаємо…" : "Зберегти призначення"}</button><button className="button secondary" type="button" onClick={() => {setShowAssignmentForm(false);setAssignmentEditor(null);}}>Скасувати</button></div>
+          </form>}
+        </section>
+
+        <section className="financeJournal">
+          <header className="financeToolbar"><div><b>Графік роботи</b><small>Нормативний тижневий режим працівника. Чергування, нічні та добові зміни ведуться окремо в «Графіку змін».</small></div><button className="button primary" type="button" onClick={newSchedule}>+ Графік роботи</button></header>
+          {currentSchedule ? <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>Назва</th><th>Тип</th><th>Період</th><th>Норма</th><th/></tr></thead><tbody>{selectedSchedules.map((row) => <tr key={row.id}><td><b>{row.name}</b>{row.note && <><br/><small>{row.note}</small></>}</td><td>{scheduleKindLabel(row.scheduleKind)}</td><td>{row.validFrom} → {row.validTo || "дотепер"}</td><td>{hoursLabel(row.weeklyMinutes)} / тиждень</td><td><button className="button secondary" type="button" onClick={() => editSchedule(row)}>Змінити</button></td></tr>)}</tbody></table></div> : <p className="notice">Базовий графік роботи ще не задано. Це не заважає вести окремий графік чергувань.</p>}
+          {showScheduleForm && <form key={scheduleEditor?.id || "new-schedule"} onSubmit={saveSchedule}>
+            <div className="formGrid">
+              <label>Назва<input name="scheduleName" defaultValue={scheduleEditor?.name || ""} placeholder="Напр. Основний робочий графік" required /></label>
+              <label>Тип<select name="scheduleKind" defaultValue={scheduleEditor?.scheduleKind || "individual"}>{SCHEDULE_KINDS.map(([value,label]) => <option key={value} value={value}>{label}</option>)}</select></label>
+              <label>Діє з<input name="validFrom" type="date" defaultValue={scheduleEditor?.validFrom || new Date().toISOString().slice(0,10)} required /></label>
+              <label>Діє до<input name="validTo" type="date" defaultValue={scheduleEditor?.validTo || ""} /></label>
+              <label style={{gridColumn:"1 / -1"}}>Примітка<input name="scheduleNote" defaultValue={scheduleEditor?.note || ""} placeholder="Необов’язково" /></label>
+              <label><span>Стан</span><span><input name="scheduleActive" type="checkbox" defaultChecked={scheduleEditor ? Boolean(scheduleEditor.active) : true} /> Активний графік</span></label>
+            </div>
+            <div className="financeTableWrap"><table className="financeTable"><thead><tr><th>День</th><th>Робочий</th><th>Початок</th><th>Кінець</th><th>Перерва з</th><th>Перерва до</th></tr></thead><tbody>{scheduleDays.map((day) => <tr key={day.weekday}><td><b>{WEEKDAYS[day.weekday - 1]}</b></td><td><input aria-label={`${WEEKDAYS[day.weekday - 1]} робочий`} type="checkbox" checked={day.isWorking} onChange={(event) => updateDay(day.weekday, event.target.checked ? {isWorking:true} : {isWorking:false,startTime:"",endTime:"",breakStart:"",breakEnd:""})} /></td><td><input aria-label={`${WEEKDAYS[day.weekday - 1]} початок`} type="time" disabled={!day.isWorking} value={day.startTime} onChange={(event) => updateDay(day.weekday,{startTime:event.target.value})} /></td><td><input aria-label={`${WEEKDAYS[day.weekday - 1]} кінець`} type="time" disabled={!day.isWorking} value={day.endTime} onChange={(event) => updateDay(day.weekday,{endTime:event.target.value})} /></td><td><input aria-label={`${WEEKDAYS[day.weekday - 1]} перерва з`} type="time" disabled={!day.isWorking} value={day.breakStart} onChange={(event) => updateDay(day.weekday,{breakStart:event.target.value})} /></td><td><input aria-label={`${WEEKDAYS[day.weekday - 1]} перерва до`} type="time" disabled={!day.isWorking} value={day.breakEnd} onChange={(event) => updateDay(day.weekday,{breakEnd:event.target.value})} /></td></tr>)}</tbody></table></div>
+            <div className="shiftPlannerActions"><button className="button primary" disabled={saving} type="submit">{saving ? "Зберігаємо…" : "Зберегти графік роботи"}</button><button className="button secondary" type="button" onClick={() => {setShowScheduleForm(false);setScheduleEditor(null);}}>Скасувати</button></div>
+          </form>}
+        </section>
+
+        <section className="financeJournal">
+          <header className="financeToolbar"><div><b>ВЛК, ДІВ та кадрові допуски</b><small>Окремі захищені реєстри використовують той самий personnelId.</small></div></header>
+          <div className="shiftPlannerActions">
+            <Link className="button secondary" href={`/staff/personnel/vlk?personnelId=${encodeURIComponent(editorRecord.id)}`}>ВЛК · {vlkLabel(editorRecord.vlkDecisionCode)}</Link>
+            <Link className="button secondary" href={`/staff/personnel/radiation-clearance?personnelId=${encodeURIComponent(editorRecord.id)}`}>Допуск до ДІВ</Link>
+            <Link className="button secondary" href={`/staff/personnel/radiation-training?personnelId=${encodeURIComponent(editorRecord.id)}`}>Навчання</Link>
+            <Link className="button secondary" href={`/staff/personnel/dosimetry?personnelId=${encodeURIComponent(editorRecord.id)}`}>Дозиметрія</Link>
+            <Link className="button secondary" href="/staff/shifts">Чергування / зміни</Link>
+          </div>
+          <p className="notice">Файли кадрових документів не зберігаються в D1. Для них потрібен окремий приватний файловий контур з контрольованим завантаженням і видачею.</p>
+        </section>
+      </>}
+    </>}
   </StaffWorkspaceShell>;
 }

--- a/app/staff/shifts/page.tsx
+++ b/app/staff/shifts/page.tsx
@@ -16,16 +16,15 @@ import {
 } from "../../../lib/shift-calendar";
 
 type StaffInfo = { email:string; displayName:string; role:string };
-type Person = { email:string; displayName:string; role:string; positionTitle:string; militaryRank:string };
-type Assignment = { staffEmail:string; presetCode:string; teamIndex:number; anchorDate:string };
-type Override = ShiftOverride & { id:number };
+type Person = {
+  personnelId:string; email:string; accountEmail:string | null; displayName:string; role:string;
+  positionTitle:string; militaryRank:string; departmentName:string;
+};
+type Assignment = { personnelId:string; staffEmail:string; presetCode:string; teamIndex:number; anchorDate:string };
+type Override = ShiftOverride & { id:number; personnelId:string };
 type ApiData = {
-  month:string;
-  canManage:boolean;
-  staff:StaffInfo;
-  people:Person[];
-  assignments:Assignment[];
-  overrides:Override[];
+  month:string; canManage:boolean; personnelLinked:boolean; staff:StaffInfo; people:Person[];
+  assignments:Assignment[]; overrides:Override[];
 };
 
 const WEEKDAY = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
@@ -33,17 +32,14 @@ const WEEKDAY = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
 function monthKey(date:Date) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 }
-
 function moveMonth(value:string, delta:number) {
   const [year, month] = value.split("-").map(Number);
   return monthKey(new Date(year, month - 1 + delta, 1));
 }
-
 function dateLabel(value:string) {
   const [year, month, day] = value.split("-").map(Number);
   return WEEKDAY[new Date(year, month - 1, day).getDay()];
 }
-
 function monthLabel(value:string) {
   const [year, month] = value.split("-").map(Number);
   return new Intl.DateTimeFormat("uk-UA", { month:"long", year:"numeric" }).format(new Date(year, month - 1, 1));
@@ -57,7 +53,7 @@ export default function StaffShiftsPage() {
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
   const [saving, setSaving] = useState(false);
-  const [selectedEmail, setSelectedEmail] = useState("");
+  const [selectedPersonnelId, setSelectedPersonnelId] = useState("");
   const [presetCode, setPresetCode] = useState(CALENDAR6_PRESETS[0].code);
   const [teamIndex, setTeamIndex] = useState(1);
   const [anchorDate, setAnchorDate] = useState(() => `${monthKey(new Date())}-01`);
@@ -68,29 +64,24 @@ export default function StaffShiftsPage() {
   const [overrideEnd, setOverrideEnd] = useState("");
   const [overrideNote, setOverrideNote] = useState("");
 
-  const load = useCallback(async (preferredEmail?:string) => {
+  const load = useCallback(async (preferredPersonnelId?:string) => {
     setLoaded(false); setError("");
     try {
       const res = await fetch(`/api/staff/shifts?month=${encodeURIComponent(month)}`, { cache:"no-store" });
       if (res.status === 401 || res.status === 403) { setForbidden(true); return; }
       const body = await res.json().catch(() => ({})) as ApiData & { error?:string };
       if (!res.ok) throw new Error(body.error || "Не вдалося завантажити графік");
-      setData(body);
-      setForbidden(false);
-      const nextEmail = preferredEmail && body.people.some((person) => person.email === preferredEmail)
-        ? preferredEmail
-        : body.people[0]?.email || "";
-      const assignment = body.assignments.find((row) => row.staffEmail === nextEmail);
-      setSelectedEmail(nextEmail);
+      setData(body); setForbidden(false);
+      const nextId = preferredPersonnelId && body.people.some((person) => person.personnelId === preferredPersonnelId)
+        ? preferredPersonnelId : body.people[0]?.personnelId || "";
+      const assignment = body.assignments.find((row) => row.personnelId === nextId);
+      setSelectedPersonnelId(nextId);
       setPresetCode(assignment?.presetCode || CALENDAR6_PRESETS[0].code);
       setTeamIndex(assignment?.teamIndex || 1);
       setAnchorDate(assignment?.anchorDate || `${month}-01`);
       setSelectedDate("");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Не вдалося завантажити графік");
-    } finally {
-      setLoaded(true);
-    }
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося завантажити графік"); }
+    finally { setLoaded(true); }
   }, [month]);
 
   useEffect(() => {
@@ -98,16 +89,16 @@ export default function StaffShiftsPage() {
     return () => window.clearTimeout(timer);
   }, [load]);
 
-  const assignments = useMemo(() => new Map((data?.assignments || []).map((row) => [row.staffEmail, row])), [data]);
-  const overrides = useMemo(() => new Map((data?.overrides || []).map((row) => [`${row.staffEmail}:${row.shiftDate}`, row])), [data]);
+  const assignments = useMemo(() => new Map((data?.assignments || []).map((row) => [row.personnelId, row])), [data]);
+  const overrides = useMemo(() => new Map((data?.overrides || []).map((row) => [`${row.personnelId}:${row.shiftDate}`, row])), [data]);
   const dates = useMemo(() => datesForMonth(month), [month]);
-  const selectedAssignment = selectedEmail ? assignments.get(selectedEmail) : undefined;
+  const selectedAssignment = selectedPersonnelId ? assignments.get(selectedPersonnelId) : undefined;
   const selectedPreset = shiftPreset(presetCode);
-  const selectedPerson = data?.people.find((person) => person.email === selectedEmail) || null;
+  const selectedPerson = data?.people.find((person) => person.personnelId === selectedPersonnelId) || null;
 
-  function choosePerson(email:string) {
-    const assignment = assignments.get(email);
-    setSelectedEmail(email);
+  function choosePerson(personnelId:string) {
+    const assignment = assignments.get(personnelId);
+    setSelectedPersonnelId(personnelId);
     setPresetCode(assignment?.presetCode || CALENDAR6_PRESETS[0].code);
     setTeamIndex(assignment?.teamIndex || 1);
     setAnchorDate(assignment?.anchorDate || `${month}-01`);
@@ -115,67 +106,45 @@ export default function StaffShiftsPage() {
   }
 
   function selectDay(person:Person, date:string) {
-    choosePerson(person.email);
-    setSelectedDate(date);
-    const existing = overrides.get(`${person.email}:${date}`);
-    const assignment = assignments.get(person.email);
-    const computed = assignment
-      ? resolvePresetShift(assignment.presetCode, assignment.teamIndex, assignment.anchorDate, date)
-      : null;
+    choosePerson(person.personnelId); setSelectedDate(date);
+    const existing = overrides.get(`${person.personnelId}:${date}`);
+    const assignment = assignments.get(person.personnelId);
+    const computed = assignment ? resolvePresetShift(assignment.presetCode, assignment.teamIndex, assignment.anchorDate, date) : null;
     setOverrideKind(existing?.kind || computed?.kind || "off");
     setOverrideLabel(existing?.label || computed?.label || "");
     setOverrideStart(existing?.startTime || computed?.start || "");
     setOverrideEnd(existing?.endTime || computed?.end || "");
-    setOverrideNote(existing?.note || "");
-    setNotice(""); setError("");
+    setOverrideNote(existing?.note || ""); setNotice(""); setError("");
   }
 
   async function action(payload:Record<string, unknown>) {
     setSaving(true); setError(""); setNotice("");
     try {
-      const res = await fetch("/api/staff/shifts", {
-        method:"POST",
-        headers:{ "content-type":"application/json" },
-        body:JSON.stringify(payload),
-      });
-      const body = await res.json().catch(() => ({})) as { ok?:boolean; error?:string };
+      const res = await fetch("/api/staff/shifts", { method:"POST", headers:{"content-type":"application/json"}, body:JSON.stringify(payload) });
+      const body = await res.json().catch(() => ({})) as {ok?:boolean;error?:string};
       if (!res.ok || !body.ok) throw new Error(body.error || "Не вдалося зберегти");
-      await load(selectedEmail);
-      setNotice("Графік збережено.");
-      return true;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Не вдалося зберегти");
-      return false;
-    } finally {
-      setSaving(false);
-    }
+      await load(selectedPersonnelId); setNotice("Графік збережено."); return true;
+    } catch (e) { setError(e instanceof Error ? e.message : "Не вдалося зберегти"); return false; }
+    finally { setSaving(false); }
   }
 
   async function saveAssignment(event:FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!selectedEmail) return;
-    await action({ action:"assignment", staffEmail:selectedEmail, presetCode, teamIndex, anchorDate });
+    event.preventDefault(); if (!selectedPersonnelId) return;
+    await action({ action:"assignment", personnelId:selectedPersonnelId, presetCode, teamIndex, anchorDate });
   }
-
   async function clearAssignment() {
-    if (!selectedEmail) return;
-    const ok = await action({ action:"clear_assignment", staffEmail:selectedEmail });
+    if (!selectedPersonnelId) return;
+    const ok = await action({ action:"clear_assignment", personnelId:selectedPersonnelId });
     if (ok) setSelectedDate("");
   }
-
   async function saveOverride(event:FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!selectedEmail || !selectedDate) return;
-    await action({
-      action:"override", staffEmail:selectedEmail, shiftDate:selectedDate,
-      kind:overrideKind, label:overrideLabel, startTime:overrideStart,
-      endTime:overrideEnd, note:overrideNote,
-    });
+    event.preventDefault(); if (!selectedPersonnelId || !selectedDate) return;
+    await action({ action:"override", personnelId:selectedPersonnelId, shiftDate:selectedDate,
+      kind:overrideKind, label:overrideLabel, startTime:overrideStart, endTime:overrideEnd, note:overrideNote });
   }
-
   async function clearOverride() {
-    if (!selectedEmail || !selectedDate) return;
-    const ok = await action({ action:"clear_override", staffEmail:selectedEmail, shiftDate:selectedDate });
+    if (!selectedPersonnelId || !selectedDate) return;
+    const ok = await action({ action:"clear_override", personnelId:selectedPersonnelId, shiftDate:selectedDate });
     if (ok) setSelectedDate("");
   }
 
@@ -187,8 +156,9 @@ export default function StaffShiftsPage() {
     : !loaded
       ? <p className="notice">Завантаження графіка…</p>
       : <div className="shiftPlanner">
+          {!data?.canManage && !data?.personnelLinked && <p className="notice warning">Ваш обліковий запис ще не пов’язаний з кадровою карткою. Зверніться до адміністратора кадрового довідника.</p>}
           <section className="shiftPlannerSummary">
-            <article><small>Працівники</small><b>{data?.people.length || 0}</b><span>{data?.canManage ? "активні у tenant" : "ваш профіль"}</span></article>
+            <article><small>Працівники</small><b>{data?.people.length || 0}</b><span>{data?.canManage ? "активні кадрові картки" : "ваша кадрова картка"}</span></article>
             <article><small>Налаштовано</small><b>{configuredCount}</b><span>мають циклічний графік</span></article>
             <article><small>Корекції місяця</small><b>{data?.overrides.length || 0}</b><span>відпустки, заміни, вихідні</span></article>
           </section>
@@ -200,36 +170,33 @@ export default function StaffShiftsPage() {
               <b>{monthLabel(month)}</b>
               <button type="button" onClick={() => setMonth(moveMonth(month, 1))} aria-label="Наступний місяць">›</button>
             </div>
-            <div className="shiftPlannerActions">
-              <a className="button secondary" href={`/api/staff/shifts?month=${encodeURIComponent(month)}&format=csv`}>CSV</a>
-              <button type="button" className="button secondary" onClick={() => window.print()}>Друк</button>
-            </div>
+            <div className="shiftPlannerActions"><a className="button secondary" href={`/api/staff/shifts?month=${encodeURIComponent(month)}&format=csv`}>CSV</a><button type="button" className="button secondary" onClick={() => window.print()}>Друк</button></div>
           </section>
 
           {data?.canManage && <section className="shiftPlannerEditor">
             <form className="shiftAssignmentForm" onSubmit={saveAssignment}>
-              <div className="shiftEditorHead"><div><h3>Циклічний графік працівника</h3><p>Пресети відтворені з Calendar6. Опорна дата відповідає першому стовпцю матриці обраної бригади.</p></div></div>
+              <div className="shiftEditorHead"><div><h3>Циклічний графік чергувань</h3><p>Це фактичні зміни/чергування. Нормативний тижневий графік роботи ведеться в кадровій картці окремо.</p></div></div>
               <div className="shiftEditorGrid">
-                <label><span>Працівник</span><select value={selectedEmail} onChange={(e) => choosePerson(e.target.value)}>{(data?.people || []).map((person) => <option key={person.email} value={person.email}>{person.displayName || person.email}</option>)}</select></label>
-                <label><span>Тип графіка</span><select value={presetCode} onChange={(e) => { setPresetCode(e.target.value); setTeamIndex(1); }}>{CALENDAR6_PRESETS.map((preset) => <option key={preset.code} value={preset.code}>{preset.name}</option>)}</select></label>
-                <label><span>Бригада / фаза</span><select value={teamIndex} onChange={(e) => setTeamIndex(Number(e.target.value))}>{Array.from({ length:selectedPreset?.teams.length || 0 }, (_, index) => <option key={index + 1} value={index + 1}>Бригада {index + 1}</option>)}</select></label>
-                <label><span>Опорна дата</span><input type="date" value={anchorDate} onChange={(e) => setAnchorDate(e.target.value)} required /></label>
+                <label><span>Працівник</span><select value={selectedPersonnelId} onChange={(event) => choosePerson(event.target.value)}>{(data?.people || []).map((person) => <option key={person.personnelId} value={person.personnelId}>{person.displayName || person.personnelId}{person.accountEmail ? "" : " · без акаунта"}</option>)}</select></label>
+                <label><span>Тип графіка</span><select value={presetCode} onChange={(event) => {setPresetCode(event.target.value);setTeamIndex(1);}}>{CALENDAR6_PRESETS.map((preset) => <option key={preset.code} value={preset.code}>{preset.name}</option>)}</select></label>
+                <label><span>Бригада / фаза</span><select value={teamIndex} onChange={(event) => setTeamIndex(Number(event.target.value))}>{Array.from({length:selectedPreset?.teams.length || 0}, (_, index) => <option key={index + 1} value={index + 1}>Бригада {index + 1}</option>)}</select></label>
+                <label><span>Опорна дата</span><input type="date" value={anchorDate} onChange={(event) => setAnchorDate(event.target.value)} required /></label>
               </div>
               {selectedPreset?.sourceWarning && <p className="notice warning">{selectedPreset.sourceWarning}</p>}
-              <div className="shiftEditorButtons"><button className="button primary" disabled={saving || !selectedEmail} type="submit">{saving ? "Збереження…" : "Зберегти графік"}</button>{selectedAssignment && <button className="button ghost" type="button" disabled={saving} onClick={() => void clearAssignment()}>Прибрати графік</button>}</div>
+              <div className="shiftEditorButtons"><button className="button primary" disabled={saving || !selectedPersonnelId} type="submit">{saving ? "Збереження…" : "Зберегти графік"}</button>{selectedAssignment && <button className="button ghost" type="button" disabled={saving} onClick={() => void clearAssignment()}>Прибрати графік</button>}</div>
             </form>
 
             <form className="shiftOverrideForm" onSubmit={saveOverride}>
               <div><h3>Персональна корекція дня</h3><p>{selectedDate ? `${selectedPerson?.displayName || "Працівник"} · ${selectedDate}` : "Натисніть день у таблиці нижче."}</p></div>
               {selectedDate && <>
                 <div className="shiftEditorGrid overrideGrid">
-                  <label><span>Тип</span><select value={overrideKind} onChange={(e) => setOverrideKind(e.target.value as ShiftKind)}>{SHIFT_OVERRIDE_KINDS.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}</select></label>
-                  <label><span>Позначка</span><input value={overrideLabel} maxLength={24} onChange={(e) => setOverrideLabel(e.target.value)} placeholder="Напр. Вп" /></label>
-                  <label><span>З</span><input type="time" value={overrideStart} onChange={(e) => setOverrideStart(e.target.value)} /></label>
-                  <label><span>До</span><input type="time" value={overrideEnd} onChange={(e) => setOverrideEnd(e.target.value)} /></label>
-                  <label className="shiftNoteField"><span>Примітка</span><input value={overrideNote} maxLength={240} onChange={(e) => setOverrideNote(e.target.value)} placeholder="Без медичних даних" /></label>
+                  <label><span>Тип</span><select value={overrideKind} onChange={(event) => setOverrideKind(event.target.value as ShiftKind)}>{SHIFT_OVERRIDE_KINDS.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}</select></label>
+                  <label><span>Позначка</span><input value={overrideLabel} maxLength={24} onChange={(event) => setOverrideLabel(event.target.value)} placeholder="Напр. Вп" /></label>
+                  <label><span>З</span><input type="time" value={overrideStart} onChange={(event) => setOverrideStart(event.target.value)} /></label>
+                  <label><span>До</span><input type="time" value={overrideEnd} onChange={(event) => setOverrideEnd(event.target.value)} /></label>
+                  <label className="shiftNoteField"><span>Примітка</span><input value={overrideNote} maxLength={240} onChange={(event) => setOverrideNote(event.target.value)} placeholder="Без медичних даних" /></label>
                 </div>
-                <div className="shiftEditorButtons"><button className="button primary" disabled={saving} type="submit">Застосувати корекцію</button>{overrides.has(`${selectedEmail}:${selectedDate}`) && <button className="button ghost" type="button" disabled={saving} onClick={() => void clearOverride()}>Повернути цикл</button>}</div>
+                <div className="shiftEditorButtons"><button className="button primary" disabled={saving} type="submit">Застосувати корекцію</button>{overrides.has(`${selectedPersonnelId}:${selectedDate}`) && <button className="button ghost" type="button" disabled={saving} onClick={() => void clearOverride()}>Повернути цикл</button>}</div>
               </>}
             </form>
           </section>}
@@ -239,38 +206,30 @@ export default function StaffShiftsPage() {
 
           <section className="shiftCalendarCard">
             <div className="shiftCalendarIntro"><div><h3>Табель змін · {monthLabel(month)}</h3><p>Клік по дню відкриває персональну корекцію. Жирна крапка означає ручний виняток від циклу.</p></div><div className="shiftLegend"><span className="day">Д</span><small>день</small><span className="night">Н</span><small>ніч</small><span className="off">В</span><small>вихідний</small><span className="leave">Вп</span><small>відпустка</small></div></div>
-            <div className="shiftTableWrap">
-              <table className="shiftTable">
-                <thead><tr><th className="shiftPersonColumn">Працівник</th>{dates.map((date) => <th key={date} className={date === today ? "today" : ""}><b>{date.slice(-2)}</b><small>{dateLabel(date)}</small></th>)}</tr></thead>
-                <tbody>{(data?.people || []).map((person) => {
-                  const assignment = assignments.get(person.email);
-                  const preset = assignment ? shiftPreset(assignment.presetCode) : null;
-                  return <tr key={person.email}>
-                    <th className="shiftPersonColumn"><b>{person.displayName || person.email}</b><small>{[person.militaryRank, person.positionTitle].filter(Boolean).join(" · ") || roleLabelUk(person.role)}</small><span>{preset ? `${preset.name} · бригада ${assignment?.teamIndex}` : "Графік не призначено"}</span></th>
-                    {dates.map((date) => {
-                      const override = overrides.get(`${person.email}:${date}`);
-                      const base = assignment ? resolvePresetShift(assignment.presetCode, assignment.teamIndex, assignment.anchorDate, date) : null;
-                      const shift = override ? resolvedOverride(override) : base;
-                      const title = `${date} · ${shiftCellText(shift)}${shift?.note ? ` · ${shift.note}` : ""}`;
-                      return <td key={date} className={`${date === today ? "today " : ""}${shift ? `kind-${shift.kind}` : "kind-empty"}${override ? " manual" : ""}`}>
-                        <button type="button" disabled={!data?.canManage} onClick={() => selectDay(person, date)} title={title} aria-label={`${person.displayName || person.email}, ${date}: ${shiftCellText(shift)}`}>
-                          <b>{shift?.label || "—"}</b>{shift?.start || shift?.end ? <small>{shift?.start || "?"}<br />{shift?.end || "?"}</small> : null}{override && <i aria-label="Ручна корекція">•</i>}
-                        </button>
-                      </td>;
-                    })}
-                  </tr>;
-                })}</tbody>
-              </table>
-            </div>
-            {(data?.people.length || 0) === 0 && <p className="empty">У цій організації немає активних працівників.</p>}
+            <div className="shiftTableWrap"><table className="shiftTable">
+              <thead><tr><th className="shiftPersonColumn">Працівник</th>{dates.map((date) => <th key={date} className={date === today ? "today" : ""}><b>{date.slice(-2)}</b><small>{dateLabel(date)}</small></th>)}</tr></thead>
+              <tbody>{(data?.people || []).map((person) => {
+                const assignment = assignments.get(person.personnelId);
+                const preset = assignment ? shiftPreset(assignment.presetCode) : null;
+                return <tr key={person.personnelId}>
+                  <th className="shiftPersonColumn"><b>{person.displayName || person.personnelId}</b><small>{[person.militaryRank,person.positionTitle,person.departmentName].filter(Boolean).join(" · ") || (person.role ? roleLabelUk(person.role) : "Кадрова картка")}</small><span>{preset ? `${preset.name} · бригада ${assignment?.teamIndex}` : "Графік не призначено"}{person.accountEmail ? "" : " · без акаунта"}</span></th>
+                  {dates.map((date) => {
+                    const override = overrides.get(`${person.personnelId}:${date}`);
+                    const base = assignment ? resolvePresetShift(assignment.presetCode, assignment.teamIndex, assignment.anchorDate, date) : null;
+                    const shift = override ? resolvedOverride(override) : base;
+                    const title = `${date} · ${shiftCellText(shift)}${shift?.note ? ` · ${shift.note}` : ""}`;
+                    return <td key={date} className={`${date === today ? "today " : ""}${shift ? `kind-${shift.kind}` : "kind-empty"}${override ? " manual" : ""}`}>
+                      <button type="button" disabled={!data?.canManage} onClick={() => selectDay(person,date)} title={title} aria-label={`${person.displayName || person.personnelId}, ${date}: ${shiftCellText(shift)}`}>
+                        <b>{shift?.label || "—"}</b>{shift?.start || shift?.end ? <small>{shift?.start || "?"}<br/>{shift?.end || "?"}</small> : null}{override && <i aria-label="Ручна корекція">•</i>}
+                      </button>
+                    </td>;
+                  })}
+                </tr>;
+              })}</tbody>
+            </table></div>
+            {(data?.people.length || 0) === 0 && <p className="empty">Немає активної кадрової картки для цього доступу.</p>}
           </section>
         </div>;
 
-  return <StaffWorkspaceShell
-    active="schedule"
-    title="Графік змін персоналу"
-    description="Циклічні графіки, бригади, денні/нічні зміни та персональні корекції — сучасна веб-версія логіки Calendar6."
-    staffName={data?.staff.displayName}
-    staffRole={roleLabelUk(data?.staff.role)}
-  >{content}</StaffWorkspaceShell>;
+  return <StaffWorkspaceShell active="schedule" title="Графік змін персоналу" description="Чергування та фактичні зміни прив’язані до кадрової картки personnelId, а не до логіна працівника." staffName={data?.staff.displayName} staffRole={roleLabelUk(data?.staff.role)}>{content}</StaffWorkspaceShell>;
 }

--- a/drizzle/0115_personnel_assignments_schedules.sql
+++ b/drizzle/0115_personnel_assignments_schedules.sql
@@ -1,0 +1,369 @@
+CREATE TABLE IF NOT EXISTS `department_structure` (
+  `organization_id` integer NOT NULL,
+  `department_id` integer NOT NULL,
+  `parent_department_id` integer,
+  `unit_type` text DEFAULT 'unit' NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`organization_id`, `department_id`),
+  FOREIGN KEY (`department_id`) REFERENCES `departments`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`parent_department_id`) REFERENCES `departments`(`id`) ON DELETE SET NULL,
+  CHECK (`unit_type` IN ('department','subdivision','cabinet','unit','other')),
+  CHECK (`parent_department_id` IS NULL OR `parent_department_id` <> `department_id`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `department_structure_org_parent_idx`
+  ON `department_structure` (`organization_id`, `parent_department_id`, `unit_type`);
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `department_structure_scope_insert`
+BEFORE INSERT ON `department_structure`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `departments` child
+  WHERE child.`id` = NEW.`department_id`
+    AND child.`organization_id` = NEW.`organization_id`
+) OR (
+  NEW.`parent_department_id` IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM `departments` parent
+    WHERE parent.`id` = NEW.`parent_department_id`
+      AND parent.`organization_id` = NEW.`organization_id`
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'department_structure_scope');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `department_structure_scope_update`
+BEFORE UPDATE OF `organization_id`, `department_id`, `parent_department_id` ON `department_structure`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `departments` child
+  WHERE child.`id` = NEW.`department_id`
+    AND child.`organization_id` = NEW.`organization_id`
+) OR (
+  NEW.`parent_department_id` IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM `departments` parent
+    WHERE parent.`id` = NEW.`parent_department_id`
+      AND parent.`organization_id` = NEW.`organization_id`
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'department_structure_scope');
+END;
+--> statement-breakpoint
+INSERT OR IGNORE INTO `department_structure`
+  (`organization_id`, `department_id`, `parent_department_id`, `unit_type`)
+SELECT d.`organization_id`, d.`id`,
+       CASE
+         WHEN d.`name` IN ('Пересувний рентгенівський кабінет (ПРК)', 'Кабінет ультразвукової діагностики (УЗД)')
+           THEN (
+             SELECT parent.`id` FROM `departments` parent
+             WHERE parent.`organization_id` = d.`organization_id`
+               AND parent.`name` = 'Відділення променевої діагностики'
+             ORDER BY parent.`id` LIMIT 1
+           )
+         ELSE NULL
+       END,
+       CASE
+         WHEN d.`name` = 'Відділення променевої діагностики' THEN 'department'
+         WHEN d.`name` LIKE '%кабінет%' OR d.`name` LIKE '%Кабінет%' THEN 'cabinet'
+         WHEN d.`name` LIKE '%ПРК%' OR d.`name` LIKE '%УЗД%' THEN 'subdivision'
+         ELSE 'unit'
+       END
+FROM `departments` d;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `personnel_assignments` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` integer NOT NULL,
+  `personnel_id` text NOT NULL,
+  `department_id` integer,
+  `position_title` text NOT NULL,
+  `assignment_kind` text DEFAULT 'primary' NOT NULL,
+  `duties` text DEFAULT '' NOT NULL,
+  `starts_on` text DEFAULT '' NOT NULL,
+  `ends_on` text DEFAULT '' NOT NULL,
+  `order_reference` text DEFAULT '' NOT NULL,
+  `created_by` text NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_by` text NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`personnel_id`) REFERENCES `personnel_records`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`department_id`) REFERENCES `departments`(`id`) ON DELETE RESTRICT,
+  CHECK (`assignment_kind` IN ('primary','acting','secondary','temporary','other')),
+  CHECK (length(trim(`position_title`)) > 0),
+  CHECK (`starts_on` = '' OR length(`starts_on`) = 10),
+  CHECK (`ends_on` = '' OR length(`ends_on`) = 10),
+  CHECK (`starts_on` = '' OR `ends_on` = '' OR `ends_on` >= `starts_on`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `personnel_assignments_org_person_idx`
+  ON `personnel_assignments` (`organization_id`, `personnel_id`, `ends_on`, `starts_on`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `personnel_assignments_org_department_idx`
+  ON `personnel_assignments` (`organization_id`, `department_id`, `ends_on`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `personnel_assignments_current_primary_idx`
+  ON `personnel_assignments` (`organization_id`, `personnel_id`)
+  WHERE `assignment_kind` = 'primary' AND `ends_on` = '';
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_assignments_scope_insert`
+BEFORE INSERT ON `personnel_assignments`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+) OR (
+  NEW.`department_id` IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM `departments` d
+    WHERE d.`id` = NEW.`department_id`
+      AND d.`organization_id` = NEW.`organization_id`
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_assignment_scope');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_assignments_scope_update`
+BEFORE UPDATE OF `organization_id`, `personnel_id`, `department_id` ON `personnel_assignments`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+) OR (
+  NEW.`department_id` IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM `departments` d
+    WHERE d.`id` = NEW.`department_id`
+      AND d.`organization_id` = NEW.`organization_id`
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_assignment_scope');
+END;
+--> statement-breakpoint
+INSERT OR IGNORE INTO `personnel_assignments`
+  (`id`, `organization_id`, `personnel_id`, `department_id`, `position_title`,
+   `assignment_kind`, `duties`, `starts_on`, `ends_on`, `order_reference`,
+   `created_by`, `updated_by`)
+SELECT 'assignment-backfill-' || p.`id`, p.`organization_id`, p.`id`, p.`department_id`,
+       p.`position_title`, 'primary', '', substr(p.`created_at`, 1, 10), '', '',
+       'migration-0115', 'migration-0115'
+FROM `personnel_records` p
+WHERE length(trim(p.`position_title`)) > 0;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `personnel_work_schedules` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` integer NOT NULL,
+  `personnel_id` text NOT NULL,
+  `name` text DEFAULT '' NOT NULL,
+  `schedule_kind` text DEFAULT 'individual' NOT NULL,
+  `valid_from` text NOT NULL,
+  `valid_to` text DEFAULT '' NOT NULL,
+  `weekly_minutes` integer DEFAULT 0 NOT NULL,
+  `note` text DEFAULT '' NOT NULL,
+  `active` integer DEFAULT 1 NOT NULL,
+  `created_by` text NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_by` text NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`personnel_id`) REFERENCES `personnel_records`(`id`) ON DELETE CASCADE,
+  CHECK (`schedule_kind` IN ('five_day','six_day','shift','individual','other')),
+  CHECK (length(`valid_from`) = 10),
+  CHECK (`valid_to` = '' OR length(`valid_to`) = 10),
+  CHECK (`valid_to` = '' OR `valid_to` >= `valid_from`),
+  CHECK (`weekly_minutes` >= 0 AND `weekly_minutes` <= 10080),
+  CHECK (`active` IN (0,1))
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `personnel_work_schedules_org_person_idx`
+  ON `personnel_work_schedules` (`organization_id`, `personnel_id`, `active`, `valid_from`, `valid_to`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `personnel_work_schedules_current_idx`
+  ON `personnel_work_schedules` (`organization_id`, `personnel_id`)
+  WHERE `active` = 1 AND `valid_to` = '';
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_work_schedules_scope_insert`
+BEFORE INSERT ON `personnel_work_schedules`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_work_schedule_scope');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_work_schedules_scope_update`
+BEFORE UPDATE OF `organization_id`, `personnel_id` ON `personnel_work_schedules`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_work_schedule_scope');
+END;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `personnel_work_schedule_days` (
+  `schedule_id` text NOT NULL,
+  `organization_id` integer NOT NULL,
+  `weekday` integer NOT NULL,
+  `is_working` integer DEFAULT 0 NOT NULL,
+  `start_time` text DEFAULT '' NOT NULL,
+  `end_time` text DEFAULT '' NOT NULL,
+  `break_start` text DEFAULT '' NOT NULL,
+  `break_end` text DEFAULT '' NOT NULL,
+  PRIMARY KEY (`schedule_id`, `weekday`),
+  FOREIGN KEY (`schedule_id`) REFERENCES `personnel_work_schedules`(`id`) ON DELETE CASCADE,
+  CHECK (`weekday` BETWEEN 1 AND 7),
+  CHECK (`is_working` IN (0,1)),
+  CHECK (`start_time` = '' OR length(`start_time`) = 5),
+  CHECK (`end_time` = '' OR length(`end_time`) = 5),
+  CHECK (`break_start` = '' OR length(`break_start`) = 5),
+  CHECK (`break_end` = '' OR length(`break_end`) = 5),
+  CHECK (`is_working` = 0 OR (`start_time` <> '' AND `end_time` <> '')),
+  CHECK (`is_working` = 1 OR (`start_time` = '' AND `end_time` = '' AND `break_start` = '' AND `break_end` = ''))
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `personnel_work_schedule_days_org_idx`
+  ON `personnel_work_schedule_days` (`organization_id`, `schedule_id`, `weekday`);
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_work_schedule_days_scope_insert`
+BEFORE INSERT ON `personnel_work_schedule_days`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_work_schedules` s
+  WHERE s.`id` = NEW.`schedule_id`
+    AND s.`organization_id` = NEW.`organization_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_work_schedule_day_scope');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_work_schedule_days_scope_update`
+BEFORE UPDATE OF `schedule_id`, `organization_id` ON `personnel_work_schedule_days`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_work_schedules` s
+  WHERE s.`id` = NEW.`schedule_id`
+    AND s.`organization_id` = NEW.`organization_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_work_schedule_day_scope');
+END;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `personnel_shift_assignments` (
+  `organization_id` integer NOT NULL,
+  `personnel_id` text NOT NULL,
+  `preset_code` text NOT NULL,
+  `team_index` integer NOT NULL,
+  `anchor_date` text NOT NULL,
+  `created_by` text NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_by` text NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (`organization_id`, `personnel_id`),
+  FOREIGN KEY (`personnel_id`) REFERENCES `personnel_records`(`id`) ON DELETE CASCADE,
+  CHECK (`team_index` >= 1),
+  CHECK (length(`anchor_date`) = 10)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `personnel_shift_assignments_org_idx`
+  ON `personnel_shift_assignments` (`organization_id`, `preset_code`);
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_shift_assignments_scope_insert`
+BEFORE INSERT ON `personnel_shift_assignments`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_shift_assignment_scope');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_shift_assignments_scope_update`
+BEFORE UPDATE OF `organization_id`, `personnel_id` ON `personnel_shift_assignments`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_shift_assignment_scope');
+END;
+--> statement-breakpoint
+INSERT OR IGNORE INTO `personnel_shift_assignments`
+  (`organization_id`, `personnel_id`, `preset_code`, `team_index`, `anchor_date`,
+   `created_by`, `created_at`, `updated_by`, `updated_at`)
+SELECT old.`organization_id`, p.`id`, old.`preset_code`, old.`team_index`, old.`anchor_date`,
+       old.`created_by`, old.`created_at`, old.`updated_by`, old.`updated_at`
+FROM `staff_shift_assignments` old
+JOIN `personnel_records` p
+  ON p.`organization_id` = old.`organization_id`
+ AND p.`account_email` = old.`staff_email`;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `personnel_shift_overrides` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `organization_id` integer NOT NULL,
+  `personnel_id` text NOT NULL,
+  `shift_date` text NOT NULL,
+  `kind` text NOT NULL,
+  `label` text DEFAULT '' NOT NULL,
+  `start_time` text DEFAULT '' NOT NULL,
+  `end_time` text DEFAULT '' NOT NULL,
+  `note` text DEFAULT '' NOT NULL,
+  `created_by` text NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updated_by` text NOT NULL,
+  `updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (`personnel_id`) REFERENCES `personnel_records`(`id`) ON DELETE CASCADE,
+  UNIQUE (`organization_id`, `personnel_id`, `shift_date`),
+  CHECK (`kind` IN ('day','evening','night','duty','work','off','recovery','leave','sick','custom')),
+  CHECK (length(`shift_date`) = 10)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `personnel_shift_overrides_org_date_idx`
+  ON `personnel_shift_overrides` (`organization_id`, `shift_date`, `personnel_id`);
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_shift_overrides_scope_insert`
+BEFORE INSERT ON `personnel_shift_overrides`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+) OR NOT EXISTS (
+  SELECT 1 FROM `personnel_shift_assignments` a
+  WHERE a.`organization_id` = NEW.`organization_id`
+    AND a.`personnel_id` = NEW.`personnel_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_shift_override_scope');
+END;
+--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `personnel_shift_overrides_scope_update`
+BEFORE UPDATE OF `organization_id`, `personnel_id` ON `personnel_shift_overrides`
+WHEN NOT EXISTS (
+  SELECT 1 FROM `personnel_records` p
+  WHERE p.`id` = NEW.`personnel_id`
+    AND p.`organization_id` = NEW.`organization_id`
+) OR NOT EXISTS (
+  SELECT 1 FROM `personnel_shift_assignments` a
+  WHERE a.`organization_id` = NEW.`organization_id`
+    AND a.`personnel_id` = NEW.`personnel_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'personnel_shift_override_scope');
+END;
+--> statement-breakpoint
+INSERT OR IGNORE INTO `personnel_shift_overrides`
+  (`organization_id`, `personnel_id`, `shift_date`, `kind`, `label`, `start_time`, `end_time`, `note`,
+   `created_by`, `created_at`, `updated_by`, `updated_at`)
+SELECT old.`organization_id`, p.`id`, old.`shift_date`, old.`kind`, old.`label`, old.`start_time`, old.`end_time`, old.`note`,
+       old.`created_by`, old.`created_at`, old.`updated_by`, old.`updated_at`
+FROM `staff_shift_overrides` old
+JOIN `personnel_records` p
+  ON p.`organization_id` = old.`organization_id`
+ AND p.`account_email` = old.`staff_email`;

--- a/drizzle/0115_personnel_assignments_schedules.sql
+++ b/drizzle/0115_personnel_assignments_schedules.sql
@@ -66,8 +66,8 @@ SELECT d.`organization_id`, d.`id`,
        END,
        CASE
          WHEN d.`name` = 'Відділення променевої діагностики' THEN 'department'
-         WHEN d.`name` LIKE '%кабінет%' OR d.`name` LIKE '%Кабінет%' THEN 'cabinet'
          WHEN d.`name` LIKE '%ПРК%' OR d.`name` LIKE '%УЗД%' THEN 'subdivision'
+         WHEN d.`name` LIKE '%кабінет%' OR d.`name` LIKE '%Кабінет%' THEN 'cabinet'
          ELSE 'unit'
        END
 FROM `departments` d;

--- a/drizzle/meta/0115_snapshot.json
+++ b/drizzle/meta/0115_snapshot.json
@@ -1,0 +1,10069 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5d1d3bc4-8e34-4505-a1c5-b4239ea00368",
+  "prevId": "d8a3f6cc-51bf-4e6d-9d4e-8e7cc08d5f10",
+  "tables": {
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "page_key": {
+          "name": "page_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "analytics_events_journey_idx": {
+          "name": "analytics_events_journey_idx",
+          "columns": [
+            "organization_id",
+            "journey_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "analytics_events_org_event_time_idx": {
+          "name": "analytics_events_org_event_time_idx",
+          "columns": [
+            "organization_id",
+            "event_name",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "analytics_events_org_time_idx": {
+          "name": "analytics_events_org_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "analytics_events_check_1": {
+          "name": "analytics_events_check_1",
+          "value": "`event_name` IN ('page_view','service_view','booking_started','slot_selected','booking_created','payment_started','payment_completed','patient_arrived','study_completed')"
+        },
+        "analytics_events_check_2": {
+          "name": "analytics_events_check_2",
+          "value": "`patient_category` IN ('','civilian','military')"
+        },
+        "analytics_events_check_3": {
+          "name": "analytics_events_check_3",
+          "value": "`source` IN ('client','server')"
+        },
+        "analytics_events_check_4": {
+          "name": "analytics_events_check_4",
+          "value": "length(`journey_id`) <= 64"
+        },
+        "analytics_events_check_5": {
+          "name": "analytics_events_check_5",
+          "value": "length(`service_code`) <= 16"
+        },
+        "analytics_events_check_6": {
+          "name": "analytics_events_check_6",
+          "value": "length(`page_key`) <= 64"
+        }
+      }
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "appointment_details": {
+      "name": "appointment_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appointment_version": {
+          "name": "appointment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "appointment_booking_version_unique": {
+          "name": "appointment_booking_version_unique",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "appointment_version"
+          ],
+          "isUnique": true
+        },
+        "appointment_booking_history_idx": {
+          "name": "appointment_booking_history_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "appointment_version",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "appointment_details_booking_id_bookings_id_fk": {
+          "name": "appointment_details_booking_id_bookings_id_fk",
+          "tableFrom": "appointment_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "appointment_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "appointment_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "appointment_details_check_1": {
+          "name": "appointment_details_check_1",
+          "value": "`appointment_version` > 0"
+        },
+        "appointment_details_check_2": {
+          "name": "appointment_details_check_2",
+          "value": "`duration_minutes` > 0"
+        },
+        "appointment_details_check_3": {
+          "name": "appointment_details_check_3",
+          "value": "length(trim(`scheduled_date`)) > 0"
+        },
+        "appointment_details_check_4": {
+          "name": "appointment_details_check_4",
+          "value": "length(trim(`scheduled_time`)) > 0"
+        }
+      }
+    },
+    "booking_capacity_locks": {
+      "name": "booking_capacity_locks",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minute": {
+          "name": "minute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_code": {
+          "name": "booking_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "booking_capacity_locks_booking_idx": {
+          "name": "booking_capacity_locks_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "booking_capacity_locks_organization_id_equipment_id_booking_date_minute_pk": {
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "booking_date",
+            "minute"
+          ],
+          "name": "booking_capacity_locks_organization_id_equipment_id_booking_date_minute_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_comments": {
+      "name": "booking_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "booking_comments_org_author_idx": {
+          "name": "booking_comments_org_author_idx",
+          "columns": [
+            "organization_id",
+            "author_email",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "booking_comments_org_booking_idx": {
+          "name": "booking_comments_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_events": {
+      "name": "booking_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "booking_events_booking_idx": {
+          "name": "booking_events_booking_idx",
+          "columns": [
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_minute_offsets": {
+      "name": "booking_minute_offsets",
+      "columns": {
+        "minute_offset": {
+          "name": "minute_offset",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_requests": {
+      "name": "booking_requests",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_json": {
+          "name": "response_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_staff_notes": {
+      "name": "booking_staff_notes",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookings": {
+      "name": "bookings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desired_date": {
+          "name": "desired_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desired_time": {
+          "name": "desired_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referral": {
+          "name": "referral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Уточню у адміністратора'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ct'"
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'civilian'"
+        },
+        "referral_type": {
+          "name": "referral_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "referral_number": {
+          "name": "referral_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "marketing_source": {
+          "name": "marketing_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_number": {
+          "name": "protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_status": {
+          "name": "protocol_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "protocol_updated_at": {
+          "name": "protocol_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_set'"
+        },
+        "payment_amount": {
+          "name": "payment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "nszu_status": {
+          "name": "nszu_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_applicable'"
+        },
+        "nszu_reference": {
+          "name": "nszu_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_radiologist_email": {
+          "name": "assigned_radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_radiographer_email": {
+          "name": "assigned_radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "protocol_ready_at": {
+          "name": "protocol_ready_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_issued_at": {
+          "name": "protocol_issued_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_email": {
+          "name": "patient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consent_at": {
+          "name": "consent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "consent_source": {
+          "name": "consent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_verified_at": {
+          "name": "military_verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_verified_by": {
+          "name": "military_verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "bookings_org_patient_idx": {
+          "name": "bookings_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "desired_date"
+          ],
+          "isUnique": false
+        },
+        "bookings_org_schedule_idx": {
+          "name": "bookings_org_schedule_idx",
+          "columns": [
+            "organization_id",
+            "desired_date",
+            "desired_time"
+          ],
+          "isUnique": false
+        },
+        "bookings_patient_idx": {
+          "name": "bookings_patient_idx",
+          "columns": [
+            "phone_normalized",
+            "desired_date"
+          ],
+          "isUnique": false
+        },
+        "bookings_staff_report_idx": {
+          "name": "bookings_staff_report_idx",
+          "columns": [
+            "assigned_radiologist_email",
+            "assigned_radiographer_email"
+          ],
+          "isUnique": false
+        },
+        "bookings_performed_report_idx": {
+          "name": "bookings_performed_report_idx",
+          "columns": [
+            "performed_at",
+            "equipment_id"
+          ],
+          "isUnique": false
+        },
+        "bookings_report_date_idx": {
+          "name": "bookings_report_date_idx",
+          "columns": [
+            "desired_date",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bookings_equipment_schedule_idx": {
+          "name": "bookings_equipment_schedule_idx",
+          "columns": [
+            "equipment_id",
+            "desired_date",
+            "desired_time"
+          ],
+          "isUnique": false
+        },
+        "bookings_code_unique": {
+          "name": "bookings_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "branches": {
+      "name": "branches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "branches_org_idx": {
+          "name": "branches_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "business_documents": {
+      "name": "business_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reversed_document_id": {
+          "name": "reversed_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "basis_document_id": {
+          "name": "basis_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "business_documents_basis_idx": {
+          "name": "business_documents_basis_idx",
+          "columns": [
+            "organization_id",
+            "basis_document_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`basis_document_id` IS NOT NULL"
+        },
+        "business_documents_id_org_idx": {
+          "name": "business_documents_id_org_idx",
+          "columns": [
+            "id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "business_documents_org_type_state_idx": {
+          "name": "business_documents_org_type_state_idx",
+          "columns": [
+            "organization_id",
+            "document_type",
+            "state",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "business_documents_org_type_number_idx": {
+          "name": "business_documents_org_type_number_idx",
+          "columns": [
+            "organization_id",
+            "document_type",
+            "number"
+          ],
+          "isUnique": true,
+          "where": "`number` <> ''"
+        },
+        "business_documents_org_id_idx": {
+          "name": "business_documents_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "business_documents_organization_id_organizations_id_fk": {
+          "name": "business_documents_organization_id_organizations_id_fk",
+          "tableFrom": "business_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "business_documents_reversed_document_id_business_documents_id_fk": {
+          "name": "business_documents_reversed_document_id_business_documents_id_fk",
+          "tableFrom": "business_documents",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "reversed_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "business_documents_check_1": {
+          "name": "business_documents_check_1",
+          "value": "`document_type` IN (\n    'patient_order','appointment','service_delivery','payment','refund',\n    'inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count',\n    'study_performance','result_delivery','study_correction'\n  )"
+        },
+        "business_documents_check_2": {
+          "name": "business_documents_check_2",
+          "value": "`state` IN ('draft','posted','reversed','cancelled')"
+        }
+      }
+    },
+    "cash_accounts": {
+      "name": "cash_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cash'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "cash_accounts_org_type_active_idx": {
+          "name": "cash_accounts_org_type_active_idx",
+          "columns": [
+            "organization_id",
+            "account_type",
+            "currency",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "cash_accounts_one_default_idx": {
+          "name": "cash_accounts_one_default_idx",
+          "columns": [
+            "organization_id",
+            "account_type",
+            "currency"
+          ],
+          "isUnique": true,
+          "where": "`is_default`=1"
+        },
+        "cash_accounts_org_code_idx": {
+          "name": "cash_accounts_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "cash_accounts_org_id_idx": {
+          "name": "cash_accounts_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cash_accounts_organization_id_organizations_id_fk": {
+          "name": "cash_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "cash_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cash_accounts_check_1": {
+          "name": "cash_accounts_check_1",
+          "value": "`account_type` IN ('cash','bank','provider','other')"
+        },
+        "cash_accounts_check_2": {
+          "name": "cash_accounts_check_2",
+          "value": "`active` IN (0,1)"
+        },
+        "cash_accounts_check_3": {
+          "name": "cash_accounts_check_3",
+          "value": "`is_default` IN (0,1)"
+        }
+      }
+    },
+    "cash_movements": {
+      "name": "cash_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "cash_movements_account_time_idx": {
+          "name": "cash_movements_account_time_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`cash_account_id` IS NOT NULL"
+        },
+        "cash_movements_time_idx": {
+          "name": "cash_movements_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "cash_movements_document_idx": {
+          "name": "cash_movements_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cash_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "cash_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "cash_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cash_movements_check_1": {
+          "name": "cash_movements_check_1",
+          "value": "`movement_type` IN ('payment','refund')"
+        },
+        "cash_movements_check_2": {
+          "name": "cash_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "counterparties": {
+      "name": "counterparties",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'supplier'"
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "counterparties_org_kind_active_idx": {
+          "name": "counterparties_org_kind_active_idx",
+          "columns": [
+            "organization_id",
+            "kind",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "counterparties_org_code_idx": {
+          "name": "counterparties_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "counterparties_org_id_idx": {
+          "name": "counterparties_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "counterparties_organization_id_organizations_id_fk": {
+          "name": "counterparties_organization_id_organizations_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "counterparties_check_1": {
+          "name": "counterparties_check_1",
+          "value": "`kind` IN ('supplier','payer','both','other')"
+        },
+        "counterparties_check_2": {
+          "name": "counterparties_check_2",
+          "value": "`active` IN (0,1)"
+        }
+      }
+    },
+    "custom_field_definitions": {
+      "name": "custom_field_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'booking'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "idx_custom_field_definitions_org_entity": {
+          "name": "idx_custom_field_definitions_org_entity",
+          "columns": [
+            "organization_id",
+            "entity_type",
+            "active",
+            "sort_order",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_field_definitions_organization_id_organizations_id_fk": {
+          "name": "custom_field_definitions_organization_id_organizations_id_fk",
+          "tableFrom": "custom_field_definitions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "custom_field_definitions_check_1": {
+          "name": "custom_field_definitions_check_1",
+          "value": "entity_type IN ('booking')"
+        },
+        "custom_field_definitions_check_2": {
+          "name": "custom_field_definitions_check_2",
+          "value": "field_type IN ('text','number','date','boolean','select')"
+        },
+        "custom_field_definitions_check_3": {
+          "name": "custom_field_definitions_check_3",
+          "value": "required IN (0,1)"
+        },
+        "custom_field_definitions_check_4": {
+          "name": "custom_field_definitions_check_4",
+          "value": "active IN (0,1)"
+        }
+      }
+    },
+    "custom_field_values": {
+      "name": "custom_field_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'booking'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "idx_custom_field_values_org_entity": {
+          "name": "idx_custom_field_values_org_entity",
+          "columns": [
+            "organization_id",
+            "entity_type",
+            "entity_id",
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_field_values_organization_id_organizations_id_fk": {
+          "name": "custom_field_values_organization_id_organizations_id_fk",
+          "tableFrom": "custom_field_values",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "custom_field_values_organization_id_definition_id_custom_field_definitions_organization_id_id_fk": {
+          "name": "custom_field_values_organization_id_definition_id_custom_field_definitions_organization_id_id_fk",
+          "tableFrom": "custom_field_values",
+          "tableTo": "custom_field_definitions",
+          "columnsFrom": [
+            "organization_id",
+            "definition_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "custom_field_values_check_1": {
+          "name": "custom_field_values_check_1",
+          "value": "entity_type IN ('booking')"
+        }
+      }
+    },
+    "departments": {
+      "name": "departments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "departments_org_idx": {
+          "name": "departments_org_idx",
+          "columns": [
+            "organization_id",
+            "branch_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "equipment_blocks": {
+      "name": "equipment_blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked_date": {
+          "name": "blocked_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "equipment_blocks_schedule_idx": {
+          "name": "equipment_blocks_schedule_idx",
+          "columns": [
+            "equipment_id",
+            "blocked_date",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "equipment_load_movements": {
+      "name": "equipment_load_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minutes_delta": {
+          "name": "minutes_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "equipment_load_equipment_idx": {
+          "name": "equipment_load_equipment_idx",
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "equipment_load_document_idx": {
+          "name": "equipment_load_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "equipment_load_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "equipment_load_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "equipment_load_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "equipment_load_movements_check_1": {
+          "name": "equipment_load_movements_check_1",
+          "value": "`minutes_delta` <> 0"
+        }
+      }
+    },
+    "equipment_maintenance": {
+      "name": "equipment_maintenance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_email": {
+          "name": "assigned_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "downtime_start": {
+          "name": "downtime_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "downtime_end": {
+          "name": "downtime_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "equipment_maintenance_org_status_idx": {
+          "name": "equipment_maintenance_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "due_date",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "equipment_maintenance_org_equipment_idx": {
+          "name": "equipment_maintenance_org_equipment_idx",
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expense_movements": {
+      "name": "expense_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "inventory_movement_id": {
+          "name": "inventory_movement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_line_id": {
+          "name": "document_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_receipt_document_id": {
+          "name": "source_receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_receipt_line_id": {
+          "name": "source_receipt_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "expense_movements_inventory_movement_idx": {
+          "name": "expense_movements_inventory_movement_idx",
+          "columns": [
+            "organization_id",
+            "inventory_movement_id"
+          ],
+          "isUnique": true
+        },
+        "expense_movements_org_time_idx": {
+          "name": "expense_movements_org_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "expense_movements_org_item_time_idx": {
+          "name": "expense_movements_org_item_time_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "expense_movements_org_lot_idx": {
+          "name": "expense_movements_org_lot_idx",
+          "columns": [
+            "organization_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "expense_movements_unit_cost_nonnegative": {
+          "name": "expense_movements_unit_cost_nonnegative",
+          "value": "\"expense_movements\".\"unit_cost\" >= 0"
+        },
+        "expense_movements_amount_positive": {
+          "name": "expense_movements_amount_positive",
+          "value": "\"expense_movements\".\"amount_delta\" > 0"
+        }
+      }
+    },
+    "finance_document_details": {
+      "name": "finance_document_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_transaction_id": {
+          "name": "source_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "finance_document_cash_account_idx": {
+          "name": "finance_document_cash_account_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "document_id"
+          ],
+          "isUnique": false,
+          "where": "`cash_account_id` IS NOT NULL"
+        },
+        "finance_document_details_source_transaction_idx": {
+          "name": "finance_document_details_source_transaction_idx",
+          "columns": [
+            "organization_id",
+            "source_transaction_id"
+          ],
+          "isUnique": true,
+          "where": "`source_transaction_id` IS NOT NULL"
+        },
+        "finance_document_details_booking_idx": {
+          "name": "finance_document_details_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "finance_document_details_booking_id_bookings_id_fk": {
+          "name": "finance_document_details_booking_id_bookings_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_source_document_id_business_documents_id_fk": {
+          "name": "finance_document_details_source_document_id_business_documents_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_source_transaction_id_payment_transactions_id_fk": {
+          "name": "finance_document_details_source_transaction_id_payment_transactions_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "payment_transactions",
+          "columnsFrom": [
+            "source_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "finance_document_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "finance_document_details_check_1": {
+          "name": "finance_document_details_check_1",
+          "value": "`amount` > 0"
+        }
+      }
+    },
+    "imaging_studies": {
+      "name": "imaging_studies",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accession_number": {
+          "name": "accession_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "study_instance_uid": {
+          "name": "study_instance_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "series_count": {
+          "name": "series_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "instances_count": {
+          "name": "instances_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "study_status": {
+          "name": "study_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_linked'"
+        },
+        "study_datetime": {
+          "name": "study_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "imaging_studies_org_uid_idx": {
+          "name": "imaging_studies_org_uid_idx",
+          "columns": [
+            "organization_id",
+            "study_instance_uid"
+          ],
+          "isUnique": true,
+          "where": "study_instance_uid != ''"
+        },
+        "imaging_studies_org_idx": {
+          "name": "imaging_studies_org_idx",
+          "columns": [
+            "organization_id",
+            "study_status"
+          ],
+          "isUnique": false
+        },
+        "imaging_studies_status_idx": {
+          "name": "imaging_studies_status_idx",
+          "columns": [
+            "study_status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_count_lines": {
+      "name": "inventory_count_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "item_unit": {
+          "name": "item_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "book_quantity": {
+          "name": "book_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counted_quantity": {
+          "name": "counted_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "inventory_count_lines_doc_line_idx": {
+          "name": "inventory_count_lines_doc_line_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": true
+        },
+        "inventory_count_lines_bucket_unique": {
+          "name": "inventory_count_lines_bucket_unique",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "warehouse_id",
+            "lot_id"
+          ],
+          "isUnique": true
+        },
+        "inventory_count_lines_warehouse_idx": {
+          "name": "inventory_count_lines_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_count_lines_item_id_inventory_items_id_fk": {
+          "name": "inventory_count_lines_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_count_lines_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_count_lines_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_count_lines_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "inventory_count_lines_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_count_lines_book_nonnegative": {
+          "name": "inventory_count_lines_book_nonnegative",
+          "value": "book_quantity >= 0"
+        },
+        "inventory_count_lines_counted_nonnegative": {
+          "name": "inventory_count_lines_counted_nonnegative",
+          "value": "counted_quantity >= 0"
+        }
+      }
+    },
+    "inventory_document_lines": {
+      "name": "inventory_document_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination_warehouse_code": {
+          "name": "destination_warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "destination_warehouse_name": {
+          "name": "destination_warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "line_amount": {
+          "name": "line_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reservation_movement_id": {
+          "name": "reservation_movement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inventory_lines_reservation_idx": {
+          "name": "inventory_lines_reservation_idx",
+          "columns": [
+            "organization_id",
+            "reservation_movement_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`reservation_movement_id` IS NOT NULL"
+        },
+        "inventory_lines_destination_warehouse_idx": {
+          "name": "inventory_lines_destination_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "destination_warehouse_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`destination_warehouse_id` IS NOT NULL"
+        },
+        "inventory_lines_warehouse_idx": {
+          "name": "inventory_lines_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_document_lines_supplier_idx": {
+          "name": "inventory_document_lines_supplier_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "document_id"
+          ],
+          "isUnique": false,
+          "where": "`supplier_counterparty_id` IS NOT NULL"
+        },
+        "inventory_document_lines_org_id_idx": {
+          "name": "inventory_document_lines_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        },
+        "inventory_document_lines_doc_line_idx": {
+          "name": "inventory_document_lines_doc_line_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inventory_document_lines_item_id_inventory_items_id_fk": {
+          "name": "inventory_document_lines_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_document_lines_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_booking_id_bookings_id_fk": {
+          "name": "inventory_document_lines_booking_id_bookings_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "inventory_document_lines_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_document_lines_check_1": {
+          "name": "inventory_document_lines_check_1",
+          "value": "`quantity` > 0"
+        },
+        "inventory_document_lines_check_2": {
+          "name": "inventory_document_lines_check_2",
+          "value": "`unit_cost` >= 0"
+        },
+        "inventory_document_lines_check_3": {
+          "name": "inventory_document_lines_check_3",
+          "value": "`line_amount` >= 0"
+        }
+      }
+    },
+    "inventory_items": {
+      "name": "inventory_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'шт'"
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "inventory_items_org_active_idx": {
+          "name": "inventory_items_org_active_idx",
+          "columns": [
+            "organization_id",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "inventory_items_org_sku_idx": {
+          "name": "inventory_items_org_sku_idx",
+          "columns": [
+            "organization_id",
+            "sku"
+          ],
+          "isUnique": true,
+          "where": "`sku` <> ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_lots": {
+      "name": "inventory_lots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inventory_lots_supplier_idx": {
+          "name": "inventory_lots_supplier_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`supplier_counterparty_id` IS NOT NULL"
+        },
+        "inventory_lots_org_item_idx": {
+          "name": "inventory_lots_org_item_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "expires_on"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_lots_item_id_inventory_items_id_fk": {
+          "name": "inventory_lots_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_lots",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_movements": {
+      "name": "inventory_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_line_id": {
+          "name": "document_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "inventory_movements_document_line_type_idx": {
+          "name": "inventory_movements_document_line_type_idx",
+          "columns": [
+            "organization_id",
+            "document_line_id",
+            "movement_type"
+          ],
+          "isUnique": true,
+          "where": "`document_line_id` IS NOT NULL"
+        },
+        "inventory_movements_warehouse_lot_idx": {
+          "name": "inventory_movements_warehouse_lot_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_movements_warehouse_item_idx": {
+          "name": "inventory_movements_warehouse_item_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_movements_document_idx": {
+          "name": "inventory_movements_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`document_id` IS NOT NULL"
+        },
+        "inventory_movements_org_lot_idx": {
+          "name": "inventory_movements_org_lot_idx",
+          "columns": [
+            "organization_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "inventory_movements_org_item_idx": {
+          "name": "inventory_movements_org_item_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_movements_item_id_inventory_items_id_fk": {
+          "name": "inventory_movements_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_movements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movements_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_movements_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_movements",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_reservation_movements": {
+      "name": "inventory_reservation_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appointment_document_id": {
+          "name": "appointment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "inventory_reservation_exact_movement_unique": {
+          "name": "inventory_reservation_exact_movement_unique",
+          "columns": [
+            "organization_id",
+            "appointment_document_id",
+            "requirement_id",
+            "movement_type"
+          ],
+          "isUnique": true
+        },
+        "inventory_reservation_balance_idx": {
+          "name": "inventory_reservation_balance_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "inventory_reservation_booking_idx": {
+          "name": "inventory_reservation_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_reservation_movements_organization_id_organizations_id_fk": {
+          "name": "inventory_reservation_movements_organization_id_organizations_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_booking_id_bookings_id_fk": {
+          "name": "inventory_reservation_movements_booking_id_bookings_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_requirement_id_service_material_requirements_id_fk": {
+          "name": "inventory_reservation_movements_requirement_id_service_material_requirements_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "service_material_requirements",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_item_id_inventory_items_id_fk": {
+          "name": "inventory_reservation_movements_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_warehouse_id_warehouses_id_fk": {
+          "name": "inventory_reservation_movements_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_appointment_tenant_fk": {
+          "name": "inventory_reservation_appointment_tenant_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "appointment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_reservation_movements_check_1": {
+          "name": "inventory_reservation_movements_check_1",
+          "value": "`movement_type` IN ('reserve','release')"
+        },
+        "inventory_reservation_movements_check_2": {
+          "name": "inventory_reservation_movements_check_2",
+          "value": "(`movement_type`='reserve' AND `quantity_delta` > 0) OR (`movement_type`='release' AND `quantity_delta` < 0)"
+        }
+      }
+    },
+    "memberships": {
+      "name": "memberships",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "memberships_member_idx": {
+          "name": "memberships_member_idx",
+          "columns": [
+            "member_email"
+          ],
+          "isUnique": false
+        },
+        "memberships_org_member_idx": {
+          "name": "memberships_org_member_idx",
+          "columns": [
+            "organization_id",
+            "member_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mwl_bridge_tokens": {
+      "name": "mwl_bridge_tokens",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "mwl_bridge_tokens_hash_idx": {
+          "name": "mwl_bridge_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mwl_patient_ids": {
+      "name": "mwl_patient_ids",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "mwl_patient_ids_org_patient_idx": {
+          "name": "mwl_patient_ids_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mwl_patient_ids_organization_id_identity_key_pk": {
+          "columns": [
+            "organization_id",
+            "identity_key"
+          ],
+          "name": "mwl_patient_ids_organization_id_identity_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_integration_settings": {
+      "name": "organization_integration_settings",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_integration_settings_org_idx": {
+          "name": "organization_integration_settings_org_idx",
+          "columns": [
+            "organization_id",
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_integration_settings_organization_id_organizations_id_fk": {
+          "name": "organization_integration_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_integration_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_integration_settings_organization_id_key_pk": {
+          "columns": [
+            "organization_id",
+            "key"
+          ],
+          "name": "organization_integration_settings_organization_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_profiles": {
+      "name": "organization_profiles",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_type": {
+          "name": "profile_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hospital_radiology'"
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "feature_flags_json": {
+          "name": "feature_flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pacs_settings": {
+      "name": "pacs_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dicomweb_base_url": {
+          "name": "dicomweb_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "viewer_base_url": {
+          "name": "viewer_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ae_title": {
+          "name": "ae_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "pacs_settings_organization_idx": {
+          "name": "pacs_settings_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_communications": {
+      "name": "patient_communications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'call'"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'outbound'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_communications_org_patient_idx": {
+          "name": "patient_communications_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_comm_external_idx": {
+          "name": "patient_comm_external_idx",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true,
+          "where": "`external_id` != ''"
+        },
+        "patient_communications_org_idx": {
+          "name": "patient_communications_org_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        },
+        "patient_communications_phone_idx": {
+          "name": "patient_communications_phone_idx",
+          "columns": [
+            "phone_normalized",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_notifications": {
+      "name": "patient_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "patient_notifications_org_idx": {
+          "name": "patient_notifications_org_idx",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": false
+        },
+        "patient_notifications_booking_idx": {
+          "name": "patient_notifications_booking_idx",
+          "columns": [
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_order_details": {
+      "name": "patient_order_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_order_patient_idx": {
+          "name": "patient_order_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "patient_order_booking_unique": {
+          "name": "patient_order_booking_unique",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "patient_order_details_booking_id_bookings_id_fk": {
+          "name": "patient_order_details_booking_id_bookings_id_fk",
+          "tableFrom": "patient_order_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_order_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "patient_order_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "patient_order_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "patient_order_details_check_1": {
+          "name": "patient_order_details_check_1",
+          "value": "`duration_minutes` > 0"
+        },
+        "patient_order_details_check_2": {
+          "name": "patient_order_details_check_2",
+          "value": "`price_amount` >= 0"
+        },
+        "patient_order_details_check_3": {
+          "name": "patient_order_details_check_3",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "patient_otp_challenges": {
+      "name": "patient_otp_challenges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cabinet_login'"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_otp_patient_idx": {
+          "name": "patient_otp_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_identity_scope_idx": {
+          "name": "patient_otp_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_expiry_idx": {
+          "name": "patient_otp_expiry_idx",
+          "columns": [
+            "expires_at",
+            "consumed_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_phone_idx": {
+          "name": "patient_otp_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_profiles": {
+      "name": "patient_profiles",
+      "columns": {
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(lower(hex(randomblob(16))))"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_not_contact": {
+          "name": "do_not_contact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_profiles_org_updated_idx": {
+          "name": "patient_profiles_org_updated_idx",
+          "columns": [
+            "organization_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "patient_profiles_org_phone_idx": {
+          "name": "patient_profiles_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        },
+        "patient_profiles_phone_idx": {
+          "name": "patient_profiles_phone_idx",
+          "columns": [
+            "phone_normalized"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_sessions": {
+      "name": "patient_sessions",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_sessions_patient_idx": {
+          "name": "patient_sessions_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_identity_scope_idx": {
+          "name": "patient_sessions_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_org_phone_idx": {
+          "name": "patient_sessions_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_expiry_idx": {
+          "name": "patient_sessions_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_settlement_movements": {
+      "name": "patient_settlement_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_settlement_booking_idx": {
+          "name": "patient_settlement_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "patient_settlement_patient_idx": {
+          "name": "patient_settlement_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "patient_settlement_document_idx": {
+          "name": "patient_settlement_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "patient_settlement_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "patient_settlement_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "patient_settlement_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "patient_settlement_movements_check_1": {
+          "name": "patient_settlement_movements_check_1",
+          "value": "`movement_type` IN ('charge','payment','refund','adjustment')"
+        },
+        "patient_settlement_movements_check_2": {
+          "name": "patient_settlement_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "patient_telegram_identities": {
+      "name": "patient_telegram_identities",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_telegram_patient_idx": {
+          "name": "patient_telegram_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "patient_telegram_chat_idx": {
+          "name": "patient_telegram_chat_idx",
+          "columns": [
+            "telegram_chat_id"
+          ],
+          "isUnique": false,
+          "where": "telegram_chat_id != ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "patient_telegram_identities_organization_id_phone_normalized_identity_kind_identity_value_pk": {
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value"
+          ],
+          "name": "patient_telegram_identities_organization_id_phone_normalized_identity_kind_identity_value_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payment_transactions": {
+      "name": "payment_transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refund_document_id": {
+          "name": "refund_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payment_transactions_one_linked_paid_booking_idx": {
+          "name": "payment_transactions_one_linked_paid_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true,
+          "where": "`status`='paid' AND `payment_document_id` IS NOT NULL"
+        },
+        "payment_transactions_refund_document_idx": {
+          "name": "payment_transactions_refund_document_idx",
+          "columns": [
+            "organization_id",
+            "refund_document_id"
+          ],
+          "isUnique": true,
+          "where": "`refund_document_id` IS NOT NULL"
+        },
+        "payment_transactions_payment_document_idx": {
+          "name": "payment_transactions_payment_document_idx",
+          "columns": [
+            "organization_id",
+            "payment_document_id"
+          ],
+          "isUnique": true,
+          "where": "`payment_document_id` IS NOT NULL"
+        },
+        "payment_transactions_provider_ref_idx": {
+          "name": "payment_transactions_provider_ref_idx",
+          "columns": [
+            "organization_id",
+            "provider",
+            "provider_reference"
+          ],
+          "isUnique": true,
+          "where": "provider_reference != ''"
+        },
+        "payment_transactions_booking_idx": {
+          "name": "payment_transactions_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "payment_transactions_check_1": {
+          "name": "payment_transactions_check_1",
+          "value": "amount >= 0"
+        },
+        "payment_transactions_check_2": {
+          "name": "payment_transactions_check_2",
+          "value": "status IN ('pending','paid','failed','refunded','cancelled')"
+        }
+      }
+    },
+    "printed_form_snapshots": {
+      "name": "printed_form_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_type": {
+          "name": "form_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_state": {
+          "name": "document_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "printed_service_act_state_unique": {
+          "name": "printed_service_act_state_unique",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "document_state"
+          ],
+          "isUnique": true,
+          "where": "`form_type`='service_act' AND `document_state` IN ('posted','reversed')"
+        },
+        "printed_form_snapshots_state_idx": {
+          "name": "printed_form_snapshots_state_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "document_state",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "printed_form_snapshots_document_idx": {
+          "name": "printed_form_snapshots_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "printed_form_snapshots_same_render_idx": {
+          "name": "printed_form_snapshots_same_render_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "sha256"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "printed_form_snapshots_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "printed_form_snapshots_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "printed_form_snapshots",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "printed_form_snapshots_check_1": {
+          "name": "printed_form_snapshots_check_1",
+          "value": "`form_type` IN (\n    'invoice','payment_receipt','service_act','referral','protocol','result',\n    'inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count','service_note'\n  )"
+        },
+        "printed_form_snapshots_check_2": {
+          "name": "printed_form_snapshots_check_2",
+          "value": "`template_version` > 0"
+        }
+      }
+    },
+    "protocol_addenda": {
+      "name": "protocol_addenda",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "correction_text": {
+          "name": "correction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_version": {
+          "name": "signed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "protocol_addenda_status_idx": {
+          "name": "protocol_addenda_status_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "protocol_addenda_org_booking_idx": {
+          "name": "protocol_addenda_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protocol_addenda_check_1": {
+          "name": "protocol_addenda_check_1",
+          "value": "`length`(`id`) = 32 AND `id` NOT GLOB '*[^0-9a-f]*'"
+        },
+        "protocol_addenda_check_2": {
+          "name": "protocol_addenda_check_2",
+          "value": "`length`(`trim`(`reason`)) BETWEEN 1 AND 500"
+        },
+        "protocol_addenda_check_3": {
+          "name": "protocol_addenda_check_3",
+          "value": "`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000"
+        },
+        "protocol_addenda_check_4": {
+          "name": "protocol_addenda_check_4",
+          "value": "`length`(`trim`(`author_email`)) > 0"
+        },
+        "protocol_addenda_check_5": {
+          "name": "protocol_addenda_check_5",
+          "value": "`length`(`trim`(`updated_by`)) > 0"
+        },
+        "protocol_addenda_check_6": {
+          "name": "protocol_addenda_check_6",
+          "value": "`status` IN ('draft','ready','signed','issued')"
+        },
+        "protocol_addenda_check_7": {
+          "name": "protocol_addenda_check_7",
+          "value": "`base_protocol_version` > 0"
+        },
+        "protocol_addenda_check_8": {
+          "name": "protocol_addenda_check_8",
+          "value": "`version` > 0"
+        }
+      }
+    },
+    "protocol_addendum_revisions": {
+      "name": "protocol_addendum_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "addendum_id": {
+          "name": "addendum_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "correction_text": {
+          "name": "correction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "protocol_addendum_revisions_scope_idx": {
+          "name": "protocol_addendum_revisions_scope_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "addendum_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protocol_addendum_revisions_check_1": {
+          "name": "protocol_addendum_revisions_check_1",
+          "value": "`length`(`addendum_id`) = 32 AND `addendum_id` NOT GLOB '*[^0-9a-f]*'"
+        },
+        "protocol_addendum_revisions_check_2": {
+          "name": "protocol_addendum_revisions_check_2",
+          "value": "`length`(`trim`(`reason`)) BETWEEN 1 AND 500"
+        },
+        "protocol_addendum_revisions_check_3": {
+          "name": "protocol_addendum_revisions_check_3",
+          "value": "`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000"
+        },
+        "protocol_addendum_revisions_check_4": {
+          "name": "protocol_addendum_revisions_check_4",
+          "value": "`length`(`trim`(`saved_by`)) > 0"
+        },
+        "protocol_addendum_revisions_check_5": {
+          "name": "protocol_addendum_revisions_check_5",
+          "value": "`status` IN ('draft','ready','signed')"
+        },
+        "protocol_addendum_revisions_check_6": {
+          "name": "protocol_addendum_revisions_check_6",
+          "value": "`base_protocol_version` > 0"
+        },
+        "protocol_addendum_revisions_check_7": {
+          "name": "protocol_addendum_revisions_check_7",
+          "value": "`version` > 0"
+        }
+      }
+    },
+    "protocol_revisions": {
+      "name": "protocol_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "protocol_revisions_org_booking_idx": {
+          "name": "protocol_revisions_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "version"
+          ],
+          "isUnique": false
+        },
+        "protocol_revisions_booking_idx": {
+          "name": "protocol_revisions_booking_idx",
+          "columns": [
+            "booking_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "protocol_revisions_booking_id_bookings_id_fk": {
+          "name": "protocol_revisions_booking_id_bookings_id_fk",
+          "tableFrom": "protocol_revisions",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "protocols": {
+      "name": "protocols",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'generic'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_version": {
+          "name": "signed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "protocols_org_number_idx": {
+          "name": "protocols_org_number_idx",
+          "columns": [
+            "organization_id",
+            "number"
+          ],
+          "isUnique": false
+        },
+        "protocols_org_idx": {
+          "name": "protocols_org_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "protocols_status_idx": {
+          "name": "protocols_status_idx",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_exports": {
+      "name": "report_exports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filters_json": {
+          "name": "filters_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "columns_json": {
+          "name": "columns_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'xlsx'"
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contains_personal_data": {
+          "name": "contains_personal_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "report_exports_created_idx": {
+          "name": "report_exports_created_idx",
+          "columns": [
+            "created_at",
+            "requested_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_limits": {
+      "name": "request_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "result_addendum_delivery_details": {
+      "name": "result_addendum_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addendum_id": {
+          "name": "addendum_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_number": {
+          "name": "base_protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addendum_version": {
+          "name": "addendum_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "result_addendum_delivery_addendum_unique": {
+          "name": "result_addendum_delivery_addendum_unique",
+          "columns": [
+            "organization_id",
+            "addendum_id"
+          ],
+          "isUnique": true
+        },
+        "result_addendum_delivery_booking_idx": {
+          "name": "result_addendum_delivery_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "result_addendum_delivery_document_idx": {
+          "name": "result_addendum_delivery_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "result_addendum_delivery_details_addendum_id_protocol_addenda_id_fk": {
+          "name": "result_addendum_delivery_details_addendum_id_protocol_addenda_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "protocol_addenda",
+          "columnsFrom": [
+            "addendum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_addendum_delivery_details_booking_id_bookings_id_fk": {
+          "name": "result_addendum_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_addendum_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "result_addendum_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "result_addendum_delivery_details_check_1": {
+          "name": "result_addendum_delivery_details_check_1",
+          "value": "`base_protocol_version` > 0"
+        },
+        "result_addendum_delivery_details_check_2": {
+          "name": "result_addendum_delivery_details_check_2",
+          "value": "`addendum_version` > 0"
+        }
+      }
+    },
+    "result_delivery_details": {
+      "name": "result_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_number": {
+          "name": "protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "result_delivery_booking_unique": {
+          "name": "result_delivery_booking_unique",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true
+        },
+        "result_delivery_document_idx": {
+          "name": "result_delivery_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "result_delivery_details_booking_id_bookings_id_fk": {
+          "name": "result_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "result_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "result_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "result_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "result_delivery_details_check_1": {
+          "name": "result_delivery_details_check_1",
+          "value": "`protocol_version` > 0"
+        }
+      }
+    },
+    "revenue_movements": {
+      "name": "revenue_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "revenue_time_idx": {
+          "name": "revenue_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "revenue_document_idx": {
+          "name": "revenue_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "revenue_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "revenue_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "revenue_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "revenue_movements_check_1": {
+          "name": "revenue_movements_check_1",
+          "value": "`movement_type` IN ('service_delivery','service_correction')"
+        },
+        "revenue_movements_check_2": {
+          "name": "revenue_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "saved_report_views": {
+      "name": "saved_report_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_key": {
+          "name": "report_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'register_turnover'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configuration_json": {
+          "name": "configuration_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "saved_report_views_org_report_name_unique": {
+          "name": "saved_report_views_org_report_name_unique",
+          "columns": [
+            "organization_id",
+            "report_key",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "saved_report_views_org_report_idx": {
+          "name": "saved_report_views_org_report_idx",
+          "columns": [
+            "organization_id",
+            "report_key",
+            "updated_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "saved_report_views_report_key_check": {
+          "name": "saved_report_views_report_key_check",
+          "value": "`report_key` = 'register_turnover'"
+        },
+        "saved_report_views_name_check": {
+          "name": "saved_report_views_name_check",
+          "value": "length(trim(`name`)) BETWEEN 1 AND 80"
+        }
+      }
+    },
+    "security_audit_log": {
+      "name": "security_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "security_audit_created_idx": {
+          "name": "security_audit_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "actor_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_correction_details": {
+      "name": "service_correction_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correction_kind": {
+          "name": "correction_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'storno'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "radiologist_email": {
+          "name": "radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "radiographer_email": {
+          "name": "radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_correction_booking_idx": {
+          "name": "service_correction_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "service_correction_source_unique": {
+          "name": "service_correction_source_unique",
+          "columns": [
+            "organization_id",
+            "source_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_correction_details_booking_id_bookings_id_fk": {
+          "name": "service_correction_details_booking_id_bookings_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_details_source_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_details_source_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_correction_details_check_1": {
+          "name": "service_correction_details_check_1",
+          "value": "`correction_kind`='storno'"
+        },
+        "service_correction_details_check_2": {
+          "name": "service_correction_details_check_2",
+          "value": "length(trim(`reason`)) >= 5"
+        },
+        "service_correction_details_check_3": {
+          "name": "service_correction_details_check_3",
+          "value": "`duration_minutes` > 0"
+        },
+        "service_correction_details_check_4": {
+          "name": "service_correction_details_check_4",
+          "value": "`anatomical_regions_count` > 0"
+        },
+        "service_correction_details_check_5": {
+          "name": "service_correction_details_check_5",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "service_correction_movements": {
+      "name": "service_correction_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_delta": {
+          "name": "anatomical_regions_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_correction_movement_source_idx": {
+          "name": "service_correction_movement_source_idx",
+          "columns": [
+            "organization_id",
+            "source_document_id"
+          ],
+          "isUnique": true
+        },
+        "service_correction_movement_document_idx": {
+          "name": "service_correction_movement_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_correction_movements_source_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_movements_source_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_correction_movements_check_1": {
+          "name": "service_correction_movements_check_1",
+          "value": "`quantity_delta`=-1"
+        },
+        "service_correction_movements_check_2": {
+          "name": "service_correction_movements_check_2",
+          "value": "`anatomical_regions_delta` < 0"
+        }
+      }
+    },
+    "service_delivery_details": {
+      "name": "service_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "radiologist_email": {
+          "name": "radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "radiographer_email": {
+          "name": "radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_delivery_booking_idx": {
+          "name": "service_delivery_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "service_delivery_details_booking_id_bookings_id_fk": {
+          "name": "service_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "service_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_delivery_details_check_1": {
+          "name": "service_delivery_details_check_1",
+          "value": "`duration_minutes` > 0"
+        },
+        "service_delivery_details_check_2": {
+          "name": "service_delivery_details_check_2",
+          "value": "`anatomical_regions_count` > 0"
+        },
+        "service_delivery_details_check_3": {
+          "name": "service_delivery_details_check_3",
+          "value": "`price_amount` >= 0"
+        },
+        "service_delivery_details_check_4": {
+          "name": "service_delivery_details_check_4",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "service_material_requirements": {
+      "name": "service_material_requirements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_material_requirements_service_idx": {
+          "name": "service_material_requirements_service_idx",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "active",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "service_material_requirements_active_unique": {
+          "name": "service_material_requirements_active_unique",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "item_id",
+            "warehouse_id"
+          ],
+          "isUnique": true,
+          "where": "`active` = 1"
+        }
+      },
+      "foreignKeys": {
+        "service_material_requirements_organization_id_organizations_id_fk": {
+          "name": "service_material_requirements_organization_id_organizations_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_material_requirements_item_id_inventory_items_id_fk": {
+          "name": "service_material_requirements_item_id_inventory_items_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_material_requirements_warehouse_id_warehouses_id_fk": {
+          "name": "service_material_requirements_warehouse_id_warehouses_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_material_requirements_check_1": {
+          "name": "service_material_requirements_check_1",
+          "value": "length(trim(`service_code`)) > 0"
+        },
+        "service_material_requirements_check_2": {
+          "name": "service_material_requirements_check_2",
+          "value": "`quantity` > 0"
+        },
+        "service_material_requirements_check_3": {
+          "name": "service_material_requirements_check_3",
+          "value": "`active` IN (0,1)"
+        }
+      }
+    },
+    "service_prices": {
+      "name": "service_prices",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services_delivered_movements": {
+      "name": "services_delivered_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "services_delivered_service_idx": {
+          "name": "services_delivered_service_idx",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "services_delivered_document_idx": {
+          "name": "services_delivered_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "services_delivered_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "services_delivered_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "services_delivered_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "services_delivered_movements_check_1": {
+          "name": "services_delivered_movements_check_1",
+          "value": "`quantity` > 0"
+        },
+        "services_delivered_movements_check_2": {
+          "name": "services_delivered_movements_check_2",
+          "value": "`anatomical_regions_count` > 0"
+        }
+      }
+    },
+    "staff_members": {
+      "name": "staff_members",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patronymic": {
+          "name": "patronymic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_rank": {
+          "name": "military_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_title": {
+          "name": "position_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "staff_members_phone_idx": {
+          "name": "staff_members_phone_idx",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true,
+          "where": "`phone` != ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_output_movements": {
+      "name": "staff_output_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "units_delta": {
+          "name": "units_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_output_member_idx": {
+          "name": "staff_output_member_idx",
+          "columns": [
+            "organization_id",
+            "member_email",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "staff_output_document_role_idx": {
+          "name": "staff_output_document_role_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "staff_role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "staff_output_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "staff_output_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "staff_output_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_output_movements_check_1": {
+          "name": "staff_output_movements_check_1",
+          "value": "`staff_role` IN ('radiologist','radiographer')"
+        },
+        "staff_output_movements_check_2": {
+          "name": "staff_output_movements_check_2",
+          "value": "`units_delta` <> 0"
+        },
+        "staff_output_movements_check_3": {
+          "name": "staff_output_movements_check_3",
+          "value": "`anatomical_regions_count` > 0"
+        }
+      }
+    },
+    "staff_saved_views": {
+      "name": "staff_saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_saved_views_owner_surface_idx": {
+          "name": "staff_saved_views_owner_surface_idx",
+          "columns": [
+            "organization_id",
+            "member_email",
+            "surface",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_saved_views_organization_id_organizations_id_fk": {
+          "name": "staff_saved_views_organization_id_organizations_id_fk",
+          "tableFrom": "staff_saved_views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_saved_views_member_email_staff_members_email_fk": {
+          "name": "staff_saved_views_member_email_staff_members_email_fk",
+          "tableFrom": "staff_saved_views",
+          "tableTo": "staff_members",
+          "columnsFrom": [
+            "member_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_sessions": {
+      "name": "staff_sessions",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "staff_sessions_expiry_idx": {
+          "name": "staff_sessions_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_shift_assignments": {
+      "name": "staff_shift_assignments",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_email": {
+          "name": "staff_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_code": {
+          "name": "preset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_index": {
+          "name": "team_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_date": {
+          "name": "anchor_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_shift_assignments_org_idx": {
+          "name": "staff_shift_assignments_org_idx",
+          "columns": [
+            "organization_id",
+            "preset_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_shift_assignments_organization_id_staff_email_memberships_organization_id_member_email_fk": {
+          "name": "staff_shift_assignments_organization_id_staff_email_memberships_organization_id_member_email_fk",
+          "tableFrom": "staff_shift_assignments",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "organization_id",
+            "staff_email"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "member_email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "staff_shift_assignments_organization_id_staff_email_pk": {
+          "columns": [
+            "organization_id",
+            "staff_email"
+          ],
+          "name": "staff_shift_assignments_organization_id_staff_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_shift_assignments_check_1": {
+          "name": "staff_shift_assignments_check_1",
+          "value": "`team_index` >= 1"
+        },
+        "staff_shift_assignments_check_2": {
+          "name": "staff_shift_assignments_check_2",
+          "value": "length(`anchor_date`) = 10"
+        }
+      }
+    },
+    "staff_shift_overrides": {
+      "name": "staff_shift_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_email": {
+          "name": "staff_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shift_date": {
+          "name": "shift_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_shift_overrides_org_date_idx": {
+          "name": "staff_shift_overrides_org_date_idx",
+          "columns": [
+            "organization_id",
+            "shift_date",
+            "staff_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_shift_overrides_organization_id_staff_email_staff_shift_assignments_organization_id_staff_email_fk": {
+          "name": "staff_shift_overrides_organization_id_staff_email_staff_shift_assignments_organization_id_staff_email_fk",
+          "tableFrom": "staff_shift_overrides",
+          "tableTo": "staff_shift_assignments",
+          "columnsFrom": [
+            "organization_id",
+            "staff_email"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "staff_email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_shift_overrides_check_1": {
+          "name": "staff_shift_overrides_check_1",
+          "value": "`kind` IN ('day','evening','night','duty','work','off','recovery','leave','sick','custom')"
+        },
+        "staff_shift_overrides_check_2": {
+          "name": "staff_shift_overrides_check_2",
+          "value": "length(`shift_date`) = 10"
+        }
+      }
+    },
+    "staff_tasks": {
+      "name": "staff_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_email": {
+          "name": "assigned_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_entity_type": {
+          "name": "source_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "staff_tasks_org_source_idx": {
+          "name": "staff_tasks_org_source_idx",
+          "columns": [
+            "organization_id",
+            "source",
+            "source_entity_type",
+            "source_entity_id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_open_automation_idx": {
+          "name": "staff_tasks_org_open_automation_idx",
+          "columns": [
+            "organization_id",
+            "automation_key"
+          ],
+          "isUnique": true,
+          "where": "`status` = 'open' AND `automation_key` <> ''"
+        },
+        "staff_tasks_org_booking_idx": {
+          "name": "staff_tasks_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_assignee_idx": {
+          "name": "staff_tasks_org_assignee_idx",
+          "columns": [
+            "organization_id",
+            "assigned_email",
+            "status",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_status_due_idx": {
+          "name": "staff_tasks_org_status_due_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "due_date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_tasks_check_1": {
+          "name": "staff_tasks_check_1",
+          "value": "status IN ('open','done')"
+        },
+        "staff_tasks_check_2": {
+          "name": "staff_tasks_check_2",
+          "value": "priority IN ('low','normal','high')"
+        }
+      }
+    },
+    "supplier_cash_movements": {
+      "name": "supplier_cash_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_cash_account_time_idx": {
+          "name": "supplier_cash_account_time_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_cash_payment_unique": {
+          "name": "supplier_cash_payment_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_cash_movements_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_cash_movements_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_cash_movements_cash_account_id_cash_accounts_id_fk": {
+          "name": "supplier_cash_movements_cash_account_id_cash_accounts_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "cash_accounts",
+          "columnsFrom": [
+            "cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_cash_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_cash_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_cash_movements_check_1": {
+          "name": "supplier_cash_movements_check_1",
+          "value": "`amount_delta` < 0"
+        }
+      }
+    },
+    "supplier_payable_movements": {
+      "name": "supplier_payable_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receipt_document_id": {
+          "name": "receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_payable_supplier_time_idx": {
+          "name": "supplier_payable_supplier_time_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payable_payment_allocation_unique": {
+          "name": "supplier_payable_payment_allocation_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id",
+            "receipt_document_id"
+          ],
+          "isUnique": true,
+          "where": "`movement_type`='payment_settlement'"
+        },
+        "supplier_payable_receipt_accrual_unique": {
+          "name": "supplier_payable_receipt_accrual_unique",
+          "columns": [
+            "organization_id",
+            "receipt_document_id",
+            "supplier_counterparty_id"
+          ],
+          "isUnique": true,
+          "where": "`movement_type`='receipt_accrual'"
+        }
+      },
+      "foreignKeys": {
+        "supplier_payable_movements_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_payable_movements_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payable_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_payable_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payable_movements_receipt_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "supplier_payable_movements_receipt_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "receipt_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payable_movements_check_1": {
+          "name": "supplier_payable_movements_check_1",
+          "value": "`movement_type` IN ('receipt_accrual','payment_settlement')"
+        },
+        "supplier_payable_movements_check_2": {
+          "name": "supplier_payable_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "supplier_payment_allocations": {
+      "name": "supplier_payment_allocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receipt_document_id": {
+          "name": "receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_payment_allocation_receipt_idx": {
+          "name": "supplier_payment_allocation_receipt_idx",
+          "columns": [
+            "organization_id",
+            "receipt_document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payment_allocation_unique": {
+          "name": "supplier_payment_allocation_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id",
+            "receipt_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_payment_allocations_receipt_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "supplier_payment_allocations_receipt_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payment_allocations",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "receipt_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_allocations_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_payment_allocations_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payment_allocations",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payment_allocations_check_1": {
+          "name": "supplier_payment_allocations_check_1",
+          "value": "`amount` > 0"
+        }
+      }
+    },
+    "supplier_payment_documents": {
+      "name": "supplier_payment_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "supplier_payment_supplier_state_idx": {
+          "name": "supplier_payment_supplier_state_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "state",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payment_org_number_idx": {
+          "name": "supplier_payment_org_number_idx",
+          "columns": [
+            "organization_id",
+            "number"
+          ],
+          "isUnique": true,
+          "where": "`number` <> ''"
+        },
+        "supplier_payment_org_id_idx": {
+          "name": "supplier_payment_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_payment_documents_organization_id_organizations_id_fk": {
+          "name": "supplier_payment_documents_organization_id_organizations_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_documents_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_payment_documents_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_documents_cash_account_id_cash_accounts_id_fk": {
+          "name": "supplier_payment_documents_cash_account_id_cash_accounts_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "cash_accounts",
+          "columnsFrom": [
+            "cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payment_documents_check_1": {
+          "name": "supplier_payment_documents_check_1",
+          "value": "`amount` > 0"
+        },
+        "supplier_payment_documents_check_2": {
+          "name": "supplier_payment_documents_check_2",
+          "value": "`state` IN ('draft','posted','cancelled')"
+        }
+      }
+    },
+    "telegram_link_tokens": {
+      "name": "telegram_link_tokens",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "telegram_link_tokens_patient_idx": {
+          "name": "telegram_link_tokens_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "telegram_link_tokens_identity_scope_idx": {
+          "name": "telegram_link_tokens_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "telegram_link_tokens_org_phone_idx": {
+          "name": "telegram_link_tokens_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "warehouses": {
+      "name": "warehouses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "warehouses_org_active_name_idx": {
+          "name": "warehouses_org_active_name_idx",
+          "columns": [
+            "organization_id",
+            "active",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "warehouses_one_default_idx": {
+          "name": "warehouses_one_default_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "`is_default`=1"
+        },
+        "warehouses_org_code_idx": {
+          "name": "warehouses_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "warehouses_org_id_idx": {
+          "name": "warehouses_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "warehouses_organization_id_organizations_id_fk": {
+          "name": "warehouses_organization_id_organizations_id_fk",
+          "tableFrom": "warehouses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "warehouses_check_1": {
+          "name": "warehouses_check_1",
+          "value": "`active` IN (0,1)"
+        },
+        "warehouses_check_2": {
+          "name": "warehouses_check_2",
+          "value": "`is_default` IN (0,1)"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -2,803 +2,120 @@
   "version": "7",
   "dialect": "sqlite",
   "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1785102722000,
-      "tag": "0000_mute_typhoid_mary",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1785104912000,
-      "tag": "0001_domain_model",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "6",
-      "when": 1785127362000,
-      "tag": "0002_operations_reporting",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "6",
-      "when": 1785134774000,
-      "tag": "0003_execution_report_builder",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "6",
-      "when": 1785135357000,
-      "tag": "0004_generic_external_reference",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "6",
-      "when": 1785165694000,
-      "tag": "0005_protocol_documents",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "6",
-      "when": 1785165694000,
-      "tag": "0006_patient_crm",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "6",
-      "when": 1785165694000,
-      "tag": "0007_dicom_pacs",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "6",
-      "when": 1785358814000,
-      "tag": "0008_staff_auth",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "6",
-      "when": 1785358814000,
-      "tag": "0009_staff_self_service",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "6",
-      "when": 1785235545000,
-      "tag": "0010_department_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "6",
-      "when": 1785249056000,
-      "tag": "0011_service_prices",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "6",
-      "when": 1785252664000,
-      "tag": "0012_calendar_token",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "6",
-      "when": 1785253225000,
-      "tag": "0013_external_calendar",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "6",
-      "when": 1785309168000,
-      "tag": "0014_patient_reminders",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "6",
-      "when": 1785353300000,
-      "tag": "0015_tenant_foundation",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "6",
-      "when": 1785358814000,
-      "tag": "0016_security_hardening",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "6",
-      "when": 1785414597000,
-      "tag": "0017_staff_phone",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "6",
-      "when": 1785427452000,
-      "tag": "0018_booking_dob",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "6",
-      "when": 1785429911000,
-      "tag": "0019_site_content",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "6",
-      "when": 1785434472000,
-      "tag": "0020_patient_profile_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "6",
-      "when": 1785436032000,
-      "tag": "0021_whatsapp",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "6",
-      "when": 1785475681000,
-      "tag": "0022_drop_equipment",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "6",
-      "when": 1785500612000,
-      "tag": "0023_security_audit_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "6",
-      "when": 1785670591000,
-      "tag": "0024_staff_profiles",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "6",
-      "when": 1786375465000,
-      "tag": "0025_patient_telegram",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "6",
-      "when": 1786392254000,
-      "tag": "0026_booking_capacity_locks",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "6",
-      "when": 1786392254000,
-      "tag": "0027_booking_capacity_triggers",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "6",
-      "when": 1786393540000,
-      "tag": "0028_patient_otp",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "6",
-      "when": 1786397320000,
-      "tag": "0029_payment_transactions",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "6",
-      "when": 1786403939000,
-      "tag": "0030_analytics_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "6",
-      "when": 1786404446000,
-      "tag": "0031_pacs_tenant_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "6",
-      "when": 1786405508000,
-      "tag": "0032_mwl_bridge_tokens",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "6",
-      "when": 1786441324000,
-      "tag": "0033_security_audit_tenant_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "6",
-      "when": 1786648771000,
-      "tag": "0034_protocol_medical_access_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "6",
-      "when": 1786725268000,
-      "tag": "0035_patient_composite_identity",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "6",
-      "when": 1786730295000,
-      "tag": "0036_staff_tasks",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "6",
-      "when": 1786731617000,
-      "tag": "0037_inventory_stock",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "6",
-      "when": 1786733733000,
-      "tag": "0038_equipment_maintenance",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "6",
-      "when": 1786735609000,
-      "tag": "0039_staff_saved_views",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "6",
-      "when": 1786736309000,
-      "tag": "0040_booking_comments",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "6",
-      "when": 1786737530000,
-      "tag": "0041_operational_task_automation",
-      "breakpoints": true
-    },
-    {
-      "idx": 42,
-      "version": "6",
-      "when": 1786738496000,
-      "tag": "0042_study_custom_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 43,
-      "version": "6",
-      "when": 1786738980000,
-      "tag": "0043_protocol_tenant_integrity",
-      "breakpoints": true
-    },
-    {
-      "idx": 44,
-      "version": "6",
-      "when": 1786739434000,
-      "tag": "0044_protocol_lifecycle_projection",
-      "breakpoints": true
-    },
-    {
-      "idx": 45,
-      "version": "6",
-      "when": 1786740056000,
-      "tag": "0045_dicom_study_integrity",
-      "breakpoints": true
-    },
-    {
-      "idx": 46,
-      "version": "6",
-      "when": 1786741324000,
-      "tag": "0046_patient_session_identity_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 47,
-      "version": "6",
-      "when": 1786743839000,
-      "tag": "0047_protocol_revisions_append_only",
-      "breakpoints": true
-    },
-    {
-      "idx": 48,
-      "version": "6",
-      "when": 1786744656000,
-      "tag": "0048_security_audit_append_only",
-      "breakpoints": true
-    },
-    {
-      "idx": 49,
-      "version": "6",
-      "when": 1786779414000,
-      "tag": "0049_protocol_signing_lifecycle",
-      "breakpoints": true
-    },
-    {
-      "idx": 50,
-      "version": "6",
-      "when": 1786782603000,
-      "tag": "0050_patient_profile_id",
-      "breakpoints": true
-    },
-    {
-      "idx": 51,
-      "version": "6",
-      "when": 1786783229000,
-      "tag": "0051_booking_patient_link",
-      "breakpoints": true
-    },
-    {
-      "idx": 52,
-      "version": "6",
-      "when": 1786784914000,
-      "tag": "0052_patient_communication_identity",
-      "breakpoints": true
-    },
-    {
-      "idx": 53,
-      "version": "6",
-      "when": 1786793714000,
-      "tag": "0053_patient_session_patient_id",
-      "breakpoints": true
-    },
-    {
-      "idx": 54,
-      "version": "6",
-      "when": 1786797390000,
-      "tag": "0054_patient_shared_phone",
-      "breakpoints": true
-    },
-    {
-      "idx": 55,
-      "version": "6",
-      "when": 1786804067000,
-      "tag": "0055_protocol_issue_transition_audit",
-      "breakpoints": true
-    },
-    {
-      "idx": 56,
-      "version": "6",
-      "when": 1786818368000,
-      "tag": "0056_protocol_addendum_lifecycle",
-      "breakpoints": true
-    },
-    {
-      "idx": 57,
-      "version": "6",
-      "when": 1786819296000,
-      "tag": "0057_telegram_patient_identity",
-      "breakpoints": true
-    },
-    {
-      "idx": 58,
-      "version": "6",
-      "when": 1786823960000,
-      "tag": "0058_staff_task_booking_integrity",
-      "breakpoints": true
-    },
-    {
-      "idx": 59,
-      "version": "6",
-      "when": 1786913323000,
-      "tag": "0059_business_inventory_documents",
-      "breakpoints": true
-    },
-    {
-      "idx": 60,
-      "version": "6",
-      "when": 1786833879000,
-      "tag": "0060_business_document_composite_key",
-      "breakpoints": true
-    },
-    {
-      "idx": 61,
-      "version": "6",
-      "when": 1786833894000,
-      "tag": "0061_printed_form_document_state",
-      "breakpoints": true
-    },
-    {
-      "idx": 62,
-      "version": "6",
-      "when": 1786834314000,
-      "tag": "0062_inventory_document_integrity_hardening",
-      "breakpoints": true
-    },
-    {
-      "idx": 63,
-      "version": "6",
-      "when": 1786849031000,
-      "tag": "0063_finance_payment_documents",
-      "breakpoints": true
-    },
-    {
-      "idx": 64,
-      "version": "6",
-      "when": 1786849575000,
-      "tag": "0064_finance_transaction_status_integrity",
-      "breakpoints": true
-    },
-    {
-      "idx": 65,
-      "version": "6",
-      "when": 1786849617000,
-      "tag": "0065_finance_refund_source_crosslink",
-      "breakpoints": true
-    },
-    {
-      "idx": 66,
-      "version": "6",
-      "when": 1786864398000,
-      "tag": "0066_service_delivery_documents",
-      "breakpoints": true
-    },
-    {
-      "idx": 67,
-      "version": "6",
-      "when": 1786864757000,
-      "tag": "0067_service_delivery_draft_integrity",
-      "breakpoints": true
-    },
-    {
-      "idx": 68,
-      "version": "6",
-      "when": 1786865115000,
-      "tag": "0068_service_delivery_execution_posting",
-      "breakpoints": true
-    },
-    {
-      "idx": 69,
-      "version": "6",
-      "when": 1786871598000,
-      "tag": "0069_service_delivery_printed_forms",
-      "breakpoints": true
-    },
-    {
-      "idx": 70,
-      "version": "6",
-      "when": 1786872059000,
-      "tag": "0070_service_delivery_storno",
-      "breakpoints": true
-    },
-    {
-      "idx": 71,
-      "version": "6",
-      "when": 1786872488000,
-      "tag": "0071_service_storno_atomic_posting",
-      "breakpoints": true
-    },
-    {
-      "idx": 72,
-      "version": "6",
-      "when": 1786872594000,
-      "tag": "0072_service_storno_draft_hardening",
-      "breakpoints": true
-    },
-    {
-      "idx": 73,
-      "version": "6",
-      "when": 1786874111000,
-      "tag": "0073_patient_order_root",
-      "breakpoints": true
-    },
-    {
-      "idx": 74,
-      "version": "6",
-      "when": 1786874187000,
-      "tag": "0074_patient_order_basis_integrity",
-      "breakpoints": true
-    },
-    {
-      "idx": 75,
-      "version": "6",
-      "when": 1786874337000,
-      "tag": "0075_patient_order_guard_precedence",
-      "breakpoints": true
-    },
-    {
-      "idx": 76,
-      "version": "6",
-      "when": 1786890106000,
-      "tag": "0076_business_document_basis_guard_order",
-      "breakpoints": true
-    },
-    {
-      "idx": 77,
-      "version": "6",
-      "when": 1786890967000,
-      "tag": "0077_counterparties_suppliers",
-      "breakpoints": true
-    },
-    {
-      "idx": 78,
-      "version": "6",
-      "when": 1786891212000,
-      "tag": "0078_historical_supplier_trace",
-      "breakpoints": true
-    },
-    {
-      "idx": 79,
-      "version": "6",
-      "when": 1786897634000,
-      "tag": "0079_cash_accounts",
-      "breakpoints": true
-    },
-    {
-      "idx": 80,
-      "version": "6",
-      "when": 1786897634000,
-      "tag": "0080_cash_account_identity_hardening",
-      "breakpoints": true
-    },
-    {
-      "idx": 81,
-      "version": "6",
-      "when": 1786898844000,
-      "tag": "0081_warehouses",
-      "breakpoints": true
-    },
-    {
-      "idx": 82,
-      "version": "6",
-      "when": 1786902535000,
-      "tag": "0082_inventory_transfers",
-      "breakpoints": true
-    },
-    {
-      "idx": 83,
-      "version": "6",
-      "when": 1786906684000,
-      "tag": "0083_patient_order_lifecycle",
-      "breakpoints": true
-    },
-    {
-      "idx": 84,
-      "version": "6",
-      "when": 1786908234000,
-      "tag": "0084_supplier_payables",
-      "breakpoints": true
-    },
-    {
-      "idx": 86,
-      "version": "6",
-      "when": 1786908465000,
-      "tag": "0086_supplier_payment_snapshot_hardening",
-      "breakpoints": true
-    },
-    {
-      "idx": 87,
-      "version": "6",
-      "when": 1786908488000,
-      "tag": "0087_supplier_payable_historical_snapshot",
-      "breakpoints": true
-    },
-    {
-      "idx": 88,
-      "version": "6",
-      "when": 1786942163000,
-      "tag": "0088_staff_shift_calendar",
-      "breakpoints": true
-    },
-    {
-      "idx": 89,
-      "version": "6",
-      "when": 1786972048000,
-      "tag": "0089_organization_integration_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 90,
-      "version": "6",
-      "when": 1786996867000,
-      "tag": "0090_study_performance_registrar",
-      "breakpoints": true
-    },
-    {
-      "idx": 91,
-      "version": "6",
-      "when": 1786998600000,
-      "tag": "0091_study_performance_operational_ownership",
-      "breakpoints": true
-    },
-    {
-      "idx": 92,
-      "version": "6",
-      "when": 1787027307427,
-      "tag": "0092_result_delivery_registrar",
-      "breakpoints": true
-    },
-    {
-      "idx": 93,
-      "version": "6",
-      "when": 1787040759481,
-      "tag": "0093_study_correction_registrar",
-      "breakpoints": true
-    },
-    {
-      "idx": 94,
-      "version": "6",
-      "when": 1787057184417,
-      "tag": "0094_result_addendum_delivery",
-      "breakpoints": true
-    },
-    {
-      "idx": 95,
-      "version": "6",
-      "when": 1787063921664,
-      "tag": "0095_appointment_registrar",
-      "breakpoints": true
-    },
-    {
-      "idx": 96,
-      "version": "6",
-      "when": 1787070899234,
-      "tag": "0096_booking_cancellation_terminal",
-      "breakpoints": true
-    },
-    {
-      "idx": 97,
-      "version": "6",
-      "when": 1787071651845,
-      "tag": "0097_service_delivery_appointment_lineage",
-      "breakpoints": true
-    },
-    {
-      "idx": 98,
-      "version": "6",
-      "when": 1787073429419,
-      "tag": "0098_inventory_expense_valuation",
-      "breakpoints": true
-    },
-    {
-      "idx": 99,
-      "version": "6",
-      "when": 1787076426927,
-      "tag": "0099_service_material_reservations",
-      "breakpoints": true
-    },
-    {
-      "idx": 100,
-      "version": "6",
-      "when": 1787079999531,
-      "tag": "0100_reservation_material_consumption",
-      "breakpoints": true
-    },
-    {
-      "idx": 101,
-      "version": "6",
-      "when": 1787082714764,
-      "tag": "0101_saved_report_views",
-      "breakpoints": true
-    },
-    {
-      "idx": 102,
-      "version": "6",
-      "when": 1787092234804,
-      "tag": "0102_inventory_count_registrar",
-      "breakpoints": true
-    },
-    {
-      "idx": 103,
-      "version": "6",
-      "when": 1787161338553,
-      "tag": "0103_material_consumption_current_appointment",
-      "breakpoints": true
-    },
-    {
-      "idx": 104,
-      "version": "6",
-      "when": 1787174034821,
-      "tag": "0104_protocol_revision_derived_history",
-      "breakpoints": true
-    },
-    {
-      "idx": 105,
-      "version": "6",
-      "when": 1787176284261,
-      "tag": "0105_protocol_lifecycle_db_guard",
-      "breakpoints": true
-    },
-    {
-      "idx": 106,
-      "version": "6",
-      "when": 1787178043176,
-      "tag": "0106_protocol_clinical_completeness",
-      "breakpoints": true
-    },
-    {
-      "idx": 107,
-      "version": "6",
-      "when": 1787179061327,
-      "tag": "0107_signed_protocol_imaging_identity",
-      "breakpoints": true
-    },
-    {
-      "idx": 108,
-      "version": "6",
-      "when": 1787266380000,
-      "tag": "0108_personnel_directory",
-      "breakpoints": true
-    },
-    {
-      "idx": 109,
-      "version": "6",
-      "when": 1787268000000,
-      "tag": "0109_personnel_vlk_history",
-      "breakpoints": true
-    },
-    {
-      "idx": 110,
-      "version": "6",
-      "when": 1787271600000,
-      "tag": "0110_personnel_radiation_clearance",
-      "breakpoints": true
-    },
-    {
-      "idx": 111,
-      "version": "6",
-      "when": 1787275200000,
-      "tag": "0111_personnel_radiation_training",
-      "breakpoints": true
-    },
-    {
-      "idx": 112,
-      "version": "6",
-      "when": 1787278800000,
-      "tag": "0112_personnel_dosimetry",
-      "breakpoints": true
-    },
-    {
-      "idx": 113,
-      "version": "6",
-      "when": 1787282400000,
-      "tag": "0113_personnel_radiation_review_policy",
-      "breakpoints": true
-    },
-    {
-      "idx": 114,
-      "version": "6",
-      "when": 1787286000000,
-      "tag": "0114_personnel_radiation_monitoring_scope",
-      "breakpoints": true
-    }
+    {"idx":0,"version":"6","when":1785102722000,"tag":"0000_mute_typhoid_mary","breakpoints":true},
+    {"idx":1,"version":"6","when":1785104912000,"tag":"0001_domain_model","breakpoints":true},
+    {"idx":2,"version":"6","when":1785127362000,"tag":"0002_operations_reporting","breakpoints":true},
+    {"idx":3,"version":"6","when":1785134774000,"tag":"0003_execution_report_builder","breakpoints":true},
+    {"idx":4,"version":"6","when":1785135357000,"tag":"0004_generic_external_reference","breakpoints":true},
+    {"idx":5,"version":"6","when":1785165694000,"tag":"0005_protocol_documents","breakpoints":true},
+    {"idx":6,"version":"6","when":1785165694000,"tag":"0006_patient_crm","breakpoints":true},
+    {"idx":7,"version":"6","when":1785165694000,"tag":"0007_dicom_pacs","breakpoints":true},
+    {"idx":8,"version":"6","when":1785358814000,"tag":"0008_staff_auth","breakpoints":true},
+    {"idx":9,"version":"6","when":1785358814000,"tag":"0009_staff_self_service","breakpoints":true},
+    {"idx":10,"version":"6","when":1785235545000,"tag":"0010_department_settings","breakpoints":true},
+    {"idx":11,"version":"6","when":1785249056000,"tag":"0011_service_prices","breakpoints":true},
+    {"idx":12,"version":"6","when":1785252664000,"tag":"0012_calendar_token","breakpoints":true},
+    {"idx":13,"version":"6","when":1785253225000,"tag":"0013_external_calendar","breakpoints":true},
+    {"idx":14,"version":"6","when":1785309168000,"tag":"0014_patient_reminders","breakpoints":true},
+    {"idx":15,"version":"6","when":1785353300000,"tag":"0015_tenant_foundation","breakpoints":true},
+    {"idx":16,"version":"6","when":1785358814000,"tag":"0016_security_hardening","breakpoints":true},
+    {"idx":17,"version":"6","when":1785414597000,"tag":"0017_staff_phone","breakpoints":true},
+    {"idx":18,"version":"6","when":1785427452000,"tag":"0018_booking_dob","breakpoints":true},
+    {"idx":19,"version":"6","when":1785429911000,"tag":"0019_site_content","breakpoints":true},
+    {"idx":20,"version":"6","when":1785434472000,"tag":"0020_patient_profile_fields","breakpoints":true},
+    {"idx":21,"version":"6","when":1785436032000,"tag":"0021_whatsapp","breakpoints":true},
+    {"idx":22,"version":"6","when":1785475681000,"tag":"0022_drop_equipment","breakpoints":true},
+    {"idx":23,"version":"6","when":1785500612000,"tag":"0023_security_audit_log","breakpoints":true},
+    {"idx":24,"version":"6","when":1785670591000,"tag":"0024_staff_profiles","breakpoints":true},
+    {"idx":25,"version":"6","when":1786375465000,"tag":"0025_patient_telegram","breakpoints":true},
+    {"idx":26,"version":"6","when":1786392254000,"tag":"0026_booking_capacity_locks","breakpoints":true},
+    {"idx":27,"version":"6","when":1786392254000,"tag":"0027_booking_capacity_triggers","breakpoints":true},
+    {"idx":28,"version":"6","when":1786393540000,"tag":"0028_patient_otp","breakpoints":true},
+    {"idx":29,"version":"6","when":1786397320000,"tag":"0029_payment_transactions","breakpoints":true},
+    {"idx":30,"version":"6","when":1786403939000,"tag":"0030_analytics_events","breakpoints":true},
+    {"idx":31,"version":"6","when":1786404446000,"tag":"0031_pacs_tenant_scope","breakpoints":true},
+    {"idx":32,"version":"6","when":1786405508000,"tag":"0032_mwl_bridge_tokens","breakpoints":true},
+    {"idx":33,"version":"6","when":1786441324000,"tag":"0033_security_audit_tenant_scope","breakpoints":true},
+    {"idx":34,"version":"6","when":1786648771000,"tag":"0034_protocol_medical_access_scope","breakpoints":true},
+    {"idx":35,"version":"6","when":1786725268000,"tag":"0035_patient_composite_identity","breakpoints":true},
+    {"idx":36,"version":"6","when":1786730295000,"tag":"0036_staff_tasks","breakpoints":true},
+    {"idx":37,"version":"6","when":1786731617000,"tag":"0037_inventory_stock","breakpoints":true},
+    {"idx":38,"version":"6","when":1786733733000,"tag":"0038_equipment_maintenance","breakpoints":true},
+    {"idx":39,"version":"6","when":1786735609000,"tag":"0039_staff_saved_views","breakpoints":true},
+    {"idx":40,"version":"6","when":1786736309000,"tag":"0040_booking_comments","breakpoints":true},
+    {"idx":41,"version":"6","when":1786737530000,"tag":"0041_operational_task_automation","breakpoints":true},
+    {"idx":42,"version":"6","when":1786738496000,"tag":"0042_study_custom_fields","breakpoints":true},
+    {"idx":43,"version":"6","when":1786738980000,"tag":"0043_protocol_tenant_integrity","breakpoints":true},
+    {"idx":44,"version":"6","when":1786739434000,"tag":"0044_protocol_lifecycle_projection","breakpoints":true},
+    {"idx":45,"version":"6","when":1786740056000,"tag":"0045_dicom_study_integrity","breakpoints":true},
+    {"idx":46,"version":"6","when":1786741324000,"tag":"0046_patient_session_identity_scope","breakpoints":true},
+    {"idx":47,"version":"6","when":1786743839000,"tag":"0047_protocol_revisions_append_only","breakpoints":true},
+    {"idx":48,"version":"6","when":1786744656000,"tag":"0048_security_audit_append_only","breakpoints":true},
+    {"idx":49,"version":"6","when":1786779414000,"tag":"0049_protocol_signing_lifecycle","breakpoints":true},
+    {"idx":50,"version":"6","when":1786782603000,"tag":"0050_patient_profile_id","breakpoints":true},
+    {"idx":51,"version":"6","when":1786783229000,"tag":"0051_booking_patient_link","breakpoints":true},
+    {"idx":52,"version":"6","when":1786784914000,"tag":"0052_patient_communication_identity","breakpoints":true},
+    {"idx":53,"version":"6","when":1786793714000,"tag":"0053_patient_session_patient_id","breakpoints":true},
+    {"idx":54,"version":"6","when":1786797390000,"tag":"0054_patient_shared_phone","breakpoints":true},
+    {"idx":55,"version":"6","when":1786804067000,"tag":"0055_protocol_issue_transition_audit","breakpoints":true},
+    {"idx":56,"version":"6","when":1786818368000,"tag":"0056_protocol_addendum_lifecycle","breakpoints":true},
+    {"idx":57,"version":"6","when":1786819296000,"tag":"0057_telegram_patient_identity","breakpoints":true},
+    {"idx":58,"version":"6","when":1786823960000,"tag":"0058_staff_task_booking_integrity","breakpoints":true},
+    {"idx":59,"version":"6","when":1786913323000,"tag":"0059_business_inventory_documents","breakpoints":true},
+    {"idx":60,"version":"6","when":1786833879000,"tag":"0060_business_document_composite_key","breakpoints":true},
+    {"idx":61,"version":"6","when":1786833894000,"tag":"0061_printed_form_document_state","breakpoints":true},
+    {"idx":62,"version":"6","when":1786834314000,"tag":"0062_inventory_document_integrity_hardening","breakpoints":true},
+    {"idx":63,"version":"6","when":1786849031000,"tag":"0063_finance_payment_documents","breakpoints":true},
+    {"idx":64,"version":"6","when":1786849575000,"tag":"0064_finance_transaction_status_integrity","breakpoints":true},
+    {"idx":65,"version":"6","when":1786849617000,"tag":"0065_finance_refund_source_crosslink","breakpoints":true},
+    {"idx":66,"version":"6","when":1786864398000,"tag":"0066_service_delivery_documents","breakpoints":true},
+    {"idx":67,"version":"6","when":1786864757000,"tag":"0067_service_delivery_draft_integrity","breakpoints":true},
+    {"idx":68,"version":"6","when":1786865115000,"tag":"0068_service_delivery_execution_posting","breakpoints":true},
+    {"idx":69,"version":"6","when":1786871598000,"tag":"0069_service_delivery_printed_forms","breakpoints":true},
+    {"idx":70,"version":"6","when":1786872059000,"tag":"0070_service_delivery_storno","breakpoints":true},
+    {"idx":71,"version":"6","when":1786872488000,"tag":"0071_service_storno_atomic_posting","breakpoints":true},
+    {"idx":72,"version":"6","when":1786872594000,"tag":"0072_service_storno_draft_hardening","breakpoints":true},
+    {"idx":73,"version":"6","when":1786874111000,"tag":"0073_patient_order_root","breakpoints":true},
+    {"idx":74,"version":"6","when":1786874187000,"tag":"0074_patient_order_basis_integrity","breakpoints":true},
+    {"idx":75,"version":"6","when":1786874337000,"tag":"0075_patient_order_guard_precedence","breakpoints":true},
+    {"idx":76,"version":"6","when":1786890106000,"tag":"0076_business_document_basis_guard_order","breakpoints":true},
+    {"idx":77,"version":"6","when":1786890967000,"tag":"0077_counterparties_suppliers","breakpoints":true},
+    {"idx":78,"version":"6","when":1786891212000,"tag":"0078_historical_supplier_trace","breakpoints":true},
+    {"idx":79,"version":"6","when":1786897634000,"tag":"0079_cash_accounts","breakpoints":true},
+    {"idx":80,"version":"6","when":1786897634000,"tag":"0080_cash_account_identity_hardening","breakpoints":true},
+    {"idx":81,"version":"6","when":1786898844000,"tag":"0081_warehouses","breakpoints":true},
+    {"idx":82,"version":"6","when":1786902535000,"tag":"0082_inventory_transfers","breakpoints":true},
+    {"idx":83,"version":"6","when":1786906684000,"tag":"0083_patient_order_lifecycle","breakpoints":true},
+    {"idx":84,"version":"6","when":1786908234000,"tag":"0084_supplier_payables","breakpoints":true},
+    {"idx":86,"version":"6","when":1786908465000,"tag":"0086_supplier_payment_snapshot_hardening","breakpoints":true},
+    {"idx":87,"version":"6","when":1786908488000,"tag":"0087_supplier_payable_historical_snapshot","breakpoints":true},
+    {"idx":88,"version":"6","when":1786942163000,"tag":"0088_staff_shift_calendar","breakpoints":true},
+    {"idx":89,"version":"6","when":1786972048000,"tag":"0089_organization_integration_settings","breakpoints":true},
+    {"idx":90,"version":"6","when":1786996867000,"tag":"0090_study_performance_registrar","breakpoints":true},
+    {"idx":91,"version":"6","when":1786998600000,"tag":"0091_study_performance_operational_ownership","breakpoints":true},
+    {"idx":92,"version":"6","when":1787027307427,"tag":"0092_result_delivery_registrar","breakpoints":true},
+    {"idx":93,"version":"6","when":1787040759481,"tag":"0093_study_correction_registrar","breakpoints":true},
+    {"idx":94,"version":"6","when":1787057184417,"tag":"0094_result_addendum_delivery","breakpoints":true},
+    {"idx":95,"version":"6","when":1787063921664,"tag":"0095_appointment_registrar","breakpoints":true},
+    {"idx":96,"version":"6","when":1787070899234,"tag":"0096_booking_cancellation_terminal","breakpoints":true},
+    {"idx":97,"version":"6","when":1787071651845,"tag":"0097_service_delivery_appointment_lineage","breakpoints":true},
+    {"idx":98,"version":"6","when":1787073429419,"tag":"0098_inventory_expense_valuation","breakpoints":true},
+    {"idx":99,"version":"6","when":1787076426927,"tag":"0099_service_material_reservations","breakpoints":true},
+    {"idx":100,"version":"6","when":1787079999531,"tag":"0100_reservation_material_consumption","breakpoints":true},
+    {"idx":101,"version":"6","when":1787082714764,"tag":"0101_saved_report_views","breakpoints":true},
+    {"idx":102,"version":"6","when":1787092234804,"tag":"0102_inventory_count_registrar","breakpoints":true},
+    {"idx":103,"version":"6","when":1787161338553,"tag":"0103_material_consumption_current_appointment","breakpoints":true},
+    {"idx":104,"version":"6","when":1787174034821,"tag":"0104_protocol_revision_derived_history","breakpoints":true},
+    {"idx":105,"version":"6","when":1787176284261,"tag":"0105_protocol_lifecycle_db_guard","breakpoints":true},
+    {"idx":106,"version":"6","when":1787178043176,"tag":"0106_protocol_clinical_completeness","breakpoints":true},
+    {"idx":107,"version":"6","when":1787179061327,"tag":"0107_signed_protocol_imaging_identity","breakpoints":true},
+    {"idx":108,"version":"6","when":1787266380000,"tag":"0108_personnel_directory","breakpoints":true},
+    {"idx":109,"version":"6","when":1787268000000,"tag":"0109_personnel_vlk_history","breakpoints":true},
+    {"idx":110,"version":"6","when":1787271600000,"tag":"0110_personnel_radiation_clearance","breakpoints":true},
+    {"idx":111,"version":"6","when":1787275200000,"tag":"0111_personnel_radiation_training","breakpoints":true},
+    {"idx":112,"version":"6","when":1787278800000,"tag":"0112_personnel_dosimetry","breakpoints":true},
+    {"idx":113,"version":"6","when":1787282400000,"tag":"0113_personnel_radiation_review_policy","breakpoints":true},
+    {"idx":114,"version":"6","when":1787286000000,"tag":"0114_personnel_radiation_monitoring_scope","breakpoints":true},
+    {"idx":115,"version":"6","when":1787335200000,"tag":"0115_personnel_assignments_schedules","breakpoints":true}
   ]
 }

--- a/tests/personnel-assignments-schedules.test.mjs
+++ b/tests/personnel-assignments-schedules.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DatabaseSync } from "node:sqlite";
+import { readFile } from "node:fs/promises";
+
+const MIGRATION_URL = new URL("../drizzle/0115_personnel_assignments_schedules.sql", import.meta.url);
+const PERSONNEL_API_URL = new URL("../app/api/staff/personnel/route.ts", import.meta.url);
+const SHIFTS_API_URL = new URL("../app/api/staff/shifts/route.ts", import.meta.url);
+const PERSONNEL_PAGE_URL = new URL("../app/staff/personnel/page.tsx", import.meta.url);
+const SHIFTS_PAGE_URL = new URL("../app/staff/shifts/page.tsx", import.meta.url);
+
+function baseline() {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE departments (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      organization_id integer NOT NULL,
+      branch_id integer DEFAULT 0 NOT NULL,
+      name text NOT NULL,
+      active integer DEFAULT 1 NOT NULL,
+      created_at text DEFAULT CURRENT_TIMESTAMP NOT NULL
+    );
+    CREATE TABLE personnel_records (
+      id text PRIMARY KEY NOT NULL,
+      organization_id integer NOT NULL,
+      account_email text,
+      position_title text DEFAULT '' NOT NULL,
+      department_id integer,
+      display_name text DEFAULT '' NOT NULL,
+      created_at text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      updated_at text DEFAULT CURRENT_TIMESTAMP NOT NULL
+    );
+    CREATE TABLE staff_shift_assignments (
+      organization_id integer NOT NULL,
+      staff_email text NOT NULL,
+      preset_code text NOT NULL,
+      team_index integer NOT NULL,
+      anchor_date text NOT NULL,
+      created_by text NOT NULL,
+      created_at text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      updated_by text NOT NULL,
+      updated_at text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      PRIMARY KEY (organization_id, staff_email)
+    );
+    CREATE TABLE staff_shift_overrides (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      organization_id integer NOT NULL,
+      staff_email text NOT NULL,
+      shift_date text NOT NULL,
+      kind text NOT NULL,
+      label text DEFAULT '' NOT NULL,
+      start_time text DEFAULT '' NOT NULL,
+      end_time text DEFAULT '' NOT NULL,
+      note text DEFAULT '' NOT NULL,
+      created_by text NOT NULL,
+      created_at text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      updated_by text NOT NULL,
+      updated_at text DEFAULT CURRENT_TIMESTAMP NOT NULL
+    );
+    INSERT INTO departments (id, organization_id, name) VALUES
+      (1, 1, 'Відділення променевої діагностики'),
+      (2, 1, 'Пересувний рентгенівський кабінет (ПРК)'),
+      (3, 1, 'Кабінет ультразвукової діагностики (УЗД)'),
+      (20, 2, 'Чужий підрозділ');
+    INSERT INTO personnel_records
+      (id, organization_id, account_email, position_title, department_id, display_name)
+    VALUES
+      ('person-1', 1, 'one@example.test', 'Начальник відділення', 1, 'Працівник Один'),
+      ('person-accountless', 1, NULL, 'Рентгенолаборант ПРК', 2, 'Працівник Без Акаунта'),
+      ('person-other-org', 2, 'other@example.test', 'Лікар', 20, 'Працівник Іншої Організації');
+    INSERT INTO staff_shift_assignments
+      (organization_id, staff_email, preset_code, team_index, anchor_date, created_by, updated_by)
+    VALUES (1, 'one@example.test', 'calendar6-4', 1, '2026-08-01', 'admin', 'admin');
+    INSERT INTO staff_shift_overrides
+      (organization_id, staff_email, shift_date, kind, label, start_time, end_time, note, created_by, updated_by)
+    VALUES (1, 'one@example.test', '2026-08-03', 'leave', 'Вп', '', '', '', 'admin', 'admin');
+  `);
+  return db;
+}
+
+test("personnel assignment migration preserves one person with multiple service assignments", async () => {
+  const db = baseline();
+  try {
+    db.exec(await readFile(MIGRATION_URL, "utf8"));
+    const base = db.prepare(
+      "SELECT personnel_id AS personnelId, position_title AS positionTitle FROM personnel_assignments WHERE personnel_id = 'person-1'"
+    ).all();
+    assert.equal(base.length, 1);
+    assert.equal(base[0].positionTitle, "Начальник відділення");
+
+    assert.doesNotThrow(() => db.prepare(`
+      INSERT INTO personnel_assignments
+        (id, organization_id, personnel_id, department_id, position_title, assignment_kind,
+         starts_on, created_by, updated_by)
+      VALUES ('acting-1', 1, 'person-1', 2, 'ТВО начальника ПРК', 'acting',
+              '2026-08-01', 'admin', 'admin')
+    `).run());
+    assert.equal(db.prepare(
+      "SELECT COUNT(*) AS count FROM personnel_assignments WHERE personnel_id = 'person-1'"
+    ).get().count, 2);
+    assert.equal(db.prepare(
+      "SELECT COUNT(*) AS count FROM personnel_records WHERE id = 'person-1'"
+    ).get().count, 1);
+
+    assert.throws(() => db.prepare(`
+      INSERT INTO personnel_assignments
+        (id, organization_id, personnel_id, department_id, position_title, assignment_kind,
+         starts_on, created_by, updated_by)
+      VALUES ('primary-duplicate', 1, 'person-1', 2, 'Ще одна основна', 'primary',
+              '2026-08-01', 'admin', 'admin')
+    `).run(), /UNIQUE constraint failed/);
+  } finally { db.close(); }
+});
+
+test("department hierarchy and personnel scoped roster work without an account", async () => {
+  const db = baseline();
+  try {
+    db.exec(await readFile(MIGRATION_URL, "utf8"));
+    const prk = db.prepare(`
+      SELECT parent_department_id AS parentId, unit_type AS unitType
+      FROM department_structure WHERE organization_id = 1 AND department_id = 2
+    `).get();
+    assert.equal(prk.parentId, 1);
+    assert.equal(prk.unitType, "subdivision");
+
+    assert.doesNotThrow(() => db.prepare(`
+      INSERT INTO personnel_shift_assignments
+        (organization_id, personnel_id, preset_code, team_index, anchor_date, created_by, updated_by)
+      VALUES (1, 'person-accountless', 'calendar6-3', 1, '2026-08-01', 'admin', 'admin')
+    `).run());
+    assert.equal(db.prepare(
+      "SELECT preset_code AS presetCode FROM personnel_shift_assignments WHERE personnel_id = 'person-accountless'"
+    ).get().presetCode, "calendar6-3");
+
+    const migrated = db.prepare(
+      "SELECT personnel_id AS personnelId FROM personnel_shift_assignments WHERE personnel_id = 'person-1'"
+    ).get();
+    assert.equal(migrated.personnelId, "person-1");
+    assert.equal(db.prepare(
+      "SELECT kind FROM personnel_shift_overrides WHERE personnel_id = 'person-1' AND shift_date = '2026-08-03'"
+    ).get().kind, "leave");
+
+    assert.throws(() => db.prepare(`
+      INSERT INTO personnel_shift_assignments
+        (organization_id, personnel_id, preset_code, team_index, anchor_date, created_by, updated_by)
+      VALUES (1, 'person-other-org', 'calendar6-1', 1, '2026-08-01', 'admin', 'admin')
+    `).run(), /personnel_shift_assignment_scope/);
+  } finally { db.close(); }
+});
+
+test("work schedules keep seven-day normative templates separate from operational shifts", async () => {
+  const db = baseline();
+  try {
+    db.exec(await readFile(MIGRATION_URL, "utf8"));
+    db.prepare(`
+      INSERT INTO personnel_work_schedules
+        (id, organization_id, personnel_id, name, schedule_kind, valid_from,
+         weekly_minutes, created_by, updated_by)
+      VALUES ('schedule-1', 1, 'person-1', 'Основний режим', 'five_day', '2026-08-01',
+              2400, 'admin', 'admin')
+    `).run();
+    const insertDay = db.prepare(`
+      INSERT INTO personnel_work_schedule_days
+        (schedule_id, organization_id, weekday, is_working, start_time, end_time, break_start, break_end)
+      VALUES ('schedule-1', 1, ?, ?, ?, ?, ?, ?)
+    `);
+    for (let weekday = 1; weekday <= 7; weekday += 1) {
+      const working = weekday <= 5;
+      insertDay.run(weekday, working ? 1 : 0, working ? '08:30' : '', working ? '17:30' : '', working ? '12:30' : '', working ? '13:30' : '');
+    }
+    assert.equal(db.prepare(
+      "SELECT COUNT(*) AS count FROM personnel_work_schedule_days WHERE schedule_id = 'schedule-1'"
+    ).get().count, 7);
+    assert.equal(db.prepare(
+      "SELECT COUNT(*) AS count FROM personnel_shift_assignments WHERE personnel_id = 'person-1'"
+    ).get().count, 1, "operational roster remains a separate register");
+
+    assert.throws(() => db.prepare(`
+      INSERT INTO personnel_work_schedules
+        (id, organization_id, personnel_id, name, schedule_kind, valid_from,
+         weekly_minutes, created_by, updated_by)
+      VALUES ('bad-schedule', 1, 'person-other-org', 'Bad', 'individual', '2026-08-01',
+              0, 'admin', 'admin')
+    `).run(), /personnel_work_schedule_scope/);
+  } finally { db.close(); }
+});
+
+test("personnel and shift source contracts use stable personnelId and expose the integrated HR card", async () => {
+  const [personnelApi, shiftsApi, personnelPage, shiftsPage] = await Promise.all([
+    readFile(PERSONNEL_API_URL, "utf8"), readFile(SHIFTS_API_URL, "utf8"),
+    readFile(PERSONNEL_PAGE_URL, "utf8"), readFile(SHIFTS_PAGE_URL, "utf8"),
+  ]);
+  assert.match(personnelApi, /personnel_assignments/);
+  assert.match(personnelApi, /personnel_work_schedules/);
+  assert.match(personnelApi, /weeklyMinutes/);
+  assert.match(personnelApi, /vlkDecisionCode/);
+  assert.match(shiftsApi, /personnel_shift_assignments/);
+  assert.match(shiftsApi, /body\.personnelId/);
+  assert.match(shiftsApi, /p\.account_email = \?/);
+  assert.match(personnelPage, /Призначення і посадові обов’язки/);
+  assert.match(personnelPage, /Графік роботи/);
+  assert.match(personnelPage, /Працівник не дублюється/);
+  assert.match(shiftsPage, /без акаунта/);
+  assert.match(shiftsPage, /personnelId/);
+});

--- a/tests/staff-shift-calendar.behavior.test.mjs
+++ b/tests/staff-shift-calendar.behavior.test.mjs
@@ -4,47 +4,42 @@ import { readFile } from "node:fs/promises";
 import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
-
-function get(path, cookie) {
-  return jsonRequest(path, undefined, { method:"GET", headers:{ cookie } });
-}
-
-function post(path, cookie, body) {
-  return jsonRequest(path, body, { method:"POST", headers:{ cookie } });
-}
+function get(path, cookie) { return jsonRequest(path, undefined, {method:"GET",headers:{cookie}}); }
+function post(path, cookie, body) { return jsonRequest(path, body, {method:"POST",headers:{cookie}}); }
 
 async function addOrgTwo(db) {
-  await db.prepare(
-    "INSERT OR IGNORE INTO organizations (id, slug, name, active) VALUES (2, 'shift-org-two', 'Shift Org Two', 1)"
-  ).run();
+  await db.prepare("INSERT OR IGNORE INTO organizations (id, slug, name, active) VALUES (2, 'shift-org-two', 'Shift Org Two', 1)").run();
 }
 
 async function seedScopedStaffSession(db, options) {
   const organizationId = Number(options.organizationId || 1);
-  const cookie = await seedStaffSession(db, { ...options, withMembership:false });
+  const cookie = await seedStaffSession(db, {...options,withMembership:false});
   const existing = await db.prepare(
-    `SELECT 1 AS ok FROM memberships
-     WHERE organization_id = ? AND member_email = ? LIMIT 1`
+    `SELECT 1 AS ok FROM memberships WHERE organization_id = ? AND member_email = ? LIMIT 1`
   ).bind(organizationId, options.email).first();
   if (existing) {
-    await db.prepare(
-      `UPDATE memberships SET role = ?, active = 1
-       WHERE organization_id = ? AND member_email = ?`
-    ).bind(options.role, organizationId, options.email).run();
+    await db.prepare("UPDATE memberships SET role = ?, active = 1 WHERE organization_id = ? AND member_email = ?")
+      .bind(options.role, organizationId, options.email).run();
   } else {
-    await db.prepare(
-      `INSERT INTO memberships (organization_id, member_email, role, active)
-       VALUES (?, ?, ?, 1)`
-    ).bind(organizationId, options.email, options.role).run();
+    await db.prepare("INSERT INTO memberships (organization_id, member_email, role, active) VALUES (?, ?, ?, 1)")
+      .bind(organizationId, options.email, options.role).run();
   }
   return cookie;
 }
 
+async function ensurePersonnel(db, {organizationId=1,email=null,displayName="Працівник",positionTitle="Лікар-рентгенолог",id}) {
+  const personnelId = id || `personnel-test-${organizationId}-${String(email || displayName).replace(/[^a-z0-9]+/gi,"-").toLowerCase()}`;
+  await db.prepare(`
+    INSERT OR IGNORE INTO personnel_records
+      (id, organization_id, account_email, display_name, position_title, active, created_by, updated_by)
+    VALUES (?, ?, ?, ?, ?, 1, 'test', 'test')
+  `).bind(personnelId, organizationId, email, displayName, positionTitle).run();
+  return personnelId;
+}
+
 test("Calendar6 port keeps the eight source schedule types and exact matrix concepts", async () => {
   const source = await read("lib/shift-calendar.ts");
-  for (let index = 1; index <= 8; index += 1) {
-    assert.match(source, new RegExp(`code:"calendar6-${index}"`));
-  }
+  for (let index=1; index<=8; index+=1) assert.match(source, new RegExp(`code:"calendar6-${index}"`));
   assert.match(source, /День — ніч — троє вдома/);
   assert.match(source, /Два дні через два/);
   assert.match(source, /Доба — троє/);
@@ -56,131 +51,114 @@ test("Calendar6 port keeps the eight source schedule types and exact matrix conc
   assert.match(source, /resolvePresetShift/);
 });
 
-test("staff shift calendar is tenant scoped, self scoped for clinicians, and manager writable", async () => {
+test("staff shift calendar is personnel keyed, tenant scoped, self scoped for clinicians, and manager writable", async () => {
   await withD1(async (db) => {
     await addOrgTwo(db);
-    const adminCookie = await seedStaffSession(db, {
-      email:"shift-admin@example.com", role:"admin", displayName:"Shift Admin", organizationId:1,
-    });
-    await seedStaffSession(db, {
-      email:"doctor-one@example.com", role:"radiologist", displayName:"Doctor One", organizationId:1,
-    });
-    await seedStaffSession(db, {
-      email:"doctor-two@example.com", role:"radiologist", displayName:"Doctor Two", organizationId:2,
-    });
-    const doctorCookie = await seedStaffSession(db, {
-      email:"doctor-self@example.com", role:"radiologist", displayName:"Doctor Self", organizationId:1,
-    });
+    const adminCookie = await seedStaffSession(db, {email:"shift-admin@example.com",role:"admin",displayName:"Shift Admin",organizationId:1});
+    await ensurePersonnel(db,{email:"shift-admin@example.com",displayName:"Shift Admin",positionTitle:"Адміністратор"});
 
-    const list = await callWorker(get("/api/staff/shifts?month=2026-08", adminCookie), db);
-    assert.equal(list.status, 200);
+    await seedStaffSession(db,{email:"doctor-one@example.com",role:"radiologist",displayName:"Doctor One",organizationId:1});
+    const doctorOneId = await ensurePersonnel(db,{email:"doctor-one@example.com",displayName:"Doctor One"});
+
+    await seedStaffSession(db,{email:"doctor-two@example.com",role:"radiologist",displayName:"Doctor Two",organizationId:2});
+    const doctorTwoId = await ensurePersonnel(db,{organizationId:2,email:"doctor-two@example.com",displayName:"Doctor Two"});
+
+    const doctorCookie = await seedStaffSession(db,{email:"doctor-self@example.com",role:"radiologist",displayName:"Doctor Self",organizationId:1});
+    const doctorSelfId = await ensurePersonnel(db,{email:"doctor-self@example.com",displayName:"Doctor Self"});
+
+    const accountlessId = await ensurePersonnel(db,{email:null,displayName:"Accountless Radiographer",positionTitle:"Рентгенолаборант",id:"personnel-accountless-shift"});
+
+    const list = await callWorker(get("/api/staff/shifts?month=2026-08",adminCookie),db);
+    assert.equal(list.status,200);
     const listBody = await list.json();
-    assert.equal(listBody.canManage, true);
-    assert.ok(listBody.people.some((row) => row.email === "doctor-one@example.com"));
-    assert.ok(listBody.people.every((row) => row.email !== "doctor-two@example.com"));
-    assert.equal(listBody.presets.length, 8);
+    assert.equal(listBody.canManage,true);
+    assert.ok(listBody.people.some((row)=>row.personnelId===doctorOneId && row.email==="doctor-one@example.com"));
+    assert.ok(listBody.people.some((row)=>row.personnelId===accountlessId && row.accountEmail===null));
+    assert.ok(listBody.people.every((row)=>row.personnelId!==doctorTwoId));
+    assert.equal(listBody.presets.length,8);
 
-    const assign = await callWorker(post("/api/staff/shifts", adminCookie, {
-      action:"assignment",
-      staffEmail:"doctor-one@example.com",
-      presetCode:"calendar6-4",
-      teamIndex:4,
-      anchorDate:"2026-08-01",
-    }), db);
-    assert.equal(assign.status, 200);
+    const assign = await callWorker(post("/api/staff/shifts",adminCookie,{
+      action:"assignment",personnelId:doctorOneId,presetCode:"calendar6-4",teamIndex:4,anchorDate:"2026-08-01",
+    }),db);
+    assert.equal(assign.status,200);
 
-    const crossTenant = await callWorker(post("/api/staff/shifts", adminCookie, {
-      action:"assignment",
-      staffEmail:"doctor-two@example.com",
-      presetCode:"calendar6-2",
-      teamIndex:1,
-      anchorDate:"2026-08-01",
-    }), db);
-    assert.equal(crossTenant.status, 404);
+    const legacyCompatibility = await callWorker(post("/api/staff/shifts",adminCookie,{
+      action:"assignment",staffEmail:"doctor-one@example.com",presetCode:"calendar6-4",teamIndex:4,anchorDate:"2026-08-01",
+    }),db);
+    assert.equal(legacyCompatibility.status,200);
 
-    const override = await callWorker(post("/api/staff/shifts", adminCookie, {
-      action:"override",
-      staffEmail:"doctor-one@example.com",
-      shiftDate:"2026-08-03",
-      kind:"leave",
-      label:"Вп",
-      startTime:"",
-      endTime:"",
-      note:"Планова відпустка",
-    }), db);
-    assert.equal(override.status, 200);
+    const accountlessAssign = await callWorker(post("/api/staff/shifts",adminCookie,{
+      action:"assignment",personnelId:accountlessId,presetCode:"calendar6-3",teamIndex:1,anchorDate:"2026-08-01",
+    }),db);
+    assert.equal(accountlessAssign.status,200);
 
-    const updated = await callWorker(get("/api/staff/shifts?month=2026-08", adminCookie), db);
+    const crossTenant = await callWorker(post("/api/staff/shifts",adminCookie,{
+      action:"assignment",personnelId:doctorTwoId,presetCode:"calendar6-2",teamIndex:1,anchorDate:"2026-08-01",
+    }),db);
+    assert.equal(crossTenant.status,404);
+
+    const override = await callWorker(post("/api/staff/shifts",adminCookie,{
+      action:"override",personnelId:doctorOneId,shiftDate:"2026-08-03",kind:"leave",label:"Вп",
+      startTime:"",endTime:"",note:"Планова відпустка",
+    }),db);
+    assert.equal(override.status,200);
+
+    const updated = await callWorker(get("/api/staff/shifts?month=2026-08",adminCookie),db);
     const updatedBody = await updated.json();
-    assert.deepEqual(updatedBody.assignments, [{
-      staffEmail:"doctor-one@example.com",
-      presetCode:"calendar6-4",
-      teamIndex:4,
-      anchorDate:"2026-08-01",
-    }]);
-    assert.equal(updatedBody.overrides.length, 1);
-    assert.equal(updatedBody.overrides[0].kind, "leave");
+    const doctorAssignment = updatedBody.assignments.find((row)=>row.personnelId===doctorOneId);
+    assert.equal(doctorAssignment.staffEmail,"doctor-one@example.com");
+    assert.equal(doctorAssignment.presetCode,"calendar6-4");
+    assert.ok(updatedBody.assignments.some((row)=>row.personnelId===accountlessId && row.staffEmail===""));
+    assert.equal(updatedBody.overrides.length,1);
+    assert.equal(updatedBody.overrides[0].personnelId,doctorOneId);
+    assert.equal(updatedBody.overrides[0].kind,"leave");
 
-    const self = await callWorker(get("/api/staff/shifts?month=2026-08", doctorCookie), db);
-    assert.equal(self.status, 200);
+    const self = await callWorker(get("/api/staff/shifts?month=2026-08",doctorCookie),db);
+    assert.equal(self.status,200);
     const selfBody = await self.json();
-    assert.equal(selfBody.canManage, false);
-    assert.deepEqual(selfBody.people.map((row) => row.email), ["doctor-self@example.com"]);
-    assert.deepEqual(selfBody.assignments, []);
+    assert.equal(selfBody.canManage,false);
+    assert.equal(selfBody.personnelLinked,true);
+    assert.deepEqual(selfBody.people.map((row)=>row.personnelId),[doctorSelfId]);
+    assert.deepEqual(selfBody.assignments,[]);
 
-    const denied = await callWorker(post("/api/staff/shifts", doctorCookie, {
-      action:"assignment",
-      staffEmail:"doctor-self@example.com",
-      presetCode:"calendar6-2",
-      teamIndex:1,
-      anchorDate:"2026-08-01",
-    }), db);
-    assert.equal(denied.status, 403);
+    const denied = await callWorker(post("/api/staff/shifts",doctorCookie,{
+      action:"assignment",personnelId:doctorSelfId,presetCode:"calendar6-2",teamIndex:1,anchorDate:"2026-08-01",
+    }),db);
+    assert.equal(denied.status,403);
 
-    const csv = await callWorker(get("/api/staff/shifts?month=2026-08&format=csv", adminCookie), db);
-    assert.equal(csv.status, 200);
-    assert.match(csv.headers.get("content-type") || "", /text\/csv/);
+    const csv = await callWorker(get("/api/staff/shifts?month=2026-08&format=csv",adminCookie),db);
+    assert.equal(csv.status,200);
+    assert.match(csv.headers.get("content-type") || "",/text\/csv/);
     const csvText = await csv.text();
-    assert.match(csvText, /Doctor One/);
-    assert.doesNotMatch(csvText, /Doctor Two/);
-    assert.match(csvText, /Вп/);
+    assert.match(csvText,/Doctor One/);
+    assert.match(csvText,/Accountless Radiographer/);
+    assert.doesNotMatch(csvText,/Doctor Two/);
+    assert.match(csvText,/Вп/);
   });
 });
 
-test("department head can manage staff shifts while organization admin stays control-plane only", async () => {
+test("department head can manage personnel shifts while organization admin stays control-plane only", async () => {
   await withD1(async (db) => {
-    const headCookie = await seedScopedStaffSession(db, {
-      email:"shift-department-head@example.com", role:"department_head", displayName:"Department Head", organizationId:1,
-    });
-    await seedScopedStaffSession(db, {
-      email:"shift-radiographer@example.com", role:"radiographer", displayName:"Radiographer", organizationId:1,
-    });
-    const sysCookie = await seedScopedStaffSession(db, {
-      email:"shift-system-admin@example.com", role:"organization_admin", displayName:"System Admin", organizationId:1,
-    });
+    const headCookie = await seedScopedStaffSession(db,{email:"shift-department-head@example.com",role:"department_head",displayName:"Department Head",organizationId:1});
+    await ensurePersonnel(db,{email:"shift-department-head@example.com",displayName:"Department Head",positionTitle:"Начальник відділення"});
+    await seedScopedStaffSession(db,{email:"shift-radiographer@example.com",role:"radiographer",displayName:"Radiographer",organizationId:1});
+    const radiographerId = await ensurePersonnel(db,{email:"shift-radiographer@example.com",displayName:"Radiographer",positionTitle:"Рентгенолаборант"});
+    const sysCookie = await seedScopedStaffSession(db,{email:"shift-system-admin@example.com",role:"organization_admin",displayName:"System Admin",organizationId:1});
+    await ensurePersonnel(db,{email:"shift-system-admin@example.com",displayName:"System Admin",positionTitle:"System Admin"});
 
-    const headSave = await callWorker(post("/api/staff/shifts", headCookie, {
-      action:"assignment",
-      staffEmail:"shift-radiographer@example.com",
-      presetCode:"calendar6-1",
-      teamIndex:2,
-      anchorDate:"2026-08-17",
-    }), db);
-    assert.equal(headSave.status, 200);
+    const headSave = await callWorker(post("/api/staff/shifts",headCookie,{
+      action:"assignment",personnelId:radiographerId,presetCode:"calendar6-1",teamIndex:2,anchorDate:"2026-08-17",
+    }),db);
+    assert.equal(headSave.status,200);
 
-    const sysSave = await callWorker(post("/api/staff/shifts", sysCookie, {
-      action:"assignment",
-      staffEmail:"shift-radiographer@example.com",
-      presetCode:"calendar6-1",
-      teamIndex:1,
-      anchorDate:"2026-08-17",
-    }), db);
-    assert.equal(sysSave.status, 403);
+    const sysSave = await callWorker(post("/api/staff/shifts",sysCookie,{
+      action:"assignment",personnelId:radiographerId,presetCode:"calendar6-1",teamIndex:1,anchorDate:"2026-08-17",
+    }),db);
+    assert.equal(sysSave.status,403);
 
     const auditRows = await db.prepare(
-      `SELECT action, organization_id AS organizationId
-       FROM security_audit_log WHERE action LIKE 'staff_shift_%' ORDER BY id`
+      "SELECT action, organization_id AS organizationId FROM security_audit_log WHERE action LIKE 'staff_shift_%' ORDER BY id"
     ).all();
-    assert.ok(auditRows.results.some((row) => row.action === "staff_shift_assignment_saved" && row.organizationId === 1));
+    assert.ok(auditRows.results.some((row)=>row.action==="staff_shift_assignment_saved" && row.organizationId===1));
   });
 });


### PR DESCRIPTION
## Що змінено
- одна кадрова картка `personnelId` може мати кілька службових призначень (основне, ТВО, додаткове, тимчасове) з датами, підрозділом, обов’язками та підставою;
- додано структурний зв’язок «відділення → підрозділ/кабінет» без дублювання працівника;
- додано окремий нормативний `Графік роботи` (7 днів, час, перерва, строк дії, тижнева норма);
- Calendar6/чергування переведено на `personnelId`, тому працівник може бути в розкладі без облікового запису RadiologyOS;
- старі shift-дані мігруються через зв’язаний `account_email`, старий `staffEmail` приймається API як перехідна сумісність;
- кадрова картка показує актуальний статус ВЛК і посилання на існуючі реєстри ДІВ/навчання/дозиметрії;
- додано tenant-scope DB triggers та regression-тести.

## Приватність
Жодні ПІБ, адреси, телефони чи дати народження з робочої відомості не внесені в git або migration seed. Документ використовувався лише для валідації моделі «одна людина — кілька призначень».

## Не входить у цей PR
Завантаження кадрових файлів буде окремим приватним R2-модулем; `PRINTED_FORMS` для цього не перевикористовується.

Production deploy не запускається.