### PR TITLE
appointments: легенда статусів + статус-кольори в денному вигляді

### DIFF
--- a/app/staff/week-calendar.tsx
+++ b/app/staff/week-calendar.tsx
@@ -41,6 +41,14 @@ function groupOf(status: string): string {
   for (const [group, list] of Object.entries(GROUPS)) if (list.includes(status)) return group;
   return "planned";
 }
+const STATUS_LEGEND: { key: string; label: string }[] = [
+  { key: "planned", label: "Заплановано" },
+  { key: "confirmed", label: "Підтверджено" },
+  { key: "arrived", label: "Прибув" },
+  { key: "inroom", label: "У кабінеті" },
+  { key: "done", label: "Виконано" },
+  { key: "cancelled", label: "Скасовано" },
+];
 const EQUIP: Record<string, string> = { ct: "КТ", xray: "Рентген", fluoro: "Флюорограф" };
 const WEEKDAY = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
 const DAY_START = 8, DAY_END = 19, HOUR_PX = 76;
@@ -240,6 +248,9 @@ export default function WeekCalendar({
           </button>
         ))}
       </div>}
+      <div className="apptStatusLegend" aria-label="Легенда статусів запису">
+        {STATUS_LEGEND.map(s => <span key={s.key}><i className={`grp-${s.key}`} aria-hidden="true" />{s.label}</span>)}
+      </div>
       {view === "day" && <p className="slotBoardHint">Натисніть зелений вільний слот, щоб одразу записати пацієнта на цей кабінет, дату і час.</p>}
 
       {view === "week"
@@ -279,7 +290,7 @@ export default function WeekCalendar({
                     ? <p className="roomClosed">Кабінет цього дня не працює</p>
                     : <div className="roomSlots">{candidateTimesFor(schedule.equipment[equipmentId] || SCHEDULE_DEFAULTS.equipment[equipmentId], schedule.equipment[equipmentId]?.slotMinutes || 15).map(time => {
                         const state=roomSlot(equipmentId,time);
-                        if(state.occupied) { const occ = state.occupied; return <button type="button" onClick={()=>setOpenId(occ.id)} className={`roomSlot occupied route-${occ.patientCategory || "unknown"}`} key={time}><strong>{time}</strong><span>{occ.name}</span><small>{occ.service}</small></button>; }
+                        if(state.occupied) { const occ = state.occupied; return <button type="button" onClick={()=>setOpenId(occ.id)} className={`roomSlot occupied grp-${groupOf(occ.status)} route-${occ.patientCategory || "unknown"}`} key={time} title={`${stateLabel(occ.status)} · ${occ.name}`}><strong>{time}</strong><span>{occ.name}</span><small>{occ.service}</small></button>; }
                         if(state.blocked) return <span className="roomSlot blocked" key={time} title={state.blocked.reason}><strong>{time}</strong><span>Недоступно</span><small>{state.blocked.reason || "Технічне вікно"}</small></span>;
                         return <a className="roomSlot free" href={`/staff/book?date=${date}&time=${time}&equipment=${equipmentId}`} key={time}><strong>{time}</strong><span>Вільний слот</span></a>;
                       })}</div>}

--- a/app/styles/02-workspace.css
+++ b/app/styles/02-workspace.css
@@ -767,6 +767,15 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .apptEvent.grp-inroom{background:#eef5ec;border-left-color:#3f8a37}
 .apptEvent.grp-done{background:#eef1ef;border-left-color:#7a8b88}
 .apptEvent.grp-cancelled{background:#fdefeb;border-left-color:#c85a38}
+.apptStatusLegend{display:flex;flex-wrap:wrap;gap:6px 14px;align-items:center;padding:8px 2px 2px;font-size:12px;color:#5c6c78}
+.apptStatusLegend span{display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.apptStatusLegend i{width:13px;height:13px;border-radius:3px;flex:none;background:#b7c9c5}
+.apptStatusLegend i.grp-planned{background:#e0a638}
+.apptStatusLegend i.grp-confirmed{background:#2f7d99}
+.apptStatusLegend i.grp-arrived{background:#7a53c0}
+.apptStatusLegend i.grp-inroom{background:#3f8a37}
+.apptStatusLegend i.grp-done{background:#7a8b88}
+.apptStatusLegend i.grp-cancelled{background:#c85a38}
 /* Календар: навігація і тижневий вигляд (як Google Calendar) */
 .apptNav{display:inline-flex;align-items:center;gap:6px}
 .apptNav button{border:1px solid #cbd8d6;background:#fff;border-radius:7px;min-width:34px;height:38px;font-size:18px;line-height:1;cursor:pointer;color:#41544f;padding:0 10px}

--- a/app/styles/10-landing.css
+++ b/app/styles/10-landing.css
@@ -536,6 +536,13 @@
 .roomSlot.free:hover{background:#dcf3e6;border-color:#64ad83}
 .roomSlot.occupied{background:#e5f4f5;border-color:#78bcc0;color:#0b5960}
 .roomSlot.occupied.route-civilian{background:#edf5fc;border-color:#90b8df;color:#174f83}
+.roomSlot.occupied{border-left-width:4px}
+.roomSlot.occupied.grp-planned{border-left-color:#e0a638}
+.roomSlot.occupied.grp-confirmed{border-left-color:#2f7d99}
+.roomSlot.occupied.grp-arrived{border-left-color:#7a53c0}
+.roomSlot.occupied.grp-inroom{border-left-color:#3f8a37}
+.roomSlot.occupied.grp-done{border-left-color:#7a8b88}
+.roomSlot.occupied.grp-cancelled{border-left-color:#c85a38}
 .roomSlot.blocked{background:#f2f3f4;border-color:#d2d8da;color:#69777b}
 .roomClosed{margin:10px;padding:24px 12px;border-radius:9px;background:#f2f3f4;color:#6b787c;text-align:center;font-size:12px;font-weight:750}
 .apptCardTime{display:grid;gap:3px;font-size:22px}


### PR DESCRIPTION
За порівнянням із календарем OpenEMR. Придивившись до коду, з трьох ідей дві вже були реалізовані в RadiologyOS:
- **мультиколонка по кабінетах** на день — уже є (`roomSlotColumns`);
- **перемикач День/Тиждень/Список** — уже є.

Бракувало лише розшифровки кольорів статусів — це й додано.

## Зміни
- **Легенда статусів** у всіх виглядах календаря: Заплановано / Підтверджено / Прибув / У кабінеті / Виконано / Скасовано — з кольоровими мітками, що збігаються з подіями тижня й смужками дня.
- **Денний вигляд:** зайняті слоти отримали ліву смужку **кольору статусу** (доповнює наявне тло за категорією військовий/цивільний) + підказку зі станом.

## Перевірки
- Build OK, `tsc` чисто, **lint 0 errors**, `npm test` 981/981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_