### PR TITLE
Публічний запис: повернути вибір часу (слот-пікер був не під'єднаний)

### DIFF
--- a/public/site/assets/cart.js
+++ b/public/site/assets/cart.js
@@ -37,6 +37,7 @@ function renderCart() {
     ? cart.map(x => `<div class="cart-item"><div><strong>${x.name}</strong><small>Код ${x.code}</small></div><div style="text-align:right"><strong>${money(x.price)}</strong><br><button class="remove-item" onclick="removeFromCart('${x.code}')">Видалити</button></div></div>`).join('')
     : '<div class="cart-empty">Ви ще не додали жодної послуги.</div>';
   document.getElementById('cartTotal').textContent = money(cart.reduce((s, x) => s + x.price, 0));
+  refreshSlotPicker();
 }
 
 function openCart() {

--- a/public/site/index.html
+++ b/public/site/index.html
@@ -470,7 +470,12 @@ nav{margin-left:auto;display:flex;align-items:center;gap:12px;flex-shrink:0;font
       </div>
 
       <div class="form-step">
-        <div class="step-title"><span class="step-num">2</span>Надіслати заявку</div>
+        <div class="step-title"><span class="step-num">2</span>Оберіть зручний час</div>
+        <div class="slot-picker" id="slotPicker"></div>
+      </div>
+
+      <div class="form-step">
+        <div class="step-title"><span class="step-num">3</span>Надіслати заявку</div>
         <p class="cart-note"><strong>Візьміть із собою попередні медичні документи.</strong> Завантаження документів через сайт не виконується.</p>
         <div class="field">
           <label for="comment">Коментар <span class="opt">(необов’язково)</span></label>

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -471,7 +471,12 @@ body{background:#f3f6f8}
       </div>
 
       <div class="form-step">
-        <div class="step-title"><span class="step-num">2</span>Надіслати заявку</div>
+        <div class="step-title"><span class="step-num">2</span>Оберіть зручний час</div>
+        <div class="slot-picker" id="slotPicker"></div>
+      </div>
+
+      <div class="form-step">
+        <div class="step-title"><span class="step-num">3</span>Надіслати заявку</div>
         <p class="cart-note"><strong>Візьміть із собою попередні медичні документи.</strong> Завантаження документів через сайт не виконується.</p>
         <div class="field">
           <label for="comment">Коментар <span class="opt">(необов’язково)</span></label>

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -133,14 +133,19 @@ test("the payment QR renders on the site and in the cabinet; button only for rea
   assert.match(cabinet, /isPayUrl\(payLink\)/);
 });
 
-test("the public request does not force patients to choose a slot", async () => {
+test("civilian public request offers an optional preferred-time picker (not forced)", async () => {
   const bridge = await read("public/site/assets/d1-bridge.js");
-  assert.match(bridge, /const desiredDate = ''/);
-  assert.match(bridge, /const desiredTime = ''/);
-  for (const page of ["public/site/index.html", "public/site/price.html", "public/site/military.html"]) {
+  // Submit is never blocked on a chosen slot: desiredDate/desiredTime fall back to ''.
+  assert.match(bridge, /desiredTime = \(typeof pickedSlot[^\n]*pickedSlot\.time\) \? pickedSlot\.time : ''/);
+  // Civilian booking pages expose the optional slot picker (patient suggests a time,
+  // registrar confirms). Wiring lives in cart.js -> refreshSlotPicker().
+  for (const page of ["public/site/index.html", "public/site/price.html"]) {
     const html = await read(page);
-    assert.doesNotMatch(html, /id="(?:mil)?[Ss]lotPicker"/);
+    assert.match(html, /id="slotPicker"/);
   }
+  // Military referral form stays slot-free — scheduling is by referral, not self-service.
+  const military = await read("public/site/military.html");
+  assert.doesNotMatch(military, /id="(?:mil)?[Ss]lotPicker"/);
 });
 
 test("the military free-booking form saves to D1 as category 'military'", async () => {


### PR DESCRIPTION
## Навіщо

За фідбеком — **у формі запису немає вибору часу**. Розслідування показало: вся інфраструктура вибору вільного часу вже існувала, але не була до кінця під'єднана.

## Причина

- `slots.js` — `initSlotPicker()` (тягне вільні слоти з `/api/availability`) ✅
- `cart.js` — `refreshSlotPicker()` + `onPick`, `d1-bridge.js` читає `pickedSlot` ✅
- **АЛЕ:** у формі не було точки монтування `#slotPicker`, а `refreshSlotPicker()` був визначений, але **ніде не викликався**. Тож пікер ніколи не з'являвся.

## Що зроблено

- `index.html` + `price.html`: доданий крок **«Оберіть зручний час»** з `<div id="slotPicker">` (крок «Надіслати заявку» перенумеровано на 3).
- `cart.js`: `renderCart()` тепер викликає `refreshSlotPicker()` — пікер монтується й оновлюється разом із кошиком (за першою послугою тягне вільні слоти з розкладу).

## Модель

Вибір **не обов'язковий**: без обраного слота `desiredDate/desiredTime = ''`, заявка все одно надсилається — «пацієнт пропонує зручний час, реєстратура підтверджує». Мілітарі-форма (за направленням) лишається без слота. Тест `site-bridge` оновлено під нову вимогу (був: «пікера нема»; став: «пікер є, але не примусовий»).

## Перевірки

- `947/947` тестів; `npm run build` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_