### PR TITLE
patients: злиття карток-дублікатів (спільний номер)

### DIFF
--- a/app/api/staff/patients/issues/route.ts
+++ b/app/api/staff/patients/issues/route.ts
@@ -1,14 +1,15 @@
 // Read-only аудит суперечностей між джерелами даних пацієнта в межах
 // організації. Тільки реєстратор/адміністратор; нічого не змінює.
 
-import { canViewPatientRegistry } from "../../../../../lib/staff-auth";
+import { canViewPatientRegistry, canMergePatients } from "../../../../../lib/staff-auth";
 import { requireOrgContext } from "../../../../../lib/tenant";
 import { logSecurityEvent } from "../../../../../lib/audit";
 import { dbBinding } from "../../../../../lib/db";
 import {
-  countFindings, sortFindings,
+  countFindings, sortFindings, mergeSafetyFields,
   staleContactFindings, duplicatePhoneFindings, linkableBookingFindings, nameDivergenceFindings,
-  type StaleContactRow, type DuplicatePhoneRow, type LinkableBookingRow, type NameDivergenceRow,
+  type StaleContactRow, type DuplicatePhoneMember, type LinkableBookingRow, type NameDivergenceRow,
+  type MergeProfile,
 } from "../../../../../lib/patient-consistency";
 
 const LIMIT = 500;
@@ -35,15 +36,19 @@ export async function GET(request: Request) {
      ORDER BY b.desired_date DESC LIMIT ?`
   ).bind(orgId, LIMIT).all();
 
-  // Один номер у кількох картках — можливі дублікати / неоднозначна ідентичність.
+  // Один номер у кількох картках — картки-члени для можливого злиття.
   const dupP = db.prepare(
-    `SELECT phone_normalized AS phoneNormalized, COUNT(*) AS count,
-       GROUP_CONCAT(CASE WHEN display_name = '' THEN 'без імені' ELSE display_name END, ' | ') AS names
+    `SELECT phone_normalized AS phoneNormalized, patient_id AS patientId,
+       display_name AS displayName, birth_date AS birthDate
      FROM patient_profiles
      WHERE organization_id = ? AND phone_normalized != ''
-     GROUP BY phone_normalized HAVING COUNT(*) > 1
-     ORDER BY COUNT(*) DESC LIMIT ?`
-  ).bind(orgId, LIMIT).all();
+       AND phone_normalized IN (
+         SELECT phone_normalized FROM patient_profiles
+         WHERE organization_id = ? AND phone_normalized != ''
+         GROUP BY phone_normalized HAVING COUNT(*) > 1
+       )
+     ORDER BY phone_normalized, updated_at DESC LIMIT ?`
+  ).bind(orgId, orgId, LIMIT).all();
 
   // Неприв'язана заявка, чий номер збігається РІВНО з однією карткою.
   const linkP = db.prepare(
@@ -71,7 +76,7 @@ export async function GET(request: Request) {
 
   const findings = sortFindings([
     ...staleContactFindings(stale.results as unknown as StaleContactRow[]),
-    ...duplicatePhoneFindings(dup.results as unknown as DuplicatePhoneRow[]),
+    ...duplicatePhoneFindings(dup.results as unknown as DuplicatePhoneMember[]),
     ...linkableBookingFindings(link.results as unknown as LinkableBookingRow[]),
     ...nameDivergenceFindings(names.results as unknown as NameDivergenceRow[]),
   ]);
@@ -86,4 +91,102 @@ export async function GET(request: Request) {
   });
 
   return Response.json({ findings, counts, staff: member }, { headers: { "cache-control": "no-store" } });
+}
+
+const PATIENT_ID_RE = /^[0-9a-f]{32}$/;
+
+// Схема свідомо тримає patient_id незмінним у більшості таблиць, а фінансові/
+// клінічні regистри — append-only. Тому злиття:
+//  • ПЕРЕПРИЗНАЧАЄ patient_id лише там, де лінк дозволено переписати на картку
+//    того ж тенанта (тригери *_patient_link_update пропускають, бо головна
+//    картка існує) — це заявки й комунікації;
+//  • незмінні регістри (revenue/settlement/service/result/order/appointment…)
+//    НЕ чіпає: у них є booking_id, тож звʼязок із пацієнтом іде через заявку,
+//    яку вже перепризначено, а власний patient_id лишається як історичний зліпок;
+//  • ВИДАЛЯЄ ефемерні/переустановлювані рядки поглинутих карток, де patient_id
+//    незмінний (сесії, OTP, токени й ідентичності Telegram, MWL-мапінг).
+const REPOINT_TABLES = ["bookings", "patient_communications"];
+const PURGE_TABLES = [
+  "patient_sessions", "patient_otp_challenges", "telegram_link_tokens",
+  "patient_telegram_identities", "mwl_patient_ids",
+];
+
+// Необоротне злиття карток пацієнта: уся історія поглинутих карток
+// перепризначається головній, безпечні прапорці об'єднуються, поглинуті
+// картки видаляються. Атомарно (db.batch) і лише для повного адміністратора.
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const member = ctx.member;
+  const orgId = ctx.organizationId;
+  if (!canMergePatients(member.role)) {
+    return Response.json({ error: "Обʼєднувати картки може лише адміністратор" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const survivorId = String(body.survivorId || "").trim().toLowerCase();
+  const absorbedRaw = Array.isArray(body.absorbedIds) ? body.absorbedIds : [];
+  const absorbedIds = [...new Set(absorbedRaw.map((v) => String(v || "").trim().toLowerCase()))]
+    .filter((v) => v && v !== survivorId);
+
+  if (!PATIENT_ID_RE.test(survivorId)) {
+    return Response.json({ error: "Некоректний ідентифікатор головної картки" }, { status: 400 });
+  }
+  if (!absorbedIds.length || absorbedIds.length > 10 || !absorbedIds.every((v) => PATIENT_ID_RE.test(v))) {
+    return Response.json({ error: "Оберіть від 1 до 10 карток для приєднання" }, { status: 400 });
+  }
+
+  const allIds = [survivorId, ...absorbedIds];
+  const placeholders = allIds.map(() => "?").join(",");
+  const profiles = await db.prepare(
+    `SELECT patient_id AS patientId, contrast_alert AS contrastAlert, do_not_contact AS doNotContact,
+       allergy_note AS allergyNote, telegram_chat_id AS telegramChatId
+     FROM patient_profiles WHERE organization_id = ? AND patient_id IN (${placeholders})`
+  ).bind(orgId, ...allIds).all<MergeProfile>();
+  const found = (profiles.results || []) as MergeProfile[];
+  const survivor = found.find((p) => p.patientId === survivorId);
+  if (!survivor || found.length !== allIds.length) {
+    return Response.json({ error: "Деякі картки не знайдено в цій організації" }, { status: 404 });
+  }
+  const absorbed = found.filter((p) => p.patientId !== survivorId);
+  const safety = mergeSafetyFields(survivor, absorbed);
+
+  const absPlaceholders = absorbedIds.map(() => "?").join(",");
+  const statements = [
+    // 1) Перепризначаємо історію на головну картку (лінк дозволено переписати).
+    ...REPOINT_TABLES.map((t) =>
+      db.prepare(`UPDATE ${t} SET patient_id = ? WHERE patient_id IN (${absPlaceholders})`)
+        .bind(survivorId, ...absorbedIds)),
+    // 2) Прибираємо ефемерні/переустановлювані рядки поглинутих карток.
+    ...PURGE_TABLES.map((t) =>
+      db.prepare(`DELETE FROM ${t} WHERE patient_id IN (${absPlaceholders})`).bind(...absorbedIds)),
+    // 3) Об'єднуємо безпечні поля в головній картці.
+    db.prepare(
+      `UPDATE patient_profiles SET contrast_alert = ?, do_not_contact = ?, allergy_note = ?,
+         telegram_chat_id = ?, updated_by = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE organization_id = ? AND patient_id = ?`
+    ).bind(safety.contrastAlert, safety.doNotContact, safety.allergyNote, safety.telegramChatId, member.email, orgId, survivorId),
+    // 4) Видаляємо поглинуті картки (заявки вже перепризначені — delete-guard пройде).
+    db.prepare(`DELETE FROM patient_profiles WHERE organization_id = ? AND patient_id IN (${absPlaceholders})`)
+      .bind(orgId, ...absorbedIds),
+  ];
+
+  try {
+    await db.batch(statements);
+  } catch {
+    return Response.json({ error: "Не вдалося обʼєднати картки" }, { status: 500 });
+  }
+
+  await logSecurityEvent(db, {
+    organizationId: orgId,
+    actorEmail: member.email,
+    action: "patients_merged",
+    resource: "patient",
+    targetId: survivorId,
+    details: { absorbed: absorbedIds, count: absorbedIds.length },
+  });
+
+  return Response.json({ ok: true, survivorId, absorbed: absorbedIds });
 }

--- a/app/staff/patients/issues/page.tsx
+++ b/app/staff/patients/issues/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import StaffWorkspaceShell from "../../workspace-shell";
 
 type StaffRole = "admin" | "organization_admin" | "department_head" | "registrar" | "radiologist" | "radiographer";
 type StaffInfo = { email:string; displayName:string; role:StaffRole };
 
 type Severity = "high" | "medium" | "low";
+type Member = { patientId:string; displayName:string; birthDate:string };
 type Finding = {
   kind: string; severity: Severity; patientId: string; bookingId: number | null;
   code: string; phoneNormalized: string; title: string; detail: string; suggestion: string;
+  members?: Member[];
 };
 type Counts = { high:number; medium:number; low:number; total:number };
 
@@ -30,6 +32,58 @@ function patientHref(f: Finding): string {
   return "/staff/patients";
 }
 
+function DuplicateMerge({ finding, onMerged }: { finding: Finding; onMerged: () => void }) {
+  const members = finding.members || [];
+  const [survivor, setSurvivor] = useState(members[0]?.patientId || "");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const merge = async () => {
+    const absorbedIds = members.map((m) => m.patientId).filter((id) => id !== survivor);
+    if (!survivor || !absorbedIds.length) { setErr("Оберіть головну картку"); return; }
+    const keep = members.find((m) => m.patientId === survivor);
+    if (!window.confirm(
+      `Обʼєднати ${absorbedIds.length + 1} карток у одну?\n\n` +
+      `Головна (залишиться): ${keep?.displayName || "без імені"}.\n` +
+      `Уся історія інших карток перейде до неї, а вони будуть видалені. ` +
+      `Прапорці «контраст» і «не турбувати» та нотатки алергій зберігаються. Дію не можна скасувати.`
+    )) return;
+    setBusy(true); setErr("");
+    try {
+      const res = await fetch("/api/staff/patients/issues", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ survivorId: survivor, absorbedIds }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { setErr(data.error || "Не вдалося обʼєднати"); return; }
+      onMerged();
+    } catch {
+      setErr("Мережа недоступна");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return <div className="mergeBox">
+    <p className="mergeHint">Оберіть головну картку — решта приєднаються до неї:</p>
+    <ul className="mergeMembers">
+      {members.map((m) => <li key={m.patientId}>
+        <label>
+          <input type="radio" name={`survivor-${finding.phoneNormalized}`} checked={survivor === m.patientId}
+            onChange={() => setSurvivor(m.patientId)} disabled={busy} />
+          <b>{m.displayName || "без імені"}</b>
+          {m.birthDate ? <small> · {m.birthDate}</small> : null}
+        </label>
+        <a className="crmVisitLink" href={`/staff/patients?patientId=${encodeURIComponent(m.patientId)}`} target="_blank" rel="noreferrer">картка →</a>
+      </li>)}
+    </ul>
+    {err ? <p className="mergeError">{err}</p> : null}
+    <button type="button" className="crmAddBtn" onClick={() => void merge()} disabled={busy}>
+      {busy ? "Обʼєднуємо…" : "Обʼєднати картки"}
+    </button>
+  </div>;
+}
+
 export default function PatientIssuesPage() {
   const [staff, setStaff] = useState<StaffInfo | null>(null);
   const [findings, setFindings] = useState<Finding[]>([]);
@@ -37,30 +91,30 @@ export default function PatientIssuesPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    let alive = true;
-    (async () => {
-      try {
-        const res = await fetch("/api/staff/patients/issues", { headers: { "cache-control": "no-store" } });
-        const data = await res.json().catch(() => ({}));
-        if (!alive) return;
-        if (!res.ok) { setError(data.error || "Не вдалося завантажити аудит"); return; }
-        setStaff(data.staff || null);
-        setFindings(data.findings || []);
-        setCounts(data.counts || { high:0, medium:0, low:0, total:0 });
-      } catch {
-        if (alive) setError("Мережа недоступна");
-      } finally {
-        if (alive) setLoading(false);
-      }
-    })();
-    return () => { alive = false; };
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/staff/patients/issues", { headers: { "cache-control": "no-store" } });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(data.error || "Не вдалося завантажити аудит"); return; }
+      setError("");
+      setStaff(data.staff || null);
+      setFindings(data.findings || []);
+      setCounts(data.counts || { high:0, medium:0, low:0, total:0 });
+    } catch {
+      setError("Мережа недоступна");
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => { (async () => { await load(); })(); }, [load]);
+
+  const isAdmin = staff?.role === "admin";
 
   return <StaffWorkspaceShell
     active="patients"
     title="Неузгодженості карток"
-    description="Аудит суперечностей між картками CRM, заявками й контактами: розбіжні телефони та ПІБ, спільні номери, заявки без картки. Read-only — нічого не змінює."
+    description="Аудит суперечностей між картками CRM, заявками й контактами: розбіжні телефони та ПІБ, спільні номери, заявки без картки. Read-only, крім злиття дублікатів (лише адмін)."
     staffName={staff?.displayName || staff?.email}
     staffRole={staff ? roleLabels[staff.role] : undefined}
   >
@@ -83,7 +137,9 @@ export default function PatientIssuesPage() {
             <b>{f.title}</b>
             <p className="consistencyDetail">{f.detail}</p>
             <p className="consistencySuggestion">{f.suggestion}</p>
-            <a className="crmVisitLink" href={patientHref(f)}>Відкрити картку →</a>
+            {f.kind === "duplicate_phone" && isAdmin && (f.members?.length || 0) >= 2
+              ? <DuplicateMerge finding={f} onMerged={() => void load()} />
+              : <a className="crmVisitLink" href={patientHref(f)}>Відкрити картку →</a>}
           </li>)}
         </ul>}
     </section>}

--- a/app/styles/02-workspace.css
+++ b/app/styles/02-workspace.css
@@ -881,3 +881,12 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .consistencyItem>b{display:block;font-size:15px;letter-spacing:-.01em}
 .consistencyDetail{margin:6px 0 4px;font-size:13px;color:#3a4744}
 .consistencySuggestion{margin:0 0 10px;font-size:12px;color:#6b7976}
+
+/* Злиття карток-дублікатів на екрані неузгодженостей. */
+.mergeBox{margin-top:6px;padding:12px 14px;background:#f6f4ee;border:1px dashed #d4cdbf;border-radius:7px}
+.mergeHint{margin:0 0 8px;font-size:12px;color:#5c6a66}
+.mergeMembers{list-style:none;margin:0 0 10px;padding:0;display:grid;gap:6px}
+.mergeMembers li{display:flex;gap:10px;align-items:center;justify-content:space-between;font-size:13px}
+.mergeMembers label{display:flex;gap:8px;align-items:center;cursor:pointer}
+.mergeMembers small{color:#71807c}
+.mergeError{margin:0 0 8px;font-size:12px;color:#a1301b}

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -80,7 +80,7 @@
 
 - Картки пацієнтів — `/staff/patients`
 - Імпорт / експорт — `/staff/patients/import` *(експорт — лише Адмін)*
-- Неузгодженості карток — `/staff/patients/issues` *(read-only аудит суперечностей)*
+- Неузгодженості карток — `/staff/patients/issues` *(аудит суперечностей; злиття дублікатів — лише Адмін)*
 - Замовлення (Patient Order) — `/staff/documents?type=patient_order`
 - Чат із пацієнтами — `/staff/chat` *(клінічні ролі)*
 

--- a/lib/patient-consistency.ts
+++ b/lib/patient-consistency.ts
@@ -9,6 +9,12 @@ export type ConsistencyKind =
   | "stale_contact" | "duplicate_phone" | "linkable_booking" | "name_divergence";
 export type ConsistencySeverity = "high" | "medium" | "low";
 
+export interface ConsistencyMember {
+  patientId: string;
+  displayName: string;
+  birthDate: string;
+}
+
 export interface ConsistencyFinding {
   kind: ConsistencyKind;
   severity: ConsistencySeverity;
@@ -19,6 +25,8 @@ export interface ConsistencyFinding {
   title: string;
   detail: string;
   suggestion: string;
+  // Заповнюється лише для duplicate_phone — картки, що ділять номер (для злиття).
+  members?: ConsistencyMember[];
 }
 
 // Нормалізація ПІБ для порівняння: нижній регістр, без пунктуації, згорнуті
@@ -54,17 +62,56 @@ export function staleContactFindings(rows: StaleContactRow[]): ConsistencyFindin
   }));
 }
 
-export interface DuplicatePhoneRow {
-  phoneNormalized: string; count: number; names: string;
+export interface DuplicatePhoneMember {
+  phoneNormalized: string; patientId: string; displayName: string; birthDate: string;
 }
-export function duplicatePhoneFindings(rows: DuplicatePhoneRow[]): ConsistencyFinding[] {
-  return rows.map((r) => ({
-    kind: "duplicate_phone", severity: "medium",
-    patientId: "", bookingId: null, code: "", phoneNormalized: r.phoneNormalized,
-    title: `Один номер у ${r.count} карток`,
-    detail: `${r.phoneNormalized}: ${r.names}.`,
-    suggestion: "Якщо це та сама людина — зведіть картки в одну; якщо родина ділить номер — залиште окремі, але переконайтесь, що історії не переплутано.",
-  }));
+// Групуємо картки за номером; знахідка — на кожен номер із ≥2 картками.
+export function duplicatePhoneFindings(members: DuplicatePhoneMember[]): ConsistencyFinding[] {
+  const groups = new Map<string, ConsistencyMember[]>();
+  for (const m of members) {
+    if (!m.phoneNormalized) continue;
+    const list = groups.get(m.phoneNormalized) || [];
+    list.push({ patientId: m.patientId, displayName: m.displayName, birthDate: m.birthDate });
+    groups.set(m.phoneNormalized, list);
+  }
+  const out: ConsistencyFinding[] = [];
+  for (const [phone, list] of groups) {
+    if (list.length < 2) continue;
+    const names = list.map((m) => m.displayName || "без імені").join(" | ");
+    out.push({
+      kind: "duplicate_phone", severity: "medium",
+      patientId: "", bookingId: null, code: "", phoneNormalized: phone,
+      title: `Один номер у ${list.length} карток`,
+      detail: `${phone}: ${names}.`,
+      suggestion: "Якщо це та сама людина — оберіть головну картку й обʼєднайте; якщо родина ділить номер — залиште окремі, але переконайтесь, що історії не переплутано.",
+      members: list,
+    });
+  }
+  return out;
+}
+
+export interface MergeProfile {
+  patientId: string; contrastAlert: number; doNotContact: number;
+  allergyNote: string; telegramChatId: string;
+}
+// Об'єднання КЛІНІЧНО-безпечних полів при злитті карток: жоден прапорець
+// «контраст»/«не турбувати» й жодна нотатка алергій НЕ втрачаються. Демографію
+// (ПІБ, дата народження тощо) визначає головна картка — тут не чіпаємо.
+export function mergeSafetyFields(survivor: MergeProfile, absorbed: MergeProfile[]): {
+  contrastAlert: number; doNotContact: number; allergyNote: string; telegramChatId: string;
+} {
+  const all = [survivor, ...absorbed];
+  const contrastAlert = all.some((p) => Number(p.contrastAlert) === 1) ? 1 : 0;
+  const doNotContact = all.some((p) => Number(p.doNotContact) === 1) ? 1 : 0;
+  const notes: string[] = [];
+  for (const p of all) {
+    const n = (p.allergyNote || "").trim();
+    if (n && !notes.some((x) => x.toLowerCase() === n.toLowerCase())) notes.push(n);
+  }
+  const allergyNote = notes.join(" / ").slice(0, 400);
+  const telegramChatId = (survivor.telegramChatId || "").trim()
+    || absorbed.map((p) => (p.telegramChatId || "").trim()).find(Boolean) || "";
+  return { contrastAlert, doNotContact, allergyNote, telegramChatId };
 }
 
 export interface LinkableBookingRow {

--- a/lib/staff-auth.ts
+++ b/lib/staff-auth.ts
@@ -99,6 +99,12 @@ export function canExportPatientData(role: AccessRole) {
   return role === "admin";
 }
 
+// Злиття карток пацієнтів необоротно об'єднує клінічні історії — лише повний
+// адміністратор із доступом до медичних даних (не organization_admin).
+export function canMergePatients(role: AccessRole) {
+  return role === "admin";
+}
+
 export function canViewReports(role: AccessRole) {
   return role === "admin";
 }

--- a/tests/patient-consistency.behavior.test.mjs
+++ b/tests/patient-consistency.behavior.test.mjs
@@ -85,6 +85,88 @@ test("issues route is denied to roles without registry access", async () => {
   });
 });
 
+async function fullProfile(db, patientId, phone, name, { contrast = 0, dnc = 0, note = "" } = {}) {
+  await db.prepare(
+    `INSERT INTO patient_profiles (patient_id, organization_id, phone_normalized, display_name,
+       contrast_alert, do_not_contact, allergy_note, updated_by)
+     VALUES (?, 1, ?, ?, ?, ?, ?, 'test')`
+  ).bind(patientId, phone, name, contrast, dnc, note).run();
+}
+
+test("merge re-points history to the survivor, unions safety flags and deletes absorbed cards", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    const survivorId = PID("a"), absorbedId = PID("b");
+    await fullProfile(db, survivorId, "380501112233", "Іваненко Іван", { contrast: 0, dnc: 0, note: "" });
+    await fullProfile(db, absorbedId, "380501112233", "Іваненко І.", { contrast: 1, dnc: 1, note: "Йодовмісний контраст" });
+
+    const bId = await booking(db, "RD-M1", "Іваненко Іван", "380501112233", absorbedId, "09:00");
+    await db.prepare(
+      `INSERT INTO patient_communications (organization_id, patient_id, phone_normalized, channel, direction, summary, actor)
+       VALUES (1, ?, '380501112233', 'call', 'outbound', 'дзвінок', 'test')`
+    ).bind(absorbedId).run();
+
+    const res = await callWorker(jsonRequest("/api/staff/patients/issues",
+      { survivorId, absorbedIds: [absorbedId] }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // Поглинуту картку видалено, головна лишилась.
+    const gone = await db.prepare("SELECT patient_id FROM patient_profiles WHERE patient_id = ?").bind(absorbedId).first();
+    assert.equal(gone, null);
+    const kept = await db.prepare(
+      "SELECT contrast_alert AS c, do_not_contact AS d, allergy_note AS n FROM patient_profiles WHERE patient_id = ?"
+    ).bind(survivorId).first();
+    assert.equal(kept.c, 1); // прапорець контрасту перейшов
+    assert.equal(kept.d, 1); // «не турбувати» перейшов
+    assert.equal(kept.n, "Йодовмісний контраст"); // нотатка алергій збережена
+
+    // Історія перепризначена головній.
+    const bk = await db.prepare("SELECT patient_id AS p FROM bookings WHERE id = ?").bind(bId).first();
+    assert.equal(bk.p, survivorId);
+    const comm = await db.prepare("SELECT COUNT(*) AS n FROM patient_communications WHERE patient_id = ?").bind(survivorId).first();
+    assert.equal(comm.n, 1);
+  });
+});
+
+test("merge is denied to non-admin roles and validates input", async () => {
+  await withD1(async (db) => {
+    const survivorId = PID("a"), absorbedId = PID("b");
+    await fullProfile(db, survivorId, "380501112233", "A");
+    await fullProfile(db, absorbedId, "380501112233", "B");
+
+    const reg = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+    const denied = await callWorker(jsonRequest("/api/staff/patients/issues",
+      { survivorId, absorbedIds: [absorbedId] }, { method: "POST", headers: { cookie: reg } }), db);
+    assert.equal(denied.status, 403); // реєстратор не може обʼєднувати
+
+    const admin = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    const selfMerge = await callWorker(jsonRequest("/api/staff/patients/issues",
+      { survivorId, absorbedIds: [survivorId] }, { method: "POST", headers: { cookie: admin } }), db);
+    assert.equal(selfMerge.status, 400); // не можна приєднати картку до себе
+  });
+});
+
+test("merge refuses cards from another organization", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Other', 1)").run();
+    const cookie = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    const survivorId = PID("a"), foreignId = PID("f");
+    await fullProfile(db, survivorId, "380501112233", "Свій");
+    await db.prepare(
+      `INSERT INTO patient_profiles (patient_id, organization_id, phone_normalized, display_name, updated_by)
+       VALUES (?, 2, '380501112233', 'Чужий', 'test')`
+    ).bind(foreignId).run();
+
+    const res = await callWorker(jsonRequest("/api/staff/patients/issues",
+      { survivorId, absorbedIds: [foreignId] }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(res.status, 404); // чужа картка не знайдена в організації актора
+    const stillThere = await db.prepare("SELECT patient_id FROM patient_profiles WHERE patient_id = ?").bind(foreignId).first();
+    assert.ok(stillThere); // і не видалена
+  });
+});
+
 test("issues route isolates findings by organization", async () => {
   await withD1(async (db) => {
     await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Other', 1)").run();

--- a/tests/patient-consistency.test.mjs
+++ b/tests/patient-consistency.test.mjs
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  normalizeName, namesDiverge,
+  normalizeName, namesDiverge, mergeSafetyFields,
   staleContactFindings, duplicatePhoneFindings, linkableBookingFindings, nameDivergenceFindings,
   sortFindings, countFindings,
 } from "../lib/patient-consistency.ts";
@@ -34,12 +34,38 @@ test("staleContactFindings marks a booking whose phone differs from the linked c
   assert.match(out[0].detail, /380509998877/);
 });
 
-test("duplicatePhoneFindings marks a phone shared by several cards (medium)", () => {
-  const out = duplicatePhoneFindings([{ phoneNormalized: "380501112233", count: 2, names: "Іван | Петро" }]);
+test("duplicatePhoneFindings groups members by phone and only fires for >=2 (medium)", () => {
+  const out = duplicatePhoneFindings([
+    { phoneNormalized: "380501112233", patientId: "a".repeat(32), displayName: "Іван", birthDate: "1990-01-01" },
+    { phoneNormalized: "380501112233", patientId: "b".repeat(32), displayName: "Петро", birthDate: "1985-02-02" },
+    { phoneNormalized: "380509998877", patientId: "c".repeat(32), displayName: "Соло", birthDate: "" }, // сам-один — не знахідка
+  ]);
+  assert.equal(out.length, 1);
   assert.equal(out[0].kind, "duplicate_phone");
   assert.equal(out[0].severity, "medium");
   assert.equal(out[0].patientId, "");
+  assert.equal(out[0].members.length, 2);
   assert.match(out[0].title, /2 карток/);
+});
+
+test("mergeSafetyFields never loses a contrast/do-not-contact flag or an allergy note", () => {
+  const survivor = { patientId: "a".repeat(32), contrastAlert: 0, doNotContact: 0, allergyNote: "", telegramChatId: "" };
+  const absorbed = [
+    { patientId: "b".repeat(32), contrastAlert: 1, doNotContact: 0, allergyNote: "Йод", telegramChatId: "999" },
+    { patientId: "c".repeat(32), contrastAlert: 0, doNotContact: 1, allergyNote: "Йод", telegramChatId: "" },
+  ];
+  const merged = mergeSafetyFields(survivor, absorbed);
+  assert.equal(merged.contrastAlert, 1);   // з поглинутої
+  assert.equal(merged.doNotContact, 1);    // з поглинутої
+  assert.equal(merged.allergyNote, "Йод"); // дедуп однакових нотаток
+  assert.equal(merged.telegramChatId, "999"); // головна порожня → беремо з поглинутої
+
+  const two = mergeSafetyFields(
+    { patientId: "a".repeat(32), contrastAlert: 0, doNotContact: 0, allergyNote: "Латекс", telegramChatId: "111" },
+    [{ patientId: "b".repeat(32), contrastAlert: 0, doNotContact: 0, allergyNote: "Йод", telegramChatId: "222" }],
+  );
+  assert.equal(two.allergyNote, "Латекс / Йод"); // різні — обидві збережено
+  assert.equal(two.telegramChatId, "111");       // головна має свій — лишаємо
 });
 
 test("linkableBookingFindings suggests linking an unlinked booking (low)", () => {
@@ -67,7 +93,10 @@ test("sortFindings orders high → medium → low; countFindings tallies", () =>
   const mixed = [
     ...linkableBookingFindings([{ bookingId: 1, code: "L", bookingName: "", phoneNormalized: "1", patientId: "x", displayName: "X" }]),
     ...staleContactFindings([{ bookingId: 2, code: "S", bookingName: "", bookingPhone: "1", patientId: "y", displayName: "Y", profilePhone: "2" }]),
-    ...duplicatePhoneFindings([{ phoneNormalized: "3", count: 2, names: "A | B" }]),
+    ...duplicatePhoneFindings([
+      { phoneNormalized: "3", patientId: "a".repeat(32), displayName: "A", birthDate: "" },
+      { phoneNormalized: "3", patientId: "b".repeat(32), displayName: "B", birthDate: "" },
+    ]),
   ];
   const sorted = sortFindings(mixed);
   assert.deepEqual(sorted.map((f) => f.severity), ["high", "medium", "low"]);


### PR DESCRIPTION
## Що зроблено

Знахідка **«спільний номер»** на екрані неузгодженостей тепер не лише підсвічує проблему, а дозволяє **адміну обʼєднати картки**: обрати головну — решта приєднуються до неї, з підтвердженням.

## Як це поважає інваріанти схеми

Схема свідомо тримає `patient_id` незмінним у більшості таблиць, а фінансові/клінічні регістри — **append-only** (я перевірив тригери перед реалізацією). Тому злиття:

| Дія | Таблиці | Чому так |
|---|---|---|
| **Перепризначає** `patient_id` → головна | `bookings`, `patient_communications` | тригери `*_patient_link_update` пропускають зміну, бо цільова картка існує в тому ж тенанті |
| **Не чіпає** | 11 append-only регістрів (revenue / settlement / service / result / order / appointment…) | у них є `booking_id` — звʼязок із пацієнтом іде через уже перепризначену заявку, а власний `patient_id` лишається історичним зліпком |
| **Видаляє** рядки поглинутих карток | `patient_sessions`, `patient_otp_challenges`, `telegram_link_tokens`, `patient_telegram_identities`, `mwl_patient_ids` | там `patient_id` незмінний; це ефемерні/переустановлювані дані |
| **Видаляє картку** (останнім) | `patient_profiles` | після перепризначення заявок проходить `patient_profiles_linked_delete_guard` |

## Клінічна безпека при злитті
Прапорці **«реакція на контраст»** і **«не турбувати»** та **нотатки алергій** обʼєднуються — жоден не втрачається (`mergeSafetyFields`, з тестами). Демографію (ПІБ, дату народження) визначає головна картка. Усе атомарно через `db.batch`.

## Доступ і аудит
- Лише **повний адміністратор** (`canMergePatients` — не `organization_admin`, який не має доступу до медичних даних).
- Перевірка, що **обидві** картки належать організації актора; заборона self-merge; 1–10 карток за раз.
- Підтвердження в UI (незворотна дія) + запис у security-лог (`patients_merged`).

## Тести
- `mergeSafetyFields` — union прапорців/нотаток, вибір Telegram chat_id.
- End-to-end злиття: перепризначення заявки + комунікації, union безпечних полів, видалення поглинутої картки.
- Відмова не-адміну (403), заборона self-merge (400), заборона карток іншої організації (404, картка лишається).
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — **1003/1003** зелені.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_