### PR TITLE
Outbound: redirect \"manual\" замість \"error\" (сумісність з Cloudflare Workers)

### DIFF
--- a/lib/outbound.ts
+++ b/lib/outbound.ts
@@ -69,7 +69,13 @@ export async function fetchLimited(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(url, { ...init, redirect: "error", signal: controller.signal });
+    // "manual" (not "error") — the Cloudflare Workers runtime only accepts
+    // "follow"/"manual". We still refuse to follow redirects (SSRF guard):
+    // any 3xx / opaque redirect is treated as a failure.
+    const response = await fetch(url, { ...init, redirect: "manual", signal: controller.signal });
+    if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+      throw new Error("redirect_not_allowed");
+    }
     const length = Number(response.headers.get("content-length") || 0);
     if (length > MAX_RESPONSE_BYTES) throw new Error("response_too_large");
     return response;

--- a/tests/security-hardening.test.mjs
+++ b/tests/security-hardening.test.mjs
@@ -94,7 +94,10 @@ test("server-side integrations block SSRF and oversized responses", async () => 
   const telegram = await read("lib/telegram.ts");
   assert.match(outbound, /privateHostname/);
   assert.match(outbound, /url\.protocol !== "https:"/);
-  assert.match(outbound, /redirect: "error"/);
+  // Cloudflare Workers only accept "follow"/"manual"; we use "manual" and reject
+  // any redirect ourselves — same no-follow SSRF guard, compatible runtime.
+  assert.match(outbound, /redirect: "manual"/);
+  assert.match(outbound, /opaqueredirect|redirect_not_allowed/);
   assert.match(outbound, /MAX_RESPONSE_BYTES/);
   assert.match(outbound, /AbortController/);
   assert.match(messaging, /safeOutboundUrl\(url\)/);


### PR DESCRIPTION
## Проблема
Кнопка «Тест e-mail» (Resend) падала з помилкою рантайму:
> Invalid redirect value, must be one of "follow" or "manual" ("error" won't be implemented since it does not make sense at the edge…)

`fetchLimited` викликав `fetch(..., { redirect: "error" })`, а Cloudflare Workers приймає лише `"follow"` або `"manual"`.

## Рішення
Замінено на `redirect: "manual"` і **самі відхиляємо** будь-який редірект (3xx або `opaqueredirect`) з помилкою. Це зберігає той самий захист «не йти за редіректами» (анти-SSRF), але сумісне з edge-рантаймом — саме як радить сам текст помилки.

## Перевірка
- `npm test` — build + 964 тести зелені (тест security-hardening оновлено під `manual` + відхилення редіректу).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_