### PR TITLE
personnel: видалення кадрової картки

### DIFF
--- a/app/api/staff/personnel/route.ts
+++ b/app/api/staff/personnel/route.ts
@@ -268,3 +268,53 @@ export async function PATCH(request: Request) {
   });
   return Response.json({ ok: true, id });
 }
+
+export async function DELETE(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requirePersonnelManager(request, db);
+  if (!ctx) return Response.json({ error: "Доступ до кадрового довідника заборонено" }, { status: 403 });
+
+  const id = clean(new URL(request.url).searchParams.get("id") || "", 120);
+  if (!id) return Response.json({ error: "Не вказано працівника" }, { status: 400 });
+  const existing = await db.prepare(
+    "SELECT id FROM personnel_records WHERE id = ? AND organization_id = ? LIMIT 1",
+  ).bind(id, ctx.organizationId).first();
+  if (!existing) return Response.json({ error: "Працівника не знайдено" }, { status: 404 });
+
+  // Radiation-safety history (ДІВ / ВЛК / навчання / дозиметрія / моніторинг) is
+  // immutable by law and referenced with ON DELETE RESTRICT. A card carrying any
+  // such record must be deactivated, not deleted, so the history is preserved.
+  const deps = await db.prepare(
+    `SELECT
+       (SELECT COUNT(*) FROM personnel_vlk_records WHERE organization_id = ? AND personnel_id = ?)
+     + (SELECT COUNT(*) FROM personnel_radiation_clearance_records WHERE organization_id = ? AND personnel_id = ?)
+     + (SELECT COUNT(*) FROM personnel_radiation_training_records WHERE organization_id = ? AND personnel_id = ?)
+     + (SELECT COUNT(*) FROM personnel_dosimetry_records WHERE organization_id = ? AND personnel_id = ?)
+     + (SELECT COUNT(*) FROM personnel_radiation_monitoring_scope_records WHERE organization_id = ? AND personnel_id = ?)
+       AS dependents`,
+  ).bind(
+    ctx.organizationId, id, ctx.organizationId, id, ctx.organizationId, id,
+    ctx.organizationId, id, ctx.organizationId, id,
+  ).first<{ dependents: number }>();
+  if ((deps?.dependents || 0) > 0) {
+    return Response.json(
+      { error: "Не можна видалити картку: є пов'язані записи (ДІВ / ВЛК / навчання / дозиметрія). Вимкніть картку замість видалення." },
+      { status: 409 },
+    );
+  }
+
+  await db.prepare(
+    "DELETE FROM personnel_records WHERE id = ? AND organization_id = ?",
+  ).bind(id, ctx.organizationId).run();
+
+  await audit(db, {
+    organizationId: ctx.organizationId,
+    actorEmail: ctx.member.email,
+    action: "personnel_deleted",
+    resource: "personnel",
+    targetId: id,
+    details: {},
+  });
+  return Response.json({ ok: true, id });
+}

--- a/app/staff/personnel/page.tsx
+++ b/app/staff/personnel/page.tsx
@@ -155,6 +155,24 @@ export default function PersonnelPage() {
     }
   }
 
+  async function remove() {
+    if (!selected) return;
+    if (!window.confirm(`Видалити картку працівника «${selected.displayName}»? Дію не можна скасувати. Обліковий запис (логін/PIN) не видаляється — його вимикають окремо в «Персонал і ролі».`)) return;
+    setSaving(true); setError(""); setNotice("");
+    try {
+      const response = await fetch(`/api/staff/personnel?id=${encodeURIComponent(selected.id)}`, { method:"DELETE" });
+      const body = await response.json().catch(() => ({})) as { ok?:boolean; error?:string };
+      if (!response.ok || !body.ok) throw new Error(body.error || "Не вдалося видалити картку");
+      closeEditor();
+      await load();
+      setNotice("Картку працівника видалено.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не вдалося видалити картку");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   const editorRecord = selected;
   const showEditor = creating || Boolean(editorRecord);
 
@@ -223,7 +241,7 @@ export default function PersonnelPage() {
         <label>Адреса<input name="addressLine" defaultValue={editorRecord?.addressLine || ""} placeholder="Вулиця, будинок, квартира" /></label>
         <label>Поштовий індекс<input name="postalCode" inputMode="numeric" defaultValue={editorRecord?.postalCode || ""} /></label>
         <label><span>Статус</span><span><input name="active" type="checkbox" defaultChecked={editorRecord ? Boolean(editorRecord.active) : true} /> Активний працівник</span></label>
-        <div><button className="button primary" type="submit" disabled={saving}>{saving ? "Зберігаємо…" : "Зберегти картку"}</button></div>
+        <div className="shiftPlannerActions"><button className="button primary" type="submit" disabled={saving}>{saving ? "Зберігаємо…" : "Зберегти картку"}</button>{selected && <button className="button danger" type="button" disabled={saving} onClick={remove}>Видалити картку</button>}</div>
       </form>
       <p className="notice">Фото, дипломи, сертифікати, ВЛК, допуск до ДІВ і навчання будуть окремими захищеними вкладками цієї ж картки — без зберігання файлів у D1.</p>
     </section>}

--- a/tests/personnel-delete.behavior.test.mjs
+++ b/tests/personnel-delete.behavior.test.mjs
@@ -1,0 +1,61 @@
+// Deleting a personnel card: allowed only when no radiation-safety history is
+// attached (ON DELETE RESTRICT), tenant-scoped, and leaves the login account alone.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, callWorker, seedStaffSession } from "./helpers/d1.mjs";
+
+async function seedCard(db, { id, org = 1 }) {
+  await db.prepare(
+    `INSERT INTO personnel_records
+       (id, organization_id, account_email, employment_kind, last_name, first_name, patronymic,
+        display_name, date_of_birth, military_rank, position_title, active, created_by, updated_by)
+     VALUES (?, ?, NULL, 'military', 'Тест', 'Іван', 'Ігорович', 'Тест Іван Ігорович',
+        '1990-01-01', 'солдат', 'Рентгенолаборант', 1, 'test', 'test')`,
+  ).bind(id, org).run();
+}
+
+const del = (db, cookie, id) =>
+  callWorker(new Request(`https://radiologyos.tech/api/staff/personnel?id=${encodeURIComponent(id)}`, {
+    method: "DELETE", headers: { cookie },
+  }), db);
+
+const cardExists = async (db, id) =>
+  Number((await db.prepare("SELECT COUNT(*) AS n FROM personnel_records WHERE id = ?").bind(id).first()).n) > 0;
+
+test("a personnel card with no radiation-safety history can be deleted", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "hr@example.com", role: "admin", organizationId: 1 });
+    await seedCard(db, { id: "card-free" });
+    const res = await del(db, cookie, "card-free");
+    assert.equal(res.status, 200);
+    assert.equal(await cardExists(db, "card-free"), false);
+  });
+});
+
+test("a card carrying dosimetry history cannot be deleted (must be deactivated)", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "hr2@example.com", role: "admin", organizationId: 1 });
+    await seedCard(db, { id: "card-hist" });
+    await db.prepare(
+      `INSERT INTO personnel_dosimetry_records
+         (id, organization_id, personnel_id, period_start, period_end, measurement_status, created_by)
+       VALUES ('dose-1', 1, 'card-hist', '2026-01-01', '2026-03-31', 'measured', 'test')`,
+    ).run();
+    const res = await del(db, cookie, "card-hist");
+    assert.equal(res.status, 409);
+    assert.match((await res.json()).error, /Вимкніть картку/);
+    assert.equal(await cardExists(db, "card-hist"), true, "card must survive a refused delete");
+  });
+});
+
+test("a personnel card cannot be deleted across the tenant boundary", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'org-b', 'Б', 1)").run();
+    const cookieA = await seedStaffSession(db, { email: "hr-a@example.com", role: "admin", organizationId: 1 });
+    await seedCard(db, { id: "card-orgb", org: 2 });
+    const res = await del(db, cookieA, "card-orgb");
+    assert.equal(res.status, 404);
+    assert.equal(await cardExists(db, "card-orgb"), true);
+  });
+});


### PR DESCRIPTION
За зауваженням: у кадровому довіднику не було видалення (лише «Вимкнений»).

## Зміни
- `DELETE /api/staff/personnel?id=…` — видаляє кадрову картку. Тенант-скоуп, аудит `personnel_deleted`.
- Кнопка **«Видалити картку»** в редакторі картки (з підтвердженням).
- **Захист історії:** якщо до картки прив'язані записи радіаційної безпеки (ВЛК / допуск / навчання / дозиметрія / моніторинг — усі `ON DELETE RESTRICT`), видалення відхиляється (409) з підказкою вимкнути картку. Так незмінна мед/юр історія зберігається.
- Обліковий запис (логін/PIN) при видаленні картки **не чіпається** — його вимикають окремо в «Персонал і ролі».

## Тести (нові)
- Картка без історії → видаляється (200).
- Картка з дозиметрією → 409, картка лишається.
- Крос-тенант → 404.
- `npm test` 977/977, `tsc` чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_