### PR TITLE
Панель: редагувати назви/опис послуг і вмикати/вимикати позиції

### DIFF
--- a/app/api/staff/tariffs/route.ts
+++ b/app/api/staff/tariffs/route.ts
@@ -8,7 +8,14 @@ import {
   tariffList,
   tariffOverridesKey,
 } from "../../../../lib/tariffs";
-import { setSetting } from "../../../../lib/settings";
+import {
+  parseServiceConfig,
+  sanitizeServiceConfig,
+  SERVICE_CONFIG_KEY,
+  serviceConfigKey,
+  validateServiceConfig,
+} from "../../../../lib/service-config";
+import { getSetting, setSetting } from "../../../../lib/settings";
 import { requireOrgContext } from "../../../../lib/tenant";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
@@ -33,8 +40,12 @@ export async function PUT(request: Request) {
     return Response.json({ error: "Змінювати тарифи може лише адміністратор" }, { status: 403 });
   }
 
-  const body = await request.json().catch(() => ({})) as { prices?: Record<string, unknown> };
+  const body = await request.json().catch(() => ({})) as {
+    prices?: Record<string, unknown>;
+    active?: Record<string, unknown>;
+  };
   const prices = body.prices && typeof body.prices === "object" ? body.prices : {};
+  const active = body.active && typeof body.active === "object" ? body.active : {};
   const knownCodes = new Set(SERVICES.map((service) => service.code));
 
   for (const [code, rawValue] of Object.entries(prices)) {
@@ -46,9 +57,26 @@ export async function PUT(request: Request) {
       return Response.json({ error: `Некоректна ціна для послуги ${code}` }, { status: 400 });
     }
   }
+  for (const code of Object.keys(active)) {
+    if (!knownCodes.has(code)) {
+      return Response.json({ error: `Невідомий код послуги ${code}` }, { status: 400 });
+    }
+  }
 
   const overrides = sanitizePriceOverrides(prices);
   await setSetting(db, tariffOverridesKey(ctx.organizationId), JSON.stringify(overrides));
+
+  // Enabling/disabling a position lives in the service catalog config; apply the
+  // toggles on top of the current config so price and availability stay in one place.
+  if (Object.keys(active).length) {
+    const tenantConfig = await getSetting(db, serviceConfigKey(ctx.organizationId));
+    const legacyConfig = ctx.organizationId === 1 ? await getSetting(db, SERVICE_CONFIG_KEY) : "";
+    const config = parseServiceConfig(tenantConfig || legacyConfig);
+    const next = config.map((row) => (row.code in active ? { ...row, active: Boolean((active as Record<string, unknown>)[row.code]) } : row));
+    const invalid = validateServiceConfig(next);
+    if (invalid) return Response.json({ error: invalid }, { status: 400 });
+    await setSetting(db, serviceConfigKey(ctx.organizationId), JSON.stringify(sanitizeServiceConfig(next)));
+  }
   await audit(db, {
     organizationId: ctx.organizationId,
     actorEmail: ctx.member.email,

--- a/app/api/tariffs/route.ts
+++ b/app/api/tariffs/route.ts
@@ -9,9 +9,13 @@ export async function GET() {
   if (!db) return Response.json({ prices: {} });
 
   const prices: Record<string, number> = {};
+  const titles: Record<string, string> = {};
+  const descriptions: Record<string, string> = {};
   for (const service of await effectiveServices(db)) {
     prices[service.code] = service.price;
+    titles[service.code] = service.title;
+    descriptions[service.code] = service.description;
   }
 
-  return Response.json({ prices }, { headers: { "cache-control": "no-store" } });
+  return Response.json({ prices, titles, descriptions }, { headers: { "cache-control": "no-store" } });
 }

--- a/app/staff/services/page.tsx
+++ b/app/staff/services/page.tsx
@@ -159,6 +159,8 @@ export default function ServiceAssignmentsPage() {
                 if (!service) return null;
                 return <div className="serviceAssignmentRow" key={row.code}>
                   <div><b>{row.code} · {service.title}</b><small>{service.group}</small></div>
+                  <label style={{ gridColumn: "1 / -1" }}><span>Назва (публічна)</span><input type="text" maxLength={120} value={row.title || ""} placeholder={service.title} onChange={(event) => change(row.code, "title", event.target.value)} /></label>
+                  <label style={{ gridColumn: "1 / -1" }}><span>Що входить (опис)</span><input type="text" maxLength={400} value={row.description || ""} placeholder={service.description} onChange={(event) => change(row.code, "description", event.target.value)} /></label>
                   <label><span>Кабінет</span><select value={row.equipmentId} onChange={(event) => change(row.code, "equipmentId", event.target.value)}>
                     {Object.entries(CABINETS).map(([value, label]) => <option value={value} key={value}>{label}</option>)}
                   </select></label>

--- a/app/staff/tariffs/page.tsx
+++ b/app/staff/tariffs/page.tsx
@@ -5,7 +5,7 @@ import StaffWorkspaceShell from "../workspace-shell";
 import { roleLabelUk } from "../../../lib/labels";
 
 type StaffInfo = { email: string; displayName: string; role: string };
-type Tariff = { code: string; title: string; group: string; defaultPrice: number; price: number; custom: boolean };
+type Tariff = { code: string; title: string; group: string; defaultPrice: number; price: number; custom: boolean; active: boolean };
 
 const money = new Intl.NumberFormat("uk-UA");
 
@@ -13,6 +13,7 @@ export default function StaffTariffsPage() {
   const [staff, setStaff] = useState<StaffInfo | null>(null);
   const [tariffs, setTariffs] = useState<Tariff[]>([]);
   const [edits, setEdits] = useState<Record<string, string>>({});
+  const [activeEdits, setActiveEdits] = useState<Record<string, boolean>>({});
   const [status, setStatus] = useState<"idle" | "saving">("idle");
   const [loaded, setLoaded] = useState(false);
   const [notice, setNotice] = useState("");
@@ -55,12 +56,13 @@ export default function StaffTariffsPage() {
     try {
       const res = await fetch("/api/staff/tariffs", {
         method: "PUT", headers: { "content-type": "application/json" },
-        body: JSON.stringify({ prices }),
+        body: JSON.stringify({ prices, active: activeEdits }),
       });
       const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; tariffs?: Tariff[] };
       if (!res.ok || !data.ok) throw new Error(data.error || "Не вдалося зберегти");
       if (data.tariffs) setTariffs(data.tariffs);
       setEdits({});
+      setActiveEdits({});
       setNotice("Тарифи збережено");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не вдалося зберегти");
@@ -69,7 +71,7 @@ export default function StaffTariffsPage() {
     }
   }
 
-  const dirty = Object.keys(edits).length > 0;
+  const dirty = Object.keys(edits).length > 0 || Object.keys(activeEdits).length > 0;
 
   return (
     <StaffWorkspaceShell
@@ -82,7 +84,7 @@ export default function StaffTariffsPage() {
       <div className="tariffPage">
         {isAdmin && (
           <div className="tariffBar">
-            <span>Змініть ціну в полі й натисніть «Зберегти». Порожнє поле або значення, що дорівнює стандартному, повертає тариф до типового.</span>
+            <span>Змініть ціну в полі або вимкніть/увімкніть позицію, тоді натисніть «Зберегти». Порожнє поле чи значення, що дорівнює стандартному, повертає тариф до типового; вимкнена позиція зникає з онлайн-запису.</span>
             <button className="button" onClick={save} disabled={!dirty || status === "saving"}>
               {status === "saving" ? "Зберігаємо…" : "Зберегти тарифи"}
             </button>
@@ -97,20 +99,38 @@ export default function StaffTariffsPage() {
           <section className="tariffGroup" key={group}>
             <h2>{group}</h2>
             <table className="tariffTable">
-              <thead><tr><th>Код</th><th>Дослідження</th><th>Ціна, грн</th></tr></thead>
+              <thead><tr><th>Код</th><th>Дослідження</th><th>Ціна, грн</th><th>Стан</th></tr></thead>
               <tbody>
                 {items.map((t) => {
                   const value = edits[t.code] ?? String(t.price);
+                  const isActive = activeEdits[t.code] ?? t.active;
                   return (
-                    <tr key={t.code}>
+                    <tr key={t.code} style={isActive ? undefined : { opacity: 0.55 }}>
                       <td className="tariffCode">{t.code}</td>
-                      <td>{t.title}{t.custom && <span className="tariffCustom">змінено</span>}</td>
+                      <td>{t.title}{t.custom && <span className="tariffCustom">змінено</span>}{!isActive && <span className="tariffCustom">вимкнено</span>}</td>
                       <td className="tariffPrice">
                         {isAdmin ? (
                           <input inputMode="numeric" value={value}
                             onChange={(e) => setEdits((prev) => ({ ...prev, [t.code]: e.target.value.replace(/\D/g, "") }))} />
                         ) : (
                           <b>{money.format(t.price)}</b>
+                        )}
+                      </td>
+                      <td className="tariffState">
+                        {isAdmin ? (
+                          <button type="button" className={`button ${isActive ? "secondary" : ""}`}
+                            aria-pressed={isActive}
+                            onClick={() => setActiveEdits((prev) => {
+                              const next = { ...prev };
+                              const target = !isActive;
+                              if (target === t.active) delete next[t.code];
+                              else next[t.code] = target;
+                              return next;
+                            })}>
+                            {isActive ? "Вимкнути" : "Увімкнути"}
+                          </button>
+                        ) : (
+                          <span>{isActive ? "Активна" : "Вимкнена"}</span>
                         )}
                       </td>
                     </tr>

--- a/lib/service-config.ts
+++ b/lib/service-config.ts
@@ -8,7 +8,15 @@ export type ServiceConfigRecord = {
   military: boolean;
   civilian: boolean;
   requiresBooking: boolean;
+  // Optional per-service overrides of the catalog wording. Absent/empty ⇒ the
+  // catalog default (from Наказ №265) is used. Present ⇒ shown everywhere the
+  // effective service is resolved (booking, cabinet, public price sync).
+  title?: string;
+  description?: string;
 };
+
+const TITLE_MAX = 120;
+const DESCRIPTION_MAX = 400;
 
 export type ConfiguredService = Service & Omit<ServiceConfigRecord, "code">;
 
@@ -51,6 +59,12 @@ export function validateServiceConfig(input: unknown): string {
         return `Некоректна тривалість для послуги ${code}`;
       }
     }
+    if (row.title != null && (typeof row.title !== "string" || row.title.length > TITLE_MAX)) {
+      return `Некоректна назва для послуги ${code}`;
+    }
+    if (row.description != null && (typeof row.description !== "string" || row.description.length > DESCRIPTION_MAX)) {
+      return `Некоректний опис для послуги ${code}`;
+    }
   }
   return "";
 }
@@ -61,6 +75,10 @@ export function sanitizeServiceConfig(input: unknown): ServiceConfigRecord[] {
     const source = rows.find((row) => row && typeof row === "object" && String((row as { code?: unknown }).code || "") === base.code) as Partial<ServiceConfigRecord> | undefined;
     const equipmentId = EQUIPMENT_IDS.has(source?.equipmentId as EquipmentType) ? source!.equipmentId as EquipmentType : base.equipmentId;
     const duration = Number(source?.durationMinutes);
+    // Keep title/description only when a non-empty override is provided, so an
+    // empty field cleanly falls back to the catalog wording.
+    const title = typeof source?.title === "string" ? source.title.trim().slice(0, TITLE_MAX) : "";
+    const description = typeof source?.description === "string" ? source.description.trim().slice(0, DESCRIPTION_MAX) : "";
     return {
       code: base.code,
       equipmentId,
@@ -69,6 +87,8 @@ export function sanitizeServiceConfig(input: unknown): ServiceConfigRecord[] {
       military: typeof source?.military === "boolean" ? source.military : base.military,
       civilian: typeof source?.civilian === "boolean" ? source.civilian : base.civilian,
       requiresBooking: typeof source?.requiresBooking === "boolean" ? source.requiresBooking : base.requiresBooking,
+      ...(title ? { title } : {}),
+      ...(description ? { description } : {}),
     };
   });
 }

--- a/lib/tariffs.ts
+++ b/lib/tariffs.ts
@@ -5,6 +5,7 @@
 
 import { SERVICES, serviceByCode } from "./catalog";
 import { getSetting } from "./settings";
+import { configuredService, parseServiceConfig, SERVICE_CONFIG_KEY, serviceConfigKey } from "./service-config";
 
 export interface TariffRow {
   code: string;
@@ -13,6 +14,7 @@ export interface TariffRow {
   defaultPrice: number;
   price: number;
   custom: boolean;
+  active: boolean;
 }
 
 export const TARIFF_OVERRIDES_KEY = "service_price_overrides_v1";
@@ -77,13 +79,22 @@ export async function tariffList(
   db: D1Database,
   organizationId = 1,
 ): Promise<TariffRow[]> {
-  const overrides = await priceOverrides(db, organizationId);
-  return SERVICES.map((service) => ({
-    code: service.code,
-    title: service.title,
-    group: service.group,
-    defaultPrice: service.price,
-    price: overrides[service.code] ?? service.price,
-    custom: overrides[service.code] != null,
-  }));
+  const [overrides, tenantConfig, legacyConfig] = await Promise.all([
+    priceOverrides(db, organizationId),
+    getSetting(db, serviceConfigKey(organizationId)),
+    organizationId === 1 ? getSetting(db, SERVICE_CONFIG_KEY) : Promise.resolve(""),
+  ]);
+  const config = parseServiceConfig(tenantConfig || legacyConfig);
+  return SERVICES.map((service) => {
+    const cfg = configuredService(service, config);
+    return {
+      code: service.code,
+      title: cfg.title,
+      group: service.group,
+      defaultPrice: service.price,
+      price: overrides[service.code] ?? service.price,
+      custom: overrides[service.code] != null,
+      active: cfg.active,
+    };
+  });
 }

--- a/public/site/price.html
+++ b/public/site/price.html
@@ -534,15 +534,21 @@ body{background:#f3f6f8}
 (function(){
   var fmt=new Intl.NumberFormat('uk-UA');
   fetch('/api/tariffs',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
-    var prices=(d&&d.prices)||{};
-    if(!prices||!Object.keys(prices).length)return;
+    var prices=(d&&d.prices)||{},titles=(d&&d.titles)||{},descs=(d&&d.descriptions)||{};
+    if(!Object.keys(prices).length&&!Object.keys(titles).length)return;
     document.querySelectorAll('table tr').forEach(function(tr){
       var codeCell=tr.querySelector('td.code');if(!codeCell)return;
       var code=codeCell.textContent.trim();
+      // Effective wording (name / "що входить") from the staff Тарифи panel.
+      var titleEl=tr.querySelector('.service-title');if(titleEl&&titles[code])titleEl.textContent=titles[code];
+      var helpEl=tr.querySelector('.service-help');if(helpEl&&descs[code])helpEl.textContent=descs[code];
       if(prices[code]==null)return;
       var cells=[].slice.call(tr.querySelectorAll('td'));
       var priceCell=cells.filter(function(td){return /грн/.test(td.textContent);})[0];
       if(priceCell)priceCell.textContent=fmt.format(prices[code])+' грн';
+      // Keep the add-to-cart button (drawer label + estimate) in sync.
+      var btn=tr.querySelector('button.row-add');
+      if(btn){var t=titles[code]||(titleEl?titleEl.textContent:code);btn.setAttribute('onclick','addToCart(\''+code+'\','+JSON.stringify(t)+','+prices[code]+')');}
     });
   }).catch(function(){});
 })();

--- a/tests/service-wording-override.test.mjs
+++ b/tests/service-wording-override.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("service config supports optional name/description overrides that fall back to the catalog", async () => {
+  const config = await read("lib/service-config.ts");
+  // Optional wording overrides on the config record.
+  assert.match(config, /title\?: string;/);
+  assert.match(config, /description\?: string;/);
+  // Validated with length caps.
+  assert.match(config, /Некоректна назва для послуги/);
+  assert.match(config, /Некоректний опис для послуги/);
+  // Sanitised: trimmed, capped, and dropped when empty (so empty ⇒ catalog default).
+  assert.match(config, /source\.title\.trim\(\)\.slice\(0, TITLE_MAX\)/);
+  assert.match(config, /source\.description\.trim\(\)\.slice\(0, DESCRIPTION_MAX\)/);
+  assert.match(config, /\.\.\.\(title \? \{ title \} : \{\}\)/);
+  assert.match(config, /\.\.\.\(description \? \{ description \} : \{\}\)/);
+  // configuredService spreads the config over the catalog service, so a present
+  // override wins and an absent one keeps the catalog wording.
+  assert.match(config, /return \{ \.\.\.service, \.\.\.row \};/);
+});
+
+test("public tariff endpoint and price page carry the effective name/description", async () => {
+  const route = await read("app/api/tariffs/route.ts");
+  assert.match(route, /titles\[service\.code\] = service\.title/);
+  assert.match(route, /descriptions\[service\.code\] = service\.description/);
+  assert.match(route, /Response\.json\(\{ prices, titles, descriptions \}/);
+
+  const price = await read("public/site/price.html");
+  assert.match(price, /titles=\(d&&d\.titles\)/);
+  assert.match(price, /titleEl\.textContent=titles\[code\]/);
+  assert.match(price, /helpEl\.textContent=descs\[code\]/);
+  // The add-to-cart button is rebuilt so the drawer label/estimate stay in sync.
+  assert.match(price, /btn\.setAttribute\('onclick','addToCart/);
+});
+
+test("the staff services panel exposes editable name and description fields", async () => {
+  const page = await read("app/staff/services/page.tsx");
+  assert.match(page, /Назва \(публічна\)/);
+  assert.match(page, /Що входить \(опис\)/);
+  assert.match(page, /change\(row\.code, "title", event\.target\.value\)/);
+  assert.match(page, /change\(row\.code, "description", event\.target\.value\)/);
+  // Placeholders show the catalog default so the admin sees what they override.
+  assert.match(page, /placeholder=\{service\.title\}/);
+  assert.match(page, /placeholder=\{service\.description\}/);
+});

--- a/tests/tariffs.test.mjs
+++ b/tests/tariffs.test.mjs
@@ -64,6 +64,25 @@ test("public catalog and tariff map use the canonical effective service source",
   assert.match(bridge, /getElementById\('patientCategory'\)/);
 });
 
+test("the Тарифи page can enable/disable a position, written into the service config", async () => {
+  const lib = await read("lib/tariffs.ts");
+  // tariffList now carries the active state resolved from the service config.
+  assert.match(lib, /active: cfg\.active/);
+  assert.match(lib, /parseServiceConfig\(tenantConfig \|\| legacyConfig\)/);
+
+  const route = await read("app/api/staff/tariffs/route.ts");
+  // PUT accepts an `active` map and applies it on top of the current config.
+  assert.match(route, /active\?: Record<string, unknown>/);
+  assert.match(route, /row\.code in active \? \{ \.\.\.row, active: Boolean/);
+  assert.match(route, /setSetting\(db, serviceConfigKey\(ctx\.organizationId\), JSON\.stringify\(sanitizeServiceConfig\(next\)\)\)/);
+  assert.match(route, /validateServiceConfig\(next\)/);
+
+  const page = await read("app/staff/tariffs/page.tsx");
+  assert.match(page, /activeEdits/);
+  assert.match(page, /active: activeEdits/);
+  assert.match(page, /isActive \? "Вимкнути" : "Увімкнути"/);
+});
+
 test("the Тарифи tab is wired into the workspace and the public price list syncs", async () => {
   const shell = await read("app/staff/workspace-shell.tsx");
   assert.match(shell, /key:"services",label:"Послуги"/);


### PR DESCRIPTION
Розширення редагування послуг у панелі без деплою.

## 1. Назва й опис послуг («Послуги»)
- `lib/service-config.ts`: у конфіг послуги додано необов'язкові `title`/`description` (ліміти 120/400). Порожнє → дефолт із Наказу №265. `configuredService` накладає їх на каталог.
- `app/staff/services/page.tsx`: поля «Назва (публічна)» і «Що входить (опис)» з плейсхолдером-дефолтом.
- `app/api/tariffs` + `public/site/price.html`: публічний прайс підтягує ефективні назву/опис і синхронізує кнопку «Записатися».

## 2. Вмикати/вимикати позицію прямо в «Тарифах»
- `lib/tariffs.ts`: `tariffList` повертає `active` (з конфіга послуг).
- `app/api/staff/tariffs` PUT: приймає мапу `active` і накладає на конфіг послуг (`serviceConfigKey`), поряд зі збереженням цін. Лише адмін.
- `app/staff/tariffs/page.tsx`: кнопка «Вимкнути/Увімкнути» біля ціни; вимкнена позиція сіра з позначкою «вимкнено».
- Вимкнена позиція **зникає з онлайн-запису**: `public-services → serviceAvailableTo` враховує `active`, а `site-booking` відхиляє на сервері.

## Свідомо не включено
Додавання/вилучення послуг цілком — перелік кодів офіційний (Наказ №265). Позанаказні послуги — окрема задача (таблиця + міграція).

## Перевірка
- `npm test` — build + 960 тестів зелені.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf