### PR TITLE
personnel: норм-календар (виробничий графік роботи)

### DIFF
--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -59,6 +59,7 @@ const COMMANDS: { label: string; hint: string; href: string }[] = [
   { label: "Постачальники", hint: "контрагенти", href: "/staff/counterparties" },
   // Персонал і радіаційна безпека
   { label: "Персонал і зміни", hint: "кадрові картки", href: "/staff/personnel" },
+  { label: "Норм-календар роботи", hint: "виробничий календар / норма годин", href: "/staff/work-calendar" },
   { label: "Дозиметрія", hint: "дози опромінення", href: "/staff/personnel/dosimetry" },
   { label: "Радіаційний допуск", hint: "clearance", href: "/staff/personnel/radiation-clearance" },
   { label: "Навчання з радіобезпеки", hint: "training", href: "/staff/personnel/radiation-training" },

--- a/app/staff/personnel/page.tsx
+++ b/app/staff/personnel/page.tsx
@@ -185,7 +185,7 @@ export default function PersonnelPage() {
       <article><span>Працівники</span><b>{data?.records.filter((record) => record.active).length || 0}</b><small>активні картки</small></article>
       <article><span>Підрозділи</span><b>{data?.departments.length || 0}</b><small>доступні у структурі</small></article>
       <article><span>З акаунтом</span><b>{data?.records.filter((record) => record.accountEmail).length || 0}</b><small>мають вхід у RadiologyOS</small></article>
-      <article><span>Графіки</span><b>Calendar6</b><small><Link href="/staff/shifts">відкрити графік змін</Link></small></article>
+      <article><span>Графіки</span><b>Calendar6</b><small><Link href="/staff/shifts">графік змін</Link> · <Link href="/staff/work-calendar">норм-календар</Link></small></article>
     </section>
 
     {notice && <p className="notice success" role="status">{notice}</p>}

--- a/app/staff/work-calendar/page.tsx
+++ b/app/staff/work-calendar/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import StaffWorkspaceShell from "../workspace-shell";
+import { workCalendar, holidaysForYear, hasHolidayData } from "../../../lib/work-calendar";
+
+const WEEKDAY = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
+const YEARS = [2025, 2026, 2027];
+
+export default function WorkCalendarPage() {
+  const [year, setYear] = useState(2026);
+  const [includeHolidays, setIncludeHolidays] = useState(false);
+
+  const cal = useMemo(() => workCalendar(year, { includeHolidays }), [year, includeHolidays]);
+  const holidays = useMemo(() => holidaysForYear(year).map((h) => {
+    const weekday = new Date(`${h.date}T12:00:00Z`).getUTCDay();
+    return { ...h, weekday: WEEKDAY[weekday], isWeekend: weekday === 0 || weekday === 6 };
+  }), [year]);
+
+  return <StaffWorkspaceShell
+    active="personnel"
+    title="Норм-календар роботи"
+    description="Виробничий календар: помісячна норма робочих днів і годин за п'ятиденкою (8 год/день)."
+  >
+    <section className="financeToolbar" aria-label="Параметри календаря" style={{ display: "flex", flexWrap: "wrap", gap: "14px", alignItems: "center" }}>
+      <label>Рік{" "}
+        <select value={year} onChange={(e) => setYear(Number(e.target.value))}>
+          {YEARS.map((y) => <option key={y} value={y}>{y}</option>)}
+        </select>
+      </label>
+      <label style={{ display: "inline-flex", alignItems: "center", gap: "7px" }}>
+        <input type="checkbox" checked={includeHolidays} onChange={(e) => setIncludeHolidays(e.target.checked)} disabled={!cal.hasHolidayData} />
+        Врахувати святкові дні (Україна)
+      </label>
+      <span style={{ color: "var(--muted, #667)", fontSize: ".82rem" }}>
+        {includeHolidays
+          ? "Норма зменшена на святкові будні дні."
+          : "П'ятиденка без свят — збігається з типовим «Графіком роботи» 1С."}
+      </span>
+    </section>
+
+    {!cal.hasHolidayData && <p className="notice" role="status">
+      Для {year} року перелік свят не заданий — показано чисту п'ятиденку. Додати свята можна у <code>lib/work-calendar.ts</code>.
+    </p>}
+
+    <section className="financeSummary" aria-label="Річна норма">
+      <article><span>Робочих днів</span><b>{cal.totalDays}</b><small>за рік</small></article>
+      <article><span>Норма годин</span><b>{cal.totalHours}</b><small>за рік</small></article>
+      <article><span>Середньомісячно</span><b>{cal.avgMonthlyHours}</b><small>годин</small></article>
+      <article><span>Годин на день</span><b>{cal.hoursPerDay}</b><small>п'ятиденка</small></article>
+    </section>
+
+    <div style={{ overflowX: "auto" }}>
+      <table className="financeTable">
+        <thead>
+          <tr><th>Місяць</th><th style={{ textAlign: "right" }}>Робочих днів</th><th style={{ textAlign: "right" }}>Норма, год</th>{includeHolidays && <th style={{ textAlign: "right" }}>Свята</th>}</tr>
+        </thead>
+        <tbody>
+          {cal.months.map((m) => <tr key={m.month}>
+            <td>{m.label}</td>
+            <td style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>{m.workingDays}</td>
+            <td style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>{m.hours}</td>
+            {includeHolidays && <td style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>{m.holidays || ""}</td>}
+          </tr>)}
+        </tbody>
+        <tfoot>
+          <tr><th>Разом</th><th style={{ textAlign: "right" }}>{cal.totalDays}</th><th style={{ textAlign: "right" }}>{cal.totalHours}</th>{includeHolidays && <th />}</tr>
+        </tfoot>
+      </table>
+    </div>
+
+    {holidays.length > 0 && <section style={{ marginTop: "18px" }}>
+      <h3 style={{ margin: "0 0 8px", fontSize: "1rem" }}>Святкові та неробочі дні {year}</h3>
+      <p className="notice" role="note" style={{ marginTop: 0 }}>
+        Перелік звіряйте щороку: дати рухомих свят (Великдень, Трійця) і законодавчі зміни (напр. 8/9 травня) змінюються. Свято у вихідний норму не зменшує.
+      </p>
+      <div style={{ overflowX: "auto" }}>
+        <table className="financeTable">
+          <thead><tr><th>Дата</th><th>День</th><th>Свято</th><th>Вплив на норму</th></tr></thead>
+          <tbody>
+            {holidays.map((h) => <tr key={h.date}>
+              <td style={{ fontVariantNumeric: "tabular-nums" }}>{h.date.split("-").reverse().join(".")}</td>
+              <td>{h.weekday}</td>
+              <td>{h.name}</td>
+              <td>{h.isWeekend ? "— (вихідний)" : "−1 робочий день"}</td>
+            </tr>)}
+          </tbody>
+        </table>
+      </div>
+    </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/work-calendar/page.tsx
+++ b/app/staff/work-calendar/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import StaffWorkspaceShell from "../workspace-shell";
-import { workCalendar, holidaysForYear, hasHolidayData } from "../../../lib/work-calendar";
+import { workCalendar, holidaysForYear } from "../../../lib/work-calendar";
 
 const WEEKDAY = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
 const YEARS = [2025, 2026, 2027];
@@ -40,14 +40,14 @@ export default function WorkCalendarPage() {
     </section>
 
     {!cal.hasHolidayData && <p className="notice" role="status">
-      Для {year} року перелік свят не заданий — показано чисту п'ятиденку. Додати свята можна у <code>lib/work-calendar.ts</code>.
+      Для {year} року перелік свят не заданий — показано чисту п’ятиденку. Додати свята можна у <code>lib/work-calendar.ts</code>.
     </p>}
 
     <section className="financeSummary" aria-label="Річна норма">
       <article><span>Робочих днів</span><b>{cal.totalDays}</b><small>за рік</small></article>
       <article><span>Норма годин</span><b>{cal.totalHours}</b><small>за рік</small></article>
       <article><span>Середньомісячно</span><b>{cal.avgMonthlyHours}</b><small>годин</small></article>
-      <article><span>Годин на день</span><b>{cal.hoursPerDay}</b><small>п'ятиденка</small></article>
+      <article><span>Годин на день</span><b>{cal.hoursPerDay}</b><small>п’ятиденка</small></article>
     </section>
 
     <div style={{ overflowX: "auto" }}>

--- a/app/staff/workspace-shell.tsx
+++ b/app/staff/workspace-shell.tsx
@@ -123,6 +123,7 @@ const businessModules:BusinessModule[]=[
   ]},
   { key:"personnel",label:"Персонал",items:[
     {label:"Персонал і зміни",href:"/staff/personnel",hint:"Кадрові картки, підрозділ, посада, зв'язок з обліковим записом"},
+    {label:"Норм-календар роботи",href:"/staff/work-calendar",hint:"Виробничий календар: норма днів і годин по місяцях"},
     {label:"Дозиметрія",href:"/staff/personnel/dosimetry",hint:"Індивідуальні дози опромінення персоналу"},
     {label:"Радіаційний допуск",href:"/staff/personnel/radiation-clearance"},
     {label:"Навчання з радіобезпеки",href:"/staff/personnel/radiation-training"},

--- a/lib/work-calendar.ts
+++ b/lib/work-calendar.ts
@@ -1,0 +1,90 @@
+// Виробничий (норм-)календар: помісячна норма робочих днів і годин за п'ятиденкою.
+// Свята — явний, редаговний перелік (українські свята змінюються законодавчо),
+// тож норма рахується прозоро: будній день, що не є святом = робочий.
+//
+// Без урахування свят числа збігаються з типовим 1С-«Графіком роботи»
+// (2026: 261 день / 2088 год / 174 середньомісячно). З урахуванням свят —
+// законна норма (2026: 256 днів / 2048 год).
+
+export type Holiday = { date: string; name: string };
+export type WorkMonth = { month: number; label: string; workingDays: number; hours: number; holidays: number };
+export type WorkCalendar = {
+  year: number;
+  hoursPerDay: number;
+  includeHolidays: boolean;
+  hasHolidayData: boolean;
+  months: WorkMonth[];
+  totalDays: number;
+  totalHours: number;
+  avgMonthlyHours: number;
+};
+
+const MONTH_LABELS = [
+  "Січень", "Лютий", "Березень", "Квітень", "Травень", "Червень",
+  "Липень", "Серпень", "Вересень", "Жовтень", "Листопад", "Грудень",
+];
+
+// Державні свята та неробочі дні України. Перелік свідомо явний — його треба
+// звіряти щороку (дати рухомих свят і законодавчі зміни, напр. День перемоги
+// 8/9 травня). Свято у вихідний норму не зменшує; переноси не застосовуються
+// автоматично — за потреби додайте/приберіть дату.
+const HOLIDAYS: Record<number, Holiday[]> = {
+  2026: [
+    { date: "2026-01-01", name: "Новий рік" },
+    { date: "2026-03-08", name: "Міжнародний жіночий день" },
+    { date: "2026-04-12", name: "Великдень (Пасха)" },
+    { date: "2026-05-01", name: "День праці" },
+    { date: "2026-05-09", name: "День перемоги над нацизмом" },
+    { date: "2026-05-31", name: "Трійця" },
+    { date: "2026-06-28", name: "День Конституції України" },
+    { date: "2026-08-24", name: "День Незалежності України" },
+    { date: "2026-10-01", name: "День захисників і захисниць України" },
+    { date: "2026-12-25", name: "Різдво Христове" },
+  ],
+};
+
+export function holidaysForYear(year: number): Holiday[] {
+  return HOLIDAYS[year] ? HOLIDAYS[year].map((holiday) => ({ ...holiday })) : [];
+}
+
+export function hasHolidayData(year: number): boolean {
+  return Boolean(HOLIDAYS[year]);
+}
+
+export function workCalendar(
+  year: number,
+  options: { hoursPerDay?: number; includeHolidays?: boolean } = {},
+): WorkCalendar {
+  const hoursPerDay = options.hoursPerDay ?? 8;
+  const includeHolidays = options.includeHolidays ?? false;
+  const holidaySet = new Set(includeHolidays ? holidaysForYear(year).map((holiday) => holiday.date) : []);
+
+  const months: WorkMonth[] = [];
+  let totalDays = 0;
+  for (let m = 0; m < 12; m += 1) {
+    const daysInMonth = new Date(Date.UTC(year, m + 1, 0)).getUTCDate();
+    let workingDays = 0;
+    let holidays = 0;
+    for (let d = 1; d <= daysInMonth; d += 1) {
+      const weekday = new Date(Date.UTC(year, m, d)).getUTCDay(); // 0=Нд … 6=Сб
+      if (weekday === 0 || weekday === 6) continue; // вихідні
+      const iso = `${year}-${String(m + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+      if (holidaySet.has(iso)) { holidays += 1; continue; } // святковий будній день
+      workingDays += 1;
+    }
+    totalDays += workingDays;
+    months.push({ month: m + 1, label: MONTH_LABELS[m], workingDays, hours: workingDays * hoursPerDay, holidays });
+  }
+
+  const totalHours = totalDays * hoursPerDay;
+  return {
+    year,
+    hoursPerDay,
+    includeHolidays,
+    hasHolidayData: hasHolidayData(year),
+    months,
+    totalDays,
+    totalHours,
+    avgMonthlyHours: Math.round((totalHours / 12) * 100) / 100,
+  };
+}

--- a/tests/work-calendar.test.mjs
+++ b/tests/work-calendar.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { workCalendar, holidaysForYear, hasHolidayData } from "../lib/work-calendar.ts";
+
+test("2026 norm calendar without holidays matches the reference 1C production calendar", () => {
+  const cal = workCalendar(2026, { includeHolidays: false });
+  assert.deepEqual(cal.months.map((m) => m.workingDays), [22, 20, 22, 22, 21, 22, 23, 21, 22, 22, 21, 23]);
+  assert.deepEqual(cal.months.map((m) => m.hours), [176, 160, 176, 176, 168, 176, 184, 168, 176, 176, 168, 184]);
+  assert.equal(cal.totalDays, 261);
+  assert.equal(cal.totalHours, 2088);
+  assert.equal(cal.avgMonthlyHours, 174);
+});
+
+test("2026 with Ukrainian holidays gives the legally-correct lower norm", () => {
+  const cal = workCalendar(2026, { includeHolidays: true });
+  // Five holidays fall on weekdays (1 Jan, 1 May, 24 Aug, 1 Oct, 25 Dec) → -5 days.
+  assert.equal(cal.totalDays, 256);
+  assert.equal(cal.totalHours, 2048);
+  assert.equal(cal.months[0].workingDays, 21); // Січень: 22 - Новий рік
+  assert.equal(cal.months[0].holidays, 1);
+  assert.equal(cal.months[1].holidays, 0); // Лютий: свят немає
+});
+
+test("custom hours per day scale the norm", () => {
+  const cal = workCalendar(2026, { includeHolidays: false, hoursPerDay: 7 });
+  assert.equal(cal.totalHours, 261 * 7);
+  assert.equal(cal.months[0].hours, 22 * 7);
+});
+
+test("holiday data is exposed and years without data degrade gracefully", () => {
+  assert.equal(hasHolidayData(2026), true);
+  assert.equal(holidaysForYear(2026).length, 10);
+  assert.equal(hasHolidayData(2099), false);
+  // No holiday data → includeHolidays has no effect, pure five-day norm.
+  const a = workCalendar(2099, { includeHolidays: true });
+  const b = workCalendar(2099, { includeHolidays: false });
+  assert.equal(a.totalDays, b.totalDays);
+});


### PR DESCRIPTION
Новий модуль `/staff/work-calendar` — виробничий (норм-)календар на рік, як «Графік роботи» в 1С: помісячна норма робочих днів і годин за п'ятиденкою (8 год/день).

## Зміни
- `lib/work-calendar.ts` — чиста функція норми: робочий день = Пн-Пт і не свято. Свята — явний редаговний перелік України на 2026.
- Сторінка з річними підсумками, помісячною таблицею й списком свят.
- **Перемикач «Врахувати святкові дні»:**
  - вимкнено (типово) — чиста п'ятиденка, **збігається з 1С**: 2026 → **261 дн / 2088 год / 174** середньомісячно;
  - увімкнено — законна норма зі святами: 2026 → **256 дн / 2048 год** (5 свят припадають на будні: 1 січ, 1 трав, 24 серп, 1 жовт, 25 груд).
- Підключено в навігацію (модуль Персонал), командну палітру й плитку «Графіки».

## Нюанс
У показаній 1С-базі свята не завантажені, тому там 261. Перелік свят треба звіряти щороку (рухомі свята, зміни 8/9 травня) — це видно у примітці на сторінці й у коментарі в `lib/work-calendar.ts`.

## Тести
- Фіксують точні числа 2026 в обох режимах + масштабування годин + деградацію для року без даних.
- `npm test` 981/981, `tsc` чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_