### PR TITLE
Тести: прибрати date-bomb — стабілізувати 4 date-залежні тести

### DIFF
--- a/tests/analytics.behavior.test.mjs
+++ b/tests/analytics.behavior.test.mjs
@@ -3,6 +3,14 @@ import test from "node:test";
 import { recordAnalyticsEvent } from "../lib/analytics.ts";
 import { callWorker, jsonRequest, seedStaffSession, withD1 } from "./helpers/d1.mjs";
 
+// Analytics events are stored with occurred_at = CURRENT_TIMESTAMP, so the funnel
+// window must include "now"; a hardcoded calendar window drifts out of range.
+const ISO = (ms) => new Date(ms).toISOString().slice(0, 10);
+const NOW = Date.now();
+const REPORT_FROM = ISO(NOW - 20 * 86400000);
+const REPORT_TO = ISO(NOW + 86400000);
+const IN_PERIOD = ISO(NOW - 5 * 86400000);
+
 test("public analytics accepts only anonymous allowlisted funnel fields", async () => {
   await withD1(async (db) => {
     const valid = await callWorker(jsonRequest("/api/analytics", {
@@ -99,13 +107,13 @@ test("staff funnel report is tenant-scoped and derives clinical milestones from 
     const bookingId = Number(booking.meta.last_row_id);
     await db.prepare(
       `INSERT INTO booking_events (organization_id, booking_id, action, details, actor, created_at)
-       VALUES (1, ?, 'status_changed', 'arrived', 'test', '2026-08-20 10:00:00'),
-              (1, ?, 'status_changed', 'completed', 'test', '2026-08-20 10:30:00')`,
-    ).bind(bookingId, bookingId).run();
+       VALUES (1, ?, 'status_changed', 'arrived', 'test', ?),
+              (1, ?, 'status_changed', 'completed', 'test', ?)`,
+    ).bind(bookingId, `${IN_PERIOD} 10:00:00`, bookingId, `${IN_PERIOD} 10:30:00`).run();
 
     const cookie = await seedStaffSession(db, { email: "admin@example.com", role: "admin", organizationId: 1 });
     const response = await callWorker(new Request(
-      "https://radiologyos.test/api/staff/analytics?from=2026-08-01&to=2026-08-31",
+      `https://radiologyos.test/api/staff/analytics?from=${REPORT_FROM}&to=${REPORT_TO}`,
       { headers: { cookie } },
     ), db);
     assert.equal(response.status, 200);

--- a/tests/register-turnover-report.behavior.test.mjs
+++ b/tests/register-turnover-report.behavior.test.mjs
@@ -2,6 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
 
+// Dates are anchored relative to "now" so the report window always contains the
+// documents that the payment/refund/storno API calls create with CURRENT_TIMESTAMP.
+// A fixed calendar window (e.g. hardcoded August) silently falls out of range once
+// the wall clock moves past it, which is what previously broke this suite.
+const ISO = (ms) => new Date(ms).toISOString().slice(0, 10);
+const NOW = Date.now();
+const REPORT_FROM = ISO(NOW - 20 * 86400000);
+const REPORT_TO = ISO(NOW + 86400000); // tomorrow: safely covers now-dated documents in any timezone
+const IN_PERIOD = ISO(NOW - 5 * 86400000);
+const BEFORE_PERIOD = ISO(NOW - 40 * 86400000); // strictly before REPORT_FROM → opening balances
+
 async function seedCompleted(db,{organizationId=1,code,amount=0,category="civilian",performedAt,duration=30,regions=2}={}) {
   const result=await db.prepare(
     `INSERT INTO bookings (
@@ -47,7 +58,7 @@ async function storno(db,cookie,sourceDocumentId) {
   },{headers:{cookie}}),db);
 }
 
-async function report(db,cookie,from="2026-08-01",to="2026-08-31") {
+async function report(db,cookie,from=REPORT_FROM,to=REPORT_TO) {
   return callWorker(new Request(`http://localhost/api/staff/reports/registers?from=${from}&to=${to}`,{headers:{cookie}}),db);
 }
 
@@ -67,9 +78,9 @@ async function seedInventory(db,organizationId=1) {
   ).bind(organizationId).first();
   assert.ok(warehouse?.id,"default warehouse must exist");
   for(const movement of [
-    {date:"2026-07-31 09:00:00",delta:10,type:"receipt"},
-    {date:"2026-08-05 09:00:00",delta:5,type:"receipt"},
-    {date:"2026-08-10 09:00:00",delta:-3,type:"writeoff"},
+    {date:`${BEFORE_PERIOD} 09:00:00`,delta:10,type:"receipt"},
+    {date:`${IN_PERIOD} 09:00:00`,delta:5,type:"receipt"},
+    {date:`${IN_PERIOD} 09:00:00`,delta:-3,type:"writeoff"},
   ]){
     await db.prepare(
       `INSERT INTO inventory_movements
@@ -85,10 +96,10 @@ test("register report derives opening, period turnovers and closing balances fro
     const admin=await seedStaffSession(db,{email:"turnover-admin@example.com",role:"admin",organizationId:1});
 
     // Previous-period unpaid civilian service creates opening patient debt of 1000.
-    await seedCompleted(db,{code:"RD-TURN-JUL",amount:1000,performedAt:"2026-07-31T10:00:00",duration:25,regions:1});
+    await seedCompleted(db,{code:"RD-TURN-JUL",amount:1000,performedAt:`${BEFORE_PERIOD}T10:00:00`,duration:25,regions:1});
 
-    // August civilian service is fully neutralized by payment + refund + service storno.
-    const civilian=await seedCompleted(db,{code:"RD-TURN-AUG",amount:3000,performedAt:"2026-08-10T10:00:00",duration:30,regions:2});
+    // In-period civilian service is fully neutralized by payment + refund + service storno.
+    const civilian=await seedCompleted(db,{code:"RD-TURN-AUG",amount:3000,performedAt:`${IN_PERIOD}T10:00:00`,duration:30,regions:2});
     const paid=await pay(db,admin,civilian,"TURNOVER-PAY");
     assert.equal(paid.status,200);
     const returned=await refund(db,admin,civilian);
@@ -98,14 +109,14 @@ test("register report derives opening, period turnovers and closing balances fro
     assert.equal(reversed.status,201);
 
     // Military service has operational movements but no revenue/settlement charge.
-    await seedCompleted(db,{code:"RD-TURN-MIL",amount:5000,category:"military",performedAt:"2026-08-12T12:00:00",duration:20,regions:1});
+    await seedCompleted(db,{code:"RD-TURN-MIL",amount:5000,category:"military",performedAt:`${IN_PERIOD}T12:00:00`,duration:20,regions:1});
     const {itemId,warehouse}=await seedInventory(db);
 
     const response=await report(db,admin);
     assert.equal(response.status,200);
     const body=await response.json();
 
-    assert.deepEqual(body.period,{from:"2026-08-01",to:"2026-08-31"});
+    assert.deepEqual(body.period,{from:REPORT_FROM,to:REPORT_TO});
     assert.equal(body.registers.revenue.increase,3000);
     assert.equal(body.registers.revenue.decrease,3000);
     assert.equal(body.registers.revenue.net,0);
@@ -164,8 +175,8 @@ test("register report is tenant scoped and excludes another organization movemen
     raw.exec("INSERT OR IGNORE INTO organizations (id,name,slug,active) VALUES (2,'Turnover Org 2','turnover-org-2',1)");
     const org1=await seedStaffSession(db,{email:"turnover-org1@example.com",role:"admin",organizationId:1});
     const org2=await seedStaffSession(db,{email:"turnover-org2@example.com",role:"admin",organizationId:2});
-    await seedCompleted(db,{organizationId:1,code:"RD-TURN-ORG1",amount:1200,performedAt:"2026-08-05T10:00:00",regions:1});
-    await seedCompleted(db,{organizationId:2,code:"RD-TURN-ORG2",amount:8800,performedAt:"2026-08-05T10:00:00",regions:1});
+    await seedCompleted(db,{organizationId:1,code:"RD-TURN-ORG1",amount:1200,performedAt:`${IN_PERIOD}T10:00:00`,regions:1});
+    await seedCompleted(db,{organizationId:2,code:"RD-TURN-ORG2",amount:8800,performedAt:`${IN_PERIOD}T10:00:00`,regions:1});
 
     const one=await report(db,org1);const oneBody=await one.json();
     const two=await report(db,org2);const twoBody=await two.json();

--- a/tests/studies-performed-register.behavior.test.mjs
+++ b/tests/studies-performed-register.behavior.test.mjs
@@ -2,6 +2,15 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { callWorker,jsonRequest,seedStaffSession,withD1 } from "./helpers/d1.mjs";
 
+// Dates anchored to "now" so the report window always contains the storno document
+// that the correction API creates with CURRENT_TIMESTAMP; a hardcoded calendar
+// window drifts out of range once the wall clock moves past it.
+const ISO = (ms) => new Date(ms).toISOString().slice(0, 10);
+const NOW = Date.now();
+const REPORT_FROM = ISO(NOW - 20 * 86400000);
+const REPORT_TO = ISO(NOW + 86400000);
+const IN_PERIOD = ISO(NOW - 5 * 86400000);
+
 async function seedCompleted(db,{
   organizationId=1,
   code,
@@ -49,7 +58,7 @@ async function storno(db,cookie,sourceDocumentId) {
 
 async function report(db,cookie) {
   return callWorker(new Request(
-    "http://localhost/api/staff/reports/registers?from=2026-08-01&to=2026-08-31",
+    `http://localhost/api/staff/reports/registers?from=${REPORT_FROM}&to=${REPORT_TO}`,
     {headers:{cookie}},
   ),db);
 }
@@ -59,10 +68,10 @@ test("studies_performed projection includes civilian, military and explicit stor
     const admin=await seedStaffSession(db,{email:"studies-admin@example.com",role:"admin",organizationId:1});
 
     const civilian=await seedCompleted(db,{
-      code:"RD-STUDIES-CIV",amount:3000,category:"civilian",performedAt:"2026-08-10T10:00:00",regions:2,
+      code:"RD-STUDIES-CIV",amount:3000,category:"civilian",performedAt:`${IN_PERIOD}T10:00:00`,regions:2,
     });
     const military=await seedCompleted(db,{
-      code:"RD-STUDIES-MIL",amount:5000,category:"military",performedAt:"2026-08-11T11:00:00",regions:1,
+      code:"RD-STUDIES-MIL",amount:5000,category:"military",performedAt:`${IN_PERIOD}T11:00:00`,regions:1,
     });
     assert.ok(civilian>0);
     assert.ok(military>0);
@@ -93,10 +102,10 @@ test("studies_performed projection is tenant scoped",async()=>{
     const org2=await seedStaffSession(db,{email:"studies-org2@example.com",role:"admin",organizationId:2});
 
     await seedCompleted(db,{
-      organizationId:1,code:"RD-STUDIES-ORG1",amount:0,category:"military",performedAt:"2026-08-12T09:00:00",regions:1,
+      organizationId:1,code:"RD-STUDIES-ORG1",amount:0,category:"military",performedAt:`${IN_PERIOD}T09:00:00`,regions:1,
     });
     await seedCompleted(db,{
-      organizationId:2,code:"RD-STUDIES-ORG2",amount:0,category:"military",performedAt:"2026-08-12T09:30:00",regions:4,
+      organizationId:2,code:"RD-STUDIES-ORG2",amount:0,category:"military",performedAt:`${IN_PERIOD}T09:30:00`,regions:4,
       serviceCode:"ct-abdomen",service:"КТ ОЧП",
     });
 

--- a/tests/tenant-schedule.behavior.test.mjs
+++ b/tests/tenant-schedule.behavior.test.mjs
@@ -80,7 +80,13 @@ test("staff availability uses its tenant schedule while anonymous availability s
     await setRawSetting(db, SCHEDULE_KEY, JSON.stringify(scheduleWithCtStart("08:00")));
     await setRawSetting(db, scheduleKey(2), JSON.stringify(scheduleWithCtStart("11:00")));
 
-    const url = "/api/availability?date=2026-09-01&serviceCode=403";
+    // A future, bookable weekday (Sunday is closed in the schedule and rejected by
+    // isBookableDate). A hardcoded date silently becomes "in the past" and returns
+    // no slots once the wall clock moves past it.
+    const target = new Date(Date.now() + 7 * 86400000);
+    if (target.getUTCDay() === 0) target.setUTCDate(target.getUTCDate() + 1);
+    const date = target.toISOString().slice(0, 10);
+    const url = `/api/availability?date=${date}&serviceCode=403`;
     const staffResponse = await callWorker(jsonRequest(url, undefined, {
       method: "GET", headers: { cookie: staff2 },
     }), db);


### PR DESCRIPTION
Чотири поведінкові тести хардкодили календарне вікно серпня / початку вересня 2026. Щойно годинник минув ці дати (сьогодні 03.09.2026), вони почали падати **щодня** — і блокували CI на будь-якому PR, включно з попереднім мержем #474.

## Корінь
- **`analytics` funnel** — події сідяться з `occurred_at = CURRENT_TIMESTAMP` (зараз), а запит фільтрував серпневим вікном → 0 подій.
- **`register-turnover` / `studies-performed`** — документи `pay/refund/storno` створюються через API з `occurred_at = зараз`, тож випадали з серпневого вікна (нульові обороти, невраховані сторно).
- **`tenant-schedule` availability** — `date=2026-09-01` став минулим → `isBookableDate` past-date guard повертав порожні слоти.

## Фікс
Дати тепер обчислюються **відносно `now`**, а не хардкодяться:
- вікно звіту `[now−20д, now+1д]` завжди містить now-документи;
- «opening»-сіди датуються строго **до** `from`;
- `availability` бере майбутній робочий день (не неділю — вона закрита в розкладі й у `isBookableDate`).

Продакшн-код не змінювався — це виключно стабілізація тестів. Числові інваріанти (обороти, сальдо, воронка) збережені; змінені лише прив'язки дат.

## Перевірки
- `npm test` — 972/972.
- `npx tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_