### PR TITLE
patients: аудит неузгодженостей карток (за мотивами health-os)

### DIFF
--- a/app/api/staff/patients/issues/route.ts
+++ b/app/api/staff/patients/issues/route.ts
@@ -1,0 +1,89 @@
+// Read-only аудит суперечностей між джерелами даних пацієнта в межах
+// організації. Тільки реєстратор/адміністратор; нічого не змінює.
+
+import { canViewPatientRegistry } from "../../../../../lib/staff-auth";
+import { requireOrgContext } from "../../../../../lib/tenant";
+import { logSecurityEvent } from "../../../../../lib/audit";
+import { dbBinding } from "../../../../../lib/db";
+import {
+  countFindings, sortFindings,
+  staleContactFindings, duplicatePhoneFindings, linkableBookingFindings, nameDivergenceFindings,
+  type StaleContactRow, type DuplicatePhoneRow, type LinkableBookingRow, type NameDivergenceRow,
+} from "../../../../../lib/patient-consistency";
+
+const LIMIT = 500;
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
+  const orgId = ctx.organizationId;
+  if (!canViewPatientRegistry(member.role)) {
+    return Response.json({ error: "Аудит карток доступний лише реєстратору або адміністратору" }, { status: 403 });
+  }
+
+  // Контакт exact-пацієнта в заявці розійшовся з карткою.
+  const staleP = db.prepare(
+    `SELECT b.id AS bookingId, b.code, b.name AS bookingName, b.phone_normalized AS bookingPhone,
+       p.patient_id AS patientId, p.display_name AS displayName, p.phone_normalized AS profilePhone
+     FROM bookings b
+     JOIN patient_profiles p ON p.organization_id = b.organization_id AND p.patient_id = b.patient_id
+     WHERE b.organization_id = ? AND b.patient_id != '' AND b.phone_normalized != ''
+       AND b.phone_normalized != p.phone_normalized
+     ORDER BY b.desired_date DESC LIMIT ?`
+  ).bind(orgId, LIMIT).all();
+
+  // Один номер у кількох картках — можливі дублікати / неоднозначна ідентичність.
+  const dupP = db.prepare(
+    `SELECT phone_normalized AS phoneNormalized, COUNT(*) AS count,
+       GROUP_CONCAT(CASE WHEN display_name = '' THEN 'без імені' ELSE display_name END, ' | ') AS names
+     FROM patient_profiles
+     WHERE organization_id = ? AND phone_normalized != ''
+     GROUP BY phone_normalized HAVING COUNT(*) > 1
+     ORDER BY COUNT(*) DESC LIMIT ?`
+  ).bind(orgId, LIMIT).all();
+
+  // Неприв'язана заявка, чий номер збігається РІВНО з однією карткою.
+  const linkP = db.prepare(
+    `SELECT b.id AS bookingId, b.code, b.name AS bookingName, b.phone_normalized AS phoneNormalized,
+       p.patient_id AS patientId, p.display_name AS displayName
+     FROM bookings b
+     JOIN patient_profiles p ON p.organization_id = b.organization_id AND p.phone_normalized = b.phone_normalized
+     WHERE b.organization_id = ? AND b.patient_id = '' AND b.phone_normalized != ''
+       AND (SELECT COUNT(*) FROM patient_profiles p2
+            WHERE p2.organization_id = b.organization_id AND p2.phone_normalized = b.phone_normalized) = 1
+     ORDER BY b.desired_date DESC LIMIT ?`
+  ).bind(orgId, LIMIT).all();
+
+  // Кандидати для звірки ПІБ (розбіжність рахуємо в чистій логіці).
+  const nameP = db.prepare(
+    `SELECT b.id AS bookingId, b.code, b.name AS bookingName,
+       p.patient_id AS patientId, p.display_name AS displayName, p.phone_normalized AS phoneNormalized
+     FROM bookings b
+     JOIN patient_profiles p ON p.organization_id = b.organization_id AND p.patient_id = b.patient_id
+     WHERE b.organization_id = ? AND b.name != '' AND p.display_name != ''
+     ORDER BY b.desired_date DESC LIMIT ?`
+  ).bind(orgId, LIMIT * 2).all();
+
+  const [stale, dup, link, names] = await Promise.all([staleP, dupP, linkP, nameP]);
+
+  const findings = sortFindings([
+    ...staleContactFindings(stale.results as unknown as StaleContactRow[]),
+    ...duplicatePhoneFindings(dup.results as unknown as DuplicatePhoneRow[]),
+    ...linkableBookingFindings(link.results as unknown as LinkableBookingRow[]),
+    ...nameDivergenceFindings(names.results as unknown as NameDivergenceRow[]),
+  ]);
+  const counts = countFindings(findings);
+
+  await logSecurityEvent(db, {
+    organizationId: orgId,
+    actorEmail: member.email,
+    action: "patient_consistency_viewed",
+    resource: "patient_registry",
+    details: { total: counts.total },
+  });
+
+  return Response.json({ findings, counts, staff: member }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -28,6 +28,7 @@ const COMMANDS: { label: string; hint: string; href: string }[] = [
   // Пацієнти
   { label: "Пацієнти", hint: "картки / CRM", href: "/staff/patients" },
   { label: "Імпорт пацієнтів", hint: "CSV / масове завантаження", href: "/staff/patients/import" },
+  { label: "Неузгодженості карток", hint: "аудит суперечностей CRM", href: "/staff/patients/issues" },
   { label: "Чат із пацієнтами", hint: "повідомлення", href: "/staff/chat" },
   // Медицина
   { label: "DICOM / PACS", hint: "знімки та архів", href: "/staff/imaging" },

--- a/app/staff/patients/issues/page.tsx
+++ b/app/staff/patients/issues/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+
+type StaffRole = "admin" | "organization_admin" | "department_head" | "registrar" | "radiologist" | "radiographer";
+type StaffInfo = { email:string; displayName:string; role:StaffRole };
+
+type Severity = "high" | "medium" | "low";
+type Finding = {
+  kind: string; severity: Severity; patientId: string; bookingId: number | null;
+  code: string; phoneNormalized: string; title: string; detail: string; suggestion: string;
+};
+type Counts = { high:number; medium:number; low:number; total:number };
+
+const roleLabels: Record<string,string> = {
+  admin:"Адміністратор", organization_admin:"Адміністратор організації",
+  department_head:"Завідувач відділення", registrar:"Реєстратор",
+  radiologist:"Лікар-рентгенолог", radiographer:"Рентгенолаборант",
+};
+const severityLabels: Record<Severity,string> = { high:"Високий", medium:"Середній", low:"Низький" };
+const kindLabels: Record<string,string> = {
+  stale_contact:"Розбіжність контакту", duplicate_phone:"Спільний номер",
+  linkable_booking:"Можна привʼязати", name_divergence:"Розбіжність ПІБ",
+};
+
+function patientHref(f: Finding): string {
+  if (f.patientId) return `/staff/patients?patientId=${encodeURIComponent(f.patientId)}`;
+  if (f.phoneNormalized) return `/staff/patients?phone=${encodeURIComponent(f.phoneNormalized)}`;
+  return "/staff/patients";
+}
+
+export default function PatientIssuesPage() {
+  const [staff, setStaff] = useState<StaffInfo | null>(null);
+  const [findings, setFindings] = useState<Finding[]>([]);
+  const [counts, setCounts] = useState<Counts>({ high:0, medium:0, low:0, total:0 });
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch("/api/staff/patients/issues", { headers: { "cache-control": "no-store" } });
+        const data = await res.json().catch(() => ({}));
+        if (!alive) return;
+        if (!res.ok) { setError(data.error || "Не вдалося завантажити аудит"); return; }
+        setStaff(data.staff || null);
+        setFindings(data.findings || []);
+        setCounts(data.counts || { high:0, medium:0, low:0, total:0 });
+      } catch {
+        if (alive) setError("Мережа недоступна");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  return <StaffWorkspaceShell
+    active="patients"
+    title="Неузгодженості карток"
+    description="Аудит суперечностей між картками CRM, заявками й контактами: розбіжні телефони та ПІБ, спільні номери, заявки без картки. Read-only — нічого не змінює."
+    staffName={staff?.displayName || staff?.email}
+    staffRole={staff ? roleLabels[staff.role] : undefined}
+  >
+    {error ? <section className="accessDenied"><b>Захищений розділ</b><p>{error}. Увійдіть через дозволений робочий обліковий запис.</p><a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Fpatients%2Fissues">Увійти для роботи</a></section> :
+    <section className="reportPanel">
+      <div className="consistencySummary">
+        <span className="consistencyBadge sev-high">Високий: <b>{counts.high}</b></span>
+        <span className="consistencyBadge sev-medium">Середній: <b>{counts.medium}</b></span>
+        <span className="consistencyBadge sev-low">Низький: <b>{counts.low}</b></span>
+        <a className="button compact" href="/staff/patients">← До карток</a>
+      </div>
+      {loading ? <p className="empty">Перевіряємо…</p> :
+        findings.length === 0 ? <p className="empty">Суперечностей не знайдено — дані карток узгоджені.</p> :
+        <ul className="consistencyList">
+          {findings.map((f, i) => <li key={`${f.kind}:${f.bookingId ?? f.phoneNormalized}:${i}`} className={`consistencyItem sev-${f.severity}`}>
+            <div className="consistencyItemHead">
+              <span className={`consistencyBadge sev-${f.severity}`}>{severityLabels[f.severity]}</span>
+              <span className="consistencyKind">{kindLabels[f.kind] || f.kind}</span>
+            </div>
+            <b>{f.title}</b>
+            <p className="consistencyDetail">{f.detail}</p>
+            <p className="consistencySuggestion">{f.suggestion}</p>
+            <a className="crmVisitLink" href={patientHref(f)}>Відкрити картку →</a>
+          </li>)}
+        </ul>}
+    </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/staff/patients/page.tsx
+++ b/app/staff/patients/page.tsx
@@ -273,6 +273,7 @@ export default function PatientsPage() {
           {canManage && <button type="button" className="crmAddBtn" onClick={()=>{setCreating(true);setSelectedPatientKey(null);setCard(null);setActionError("");setActionSuccess("");}}>+ Додати пацієнта</button>}
           <a className="crmExport" href="/api/staff/patients/export" download title="Завантажити CSV для імпорту в Google Контакти">↧ Експорт у Google Контакти</a>
           {canManage && <a className="crmExport" href="/staff/patients/import" title="Імпорт пацієнтів із CSV">↥ Імпорт із CSV</a>}
+          <a className="crmExport" href="/staff/patients/issues" title="Аудит суперечностей між картками, заявками й контактами">⚠ Неузгодженості</a>
         </div>
         <div className="protocolQueueList">
           {visible.length === 0 ? <p className="empty">Пацієнтів у цій категорії немає.</p> : visible.map((item)=>{

--- a/app/styles/02-workspace.css
+++ b/app/styles/02-workspace.css
@@ -862,3 +862,22 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 
 /* Код заявки як компактний моноширинний чип (RD-РРММДД-N) у списках/картках. */
 .codeTag{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-weight:700;letter-spacing:.02em;white-space:nowrap}
+
+/* Аудит неузгодженостей карток пацієнтів (/staff/patients/issues). */
+.consistencySummary{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:16px}
+.consistencySummary>a{margin-left:auto}
+.consistencyBadge{font-size:11px;font-weight:800;padding:5px 10px;border-radius:999px;background:#edf4f1;color:#164945;white-space:nowrap}
+.consistencyBadge b{font-family:var(--font-serif);font-weight:800}
+.consistencyBadge.sev-high{background:#fce6e2;color:#a1301b}
+.consistencyBadge.sev-medium{background:#fdf0da;color:#8a5a12}
+.consistencyBadge.sev-low{background:#e6f0ec;color:#2b5c4f}
+.consistencyList{list-style:none;margin:0;padding:0;display:grid;gap:12px}
+.consistencyItem{border:1px solid #dce4e3;border-left:4px solid #c9d3d1;border-radius:7px;padding:15px 17px;background:white}
+.consistencyItem.sev-high{border-left-color:#d1442b}
+.consistencyItem.sev-medium{border-left-color:#d99a2b}
+.consistencyItem.sev-low{border-left-color:#4f8f7c}
+.consistencyItemHead{display:flex;gap:9px;align-items:center;margin-bottom:8px}
+.consistencyKind{font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:#71807c;font-weight:900}
+.consistencyItem>b{display:block;font-size:15px;letter-spacing:-.01em}
+.consistencyDetail{margin:6px 0 4px;font-size:13px;color:#3a4744}
+.consistencySuggestion{margin:0 0 10px;font-size:12px;color:#6b7976}

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -80,6 +80,7 @@
 
 - Картки пацієнтів — `/staff/patients`
 - Імпорт / експорт — `/staff/patients/import` *(експорт — лише Адмін)*
+- Неузгодженості карток — `/staff/patients/issues` *(read-only аудит суперечностей)*
 - Замовлення (Patient Order) — `/staff/documents?type=patient_order`
 - Чат із пацієнтами — `/staff/chat` *(клінічні ролі)*
 

--- a/lib/patient-consistency.ts
+++ b/lib/patient-consistency.ts
@@ -1,0 +1,119 @@
+// Виявлення суперечностей між джерелами даних про пацієнта (за мотивами
+// health-os «contradiction detection»): звіряємо картки CRM, заявки й контакти
+// в межах ОДНІЄЇ організації та повертаємо перелік знахідок для реєстратури.
+//
+// Чиста логіка без залежностей — щоб виконуватись у тестах напряму (як
+// lib/reminders-core). Читання БД — у app/api/staff/patients/issues/route.ts.
+
+export type ConsistencyKind =
+  | "stale_contact" | "duplicate_phone" | "linkable_booking" | "name_divergence";
+export type ConsistencySeverity = "high" | "medium" | "low";
+
+export interface ConsistencyFinding {
+  kind: ConsistencyKind;
+  severity: ConsistencySeverity;
+  patientId: string;
+  bookingId: number | null;
+  code: string;
+  phoneNormalized: string;
+  title: string;
+  detail: string;
+  suggestion: string;
+}
+
+// Нормалізація ПІБ для порівняння: нижній регістр, без пунктуації, згорнуті
+// пробіли. Порядок слів не важить (Прізвище Ім'я vs Ім'я Прізвище).
+export function normalizeName(value: string): string {
+  return (value || "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function namesDiverge(a: string, b: string): boolean {
+  const na = normalizeName(a);
+  const nb = normalizeName(b);
+  if (!na || !nb) return false; // нема що звіряти
+  if (na === nb) return false;
+  const sortedWords = (s: string) => s.split(" ").sort().join(" ");
+  return sortedWords(na) !== sortedWords(nb);
+}
+
+export interface StaleContactRow {
+  bookingId: number; code: string; bookingName: string; bookingPhone: string;
+  patientId: string; displayName: string; profilePhone: string;
+}
+export function staleContactFindings(rows: StaleContactRow[]): ConsistencyFinding[] {
+  return rows.map((r) => ({
+    kind: "stale_contact", severity: "high",
+    patientId: r.patientId, bookingId: r.bookingId, code: r.code, phoneNormalized: r.profilePhone,
+    title: `Телефон у заявці не збігається з карткою: ${r.displayName || "без імені"}`,
+    detail: `Заявка ${r.code}: ${r.bookingPhone || "—"}; картка: ${r.profilePhone || "—"}.`,
+    suggestion: "Звірте актуальний номер і оновіть картку або заявку. Поки контакти різняться, планові нагадування для цього запису пропускаються.",
+  }));
+}
+
+export interface DuplicatePhoneRow {
+  phoneNormalized: string; count: number; names: string;
+}
+export function duplicatePhoneFindings(rows: DuplicatePhoneRow[]): ConsistencyFinding[] {
+  return rows.map((r) => ({
+    kind: "duplicate_phone", severity: "medium",
+    patientId: "", bookingId: null, code: "", phoneNormalized: r.phoneNormalized,
+    title: `Один номер у ${r.count} карток`,
+    detail: `${r.phoneNormalized}: ${r.names}.`,
+    suggestion: "Якщо це та сама людина — зведіть картки в одну; якщо родина ділить номер — залиште окремі, але переконайтесь, що історії не переплутано.",
+  }));
+}
+
+export interface LinkableBookingRow {
+  bookingId: number; code: string; bookingName: string;
+  phoneNormalized: string; patientId: string; displayName: string;
+}
+export function linkableBookingFindings(rows: LinkableBookingRow[]): ConsistencyFinding[] {
+  return rows.map((r) => ({
+    kind: "linkable_booking", severity: "low",
+    patientId: r.patientId, bookingId: r.bookingId, code: r.code, phoneNormalized: r.phoneNormalized,
+    title: `Заявка без картки збігається з пацієнтом: ${r.displayName || "без імені"}`,
+    detail: `Заявку ${r.code} (${r.bookingName || "без імені"}) можна привʼязати до картки за номером ${r.phoneNormalized}.`,
+    suggestion: "Відкрийте картку й перевірте, чи це той самий пацієнт, перш ніж зводити історію.",
+  }));
+}
+
+export interface NameDivergenceRow {
+  bookingId: number; code: string; bookingName: string;
+  patientId: string; displayName: string; phoneNormalized: string;
+}
+export function nameDivergenceFindings(rows: NameDivergenceRow[]): ConsistencyFinding[] {
+  const out: ConsistencyFinding[] = [];
+  for (const r of rows) {
+    if (!namesDiverge(r.bookingName, r.displayName)) continue;
+    out.push({
+      kind: "name_divergence", severity: "medium",
+      patientId: r.patientId, bookingId: r.bookingId, code: r.code, phoneNormalized: r.phoneNormalized,
+      title: "Різні ПІБ у заявці й картці",
+      detail: `Заявка ${r.code}: «${r.bookingName}»; картка: «${r.displayName}».`,
+      suggestion: "Переконайтесь, що заявку привʼязано до правильної картки, і зведіть написання ПІБ.",
+    });
+  }
+  return out;
+}
+
+const SEVERITY_ORDER: Record<ConsistencySeverity, number> = { high: 0, medium: 1, low: 2 };
+
+export function sortFindings(findings: ConsistencyFinding[]): ConsistencyFinding[] {
+  return [...findings].sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+}
+
+export function countFindings(findings: ConsistencyFinding[]): {
+  high: number; medium: number; low: number; total: number;
+} {
+  let high = 0, medium = 0, low = 0;
+  for (const f of findings) {
+    if (f.severity === "high") high += 1;
+    else if (f.severity === "medium") medium += 1;
+    else low += 1;
+  }
+  return { high, medium, low, total: findings.length };
+}

--- a/tests/patient-consistency.behavior.test.mjs
+++ b/tests/patient-consistency.behavior.test.mjs
@@ -1,0 +1,111 @@
+// Аудит неузгодженостей карток: end-to-end через воркер із реальним D1.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, callWorker, jsonRequest, seedStaffSession } from "./helpers/d1.mjs";
+
+const PID = (c) => c.repeat(32);
+
+async function profile(db, patientId, phone, name) {
+  await db.prepare(
+    `INSERT INTO patient_profiles (patient_id, organization_id, phone_normalized, display_name, updated_by)
+     VALUES (?, 1, ?, ?, 'test')`
+  ).bind(patientId, phone, name).run();
+}
+async function booking(db, code, name, phone, patientId, time) {
+  const r = await db.prepare(
+    `INSERT INTO bookings (organization_id, code, name, phone, phone_normalized, patient_id,
+       service, desired_date, desired_time, status)
+     VALUES (1, ?, ?, ?, ?, ?, 'КТ', '2026-07-15', ?, 'confirmed')`
+  ).bind(code, name, `+${phone}`, phone, patientId, time).run();
+  return Number(r.meta.last_row_id);
+}
+
+test("issues route surfaces stale contact, duplicate phone, linkable booking and name divergence", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+
+    // Розбіжність контакту: заявка привʼязана до картки, але телефон інший.
+    await profile(db, PID("a"), "380501112233", "Іваненко Іван");
+    const staleBooking = await booking(db, "RD-STALE", "Іваненко Іван", "380509998877", PID("a"), "10:00");
+
+    // Спільний номер у двох карток.
+    await profile(db, PID("b"), "380502223344", "Родина Один");
+    await profile(db, PID("c"), "380502223344", "Родина Два");
+
+    // Неприв'язана заявка збігається рівно з однією карткою.
+    await profile(db, PID("d"), "380503334455", "Сидоренко Сидір");
+    const linkBooking = await booking(db, "RD-LINK", "Сидір С.", "380503334455", "", "11:00");
+
+    // Розбіжність ПІБ на привʼязаній заявці (телефон збігається, ПІБ інше).
+    await profile(db, PID("e"), "380504445566", "Коваленко Микола");
+    const nameBooking = await booking(db, "RD-NAME", "Петренко Микола", "380504445566", PID("e"), "12:00");
+
+    const res = await callWorker(
+      jsonRequest("/api/staff/patients/issues", undefined, { method: "GET", headers: { cookie } }),
+      db,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const byKind = (k) => body.findings.filter((f) => f.kind === k);
+
+    const stale = byKind("stale_contact");
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].bookingId, staleBooking);
+    assert.equal(stale[0].severity, "high");
+
+    const dup = byKind("duplicate_phone");
+    assert.equal(dup.length, 1);
+    assert.equal(dup[0].phoneNormalized, "380502223344");
+
+    const link = byKind("linkable_booking");
+    assert.equal(link.length, 1);
+    assert.equal(link[0].bookingId, linkBooking);
+    assert.equal(link[0].patientId, PID("d"));
+
+    const name = byKind("name_divergence");
+    assert.equal(name.length, 1);
+    assert.equal(name[0].bookingId, nameBooking);
+
+    // Найвища серйозність — першою.
+    assert.equal(body.findings[0].severity, "high");
+    assert.equal(body.counts.total, body.findings.length);
+    assert.ok(body.counts.high >= 1 && body.counts.medium >= 2 && body.counts.low >= 1);
+  });
+});
+
+test("issues route is denied to roles without registry access", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "rad@example.com", role: "radiographer", organizationId: 1 });
+    const res = await callWorker(
+      jsonRequest("/api/staff/patients/issues", undefined, { method: "GET", headers: { cookie } }),
+      db,
+    );
+    assert.equal(res.status, 403);
+  });
+});
+
+test("issues route isolates findings by organization", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Other', 1)").run();
+    const cookie = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+
+    // Проблемна пара карток — у ЧУЖІЙ організації.
+    await db.prepare(
+      `INSERT INTO patient_profiles (patient_id, organization_id, phone_normalized, display_name, updated_by)
+       VALUES (?, 2, '380507778899', 'Чужий Один', 'test')`
+    ).bind(PID("f")).run();
+    await db.prepare(
+      `INSERT INTO patient_profiles (patient_id, organization_id, phone_normalized, display_name, updated_by)
+       VALUES (?, 2, '380507778899', 'Чужий Два', 'test')`
+    ).bind(PID("0")).run();
+
+    const res = await callWorker(
+      jsonRequest("/api/staff/patients/issues", undefined, { method: "GET", headers: { cookie } }),
+      db,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.counts.total, 0); // чужі неузгодженості не видно
+  });
+});

--- a/tests/patient-consistency.test.mjs
+++ b/tests/patient-consistency.test.mjs
@@ -1,0 +1,75 @@
+// Чиста логіка виявлення суперечностей між джерелами даних пацієнта.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeName, namesDiverge,
+  staleContactFindings, duplicatePhoneFindings, linkableBookingFindings, nameDivergenceFindings,
+  sortFindings, countFindings,
+} from "../lib/patient-consistency.ts";
+
+test("normalizeName strips punctuation/case and collapses spaces", () => {
+  assert.equal(normalizeName("  Іваненко  Іван "), "іваненко іван");
+  assert.equal(normalizeName("Петренко-Сидоренко, О.В."), "петренко сидоренко о в");
+});
+
+test("namesDiverge ignores word order and punctuation, flags real differences", () => {
+  assert.equal(namesDiverge("Іваненко Іван", "Іван Іваненко"), false); // порядок
+  assert.equal(namesDiverge("Іваненко І.", "іваненко і"), false); // пунктуація/регістр
+  assert.equal(namesDiverge("Іваненко Іван", "Петренко Іван"), true);
+  assert.equal(namesDiverge("Іваненко Іван", ""), false); // нема що звіряти
+  assert.equal(namesDiverge("Іваненко Іван", "Іваненко Іван Петрович"), true); // зайвий токен
+});
+
+test("staleContactFindings marks a booking whose phone differs from the linked card (high)", () => {
+  const out = staleContactFindings([{
+    bookingId: 5, code: "RD-1", bookingName: "Іван", bookingPhone: "380501112233",
+    patientId: "a".repeat(32), displayName: "Іваненко Іван", profilePhone: "380509998877",
+  }]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].kind, "stale_contact");
+  assert.equal(out[0].severity, "high");
+  assert.equal(out[0].bookingId, 5);
+  assert.match(out[0].detail, /380501112233/);
+  assert.match(out[0].detail, /380509998877/);
+});
+
+test("duplicatePhoneFindings marks a phone shared by several cards (medium)", () => {
+  const out = duplicatePhoneFindings([{ phoneNormalized: "380501112233", count: 2, names: "Іван | Петро" }]);
+  assert.equal(out[0].kind, "duplicate_phone");
+  assert.equal(out[0].severity, "medium");
+  assert.equal(out[0].patientId, "");
+  assert.match(out[0].title, /2 карток/);
+});
+
+test("linkableBookingFindings suggests linking an unlinked booking (low)", () => {
+  const out = linkableBookingFindings([{
+    bookingId: 9, code: "RD-2", bookingName: "Петро", phoneNormalized: "380501112233",
+    patientId: "b".repeat(32), displayName: "Петренко Петро",
+  }]);
+  assert.equal(out[0].kind, "linkable_booking");
+  assert.equal(out[0].severity, "low");
+  assert.equal(out[0].patientId, "b".repeat(32));
+});
+
+test("nameDivergenceFindings only fires when normalized names actually differ", () => {
+  const rows = [
+    { bookingId: 1, code: "RD-3", bookingName: "Іван Іваненко", patientId: "c".repeat(32), displayName: "Іваненко Іван", phoneNormalized: "380501112233" }, // порядок — не розбіжність
+    { bookingId: 2, code: "RD-4", bookingName: "Петро Петренко", patientId: "d".repeat(32), displayName: "Сидоренко Петро", phoneNormalized: "380502223344" }, // прізвище інше
+  ];
+  const out = nameDivergenceFindings(rows);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].bookingId, 2);
+  assert.equal(out[0].severity, "medium");
+});
+
+test("sortFindings orders high → medium → low; countFindings tallies", () => {
+  const mixed = [
+    ...linkableBookingFindings([{ bookingId: 1, code: "L", bookingName: "", phoneNormalized: "1", patientId: "x", displayName: "X" }]),
+    ...staleContactFindings([{ bookingId: 2, code: "S", bookingName: "", bookingPhone: "1", patientId: "y", displayName: "Y", profilePhone: "2" }]),
+    ...duplicatePhoneFindings([{ phoneNormalized: "3", count: 2, names: "A | B" }]),
+  ];
+  const sorted = sortFindings(mixed);
+  assert.deepEqual(sorted.map((f) => f.severity), ["high", "medium", "low"]);
+  assert.deepEqual(countFindings(mixed), { high: 1, medium: 1, low: 1, total: 3 });
+});


### PR DESCRIPTION
## Що зроблено

Ідея №1 з розбору `health-os` — **виявлення суперечностей між джерелами**. Новий **read-only** екран `/staff/patients/issues` звіряє картки CRM, заявки й контакти в межах однієї організації та показує неузгодженості. Нічого не змінює — лише підсвічує проблему й веде до відповідної картки.

### Детектори

| Тип | Серйозність | Що ловить |
|---|---|---|
| `stale_contact` | 🔴 високий | телефон у заявці розійшовся з привʼязаною карткою (такі записи ще й пропускаються плановими нагадуваннями) |
| `duplicate_phone` | 🟡 середній | один номер у кількох картках (дублікати / неоднозначна ідентичність) |
| `name_divergence` | 🟡 середній | різні ПІБ у заявці й картці (порядок слів і пунктуація не рахуються за розбіжність) |
| `linkable_booking` | 🟢 низький | неприв'язана заявка збігається **рівно** з однією карткою — можна звести історію |

### Безпека / межі
- Доступ — реєстратор/адмін (`canViewPatientRegistry`).
- Tenant-ізоляція за `organization_id` у кожному запиті.
- Запис у security-лог (`patient_consistency_viewed`).
- Read-only: жодних мутацій, лише посилання «Відкрити картку →».

### Архітектура
- `lib/patient-consistency.ts` — чиста логіка детекторів + нормалізація ПІБ, **без залежностей** (тестується напряму, як `reminders-core`).
- `app/api/staff/patients/issues/route.ts` — 4 org-scoped SQL-запити + RBAC + аудит.
- `app/staff/patients/issues/page.tsx` — згрупований список зі значками серйозності.
- Точки входу: кнопка «⚠ Неузгодженості» на `/staff/patients`, команд-палітра, `docs/sitemap.md`.

## Тести
- Юніт чистих детекторів (`normalizeName`/`namesDiverge`, кожен тип знахідки, сортування/підрахунок).
- End-to-end через воркер: усі 4 типи на реальному D1, відмова для ролі без доступу, ізоляція за організацією.
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — **999/999** зелені.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_