### PR TITLE
Публічний запис: кешувати дані пацієнта й підставляти автоматично

### DIFF
--- a/public/site/assets/d1-bridge.js
+++ b/public/site/assets/d1-bridge.js
@@ -131,16 +131,39 @@
     }
   }
 
-  function rememberPatient(phone, dob) {
+  // Persist the patient's own details so the next visit prefills automatically.
+  // sessionStorage carries the cabinet auto-enter hint; localStorage keeps the
+  // details across sessions on this device.
+  const PATIENT_CACHE_KEY = 'radiologyos_patient_v1';
+  function rememberPatient(phone, dob, name) {
+    const phone9 = String(phone).replace(/\D/g, '').slice(-9);
     try {
-      sessionStorage.setItem(PATIENT_PREFILL_KEY, JSON.stringify({
-        phone: String(phone).replace(/\D/g, '').slice(-9),
-        dob: String(dob || ''),
-        autoEnter: true,
-      }));
+      sessionStorage.setItem(PATIENT_PREFILL_KEY, JSON.stringify({ phone: phone9, dob: String(dob || ''), autoEnter: true }));
     } catch (e) { /* приватний режим може блокувати storage */ }
+    try {
+      localStorage.setItem(PATIENT_CACHE_KEY, JSON.stringify({ name: String(name || '').trim(), phone: phone9, dob: String(dob || '') }));
+    } catch (e) { /* ignore */ }
   }
 
+  function readPatientCache() {
+    try { return JSON.parse(localStorage.getItem(PATIENT_CACHE_KEY) || 'null') || {}; }
+    catch (e) { return {}; }
+  }
+
+  // Prefill the booking form from the cached details (only empty fields).
+  // Must run before prepareIdentityFields so the date-of-birth dropdowns pick
+  // up the saved value.
+  function prefillPatientForm() {
+    const c = readPatientCache();
+    const phone9 = String(c.phone || '').replace(/\D/g, '').slice(-9);
+    const dob = /^\d{4}-\d{2}-\d{2}$/.test(String(c.dob || '')) ? c.dob : '';
+    const set = (id, value) => { const el = document.getElementById(id); if (el && value && !el.value) el.value = value; };
+    set('patientName', c.name); set('militaryPatientName', c.name);
+    set('patientPhone', phone9); set('militaryPatientPhone', phone9);
+    set('patientDob', dob); set('militaryPatientDob', dob);
+  }
+
+  prefillPatientForm();
   prepareIdentityFields('patientName', 'patientDob');
   prepareIdentityFields('militaryPatientName', 'militaryPatientDob');
 
@@ -279,7 +302,7 @@
           items: items.map((x) => ({ code: String(x.code) })),
         }, requestKey);
         if (submitBtn) delete submitBtn.dataset.idempotencyKey;
-        rememberPatient(phone, dob);
+        rememberPatient(phone, dob, name);
         try { sessionStorage.setItem('radiologyos_last_booking_v1', JSON.stringify(result)); } catch (e) {}
         showCivilSuccess(result);
       } catch (error) {
@@ -324,7 +347,7 @@
           items: items.map((x) => ({ code: String(x.code) })),
         }, requestKey);
         if (submitBtn) delete submitBtn.dataset.idempotencyKey;
-        rememberPatient(phone, dob);
+        rememberPatient(phone, dob, name);
         try { sessionStorage.setItem('radiologyos_last_booking_v1', JSON.stringify(result)); } catch (e) {}
         window.location.assign('/site/cabinet.html?new=1');
       } catch (error) {

--- a/public/site/cabinet.html
+++ b/public/site/cabinet.html
@@ -73,6 +73,7 @@ function clearError(){errorBox.textContent='';errorBox.classList.remove('show')}
 function adultDobLimit(){const today=new Date();const limit=new Date(today.getFullYear()-18,today.getMonth(),today.getDate());return `${limit.getFullYear()}-${String(limit.getMonth()+1).padStart(2,'0')}-${String(limit.getDate()).padStart(2,'0')}`}
 document.getElementById('gateDob').max=adultDobLimit();
 try{const saved=JSON.parse(sessionStorage.getItem(PATIENT_PREFILL_KEY)||'null');if(saved&&/^\d{9}$/.test(String(saved.phone||'')))document.getElementById('gatePhone').value=saved.phone;if(saved&&/^\d{4}-\d{2}-\d{2}$/.test(String(saved.dob||'')))document.getElementById('gateDob').value=saved.dob}catch(e){}
+try{const p=JSON.parse(localStorage.getItem('radiologyos_patient_v1')||'null');if(p){const ph=String(p.phone||'').replace(/\D/g,'').slice(-9);if(ph&&/^\d{9}$/.test(ph)&&!document.getElementById('gatePhone').value)document.getElementById('gatePhone').value=ph;if(/^\d{4}-\d{2}-\d{2}$/.test(String(p.dob||''))&&!document.getElementById('gateDob').value)document.getElementById('gateDob').value=p.dob}}catch(e){}
 try{const last=JSON.parse(sessionStorage.getItem('radiologyos_last_booking_v1')||'null');const c=last&&(Array.isArray(last.codes)&&last.codes.length?last.codes[0]:last.code);if(c&&!document.getElementById('gateCode').value)document.getElementById('gateCode').value=String(c)}catch(e){}
 
 function cardHtml(b){

--- a/tests/site-bridge.test.mjs
+++ b/tests/site-bridge.test.mjs
@@ -190,6 +190,20 @@ test("site-payment builds a signed LiqPay checkout with a server-side amount, or
   assert.match(lib, /SHA-1/);
 });
 
+test("the booking form caches the patient's details and prefills them next time", async () => {
+  const bridge = await read("public/site/assets/d1-bridge.js");
+  // Details are persisted across visits in localStorage on submit…
+  assert.match(bridge, /const PATIENT_CACHE_KEY = 'radiologyos_patient_v1'/);
+  assert.match(bridge, /localStorage\.setItem\(PATIENT_CACHE_KEY/);
+  assert.match(bridge, /rememberPatient\(phone, dob, name\)/);
+  // …and prefilled back into the form (before the DOB dropdowns are built).
+  assert.match(bridge, /function prefillPatientForm/);
+  assert.match(bridge, /prefillPatientForm\(\);\s*\n\s*prepareIdentityFields/);
+  // The cabinet login prefills phone + DOB from the same cache.
+  const cabinet = await read("public/site/cabinet.html");
+  assert.match(cabinet, /localStorage\.getItem\('radiologyos_patient_v1'\)/);
+});
+
 test("the military free-booking form saves to D1 as category 'military'", async () => {
   const bridge = await read("public/site/assets/d1-bridge.js");
   assert.match(bridge, /getElementById\('militaryRequestForm'\)/);


### PR DESCRIPTION
Пацієнт вводив ПІБ, телефон і дату народження щоразу. Тепер дані кешуються й підставляються автоматично.

## Що зроблено
- Після заявки ПІБ + телефон + дата народження зберігаються в `localStorage` (на цьому пристрої, переживають закриття вкладки).
- **Форма запису** при наступному відкритті підставляє ПІБ, телефон і дату народження — зокрема випадаючі списки День/Місяць/Рік (значення ставиться до їх побудови, тож дропдауни одразу заповнені). Працює і на цивільній, і на військовій формі.
- **Вхід у кабінет** підставляє телефон + дату народження з того самого кешу, а номер заявки — з останньої заявки. Пацієнту лишається натиснути «Увійти».

## Деталі
- Заповнюються **лише порожні поля** — введене вручну не перетирається.
- Приватний режим чи заблокований storage безпечно ігноруються (try/catch).
- Дані лишаються локально в браузері пацієнта, нікуди не надсилаються.

## Перевірка
- `npm test` — build + 956 тестів зелені (додано перевірку кешування й підстановки).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_