### PR TITLE
staff nav: вивести Персонал і радіаційну безпеку в top-level модуль

### DIFF
--- a/app/staff/personnel/dosimetry/page.tsx
+++ b/app/staff/personnel/dosimetry/page.tsx
@@ -127,7 +127,7 @@ export default function PersonnelDosimetryPage(){
   }
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Індивідуальна дозиметрія"
     description="Захищена append-only історія індивідуального дозиметричного контролю, прив’язана до стабільного personnelId."
   >

--- a/app/staff/personnel/page.tsx
+++ b/app/staff/personnel/page.tsx
@@ -159,7 +159,7 @@ export default function PersonnelPage() {
   const showEditor = creating || Boolean(editorRecord);
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Персонал"
     description="Кадровий довідник працівників. Картка працівника відокремлена від облікового запису RadiologyOS."
   >

--- a/app/staff/personnel/radiation-clearance/page.tsx
+++ b/app/staff/personnel/radiation-clearance/page.tsx
@@ -132,7 +132,7 @@ export default function PersonnelRadiationClearancePage(){
   }
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Допуск персоналу до ДІВ"
     description="Окремий кадровий реєстр рішень щодо робіт з джерелами іонізуючого випромінювання. Записи незмінні; виправлення додаються новим записом."
   >

--- a/app/staff/personnel/radiation-compliance/page.tsx
+++ b/app/staff/personnel/radiation-compliance/page.tsx
@@ -176,7 +176,7 @@ export default function RadiationCompliancePage(){
   },[load]);
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Радіаційна безпека · зведення"
     description="Read-only проекція організаційного scope, допуску до ДІВ, навчання, перевірки знань та останнього стану індивідуальної дозиметрії."
   >

--- a/app/staff/personnel/radiation-dose-summary/page.tsx
+++ b/app/staff/personnel/radiation-dose-summary/page.tsx
@@ -132,7 +132,7 @@ export default function RadiationDoseSummaryPage() {
   }, [load]);
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Індивідуальна дозиметрія · дозове зведення"
     description="Read-only числовий subtotal виміряних Hp(10), Hp(0.07) та Hp(3) за вибраним інтервалом без нормативних порогів."
   >

--- a/app/staff/personnel/radiation-monitoring-scope/page.tsx
+++ b/app/staff/personnel/radiation-monitoring-scope/page.tsx
@@ -135,7 +135,7 @@ export default function PersonnelRadiationMonitoringScopePage() {
   }
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Контингент радіаційного контролю"
     description="Append-only організаційна історія: хто в RadiologyOS входить до контуру радіаційного review. Це не автоматична правова категоризація і не дозвіл на роботу."
   >

--- a/app/staff/personnel/radiation-review-policy/page.tsx
+++ b/app/staff/personnel/radiation-review-policy/page.tsx
@@ -103,7 +103,7 @@ export default function RadiationReviewPolicyPage(){
   }
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Політика ДІВ · критерії review"
     description="Append-only історія організаційних критеріїв для майбутніх alerts і ручної перевірки даних радіаційної безпеки."
   >

--- a/app/staff/personnel/radiation-review-queue/page.tsx
+++ b/app/staff/personnel/radiation-review-queue/page.tsx
@@ -96,7 +96,7 @@ export default function RadiationReviewQueuePage() {
   const policyCount = useMemo(() => records.filter((record) => record.policyReviewReasons.length > 0).length, [records]);
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Радіаційна безпека · черга review"
     description="Read-only робочий список персоналу, для якого зведення ДІВ уже має детерміновані причини ручної перевірки."
   >

--- a/app/staff/personnel/radiation-training/page.tsx
+++ b/app/staff/personnel/radiation-training/page.tsx
@@ -128,7 +128,7 @@ export default function PersonnelRadiationTrainingPage(){
   }
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="Радіаційна безпека · навчання"
     description="Історія навчання, перевірок знань та інструктажів персоналу, прив’язана до стабільного personnelId."
   >

--- a/app/staff/personnel/vlk/page.tsx
+++ b/app/staff/personnel/vlk/page.tsx
@@ -127,7 +127,7 @@ export default function PersonnelVlkPage(){
   }
 
   return <StaffWorkspaceShell
-    active="directories"
+    active="personnel"
     title="ВЛК персоналу"
     description="Окрема захищена історія рішень ВЛК. Попередні записи не редагуються і не видаляються; виправлення додається новим записом."
   >

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import CommandPalette from "./command-palette";
 
-type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "finance" | "counterparties" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks" | "inventory" | "purchases" | "documents" | "registers" | "directories";
+type WorkspaceSection = "dashboard" | "overview" | "studies" | "patients" | "protocols" | "imaging" | "reports" | "tariffs" | "finance" | "counterparties" | "settings" | "organization" | "site" | "appointments" | "whatsapp" | "chat" | "schedule" | "equipment" | "services" | "structure" | "audit" | "intake" | "board" | "tasks" | "inventory" | "purchases" | "documents" | "registers" | "directories" | "personnel";
 
 type StaffWorkspaceShellProps = {
   active: WorkspaceSection;
@@ -37,6 +37,7 @@ const quickRail:NavLink[]=[
   { label:"Склад",href:"/staff/inventory",section:"inventory",icon:"▣" },
   { label:"Фінанси",href:"/staff/finance",section:"finance",icon:"₴" },
   { label:"Звіти",href:"/staff/reports",section:"reports",icon:"⌁" },
+  { label:"Персонал",href:"/staff/personnel",section:"personnel",icon:"☢" },
 ];
 
 const businessModules:BusinessModule[]=[
@@ -120,6 +121,15 @@ const businessModules:BusinessModule[]=[
     {label:"Графік кабінетів",href:"/staff/schedule"},
     {label:"Графік змін персоналу",href:"/staff/shifts",hint:"Циклічні зміни, бригади та персональні корекції"},
   ]},
+  { key:"personnel",label:"Персонал",items:[
+    {label:"Персонал і зміни",href:"/staff/personnel",hint:"Кадрові картки, підрозділ, посада, зв'язок з обліковим записом"},
+    {label:"Дозиметрія",href:"/staff/personnel/dosimetry",hint:"Індивідуальні дози опромінення персоналу"},
+    {label:"Радіаційний допуск",href:"/staff/personnel/radiation-clearance"},
+    {label:"Навчання з радіобезпеки",href:"/staff/personnel/radiation-training"},
+    {label:"Черга радіаційного огляду",href:"/staff/personnel/radiation-review-queue"},
+    {label:"Зведення доз",href:"/staff/personnel/radiation-dose-summary"},
+    {label:"ВЛК",href:"/staff/personnel/vlk",hint:"Військово-лікарська комісія"},
+  ]},
   { key:"admin",label:"Адміністрування",shortLabel:"Адмін",items:[
     {label:"Налаштування",href:"/staff/settings"},
     {label:"Структура відділення",href:"/staff/structure"},
@@ -138,7 +148,7 @@ const moduleBySection:Record<WorkspaceSection,string>={
   finance:"finance",counterparties:"directories",
   inventory:"inventory",purchases:"purchases",
   documents:"documents",registers:"registers",reports:"reports",directories:"directories",
-  equipment:"directories",schedule:"directories",
+  equipment:"directories",schedule:"directories",personnel:"personnel",
   settings:"admin",organization:"admin",site:"admin",whatsapp:"admin",structure:"admin",audit:"admin",
 };
 
@@ -150,6 +160,7 @@ const sectionLabels:Record<WorkspaceSection,string>={
   equipment:"Обладнання",services:"Послуги",structure:"Структура відділення",audit:"Журнал дій",
   intake:"Прийом",board:"Дошка досліджень",tasks:"Завдання",inventory:"Склад",purchases:"Кредиторка постачальників",
   documents:"Журнал документів",registers:"Регістри",directories:"Довідники",
+  personnel:"Персонал і радіаційна безпека",
 };
 
 function formatDateTime(value:Date) {

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -140,7 +140,7 @@
 
 ### Довідники — *Адмін*
 
-Хаб-сторінка `/staff/directories`, що відкриває довідники та кадровий розділ:
+Хаб-сторінка `/staff/directories`, що відкриває довідники:
 
 - Обладнання — `/staff/equipment`
 - Обслуговування — `/staff/maintenance`
@@ -148,19 +148,17 @@
 - Графік змін персоналу — `/staff/shifts` *(Адмін, Завідувач)*
 - Структура відділення — `/staff/structure`
 - Довільні поля — `/staff/custom-fields`
-- **Персонал і радіаційна безпека** — `/staff/personnel` *(див. нижче)*
 
-#### Персонал і радіаційна безпека — *Адмін, Завідувач*
+### Персонал і радіаційна безпека — *Адмін, Завідувач*
 
-> Точка входу — **Довідники → Персонал** (`/staff/directories`). Це **не**
-> окремий модуль верхнього рівня в бічній навігації, хоча за вагою (юридичні
-> зобов'язання щодо доз персоналу) заслуговує на виведення нагору.
+Окремий модуль верхнього рівня в навігації (rail-іконка ☢ + модуль
+«Персонал»); також крос-лінк із хаба Довідників.
 
 - Персонал і зміни — `/staff/personnel`
 - Дозиметрія — `/staff/personnel/dosimetry`
 - Радіаційний допуск — `/staff/personnel/radiation-clearance`
-- Навчання — `/staff/personnel/radiation-training`
-- Моніторинг і черга огляду — `/staff/personnel/radiation-review-queue`
+- Навчання з радіобезпеки — `/staff/personnel/radiation-training`
+- Черга радіаційного огляду — `/staff/personnel/radiation-review-queue`
 - Політика й зведення доз — `/staff/personnel/radiation-review-policy`, `/staff/personnel/radiation-dose-summary`
 - ВЛК — `/staff/personnel/vlk`
 

--- a/tests/bas-workspace-navigation.test.mjs
+++ b/tests/bas-workspace-navigation.test.mjs
@@ -20,6 +20,19 @@ test("staff workspace exposes BAS documents and registers as first-class navigat
   assert.match(shell,/Документи · регістри · медицина/);
 });
 
+test("radiation safety is a first-class personnel navigation module, not buried under directories",()=>{
+  const personnel=readFileSync("app/staff/personnel/page.tsx","utf8");
+  // Own top-level module + rail entry, mapped and labelled as a real section.
+  assert.match(shell,/key:"personnel",label:"Персонал"/);
+  assert.match(shell,/label:"Персонал",href:"\/staff\/personnel",section:"personnel"/);
+  assert.match(shell,/\/staff\/personnel\/dosimetry/);
+  assert.match(shell,/\/staff\/personnel\/radiation-clearance/);
+  assert.match(shell,/personnel:"personnel"/);
+  assert.match(shell,/personnel:"Персонал і радіаційна безпека"/);
+  // The personnel pages now highlight their own section rather than directories.
+  assert.match(personnel,/active="personnel"/);
+});
+
 test("document journal supports canonical BAS filtering and lineage",()=>{
   assert.match(documents,/active="documents"/);
   assert.match(documents,/params\.get\("type"\)/);


### PR DESCRIPTION
Закриває 🔴-пункт аудиту структури: радіаційна безпека була закопана.

## Проблема
Радіаційний блок (дозиметрія, допуск, навчання, черга огляду, зведення доз, ВЛК) був досяжний лише через **Довідники → Персонал** — на 2+ рівні вглиб, попри юридичну вагу обліку доз персоналу у радіологічному відділенні.

## Зміни
- Новий `businessModule` **"personnel"** (7 пунктів) + запис у `quickRail` з rail-іконкою **☢**.
- `WorkspaceSection`, `moduleBySection`, `sectionLabels` розширено на `"personnel"`.
- Усі 10 сторінок `/staff/personnel/*` переведено з `active="directories"` → `active="personnel"` — підсвічується власний розділ.
- Тест `bas-workspace-navigation` розширено кейсом «radiation safety is a first-class personnel navigation module».
- `docs/sitemap.md` і схеми оновлено (Персонал знову top-level).

## Перевірки
- `npm test` — 973/973 (+1 новий).
- `npx tsc --noEmit` — чисто.

Захист без змін: навігація не гейтить за роллю (це косметика), доступ, як і раніше, — на серверних гардах `lib/staff-auth.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_