### PR TITLE
reminders: багатоканальні планові нагадування + «напередодні»

### DIFF
--- a/app/staff/settings/page.tsx
+++ b/app/staff/settings/page.tsx
@@ -24,7 +24,7 @@ export default function StaffSettingsPage() {
   const [token, setToken] = useState("");
   const [externalIcsUrl, setExternalIcsUrl] = useState("");
   const [remindersEnabled, setRemindersEnabled] = useState(false);
-  const [reminderLeadHours, setReminderLeadHours] = useState("3, 1");
+  const [reminderLeadHours, setReminderLeadHours] = useState("24, 3, 1");
   const [smsGatewayUrl, setSmsGatewayUrl] = useState("");
   const [smsGatewayAuth, setSmsGatewayAuth] = useState("");
   const [emailGatewayUrl, setEmailGatewayUrl] = useState("");
@@ -52,7 +52,7 @@ export default function StaffSettingsPage() {
       if (data.settings) {
         setSettings(data.settings); setChatId(data.settings.telegramChatId); setPayLink(data.settings.payLink); setLiqpayPublicKey(data.settings.liqpayPublicKey || ""); setExternalIcsUrl(data.settings.externalIcsUrl || "");
         setRemindersEnabled(Boolean(data.settings.remindersEnabled));
-        setReminderLeadHours(data.settings.reminderLeadHours || "3, 1");
+        setReminderLeadHours(data.settings.reminderLeadHours || "24, 3, 1");
         setSmsGatewayUrl(data.settings.smsGatewayUrl || "");
         setEmailGatewayUrl(data.settings.emailGatewayUrl || "");
         setEmailGatewayFrom(data.settings.emailGatewayFrom || "");
@@ -237,8 +237,8 @@ export default function StaffSettingsPage() {
           <span>Надсилати пацієнтам автонагадування про підтвердження та перенесення запису</span>
         </label>
         <label><span>Нагадування за (годин до візиту)</span>
-          <input value={reminderLeadHours} onChange={(e) => setReminderLeadHours(e.target.value)} placeholder="3, 1" inputMode="numeric" />
-          <small>Через кому — за скільки годин до візиту слати нагадування (напр. «3, 1»). Працює, коли підключено WhatsApp і увімкнено нагадування вище. Розсилає планувальник кожні ~15 хв.</small>
+          <input value={reminderLeadHours} onChange={(e) => setReminderLeadHours(e.target.value)} placeholder="24, 3, 1" inputMode="numeric" />
+          <small>Через кому — за скільки годин до візиту слати нагадування (напр. «24, 3, 1»; 24 = «напередодні»). Планувальник щоразу пробує канали по черзі Telegram → e-mail → WhatsApp → SMS і зупиняється на першому доступному. Розсилає кожні ~15 хв.</small>
         </label>
         <label><span>Адреса SMS-шлюзу (HTTP POST)</span>
           <input value={smsGatewayUrl} onChange={(e) => setSmsGatewayUrl(e.target.value)} placeholder="https://sms-провайдер/api/send" autoComplete="off" inputMode="url" />

--- a/lib/reminders-core.ts
+++ b/lib/reminders-core.ts
@@ -3,7 +3,8 @@
 // (читання БД, надсилання WhatsApp) — у lib/reminders.ts.
 
 export const REMINDER_LEAD_KEY = "reminder_lead_hours";
-export const REMINDER_LEAD_DEFAULT = [3, 1];
+// За замовчуванням: за добу (нагадування «напередодні»), за 3 год і за 1 год.
+export const REMINDER_LEAD_DEFAULT = [24, 3, 1];
 // Вікно «спіймати» нагадування: cron ходить ~кожні 15 хв, тож 25-хв вікно
 // переживає один пропущений запуск. Повтори не дублюються завдяки дедуплікації
 // за kind у patient_notifications.
@@ -42,10 +43,63 @@ export function dueReminders(
   return out;
 }
 
-export function leadReminderText(service: string, time: string, hours: number): string {
-  const when = time ? `сьогодні о ${time}` : "сьогодні";
+export function leadReminderText(
+  service: string, time: string, hours: number, dayLabel = "сьогодні",
+): string {
+  const when = time ? `${dayLabel} о ${time}` : dayLabel;
   return `Нагадування: за ${hours} год у вас запис на «${service}» — ${when}. `
     + `Відділення променевої діагностики. Якщо час не підходить — зателефонуйте у реєстратуру.`;
+}
+
+// Календарна різниця в днях між двома датами YYYY-MM-DD (to - from).
+export function daysBetween(from: string, to: string): number | null {
+  const a = /^(\d{4})-(\d{2})-(\d{2})$/.exec(from);
+  const b = /^(\d{4})-(\d{2})-(\d{2})$/.exec(to);
+  if (!a || !b) return null;
+  const ax = Date.UTC(Number(a[1]), Number(a[2]) - 1, Number(a[3]));
+  const bx = Date.UTC(Number(b[1]), Number(b[2]) - 1, Number(b[3]));
+  return Math.round((bx - ax) / 86_400_000);
+}
+
+// Дата YYYY-MM-DD, зсунута на N днів (для запиту «сьогодні + завтра»).
+export function addDaysToDate(dateStr: string, days: number): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!m) return dateStr;
+  const dt = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  const y = dt.getUTCFullYear();
+  const mo = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(dt.getUTCDate()).padStart(2, "0");
+  return `${y}-${mo}-${d}`;
+}
+
+// Хвилини до візиту з урахуванням переходу через добу (напр. нагадування
+// «напередодні» о 24 год для завтрашнього візиту). Може бути > 1440.
+export function minutesUntilBooking(
+  todayDate: string, nowMin: number, desiredDate: string, desiredTime: string,
+): number | null {
+  const t = minutesOfTime(desiredTime);
+  if (t == null) return null;
+  const diff = daysBetween(todayDate, desiredDate);
+  if (diff == null) return null;
+  return diff * 1440 + t - nowMin;
+}
+
+// Людський підпис дня візиту для тексту нагадування.
+export function visitDayLabel(desiredDate: string, todayDate: string): string {
+  const diff = daysBetween(todayDate, desiredDate);
+  if (diff === 0) return "сьогодні";
+  if (diff === 1) return "завтра";
+  return desiredDate;
+}
+
+export type ChannelName = "telegram" | "email" | "whatsapp" | "sms";
+
+// Ланцюжок каналів для планового нагадування: пробуємо по черзі й
+// зупиняємось на першому успішному. Порядок — Telegram → e-mail → WhatsApp → SMS.
+export function reminderChannelChain(available: Partial<Record<ChannelName, boolean>>): ChannelName[] {
+  const order: ChannelName[] = ["telegram", "email", "whatsapp", "sms"];
+  return order.filter((c) => available[c]);
 }
 
 // Поточний час у Києві: дата YYYY-MM-DD і хвилини від початку доби.

--- a/lib/reminders.ts
+++ b/lib/reminders.ts
@@ -1,18 +1,27 @@
 // Планові нагадування пацієнтам за N годин до візиту.
 // Раннер завжди отримує явний tenant і використовує тільки його integration settings.
+//
+// Канали: для кожного запису пробуємо ланцюжок Telegram → e-mail → WhatsApp → SMS
+// і зупиняємось на першому успішному (див. reminderChannelChain). Ліди можуть
+// перетинати добу (нагадування «напередодні» за 24 год) — запит бере записи на
+// сьогодні й завтра, а minutesUntilBooking рахує хвилини через межу доби.
 
 import { getOrganizationIntegrationSettings } from "./settings";
+import { createMessagingProvider } from "./providers/messaging";
+import { sendTelegramTo } from "./telegram";
 import { sendWhatsApp, whatsappConfig, whatsappConfigured } from "./whatsapp";
 import {
-  REMINDER_LEAD_KEY, dueReminders, kyivNow, leadReminderText, minutesOfTime,
-  parseLeadHours, type LeadBooking,
+  REMINDER_LEAD_KEY, addDaysToDate, dueReminders, kyivNow, leadReminderText,
+  minutesUntilBooking, parseLeadHours, reminderChannelChain, visitDayLabel,
+  type ChannelName, type LeadBooking,
 } from "./reminders-core";
 
 export { REMINDER_LEAD_KEY, parseLeadHours };
 
 type ReminderRow = {
   id: number; patientId:string; name: string; phone: string; phoneNormalized: string;
-  service: string; desiredTime: string; doNotContact:number; sharedProfileCount:number;
+  patientEmail: string; service: string; desiredDate: string; desiredTime: string;
+  telegramChatId: string; doNotContact:number; sharedProfileCount:number;
   staleLinkedContact:number;
 };
 
@@ -25,20 +34,36 @@ export async function runDueReminders(
   if (!Number.isInteger(organizationId) || organizationId <= 0) return result;
   try {
     const cfg = await getOrganizationIntegrationSettings(db, organizationId, [
-      "patient_reminders_enabled", REMINDER_LEAD_KEY,
+      "patient_reminders_enabled", REMINDER_LEAD_KEY, "telegram_bot_token",
+      "sms_gateway_url", "sms_gateway_auth",
+      "email_gateway_url", "email_gateway_auth", "email_gateway_from",
     ]);
     if (!["1", "true", "on", "yes"].includes((cfg.patient_reminders_enabled || "").trim().toLowerCase())) {
       return result;
     }
+
     const wa = await whatsappConfig(db, organizationId);
-    if (!whatsappConfigured(wa) || !wa.enabled) return result;
+    const waReady = whatsappConfigured(wa) && wa.enabled;
+    const telegramToken = (cfg.telegram_bot_token || "").trim();
+    const smsUrl = (cfg.sms_gateway_url || "").trim();
+    const emailUrl = (cfg.email_gateway_url || "").trim();
+    // Жоден канал не налаштовано — нема чим слати, вийти без запису в outbox,
+    // щоб нагадування спробувалось знову, коли адмін підключить шлюз.
+    if (!telegramToken && !emailUrl && !smsUrl && !waReady) return result;
+
+    const messaging = createMessagingProvider({
+      sms: { url: smsUrl, auth: cfg.sms_gateway_auth || "" },
+      email: { url: emailUrl, auth: cfg.email_gateway_auth || "", from: cfg.email_gateway_from || "" },
+    });
 
     const leads = parseLeadHours(cfg[REMINDER_LEAD_KEY]);
     const { date, minutes: nowMin } = kyivNow(nowMs);
+    const tomorrow = addDaysToDate(date, 1);
 
     const rows = await db.prepare(
       `SELECT b.id, b.patient_id AS patientId, b.name, b.phone,
-         b.phone_normalized AS phoneNormalized, b.service, b.desired_time AS desiredTime,
+         b.phone_normalized AS phoneNormalized, b.patient_email AS patientEmail,
+         b.service, b.desired_date AS desiredDate, b.desired_time AS desiredTime,
          CASE
            WHEN b.patient_id != '' AND EXISTS (
              SELECT 1 FROM patient_profiles p
@@ -57,51 +82,93 @@ export async function runDueReminders(
              WHERE p.organization_id = b.organization_id
                AND p.patient_id = b.patient_id
                AND p.phone_normalized = b.phone_normalized
-           ) THEN 1 ELSE 0 END AS staleLinkedContact
+           ) THEN 1 ELSE 0 END AS staleLinkedContact,
+         COALESCE((
+           SELECT ti.telegram_chat_id
+           FROM patient_telegram_identities ti
+           WHERE ti.organization_id = b.organization_id
+             AND ti.phone_normalized = b.phone_normalized
+             AND ti.telegram_chat_id != ''
+             AND (
+               (b.patient_id != '' AND ti.patient_id = b.patient_id)
+               OR (
+                 b.patient_id = '' AND ti.patient_id = ''
+                 AND ti.identity_kind = 'booking' AND ti.identity_value = b.code
+               )
+             )
+           ORDER BY ti.updated_at DESC
+           LIMIT 1
+         ), '') AS telegramChatId
        FROM bookings b
-       WHERE b.organization_id = ? AND b.desired_date = ? AND b.status IN ('confirmed','rescheduled')`
-    ).bind(organizationId, date).all<ReminderRow>();
+       WHERE b.organization_id = ? AND b.desired_date IN (?, ?)
+         AND b.status IN ('confirmed','rescheduled')`
+    ).bind(organizationId, date, tomorrow).all<ReminderRow>();
     const bookings = rows.results || [];
     if (!bookings.length) return result;
 
     const leadBookings: LeadBooking[] = [];
     const byId = new Map<number, ReminderRow>();
     for (const b of bookings) {
-      const t = minutesOfTime(b.desiredTime);
-      if (t == null) continue;
+      const minutesUntil = minutesUntilBooking(date, nowMin, b.desiredDate, b.desiredTime);
+      if (minutesUntil == null) continue;
       byId.set(b.id, b);
-      leadBookings.push({ id: b.id, minutesUntil: t - nowMin });
+      leadBookings.push({ id: b.id, minutesUntil });
     }
 
     const sentRows = await db.prepare(
       `SELECT n.booking_id AS bookingId, n.kind
        FROM patient_notifications n
        JOIN bookings b ON b.id = n.booking_id
-       WHERE b.organization_id = ? AND n.kind LIKE 'reminder_%h' AND b.desired_date = ?`
-    ).bind(organizationId, date).all<{ bookingId: number; kind: string }>();
+       WHERE b.organization_id = ? AND n.kind LIKE 'reminder_%h' AND b.desired_date IN (?, ?)`
+    ).bind(organizationId, date, tomorrow).all<{ bookingId: number; kind: string }>();
     const alreadySent = new Set((sentRows.results || []).map((r) => `${r.bookingId}:${r.kind}`));
 
     for (const due of dueReminders(leadBookings, leads, alreadySent)) {
       const b = byId.get(due.id);
       if (!b || !b.phoneNormalized) continue;
       const kind = `reminder_${due.hours}h`;
+      const dayLabel = visitDayLabel(b.desiredDate, date);
+      const body = leadReminderText(b.service, b.desiredTime, due.hours, dayLabel);
+
       if (b.doNotContact || b.staleLinkedContact || (!b.patientId && b.sharedProfileCount > 0)) {
         const reason = b.doNotContact
           ? "Пацієнт у списку «не турбувати»"
           : b.staleLinkedContact
             ? "Контакт exact-пацієнта змінено після створення запису"
             : "Неприв’язаний запис має неоднозначну CRM-ідентичність";
-        await record(db, organizationId, b, kind, "skipped", reason);
+        await record(db, organizationId, b, kind, "whatsapp", b.phone, body, "skipped", reason);
         result.skipped += 1;
         continue;
       }
-      const body = leadReminderText(b.service, b.desiredTime, due.hours);
-      try {
-        const r = await sendWhatsApp(db, b.phoneNormalized, body, organizationId);
-        if (r.ok) { await record(db, organizationId, b, kind, "sent", ""); result.sent += 1; }
-        else { await record(db, organizationId, b, kind, "failed", r.error || "WhatsApp помилка"); result.failed += 1; }
-      } catch (error) {
-        await record(db, organizationId, b, kind, "failed", error instanceof Error ? error.message : "Помилка");
+
+      const chain = reminderChannelChain({
+        telegram: !!b.telegramChatId && !!telegramToken,
+        email: !!b.patientEmail && !!emailUrl,
+        whatsapp: waReady,
+        sms: !!b.phone && !!smsUrl,
+      });
+      // Немає жодного придатного каналу саме для цього запису — не пишемо в
+      // outbox, щоб спробувати ще раз у вікні, якщо зʼявиться контакт/шлюз.
+      if (!chain.length) { result.skipped += 1; continue; }
+
+      let delivered = false;
+      let lastChannel: ChannelName = chain[chain.length - 1];
+      let lastRecipient = b.phone;
+      let lastError = "";
+      for (const channel of chain) {
+        const { recipient, run } = channelSender(channel, b, body, messaging, db, organizationId);
+        lastChannel = channel; lastRecipient = recipient;
+        try {
+          const r = await run();
+          if (r.ok) { await record(db, organizationId, b, kind, channel, recipient, body, "sent", ""); delivered = true; break; }
+          lastError = r.error || `${channel} помилка`;
+        } catch (error) {
+          lastError = error instanceof Error ? error.message : "Помилка відправлення";
+        }
+      }
+      if (delivered) { result.sent += 1; }
+      else {
+        await record(db, organizationId, b, kind, lastChannel, lastRecipient, body, "failed", lastError || "Усі канали недоступні");
         result.failed += 1;
       }
     }
@@ -111,18 +178,47 @@ export async function runDueReminders(
   return result;
 }
 
+function channelSender(
+  channel: ChannelName,
+  b: ReminderRow,
+  body: string,
+  messaging: ReturnType<typeof createMessagingProvider>,
+  db: D1Database,
+  organizationId: number,
+): { recipient: string; run: () => Promise<{ ok: boolean; error?: string }> } {
+  switch (channel) {
+    case "telegram":
+      return { recipient: "Telegram", run: () => sendTelegramTo(db, b.telegramChatId, body, organizationId) };
+    case "email":
+      return {
+        recipient: b.patientEmail,
+        run: async () => { await messaging.sendEmail(b.patientEmail, "Нагадування про запис", body); return { ok: true }; },
+      };
+    case "sms":
+      return {
+        recipient: b.phone,
+        run: async () => { await messaging.sendSms(b.phone, body); return { ok: true }; },
+      };
+    case "whatsapp":
+    default:
+      return { recipient: b.phone, run: () => sendWhatsApp(db, b.phoneNormalized, body, organizationId) };
+  }
+}
+
 async function record(
   db: D1Database,
   organizationId: number,
   b: ReminderRow,
   kind: string,
+  channel: ChannelName,
+  recipient: string,
+  body: string,
   status: string,
   error: string,
 ): Promise<void> {
-  const body = leadReminderText(b.service, b.desiredTime, 0);
   await db.prepare(
     `INSERT INTO patient_notifications
       (organization_id, booking_id, kind, channel, recipient, body, status, error, sent_at)
-     VALUES (?, ?, ?, 'whatsapp', ?, ?, ?, ?, ?)`
-  ).bind(organizationId, b.id, kind, b.phone, body, status, error.slice(0, 240), status).run();
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(organizationId, b.id, kind, channel, recipient, body, status, error.slice(0, 240), status).run();
 }

--- a/tests/reminders-tenant.behavior.test.mjs
+++ b/tests/reminders-tenant.behavior.test.mjs
@@ -17,7 +17,7 @@ async function booking(db, organizationId, code, phoneNormalized) {
 }
 
 test("scheduled reminder SQL isolates bookings, dedupe and exact contact consent by organization", async () => {
-  assert.match(remindersSource, /WHERE b\.organization_id = \? AND b\.desired_date = \? AND b\.status IN \('confirmed','rescheduled'\)/);
+  assert.match(remindersSource, /WHERE b\.organization_id = \? AND b\.desired_date IN \(\?, \?\)\s*\n\s*AND b\.status IN \('confirmed','rescheduled'\)/);
   assert.match(remindersSource, /JOIN bookings b ON b\.id = n\.booking_id[\s\S]*WHERE b\.organization_id = \?/);
   assert.match(remindersSource, /p\.organization_id = b\.organization_id/);
   assert.match(remindersSource, /p\.patient_id = b\.patient_id/);

--- a/tests/reminders.test.mjs
+++ b/tests/reminders.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
   parseLeadHours, dueReminders, leadReminderText, kyivNow, REMINDER_LEAD_DEFAULT,
+  daysBetween, addDaysToDate, minutesUntilBooking, visitDayLabel, reminderChannelChain,
 } from "../lib/reminders-core.ts";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
@@ -42,6 +43,55 @@ test("leadReminderText mentions the lead hours, service and time", () => {
   assert.match(text, /за 3 год/);
   assert.match(text, /КТ голови/);
   assert.match(text, /09:00/);
+  assert.match(text, /сьогодні/); // типовий підпис дня
+  // Нагадування «напередодні» помічає день візиту.
+  assert.match(leadReminderText("МРТ", "08:30", 24, "завтра"), /завтра о 08:30/);
+});
+
+test("daysBetween / addDaysToDate handle calendar boundaries", () => {
+  assert.equal(daysBetween("2026-07-15", "2026-07-15"), 0);
+  assert.equal(daysBetween("2026-07-15", "2026-07-16"), 1);
+  assert.equal(daysBetween("2026-07-31", "2026-08-01"), 1); // через межу місяця
+  assert.equal(daysBetween("2026-12-31", "2027-01-01"), 1); // через межу року
+  assert.equal(daysBetween("bad", "2026-07-16"), null);
+  assert.equal(addDaysToDate("2026-07-31", 1), "2026-08-01");
+  assert.equal(addDaysToDate("2026-12-31", 1), "2027-01-01");
+});
+
+test("minutesUntilBooking crosses midnight so a day-before lead fires", () => {
+  // Сьогодні 09:00, візит завтра 08:30 → 23 год 30 хв = 1410 хв.
+  assert.equal(minutesUntilBooking("2026-07-15", 9 * 60, "2026-07-16", "08:30"), 23 * 60 + 30);
+  // Візит сьогодні о 12:00, зараз 09:00 → 180 хв.
+  assert.equal(minutesUntilBooking("2026-07-15", 9 * 60, "2026-07-15", "12:00"), 180);
+  // 24-год лід для завтра о 09:00, зараз 09:05 → 1435 хв (у вікні 24 год).
+  assert.equal(minutesUntilBooking("2026-07-15", 9 * 60 + 5, "2026-07-16", "09:00"), 24 * 60 - 5);
+  assert.equal(minutesUntilBooking("2026-07-15", 540, "2026-07-16", "bad"), null);
+});
+
+test("a 24h (day-before) lead fires only inside its catch window for a next-day visit", () => {
+  const leads = [24, 3, 1];
+  // Завтра 09:00, зараз 09:10 сьогодні → 1430 хв (вікно 24 год = (1415, 1440]).
+  const m = minutesUntilBooking("2026-07-15", 9 * 60 + 10, "2026-07-16", "09:00");
+  assert.deepEqual(dueReminders([{ id: 7, minutesUntil: m }], leads, new Set()), [{ id: 7, hours: 24 }]);
+  // Зарано: зараз 08:00 сьогодні → 1500 хв, ще не час.
+  const early = minutesUntilBooking("2026-07-15", 8 * 60, "2026-07-16", "09:00");
+  assert.deepEqual(dueReminders([{ id: 7, minutesUntil: early }], leads, new Set()), []);
+});
+
+test("visitDayLabel names today / tomorrow / explicit date", () => {
+  assert.equal(visitDayLabel("2026-07-15", "2026-07-15"), "сьогодні");
+  assert.equal(visitDayLabel("2026-07-16", "2026-07-15"), "завтра");
+  assert.equal(visitDayLabel("2026-07-20", "2026-07-15"), "2026-07-20");
+});
+
+test("reminderChannelChain keeps the fixed Telegram→email→WhatsApp→SMS order", () => {
+  assert.deepEqual(
+    reminderChannelChain({ telegram: true, email: true, whatsapp: true, sms: true }),
+    ["telegram", "email", "whatsapp", "sms"],
+  );
+  assert.deepEqual(reminderChannelChain({ email: true, whatsapp: true }), ["email", "whatsapp"]);
+  assert.deepEqual(reminderChannelChain({ sms: true }), ["sms"]);
+  assert.deepEqual(reminderChannelChain({}), []);
 });
 
 test("kyivNow converts a UTC instant to Kyiv date and minutes", () => {
@@ -71,7 +121,7 @@ test("worker schedules tenant-limited reminders and internal operational tasks e
 
 test("runner scopes bookings, dedupe and contact consent by exact identity and organization", async () => {
   const src = await read("lib/reminders.ts");
-  assert.match(src, /WHERE b\.organization_id = \? AND b\.desired_date = \? AND b\.status IN \('confirmed','rescheduled'\)/);
+  assert.match(src, /WHERE b\.organization_id = \? AND b\.desired_date IN \(\?, \?\)/);
   assert.match(src, /p\.organization_id = b\.organization_id/);
   assert.match(src, /p\.patient_id = b\.patient_id/);
   assert.match(src, /p\.do_not_contact = 1/);
@@ -79,6 +129,9 @@ test("runner scopes bookings, dedupe and contact consent by exact identity and o
   assert.match(src, /staleLinkedContact/);
   assert.match(src, /!b\.patientId && b\.sharedProfileCount > 0/);
   assert.match(src, /sendWhatsApp\(db, b\.phoneNormalized, body, organizationId\)/);
+  assert.match(src, /sendTelegramTo\(db, b\.telegramChatId, body, organizationId\)/);
+  assert.match(src, /messaging\.sendEmail\(/);
+  assert.match(src, /reminderChannelChain\(/);
   assert.match(src, /kind LIKE 'reminder_%h'/);
   assert.match(src, /status IN \('confirmed','rescheduled'\)/);
 });


### PR DESCRIPTION
## Що зроблено

За запитом «1+2» до нагадувань пацієнту.

### 1. Багатоканальні планові нагадування (ланцюжок каналів)
Планувальник (`runDueReminders`) раніше слав **тільки WhatsApp**. Тепер на кожен запис пробує канали по черзі і зупиняється на першому успішному:

**Telegram → e-mail → WhatsApp → SMS**

- Telegram — якщо в пацієнта привʼязаний `chat_id` і налаштований бот.
- e-mail — якщо в заявці збережено адресу і підключено e-mail-шлюз.
- WhatsApp / SMS — як і раніше, за номером.
- Фактичний канал доставки фіксується в outbox (`patient_notifications`).
- Якщо для запису немає жодного придатного каналу — рядок в outbox не пишемо, щоб спроба повторилась у вікні, коли зʼявиться контакт/шлюз.

### 2. Нагадування «напередодні» (за день до візиту)
Лід тепер може перетинати добу:
- запит бере записи на **сьогодні й завтра** (`desired_date IN (?, ?)`);
- `minutesUntilBooking` рахує хвилини до візиту через межу доби (може бути > 1440);
- типовий набір лідів — **`24, 3, 1`** (24 год = «напередодні»);
- текст нагадування помічає день візиту: *сьогодні / завтра / дата*.

## Що лишилось без змін
- Дедуплікація за `kind` (`reminder_Nh`) на запис — повтори не дублюються.
- Консент: «не турбувати», stale/ambiguous контакт — ті самі гарди.
- Ізоляція за `organization_id`, cron `*/15`.

## Тести
- Нові юніт-тести чистої логіки: `daysBetween`, `addDaysToDate`, `minutesUntilBooking` (перехід через межу доби/місяця/року), `visitDayLabel`, `reminderChannelChain`, і що 24-год лід спрацьовує лише у своєму вікні для завтрашнього візиту.
- Оновлено source-inspection assertions під новий SQL і канали.
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — 989/989 зелені.

## UI
Підказку в налаштуваннях оновлено: типове «24, 3, 1» і опис ланцюжка каналів.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_