### PR TITLE
command palette: покрити всі top-level розділи персоналу

### DIFF
--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -12,20 +12,74 @@ type SearchResult = {
   href: string;
 };
 
+// Full navigation surface: every top-level staff section is reachable from the
+// palette, so search is a complete jump-to mechanism rather than a partial list.
+// (Server-side guards still enforce access — this list is discovery only.)
 const COMMANDS: { label: string; hint: string; href: string }[] = [
+  // Щоденна робота
   { label: "Пульт відділення", hint: "огляд дня", href: "/staff/dashboard" },
   { label: "Прийом", hint: "черга заявок", href: "/staff/intake" },
   { label: "Календар записів", hint: "розклад", href: "/staff/appointments" },
   { label: "Нова заявка", hint: "записати пацієнта", href: "/staff/book" },
-  { label: "Пацієнти", hint: "картки / CRM", href: "/staff/patients" },
+  { label: "Дошка досліджень", hint: "робочий стан", href: "/staff/board" },
+  { label: "Завдання", hint: "нагадування / to-do", href: "/staff/tasks" },
   { label: "Протоколи", hint: "опис досліджень", href: "/staff/protocols" },
-  { label: "DICOM", hint: "знімки та PACS", href: "/staff/imaging" },
-  { label: "Склад", hint: "витратні матеріали", href: "/staff/inventory" },
-  { label: "Фінанси", hint: "оплати / повернення / взаєморозрахунки", href: "/staff/finance" },
+  { label: "Видача результатів", hint: "готові дослідження", href: "/staff/studies" },
+  // Пацієнти
+  { label: "Пацієнти", hint: "картки / CRM", href: "/staff/patients" },
+  { label: "Імпорт пацієнтів", hint: "CSV / масове завантаження", href: "/staff/patients/import" },
+  { label: "Чат із пацієнтами", hint: "повідомлення", href: "/staff/chat" },
+  // Медицина
+  { label: "DICOM / PACS", hint: "знімки та архів", href: "/staff/imaging" },
+  { label: "Стан PACS / MWL", hint: "інтеграції", href: "/staff/integrations/health" },
+  { label: "Modality Worklist", hint: "MWL / робочий список", href: "/staff/integrations/mwl" },
+  // Послуги і тарифи
+  { label: "Послуги кабінетів", hint: "перелік послуг", href: "/staff/services" },
+  { label: "Надані послуги", hint: "service-delivery", href: "/staff/finance/services" },
+  { label: "Тарифи", hint: "ціни / прейскурант", href: "/staff/tariffs" },
+  // Фінанси
+  { label: "Фінансові документи", hint: "оплати / повернення / взаєморозрахунки", href: "/staff/finance" },
+  { label: "Каси і рахунки", hint: "готівка / банк", href: "/staff/cash-accounts" },
+  { label: "Дебіторська заборгованість", hint: "борги пацієнтів", href: "/staff/reports/receivables" },
+  // Документи / регістри / звіти
+  { label: "Журнал документів", hint: "BAS-реєстратори", href: "/staff/documents" },
+  { label: "Регістри", hint: "карта регістрів", href: "/staff/registers" },
+  { label: "Обороти регістрів", hint: "оборотно-сальдовий", href: "/staff/reports/registers" },
+  { label: "Звіти відділення", hint: "аналітика", href: "/staff/reports" },
+  { label: "Маржинальність послуг", hint: "план / факт матеріалів", href: "/staff/reports/material-margin" },
+  { label: "Контроль матеріалів", hint: "план / факт списання", href: "/staff/reports/material-consumption-control" },
+  // Склад
+  { label: "Склад", hint: "залишки / витратні матеріали", href: "/staff/inventory" },
+  { label: "Переміщення запасів", hint: "між складами", href: "/staff/inventory/transfers" },
+  { label: "Інвентаризація", hint: "фактичні залишки", href: "/staff/inventory/counts" },
+  { label: "Фактичне списання", hint: "резервації / партії", href: "/staff/inventory/material-consumption" },
+  { label: "Склади", hint: "warehouses", href: "/staff/warehouses" },
+  // Закупівлі
+  { label: "Кредиторка і оплати", hint: "борги постачальникам", href: "/staff/supplier-payables" },
+  { label: "Постачальники", hint: "контрагенти", href: "/staff/counterparties" },
+  // Персонал і радіаційна безпека
+  { label: "Персонал і зміни", hint: "кадрові картки", href: "/staff/personnel" },
+  { label: "Дозиметрія", hint: "дози опромінення", href: "/staff/personnel/dosimetry" },
+  { label: "Радіаційний допуск", hint: "clearance", href: "/staff/personnel/radiation-clearance" },
+  { label: "Навчання з радіобезпеки", hint: "training", href: "/staff/personnel/radiation-training" },
+  { label: "Черга радіаційного огляду", hint: "review queue", href: "/staff/personnel/radiation-review-queue" },
+  { label: "Зведення доз", hint: "dose summary", href: "/staff/personnel/radiation-dose-summary" },
+  { label: "ВЛК", hint: "військово-лікарська комісія", href: "/staff/personnel/vlk" },
+  // Довідники / обладнання / графіки
+  { label: "Довідники", hint: "master-data", href: "/staff/directories" },
+  { label: "Обладнання", hint: "апарати / кабінети", href: "/staff/equipment" },
   { label: "ТО та несправності", hint: "обладнання / сервіс", href: "/staff/maintenance" },
-  { label: "Звіти", hint: "аналітика", href: "/staff/reports" },
+  { label: "Графік кабінетів", hint: "робочі години", href: "/staff/schedule" },
+  { label: "Графік змін персоналу", hint: "зміни / бригади", href: "/staff/shifts" },
+  { label: "Структура відділення", hint: "підрозділи", href: "/staff/structure" },
+  { label: "Довільні поля", hint: "custom fields", href: "/staff/custom-fields" },
+  // Адміністрування
+  { label: "Налаштування", hint: "шлюзи / LiqPay / e-mail", href: "/staff/settings" },
+  { label: "Організація та профіль", hint: "реквізити", href: "/staff/organization" },
+  { label: "Журнал дій", hint: "аудит", href: "/staff/audit" },
+  { label: "WhatsApp і чат-бот", hint: "інтеграція", href: "/staff/whatsapp" },
   { label: "Стан системи", hint: "health / production", href: "/staff/system/health" },
-  { label: "Налаштування", hint: "адміністрування", href: "/staff/settings" },
+  { label: "Особистий кабінет", hint: "профіль / вихід", href: "/staff/profile" },
 ];
 
 const TYPE_LABEL:Record<SearchResult["type"],string> = {

--- a/tests/command-palette.behavior.test.mjs
+++ b/tests/command-palette.behavior.test.mjs
@@ -157,3 +157,31 @@ test("the palette is mounted in the workspace shell and renders typed global res
   assert.match(cp, /accession, протокол, обладнання/);
   assert.match(cp, /window\.location\.assign\(r\.href\)/);
 });
+
+test("command palette covers every top-level staff section, not a partial list", async () => {
+  const cp = await read("app/staff/command-palette.tsx");
+  // One representative route per navigation area — regression guard so newly
+  // added sections are also wired into the palette (the audit's 🟡 gap).
+  const routes = [
+    "/staff/dashboard", "/staff/intake", "/staff/appointments", "/staff/board", "/staff/tasks",
+    "/staff/protocols", "/staff/studies", "/staff/patients", "/staff/patients/import", "/staff/chat",
+    "/staff/imaging", "/staff/integrations/health", "/staff/integrations/mwl",
+    "/staff/services", "/staff/finance/services", "/staff/tariffs",
+    "/staff/finance", "/staff/cash-accounts", "/staff/reports/receivables",
+    "/staff/documents", "/staff/registers", "/staff/reports/registers", "/staff/reports",
+    "/staff/reports/material-margin", "/staff/reports/material-consumption-control",
+    "/staff/inventory", "/staff/inventory/transfers", "/staff/inventory/counts",
+    "/staff/inventory/material-consumption", "/staff/warehouses",
+    "/staff/supplier-payables", "/staff/counterparties",
+    "/staff/personnel", "/staff/personnel/dosimetry", "/staff/personnel/radiation-clearance",
+    "/staff/personnel/radiation-training", "/staff/personnel/radiation-review-queue",
+    "/staff/personnel/radiation-dose-summary", "/staff/personnel/vlk",
+    "/staff/directories", "/staff/equipment", "/staff/maintenance", "/staff/schedule",
+    "/staff/shifts", "/staff/structure", "/staff/custom-fields",
+    "/staff/settings", "/staff/organization", "/staff/audit", "/staff/whatsapp",
+    "/staff/system/health", "/staff/profile",
+  ];
+  for (const href of routes) {
+    assert.ok(cp.includes(`href: "${href}" `) || cp.includes(`href: "${href}"`), `palette missing ${href}`);
+  }
+});


### PR DESCRIPTION
Закриває останній 🟡-пункт аудиту структури.

## Проблема
Командна палітра (⌘K) мала статичний список із 13 маршрутів — решта 50+ екранів досяжні лише через дерево навігації, тож палітра не була повноцінним механізмом пошуку.

## Зміни
- `COMMANDS` розширено з 13 до **52 маршрутів**, покриваючи всю навігаційну поверхню: щоденна робота, пацієнти, медицина (+ PACS/MWL), послуги/тарифи, фінанси, документи/регістри/звіти, склад, закупівлі, **персонал і радіаційна безпека**, довідники, адміністрування.
- Кожен запис має україномовний `hint` для пошуку за ключовими словами.
- Новий регресійний тест «command palette covers every top-level staff section».

Захист без змін: палітра — лише навігація, доступ на серверних гардах `lib/staff-auth.ts`.

## Перевірки
- `npm test` — 974/974 (+1).
- `npx tsc --noEmit` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_