### PR TITLE
protocols: джерело методики / стандарт у протоколі

### DIFF
--- a/app/api/staff/protocols/route.ts
+++ b/app/api/staff/protocols/route.ts
@@ -43,6 +43,7 @@ type ExistingProtocol = {
   status: string;
   templateKey: string;
   method: string;
+  methodRef: string;
   sectionsJson: string;
   findings: string;
   conclusion: string;
@@ -56,6 +57,7 @@ type ExistingProtocol = {
 function sameClinicalDocument(existing: ExistingProtocol, document: ProtocolLifecycleDocument): boolean {
   return existing.templateKey === document.templateKey
     && existing.method === document.method
+    && existing.methodRef === document.methodRef
     && existing.sectionsJson === JSON.stringify(document.sections)
     && existing.findings === document.findings
     && existing.conclusion === document.conclusion
@@ -90,7 +92,7 @@ export async function GET(request: Request) {
     if (!booking) return Response.json({ error: "Заявку не знайдено" }, { status: 404 });
     const [row, revisions] = await Promise.all([
       db.prepare(
-      `SELECT template_key AS templateKey, method, sections_json AS sectionsJson,
+      `SELECT template_key AS templateKey, method, method_ref AS methodRef, sections_json AS sectionsJson,
         findings, conclusion, recommendations, number, status, version,
         author_email AS authorEmail, updated_by AS updatedBy, updated_at AS updatedAt,
         signed_by AS signedBy, signed_at AS signedAt, signed_version AS signedVersion
@@ -105,6 +107,7 @@ export async function GET(request: Request) {
       ? {
           templateKey: String(row.templateKey),
           method: String(row.method || ""),
+          methodRef: String(row.methodRef || ""),
           sections: parseSections(String(row.sectionsJson || "{}")),
           findings: String(row.findings || ""),
           conclusion: String(row.conclusion || ""),
@@ -182,7 +185,7 @@ export async function PUT(request: Request) {
 
   const existing = await db.prepare(
     `SELECT version, author_email AS authorEmail, status,
-       template_key AS templateKey, method, sections_json AS sectionsJson,
+       template_key AS templateKey, method, method_ref AS methodRef, sections_json AS sectionsJson,
        findings, conclusion, recommendations, number,
        signed_by AS signedBy, signed_at AS signedAt, signed_version AS signedVersion
      FROM protocols WHERE booking_id = ? AND organization_id = ? LIMIT 1`
@@ -286,12 +289,12 @@ export async function PUT(request: Request) {
     await db.batch([
       db.prepare(
         `INSERT INTO protocols
-       (organization_id, booking_id, template_key, method, sections_json, findings, conclusion, recommendations,
+       (organization_id, booking_id, template_key, method, method_ref, sections_json, findings, conclusion, recommendations,
         number, status, version, author_email, updated_by, updated_at, signed_by, signed_at, signed_version)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?)
      ON CONFLICT(booking_id) DO UPDATE SET
        organization_id = excluded.organization_id,
-       template_key = excluded.template_key, method = excluded.method,
+       template_key = excluded.template_key, method = excluded.method, method_ref = excluded.method_ref,
        sections_json = excluded.sections_json, findings = excluded.findings,
        conclusion = excluded.conclusion, recommendations = excluded.recommendations,
        number = excluded.number, status = excluded.status, version = excluded.version,
@@ -299,7 +302,7 @@ export async function PUT(request: Request) {
        signed_by = excluded.signed_by, signed_at = excluded.signed_at,
        signed_version = excluded.signed_version`
       ).bind(
-        ctx.organizationId, bookingId, document.templateKey, document.method, sectionsJson, document.findings,
+        ctx.organizationId, bookingId, document.templateKey, document.method, document.methodRef, sectionsJson, document.findings,
         document.conclusion, document.recommendations, document.number, document.status,
         version, authorEmail, member.email, signedBy, signedAt, signedVersion,
       ),

--- a/app/staff/protocols/page.tsx
+++ b/app/staff/protocols/page.tsx
@@ -5,6 +5,7 @@ import StaffWorkspaceShell from "../workspace-shell";
 import {
   PROTOCOL_TEMPLATES,
   type ProtocolDocument,
+  defaultMethodRef,
   normalDocument,
   protocolTemplateByKey,
   renderProtocolText,
@@ -122,6 +123,7 @@ export default function ProtocolsPage() {
       setDoc(data.protocol
         ? {
             templateKey:data.protocol.templateKey, method:data.protocol.method,
+            methodRef:data.protocol.methodRef || "",
             sections:data.protocol.sections || {}, findings:data.protocol.findings,
             conclusion:data.protocol.conclusion, recommendations:data.protocol.recommendations,
             number:data.protocol.number, status:data.protocol.status,
@@ -161,6 +163,7 @@ export default function ProtocolsPage() {
         ...current,
         templateKey,
         method:current.method.trim() ? current.method : template.method,
+        methodRef:current.methodRef.trim() ? current.methodRef : (template.methodRef || defaultMethodRef(template.equipmentId)),
       };
     });
     setDirty(true);
@@ -176,7 +179,12 @@ export default function ProtocolsPage() {
         for (const field of section.fields) if (field.normal && !values[field.key]?.trim()) values[field.key] = field.normal;
         sections[section.key] = values;
       }
-      return { ...current, method:current.method.trim() ? current.method : template.method, sections };
+      return {
+        ...current,
+        method:current.method.trim() ? current.method : template.method,
+        methodRef:current.methodRef.trim() ? current.methodRef : (template.methodRef || defaultMethodRef(template.equipmentId)),
+        sections,
+      };
     });
     setDirty(true);
     setActionSuccess("Поля заповнено типовими формулюваннями норми. Відредагуйте виявлені зміни.");
@@ -247,6 +255,7 @@ export default function ProtocolsPage() {
       const renderable:ProtocolDocument = {
         templateKey:doc.templateKey,
         method:doc.method,
+        methodRef:doc.methodRef,
         sections:doc.sections,
         findings:doc.findings,
         conclusion:doc.conclusion,
@@ -389,6 +398,7 @@ export default function ProtocolsPage() {
           <nav className="protocolToc" aria-label="Зміст протоколу">
             <span className="protocolTocLead">Зміст{completeness ? ` · заповнено ${completeness.filled}/${completeness.total}` : ""}</span>
             <a href="#protocol-method" className={doc.method.trim() ? "done" : ""}>Методика</a>
+            <a href="#protocol-method-ref" className={doc.methodRef.trim() ? "done" : ""}>Джерело методики</a>
             {template.sections.map((section)=>{
               const filled = section.fields.some((f)=>(doc.sections[section.key]?.[f.key] || "").trim());
               return <a key={section.key} href={`#protocol-section-${section.key}`} className={filled ? "done" : ""}>{section.title}</a>;
@@ -415,6 +425,13 @@ export default function ProtocolsPage() {
             <label className="protocolNarrative" id="protocol-method"><span>Методика</span>
               <textarea value={doc.method} maxLength={600} placeholder={template.method || "Опишіть методику дослідження"}
                 onChange={(e)=>patchDoc({method:e.target.value})}/>
+            </label>
+
+            <label className="protocolNarrative" id="protocol-method-ref"><span>Джерело методики / стандарт</span>
+              <textarea value={doc.methodRef} maxLength={300}
+                placeholder={template.methodRef || defaultMethodRef(template.equipmentId) || "Галузевий протокол, методика виробника, наказ МОЗ тощо"}
+                onChange={(e)=>patchDoc({methodRef:e.target.value})}/>
+              <small className="protocolFieldHint">Підстава методики дослідження — потрапляє в текст протоколу (аналог посилання на стандарт).</small>
             </label>
 
             {template.sections.map((section)=><div className="protocolSection" id={`protocol-section-${section.key}`} key={section.key}>
@@ -510,6 +527,7 @@ export default function ProtocolsPage() {
               <div><dt>{booking.performedAt ? "Дата виконання" : "Запланована дата"}</dt><dd>{booking.performedAt ? formatDateTime(booking.performedAt) : `${booking.desiredDate} ${booking.desiredTime}`}</dd></div>
             </dl>
             {(doc.method || template.method) && <section><h2>Методика</h2><p>{doc.method || template.method}</p></section>}
+            {(doc.methodRef || template.methodRef || defaultMethodRef(template.equipmentId)) && <section><h2>Джерело методики</h2><p>{doc.methodRef || template.methodRef || defaultMethodRef(template.equipmentId)}</p></section>}
             {template.sections.map((section)=>{
               const rendered = section.fields
                 .map((field)=>({ field, value:(doc.sections[section.key]?.[field.key] || "").trim() }))

--- a/app/styles/02-workspace.css
+++ b/app/styles/02-workspace.css
@@ -890,3 +890,6 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .mergeMembers label{display:flex;gap:8px;align-items:center;cursor:pointer}
 .mergeMembers small{color:#71807c}
 .mergeError{margin:0 0 8px;font-size:12px;color:#a1301b}
+
+/* Підказка під полем «Джерело методики» в редакторі протоколу. */
+.protocolFieldHint{display:block;margin-top:5px;font-size:11px;color:#71807c}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -142,6 +142,7 @@ export const protocols = sqliteTable("protocols", {
 	bookingId: integer("booking_id").primaryKey().notNull(),
 	templateKey: text("template_key").notNull().default("generic"),
 	method: text().notNull().default(""),
+	methodRef: text("method_ref").notNull().default(""),
 	sectionsJson: text("sections_json").notNull().default("{}"),
 	findings: text().notNull().default(""),
 	conclusion: text().notNull().default(""),

--- a/drizzle/0116_protocol_method_ref.sql
+++ b/drizzle/0116_protocol_method_ref.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `protocols` ADD `method_ref` text DEFAULT '' NOT NULL;

--- a/drizzle/meta/0116_snapshot.json
+++ b/drizzle/meta/0116_snapshot.json
@@ -1,0 +1,10101 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b7edc240-7338-40f8-8453-d92d06f13a2d",
+  "prevId": "2f356ea6-4a54-418b-8107-e763c542cd6f",
+  "tables": {
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "page_key": {
+          "name": "page_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "analytics_events_journey_idx": {
+          "name": "analytics_events_journey_idx",
+          "columns": [
+            "organization_id",
+            "journey_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "analytics_events_org_event_time_idx": {
+          "name": "analytics_events_org_event_time_idx",
+          "columns": [
+            "organization_id",
+            "event_name",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "analytics_events_org_time_idx": {
+          "name": "analytics_events_org_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "analytics_events_check_1": {
+          "name": "analytics_events_check_1",
+          "value": "`event_name` IN ('page_view','service_view','booking_started','slot_selected','booking_created','payment_started','payment_completed','patient_arrived','study_completed')"
+        },
+        "analytics_events_check_2": {
+          "name": "analytics_events_check_2",
+          "value": "`patient_category` IN ('','civilian','military')"
+        },
+        "analytics_events_check_3": {
+          "name": "analytics_events_check_3",
+          "value": "`source` IN ('client','server')"
+        },
+        "analytics_events_check_4": {
+          "name": "analytics_events_check_4",
+          "value": "length(`journey_id`) <= 64"
+        },
+        "analytics_events_check_5": {
+          "name": "analytics_events_check_5",
+          "value": "length(`service_code`) <= 16"
+        },
+        "analytics_events_check_6": {
+          "name": "analytics_events_check_6",
+          "value": "length(`page_key`) <= 64"
+        }
+      }
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "appointment_details": {
+      "name": "appointment_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appointment_version": {
+          "name": "appointment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "appointment_booking_version_unique": {
+          "name": "appointment_booking_version_unique",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "appointment_version"
+          ],
+          "isUnique": true
+        },
+        "appointment_booking_history_idx": {
+          "name": "appointment_booking_history_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "appointment_version",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "appointment_details_booking_id_bookings_id_fk": {
+          "name": "appointment_details_booking_id_bookings_id_fk",
+          "tableFrom": "appointment_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "appointment_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "appointment_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "appointment_details_check_1": {
+          "name": "appointment_details_check_1",
+          "value": "`appointment_version` > 0"
+        },
+        "appointment_details_check_2": {
+          "name": "appointment_details_check_2",
+          "value": "`duration_minutes` > 0"
+        },
+        "appointment_details_check_3": {
+          "name": "appointment_details_check_3",
+          "value": "length(trim(`scheduled_date`)) > 0"
+        },
+        "appointment_details_check_4": {
+          "name": "appointment_details_check_4",
+          "value": "length(trim(`scheduled_time`)) > 0"
+        }
+      }
+    },
+    "booking_capacity_locks": {
+      "name": "booking_capacity_locks",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minute": {
+          "name": "minute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_code": {
+          "name": "booking_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "booking_capacity_locks_booking_idx": {
+          "name": "booking_capacity_locks_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "booking_capacity_locks_organization_id_equipment_id_booking_date_minute_pk": {
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "booking_date",
+            "minute"
+          ],
+          "name": "booking_capacity_locks_organization_id_equipment_id_booking_date_minute_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_comments": {
+      "name": "booking_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "booking_comments_org_author_idx": {
+          "name": "booking_comments_org_author_idx",
+          "columns": [
+            "organization_id",
+            "author_email",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "booking_comments_org_booking_idx": {
+          "name": "booking_comments_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_events": {
+      "name": "booking_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "booking_events_booking_idx": {
+          "name": "booking_events_booking_idx",
+          "columns": [
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_minute_offsets": {
+      "name": "booking_minute_offsets",
+      "columns": {
+        "minute_offset": {
+          "name": "minute_offset",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_requests": {
+      "name": "booking_requests",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_json": {
+          "name": "response_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_staff_notes": {
+      "name": "booking_staff_notes",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookings": {
+      "name": "bookings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desired_date": {
+          "name": "desired_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desired_time": {
+          "name": "desired_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referral": {
+          "name": "referral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Уточню у адміністратора'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "clinical_indication": {
+          "name": "clinical_indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ct'"
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'civilian'"
+        },
+        "referral_type": {
+          "name": "referral_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "referral_number": {
+          "name": "referral_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "marketing_source": {
+          "name": "marketing_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_number": {
+          "name": "protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_status": {
+          "name": "protocol_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "protocol_updated_at": {
+          "name": "protocol_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_set'"
+        },
+        "payment_amount": {
+          "name": "payment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "nszu_status": {
+          "name": "nszu_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_applicable'"
+        },
+        "nszu_reference": {
+          "name": "nszu_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_radiologist_email": {
+          "name": "assigned_radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_radiographer_email": {
+          "name": "assigned_radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "protocol_ready_at": {
+          "name": "protocol_ready_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_issued_at": {
+          "name": "protocol_issued_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_email": {
+          "name": "patient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consent_at": {
+          "name": "consent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "consent_source": {
+          "name": "consent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_verified_at": {
+          "name": "military_verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_verified_by": {
+          "name": "military_verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "bookings_org_patient_idx": {
+          "name": "bookings_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "desired_date"
+          ],
+          "isUnique": false
+        },
+        "bookings_org_schedule_idx": {
+          "name": "bookings_org_schedule_idx",
+          "columns": [
+            "organization_id",
+            "desired_date",
+            "desired_time"
+          ],
+          "isUnique": false
+        },
+        "bookings_patient_idx": {
+          "name": "bookings_patient_idx",
+          "columns": [
+            "phone_normalized",
+            "desired_date"
+          ],
+          "isUnique": false
+        },
+        "bookings_staff_report_idx": {
+          "name": "bookings_staff_report_idx",
+          "columns": [
+            "assigned_radiologist_email",
+            "assigned_radiographer_email"
+          ],
+          "isUnique": false
+        },
+        "bookings_performed_report_idx": {
+          "name": "bookings_performed_report_idx",
+          "columns": [
+            "performed_at",
+            "equipment_id"
+          ],
+          "isUnique": false
+        },
+        "bookings_report_date_idx": {
+          "name": "bookings_report_date_idx",
+          "columns": [
+            "desired_date",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bookings_equipment_schedule_idx": {
+          "name": "bookings_equipment_schedule_idx",
+          "columns": [
+            "equipment_id",
+            "desired_date",
+            "desired_time"
+          ],
+          "isUnique": false
+        },
+        "bookings_code_unique": {
+          "name": "bookings_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "branches": {
+      "name": "branches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "branches_org_idx": {
+          "name": "branches_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "business_documents": {
+      "name": "business_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reversed_document_id": {
+          "name": "reversed_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "basis_document_id": {
+          "name": "basis_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "business_documents_basis_idx": {
+          "name": "business_documents_basis_idx",
+          "columns": [
+            "organization_id",
+            "basis_document_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`basis_document_id` IS NOT NULL"
+        },
+        "business_documents_id_org_idx": {
+          "name": "business_documents_id_org_idx",
+          "columns": [
+            "id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "business_documents_org_type_state_idx": {
+          "name": "business_documents_org_type_state_idx",
+          "columns": [
+            "organization_id",
+            "document_type",
+            "state",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "business_documents_org_type_number_idx": {
+          "name": "business_documents_org_type_number_idx",
+          "columns": [
+            "organization_id",
+            "document_type",
+            "number"
+          ],
+          "isUnique": true,
+          "where": "`number` <> ''"
+        },
+        "business_documents_org_id_idx": {
+          "name": "business_documents_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "business_documents_organization_id_organizations_id_fk": {
+          "name": "business_documents_organization_id_organizations_id_fk",
+          "tableFrom": "business_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "business_documents_reversed_document_id_business_documents_id_fk": {
+          "name": "business_documents_reversed_document_id_business_documents_id_fk",
+          "tableFrom": "business_documents",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "reversed_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "business_documents_check_1": {
+          "name": "business_documents_check_1",
+          "value": "`document_type` IN (\n    'patient_order','appointment','service_delivery','payment','refund',\n    'inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count',\n    'study_performance','result_delivery','study_correction'\n  )"
+        },
+        "business_documents_check_2": {
+          "name": "business_documents_check_2",
+          "value": "`state` IN ('draft','posted','reversed','cancelled')"
+        }
+      }
+    },
+    "cash_accounts": {
+      "name": "cash_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cash'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "cash_accounts_org_type_active_idx": {
+          "name": "cash_accounts_org_type_active_idx",
+          "columns": [
+            "organization_id",
+            "account_type",
+            "currency",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "cash_accounts_one_default_idx": {
+          "name": "cash_accounts_one_default_idx",
+          "columns": [
+            "organization_id",
+            "account_type",
+            "currency"
+          ],
+          "isUnique": true,
+          "where": "`is_default`=1"
+        },
+        "cash_accounts_org_code_idx": {
+          "name": "cash_accounts_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "cash_accounts_org_id_idx": {
+          "name": "cash_accounts_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cash_accounts_organization_id_organizations_id_fk": {
+          "name": "cash_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "cash_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cash_accounts_check_1": {
+          "name": "cash_accounts_check_1",
+          "value": "`account_type` IN ('cash','bank','provider','other')"
+        },
+        "cash_accounts_check_2": {
+          "name": "cash_accounts_check_2",
+          "value": "`active` IN (0,1)"
+        },
+        "cash_accounts_check_3": {
+          "name": "cash_accounts_check_3",
+          "value": "`is_default` IN (0,1)"
+        }
+      }
+    },
+    "cash_movements": {
+      "name": "cash_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "cash_movements_account_time_idx": {
+          "name": "cash_movements_account_time_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`cash_account_id` IS NOT NULL"
+        },
+        "cash_movements_time_idx": {
+          "name": "cash_movements_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "cash_movements_document_idx": {
+          "name": "cash_movements_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cash_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "cash_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "cash_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cash_movements_check_1": {
+          "name": "cash_movements_check_1",
+          "value": "`movement_type` IN ('payment','refund')"
+        },
+        "cash_movements_check_2": {
+          "name": "cash_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "counterparties": {
+      "name": "counterparties",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'supplier'"
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "counterparties_org_kind_active_idx": {
+          "name": "counterparties_org_kind_active_idx",
+          "columns": [
+            "organization_id",
+            "kind",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "counterparties_org_code_idx": {
+          "name": "counterparties_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "counterparties_org_id_idx": {
+          "name": "counterparties_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "counterparties_organization_id_organizations_id_fk": {
+          "name": "counterparties_organization_id_organizations_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "counterparties_check_1": {
+          "name": "counterparties_check_1",
+          "value": "`kind` IN ('supplier','payer','both','other')"
+        },
+        "counterparties_check_2": {
+          "name": "counterparties_check_2",
+          "value": "`active` IN (0,1)"
+        }
+      }
+    },
+    "custom_field_definitions": {
+      "name": "custom_field_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'booking'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "idx_custom_field_definitions_org_entity": {
+          "name": "idx_custom_field_definitions_org_entity",
+          "columns": [
+            "organization_id",
+            "entity_type",
+            "active",
+            "sort_order",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_field_definitions_organization_id_organizations_id_fk": {
+          "name": "custom_field_definitions_organization_id_organizations_id_fk",
+          "tableFrom": "custom_field_definitions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "custom_field_definitions_check_1": {
+          "name": "custom_field_definitions_check_1",
+          "value": "entity_type IN ('booking')"
+        },
+        "custom_field_definitions_check_2": {
+          "name": "custom_field_definitions_check_2",
+          "value": "field_type IN ('text','number','date','boolean','select')"
+        },
+        "custom_field_definitions_check_3": {
+          "name": "custom_field_definitions_check_3",
+          "value": "required IN (0,1)"
+        },
+        "custom_field_definitions_check_4": {
+          "name": "custom_field_definitions_check_4",
+          "value": "active IN (0,1)"
+        }
+      }
+    },
+    "custom_field_values": {
+      "name": "custom_field_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'booking'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "idx_custom_field_values_org_entity": {
+          "name": "idx_custom_field_values_org_entity",
+          "columns": [
+            "organization_id",
+            "entity_type",
+            "entity_id",
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_field_values_organization_id_organizations_id_fk": {
+          "name": "custom_field_values_organization_id_organizations_id_fk",
+          "tableFrom": "custom_field_values",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "custom_field_values_organization_id_definition_id_custom_field_definitions_organization_id_id_fk": {
+          "name": "custom_field_values_organization_id_definition_id_custom_field_definitions_organization_id_id_fk",
+          "tableFrom": "custom_field_values",
+          "tableTo": "custom_field_definitions",
+          "columnsFrom": [
+            "organization_id",
+            "definition_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "custom_field_values_check_1": {
+          "name": "custom_field_values_check_1",
+          "value": "entity_type IN ('booking')"
+        }
+      }
+    },
+    "departments": {
+      "name": "departments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "departments_org_idx": {
+          "name": "departments_org_idx",
+          "columns": [
+            "organization_id",
+            "branch_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "equipment_blocks": {
+      "name": "equipment_blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked_date": {
+          "name": "blocked_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "equipment_blocks_schedule_idx": {
+          "name": "equipment_blocks_schedule_idx",
+          "columns": [
+            "equipment_id",
+            "blocked_date",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "equipment_load_movements": {
+      "name": "equipment_load_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minutes_delta": {
+          "name": "minutes_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "equipment_load_equipment_idx": {
+          "name": "equipment_load_equipment_idx",
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "equipment_load_document_idx": {
+          "name": "equipment_load_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "equipment_load_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "equipment_load_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "equipment_load_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "equipment_load_movements_check_1": {
+          "name": "equipment_load_movements_check_1",
+          "value": "`minutes_delta` <> 0"
+        }
+      }
+    },
+    "equipment_maintenance": {
+      "name": "equipment_maintenance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_email": {
+          "name": "assigned_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "downtime_start": {
+          "name": "downtime_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "downtime_end": {
+          "name": "downtime_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "equipment_maintenance_org_status_idx": {
+          "name": "equipment_maintenance_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "due_date",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "equipment_maintenance_org_equipment_idx": {
+          "name": "equipment_maintenance_org_equipment_idx",
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expense_movements": {
+      "name": "expense_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "inventory_movement_id": {
+          "name": "inventory_movement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_line_id": {
+          "name": "document_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_receipt_document_id": {
+          "name": "source_receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_receipt_line_id": {
+          "name": "source_receipt_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "expense_movements_inventory_movement_idx": {
+          "name": "expense_movements_inventory_movement_idx",
+          "columns": [
+            "organization_id",
+            "inventory_movement_id"
+          ],
+          "isUnique": true
+        },
+        "expense_movements_org_time_idx": {
+          "name": "expense_movements_org_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "expense_movements_org_item_time_idx": {
+          "name": "expense_movements_org_item_time_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "expense_movements_org_lot_idx": {
+          "name": "expense_movements_org_lot_idx",
+          "columns": [
+            "organization_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "expense_movements_unit_cost_nonnegative": {
+          "name": "expense_movements_unit_cost_nonnegative",
+          "value": "\"expense_movements\".\"unit_cost\" >= 0"
+        },
+        "expense_movements_amount_positive": {
+          "name": "expense_movements_amount_positive",
+          "value": "\"expense_movements\".\"amount_delta\" > 0"
+        }
+      }
+    },
+    "finance_document_details": {
+      "name": "finance_document_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_transaction_id": {
+          "name": "source_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "finance_document_cash_account_idx": {
+          "name": "finance_document_cash_account_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "document_id"
+          ],
+          "isUnique": false,
+          "where": "`cash_account_id` IS NOT NULL"
+        },
+        "finance_document_details_source_transaction_idx": {
+          "name": "finance_document_details_source_transaction_idx",
+          "columns": [
+            "organization_id",
+            "source_transaction_id"
+          ],
+          "isUnique": true,
+          "where": "`source_transaction_id` IS NOT NULL"
+        },
+        "finance_document_details_booking_idx": {
+          "name": "finance_document_details_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "finance_document_details_booking_id_bookings_id_fk": {
+          "name": "finance_document_details_booking_id_bookings_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_source_document_id_business_documents_id_fk": {
+          "name": "finance_document_details_source_document_id_business_documents_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_source_transaction_id_payment_transactions_id_fk": {
+          "name": "finance_document_details_source_transaction_id_payment_transactions_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "payment_transactions",
+          "columnsFrom": [
+            "source_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "finance_document_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "finance_document_details_check_1": {
+          "name": "finance_document_details_check_1",
+          "value": "`amount` > 0"
+        }
+      }
+    },
+    "imaging_studies": {
+      "name": "imaging_studies",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accession_number": {
+          "name": "accession_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "study_instance_uid": {
+          "name": "study_instance_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "series_count": {
+          "name": "series_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "instances_count": {
+          "name": "instances_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "study_status": {
+          "name": "study_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_linked'"
+        },
+        "study_datetime": {
+          "name": "study_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "imaging_studies_org_uid_idx": {
+          "name": "imaging_studies_org_uid_idx",
+          "columns": [
+            "organization_id",
+            "study_instance_uid"
+          ],
+          "isUnique": true,
+          "where": "study_instance_uid != ''"
+        },
+        "imaging_studies_org_idx": {
+          "name": "imaging_studies_org_idx",
+          "columns": [
+            "organization_id",
+            "study_status"
+          ],
+          "isUnique": false
+        },
+        "imaging_studies_status_idx": {
+          "name": "imaging_studies_status_idx",
+          "columns": [
+            "study_status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_count_lines": {
+      "name": "inventory_count_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "item_unit": {
+          "name": "item_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "book_quantity": {
+          "name": "book_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counted_quantity": {
+          "name": "counted_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "inventory_count_lines_doc_line_idx": {
+          "name": "inventory_count_lines_doc_line_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": true
+        },
+        "inventory_count_lines_bucket_unique": {
+          "name": "inventory_count_lines_bucket_unique",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "warehouse_id",
+            "lot_id"
+          ],
+          "isUnique": true
+        },
+        "inventory_count_lines_warehouse_idx": {
+          "name": "inventory_count_lines_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_count_lines_item_id_inventory_items_id_fk": {
+          "name": "inventory_count_lines_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_count_lines_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_count_lines_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_count_lines_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "inventory_count_lines_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_count_lines_book_nonnegative": {
+          "name": "inventory_count_lines_book_nonnegative",
+          "value": "book_quantity >= 0"
+        },
+        "inventory_count_lines_counted_nonnegative": {
+          "name": "inventory_count_lines_counted_nonnegative",
+          "value": "counted_quantity >= 0"
+        }
+      }
+    },
+    "inventory_document_lines": {
+      "name": "inventory_document_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination_warehouse_code": {
+          "name": "destination_warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "destination_warehouse_name": {
+          "name": "destination_warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "line_amount": {
+          "name": "line_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reservation_movement_id": {
+          "name": "reservation_movement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inventory_lines_reservation_idx": {
+          "name": "inventory_lines_reservation_idx",
+          "columns": [
+            "organization_id",
+            "reservation_movement_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`reservation_movement_id` IS NOT NULL"
+        },
+        "inventory_lines_destination_warehouse_idx": {
+          "name": "inventory_lines_destination_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "destination_warehouse_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`destination_warehouse_id` IS NOT NULL"
+        },
+        "inventory_lines_warehouse_idx": {
+          "name": "inventory_lines_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_document_lines_supplier_idx": {
+          "name": "inventory_document_lines_supplier_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "document_id"
+          ],
+          "isUnique": false,
+          "where": "`supplier_counterparty_id` IS NOT NULL"
+        },
+        "inventory_document_lines_org_id_idx": {
+          "name": "inventory_document_lines_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        },
+        "inventory_document_lines_doc_line_idx": {
+          "name": "inventory_document_lines_doc_line_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inventory_document_lines_item_id_inventory_items_id_fk": {
+          "name": "inventory_document_lines_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_document_lines_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_booking_id_bookings_id_fk": {
+          "name": "inventory_document_lines_booking_id_bookings_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "inventory_document_lines_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_document_lines_check_1": {
+          "name": "inventory_document_lines_check_1",
+          "value": "`quantity` > 0"
+        },
+        "inventory_document_lines_check_2": {
+          "name": "inventory_document_lines_check_2",
+          "value": "`unit_cost` >= 0"
+        },
+        "inventory_document_lines_check_3": {
+          "name": "inventory_document_lines_check_3",
+          "value": "`line_amount` >= 0"
+        }
+      }
+    },
+    "inventory_items": {
+      "name": "inventory_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'шт'"
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "inventory_items_org_active_idx": {
+          "name": "inventory_items_org_active_idx",
+          "columns": [
+            "organization_id",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "inventory_items_org_sku_idx": {
+          "name": "inventory_items_org_sku_idx",
+          "columns": [
+            "organization_id",
+            "sku"
+          ],
+          "isUnique": true,
+          "where": "`sku` <> ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_lots": {
+      "name": "inventory_lots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inventory_lots_supplier_idx": {
+          "name": "inventory_lots_supplier_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`supplier_counterparty_id` IS NOT NULL"
+        },
+        "inventory_lots_org_item_idx": {
+          "name": "inventory_lots_org_item_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "expires_on"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_lots_item_id_inventory_items_id_fk": {
+          "name": "inventory_lots_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_lots",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_movements": {
+      "name": "inventory_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_line_id": {
+          "name": "document_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "inventory_movements_document_line_type_idx": {
+          "name": "inventory_movements_document_line_type_idx",
+          "columns": [
+            "organization_id",
+            "document_line_id",
+            "movement_type"
+          ],
+          "isUnique": true,
+          "where": "`document_line_id` IS NOT NULL"
+        },
+        "inventory_movements_warehouse_lot_idx": {
+          "name": "inventory_movements_warehouse_lot_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_movements_warehouse_item_idx": {
+          "name": "inventory_movements_warehouse_item_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_movements_document_idx": {
+          "name": "inventory_movements_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`document_id` IS NOT NULL"
+        },
+        "inventory_movements_org_lot_idx": {
+          "name": "inventory_movements_org_lot_idx",
+          "columns": [
+            "organization_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "inventory_movements_org_item_idx": {
+          "name": "inventory_movements_org_item_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_movements_item_id_inventory_items_id_fk": {
+          "name": "inventory_movements_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_movements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movements_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_movements_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_movements",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_reservation_movements": {
+      "name": "inventory_reservation_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appointment_document_id": {
+          "name": "appointment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "inventory_reservation_exact_movement_unique": {
+          "name": "inventory_reservation_exact_movement_unique",
+          "columns": [
+            "organization_id",
+            "appointment_document_id",
+            "requirement_id",
+            "movement_type"
+          ],
+          "isUnique": true
+        },
+        "inventory_reservation_balance_idx": {
+          "name": "inventory_reservation_balance_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "inventory_reservation_booking_idx": {
+          "name": "inventory_reservation_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_reservation_movements_organization_id_organizations_id_fk": {
+          "name": "inventory_reservation_movements_organization_id_organizations_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_booking_id_bookings_id_fk": {
+          "name": "inventory_reservation_movements_booking_id_bookings_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_requirement_id_service_material_requirements_id_fk": {
+          "name": "inventory_reservation_movements_requirement_id_service_material_requirements_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "service_material_requirements",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_item_id_inventory_items_id_fk": {
+          "name": "inventory_reservation_movements_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_warehouse_id_warehouses_id_fk": {
+          "name": "inventory_reservation_movements_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_appointment_tenant_fk": {
+          "name": "inventory_reservation_appointment_tenant_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "appointment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_reservation_movements_check_1": {
+          "name": "inventory_reservation_movements_check_1",
+          "value": "`movement_type` IN ('reserve','release')"
+        },
+        "inventory_reservation_movements_check_2": {
+          "name": "inventory_reservation_movements_check_2",
+          "value": "(`movement_type`='reserve' AND `quantity_delta` > 0) OR (`movement_type`='release' AND `quantity_delta` < 0)"
+        }
+      }
+    },
+    "memberships": {
+      "name": "memberships",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "memberships_member_idx": {
+          "name": "memberships_member_idx",
+          "columns": [
+            "member_email"
+          ],
+          "isUnique": false
+        },
+        "memberships_org_member_idx": {
+          "name": "memberships_org_member_idx",
+          "columns": [
+            "organization_id",
+            "member_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mwl_bridge_tokens": {
+      "name": "mwl_bridge_tokens",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "mwl_bridge_tokens_hash_idx": {
+          "name": "mwl_bridge_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mwl_patient_ids": {
+      "name": "mwl_patient_ids",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "mwl_patient_ids_org_patient_idx": {
+          "name": "mwl_patient_ids_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mwl_patient_ids_organization_id_identity_key_pk": {
+          "columns": [
+            "organization_id",
+            "identity_key"
+          ],
+          "name": "mwl_patient_ids_organization_id_identity_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_integration_settings": {
+      "name": "organization_integration_settings",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_integration_settings_org_idx": {
+          "name": "organization_integration_settings_org_idx",
+          "columns": [
+            "organization_id",
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_integration_settings_organization_id_organizations_id_fk": {
+          "name": "organization_integration_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_integration_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_integration_settings_organization_id_key_pk": {
+          "columns": [
+            "organization_id",
+            "key"
+          ],
+          "name": "organization_integration_settings_organization_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_profiles": {
+      "name": "organization_profiles",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_type": {
+          "name": "profile_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hospital_radiology'"
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "feature_flags_json": {
+          "name": "feature_flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pacs_settings": {
+      "name": "pacs_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dicomweb_base_url": {
+          "name": "dicomweb_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "viewer_base_url": {
+          "name": "viewer_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ae_title": {
+          "name": "ae_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "pacs_settings_organization_idx": {
+          "name": "pacs_settings_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_communications": {
+      "name": "patient_communications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'call'"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'outbound'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_communications_org_patient_idx": {
+          "name": "patient_communications_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_comm_external_idx": {
+          "name": "patient_comm_external_idx",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true,
+          "where": "`external_id` != ''"
+        },
+        "patient_communications_org_idx": {
+          "name": "patient_communications_org_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        },
+        "patient_communications_phone_idx": {
+          "name": "patient_communications_phone_idx",
+          "columns": [
+            "phone_normalized",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_notifications": {
+      "name": "patient_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "patient_notifications_org_idx": {
+          "name": "patient_notifications_org_idx",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": false
+        },
+        "patient_notifications_booking_idx": {
+          "name": "patient_notifications_booking_idx",
+          "columns": [
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_order_details": {
+      "name": "patient_order_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_order_patient_idx": {
+          "name": "patient_order_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "patient_order_booking_unique": {
+          "name": "patient_order_booking_unique",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "patient_order_details_booking_id_bookings_id_fk": {
+          "name": "patient_order_details_booking_id_bookings_id_fk",
+          "tableFrom": "patient_order_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_order_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "patient_order_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "patient_order_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "patient_order_details_check_1": {
+          "name": "patient_order_details_check_1",
+          "value": "`duration_minutes` > 0"
+        },
+        "patient_order_details_check_2": {
+          "name": "patient_order_details_check_2",
+          "value": "`price_amount` >= 0"
+        },
+        "patient_order_details_check_3": {
+          "name": "patient_order_details_check_3",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "patient_otp_challenges": {
+      "name": "patient_otp_challenges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cabinet_login'"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_otp_patient_idx": {
+          "name": "patient_otp_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_identity_scope_idx": {
+          "name": "patient_otp_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_expiry_idx": {
+          "name": "patient_otp_expiry_idx",
+          "columns": [
+            "expires_at",
+            "consumed_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_phone_idx": {
+          "name": "patient_otp_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_profiles": {
+      "name": "patient_profiles",
+      "columns": {
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(lower(hex(randomblob(16))))"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_not_contact": {
+          "name": "do_not_contact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contrast_alert": {
+          "name": "contrast_alert",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allergy_note": {
+          "name": "allergy_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_profiles_org_updated_idx": {
+          "name": "patient_profiles_org_updated_idx",
+          "columns": [
+            "organization_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "patient_profiles_org_phone_idx": {
+          "name": "patient_profiles_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        },
+        "patient_profiles_phone_idx": {
+          "name": "patient_profiles_phone_idx",
+          "columns": [
+            "phone_normalized"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_sessions": {
+      "name": "patient_sessions",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_sessions_patient_idx": {
+          "name": "patient_sessions_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_identity_scope_idx": {
+          "name": "patient_sessions_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_org_phone_idx": {
+          "name": "patient_sessions_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_expiry_idx": {
+          "name": "patient_sessions_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_settlement_movements": {
+      "name": "patient_settlement_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_settlement_booking_idx": {
+          "name": "patient_settlement_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "patient_settlement_patient_idx": {
+          "name": "patient_settlement_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "patient_settlement_document_idx": {
+          "name": "patient_settlement_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "patient_settlement_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "patient_settlement_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "patient_settlement_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "patient_settlement_movements_check_1": {
+          "name": "patient_settlement_movements_check_1",
+          "value": "`movement_type` IN ('charge','payment','refund','adjustment')"
+        },
+        "patient_settlement_movements_check_2": {
+          "name": "patient_settlement_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "patient_telegram_identities": {
+      "name": "patient_telegram_identities",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_telegram_patient_idx": {
+          "name": "patient_telegram_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "patient_telegram_chat_idx": {
+          "name": "patient_telegram_chat_idx",
+          "columns": [
+            "telegram_chat_id"
+          ],
+          "isUnique": false,
+          "where": "telegram_chat_id != ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "patient_telegram_identities_organization_id_phone_normalized_identity_kind_identity_value_pk": {
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value"
+          ],
+          "name": "patient_telegram_identities_organization_id_phone_normalized_identity_kind_identity_value_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payment_transactions": {
+      "name": "payment_transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refund_document_id": {
+          "name": "refund_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payment_transactions_one_linked_paid_booking_idx": {
+          "name": "payment_transactions_one_linked_paid_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true,
+          "where": "`status`='paid' AND `payment_document_id` IS NOT NULL"
+        },
+        "payment_transactions_refund_document_idx": {
+          "name": "payment_transactions_refund_document_idx",
+          "columns": [
+            "organization_id",
+            "refund_document_id"
+          ],
+          "isUnique": true,
+          "where": "`refund_document_id` IS NOT NULL"
+        },
+        "payment_transactions_payment_document_idx": {
+          "name": "payment_transactions_payment_document_idx",
+          "columns": [
+            "organization_id",
+            "payment_document_id"
+          ],
+          "isUnique": true,
+          "where": "`payment_document_id` IS NOT NULL"
+        },
+        "payment_transactions_provider_ref_idx": {
+          "name": "payment_transactions_provider_ref_idx",
+          "columns": [
+            "organization_id",
+            "provider",
+            "provider_reference"
+          ],
+          "isUnique": true,
+          "where": "provider_reference != ''"
+        },
+        "payment_transactions_booking_idx": {
+          "name": "payment_transactions_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "payment_transactions_check_1": {
+          "name": "payment_transactions_check_1",
+          "value": "amount >= 0"
+        },
+        "payment_transactions_check_2": {
+          "name": "payment_transactions_check_2",
+          "value": "status IN ('pending','paid','failed','refunded','cancelled')"
+        }
+      }
+    },
+    "printed_form_snapshots": {
+      "name": "printed_form_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_type": {
+          "name": "form_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_state": {
+          "name": "document_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "printed_service_act_state_unique": {
+          "name": "printed_service_act_state_unique",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "document_state"
+          ],
+          "isUnique": true,
+          "where": "`form_type`='service_act' AND `document_state` IN ('posted','reversed')"
+        },
+        "printed_form_snapshots_state_idx": {
+          "name": "printed_form_snapshots_state_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "document_state",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "printed_form_snapshots_document_idx": {
+          "name": "printed_form_snapshots_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "printed_form_snapshots_same_render_idx": {
+          "name": "printed_form_snapshots_same_render_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "sha256"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "printed_form_snapshots_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "printed_form_snapshots_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "printed_form_snapshots",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "printed_form_snapshots_check_1": {
+          "name": "printed_form_snapshots_check_1",
+          "value": "`form_type` IN (\n    'invoice','payment_receipt','service_act','referral','protocol','result',\n    'inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count','service_note'\n  )"
+        },
+        "printed_form_snapshots_check_2": {
+          "name": "printed_form_snapshots_check_2",
+          "value": "`template_version` > 0"
+        }
+      }
+    },
+    "protocol_addenda": {
+      "name": "protocol_addenda",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "correction_text": {
+          "name": "correction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_version": {
+          "name": "signed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "protocol_addenda_status_idx": {
+          "name": "protocol_addenda_status_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "protocol_addenda_org_booking_idx": {
+          "name": "protocol_addenda_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protocol_addenda_check_1": {
+          "name": "protocol_addenda_check_1",
+          "value": "`length`(`id`) = 32 AND `id` NOT GLOB '*[^0-9a-f]*'"
+        },
+        "protocol_addenda_check_2": {
+          "name": "protocol_addenda_check_2",
+          "value": "`length`(`trim`(`reason`)) BETWEEN 1 AND 500"
+        },
+        "protocol_addenda_check_3": {
+          "name": "protocol_addenda_check_3",
+          "value": "`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000"
+        },
+        "protocol_addenda_check_4": {
+          "name": "protocol_addenda_check_4",
+          "value": "`length`(`trim`(`author_email`)) > 0"
+        },
+        "protocol_addenda_check_5": {
+          "name": "protocol_addenda_check_5",
+          "value": "`length`(`trim`(`updated_by`)) > 0"
+        },
+        "protocol_addenda_check_6": {
+          "name": "protocol_addenda_check_6",
+          "value": "`status` IN ('draft','ready','signed','issued')"
+        },
+        "protocol_addenda_check_7": {
+          "name": "protocol_addenda_check_7",
+          "value": "`base_protocol_version` > 0"
+        },
+        "protocol_addenda_check_8": {
+          "name": "protocol_addenda_check_8",
+          "value": "`version` > 0"
+        }
+      }
+    },
+    "protocol_addendum_revisions": {
+      "name": "protocol_addendum_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "addendum_id": {
+          "name": "addendum_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "correction_text": {
+          "name": "correction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "protocol_addendum_revisions_scope_idx": {
+          "name": "protocol_addendum_revisions_scope_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "addendum_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protocol_addendum_revisions_check_1": {
+          "name": "protocol_addendum_revisions_check_1",
+          "value": "`length`(`addendum_id`) = 32 AND `addendum_id` NOT GLOB '*[^0-9a-f]*'"
+        },
+        "protocol_addendum_revisions_check_2": {
+          "name": "protocol_addendum_revisions_check_2",
+          "value": "`length`(`trim`(`reason`)) BETWEEN 1 AND 500"
+        },
+        "protocol_addendum_revisions_check_3": {
+          "name": "protocol_addendum_revisions_check_3",
+          "value": "`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000"
+        },
+        "protocol_addendum_revisions_check_4": {
+          "name": "protocol_addendum_revisions_check_4",
+          "value": "`length`(`trim`(`saved_by`)) > 0"
+        },
+        "protocol_addendum_revisions_check_5": {
+          "name": "protocol_addendum_revisions_check_5",
+          "value": "`status` IN ('draft','ready','signed')"
+        },
+        "protocol_addendum_revisions_check_6": {
+          "name": "protocol_addendum_revisions_check_6",
+          "value": "`base_protocol_version` > 0"
+        },
+        "protocol_addendum_revisions_check_7": {
+          "name": "protocol_addendum_revisions_check_7",
+          "value": "`version` > 0"
+        }
+      }
+    },
+    "protocol_revisions": {
+      "name": "protocol_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "protocol_revisions_org_booking_idx": {
+          "name": "protocol_revisions_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "version"
+          ],
+          "isUnique": false
+        },
+        "protocol_revisions_booking_idx": {
+          "name": "protocol_revisions_booking_idx",
+          "columns": [
+            "booking_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "protocol_revisions_booking_id_bookings_id_fk": {
+          "name": "protocol_revisions_booking_id_bookings_id_fk",
+          "tableFrom": "protocol_revisions",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "protocols": {
+      "name": "protocols",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'generic'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "method_ref": {
+          "name": "method_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_version": {
+          "name": "signed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "protocols_org_number_idx": {
+          "name": "protocols_org_number_idx",
+          "columns": [
+            "organization_id",
+            "number"
+          ],
+          "isUnique": false
+        },
+        "protocols_org_idx": {
+          "name": "protocols_org_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "protocols_status_idx": {
+          "name": "protocols_status_idx",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_exports": {
+      "name": "report_exports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filters_json": {
+          "name": "filters_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "columns_json": {
+          "name": "columns_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'xlsx'"
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contains_personal_data": {
+          "name": "contains_personal_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "report_exports_created_idx": {
+          "name": "report_exports_created_idx",
+          "columns": [
+            "created_at",
+            "requested_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_limits": {
+      "name": "request_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "result_addendum_delivery_details": {
+      "name": "result_addendum_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addendum_id": {
+          "name": "addendum_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_number": {
+          "name": "base_protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addendum_version": {
+          "name": "addendum_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "result_addendum_delivery_addendum_unique": {
+          "name": "result_addendum_delivery_addendum_unique",
+          "columns": [
+            "organization_id",
+            "addendum_id"
+          ],
+          "isUnique": true
+        },
+        "result_addendum_delivery_booking_idx": {
+          "name": "result_addendum_delivery_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "result_addendum_delivery_document_idx": {
+          "name": "result_addendum_delivery_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "result_addendum_delivery_details_addendum_id_protocol_addenda_id_fk": {
+          "name": "result_addendum_delivery_details_addendum_id_protocol_addenda_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "protocol_addenda",
+          "columnsFrom": [
+            "addendum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_addendum_delivery_details_booking_id_bookings_id_fk": {
+          "name": "result_addendum_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_addendum_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "result_addendum_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "result_addendum_delivery_details_check_1": {
+          "name": "result_addendum_delivery_details_check_1",
+          "value": "`base_protocol_version` > 0"
+        },
+        "result_addendum_delivery_details_check_2": {
+          "name": "result_addendum_delivery_details_check_2",
+          "value": "`addendum_version` > 0"
+        }
+      }
+    },
+    "result_delivery_details": {
+      "name": "result_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_number": {
+          "name": "protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "result_delivery_booking_unique": {
+          "name": "result_delivery_booking_unique",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true
+        },
+        "result_delivery_document_idx": {
+          "name": "result_delivery_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "result_delivery_details_booking_id_bookings_id_fk": {
+          "name": "result_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "result_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "result_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "result_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "result_delivery_details_check_1": {
+          "name": "result_delivery_details_check_1",
+          "value": "`protocol_version` > 0"
+        }
+      }
+    },
+    "revenue_movements": {
+      "name": "revenue_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "revenue_time_idx": {
+          "name": "revenue_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "revenue_document_idx": {
+          "name": "revenue_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "revenue_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "revenue_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "revenue_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "revenue_movements_check_1": {
+          "name": "revenue_movements_check_1",
+          "value": "`movement_type` IN ('service_delivery','service_correction')"
+        },
+        "revenue_movements_check_2": {
+          "name": "revenue_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "saved_report_views": {
+      "name": "saved_report_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_key": {
+          "name": "report_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'register_turnover'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configuration_json": {
+          "name": "configuration_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "saved_report_views_org_report_name_unique": {
+          "name": "saved_report_views_org_report_name_unique",
+          "columns": [
+            "organization_id",
+            "report_key",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "saved_report_views_org_report_idx": {
+          "name": "saved_report_views_org_report_idx",
+          "columns": [
+            "organization_id",
+            "report_key",
+            "updated_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "saved_report_views_report_key_check": {
+          "name": "saved_report_views_report_key_check",
+          "value": "`report_key` = 'register_turnover'"
+        },
+        "saved_report_views_name_check": {
+          "name": "saved_report_views_name_check",
+          "value": "length(trim(`name`)) BETWEEN 1 AND 80"
+        }
+      }
+    },
+    "security_audit_log": {
+      "name": "security_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "security_audit_created_idx": {
+          "name": "security_audit_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "actor_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_correction_details": {
+      "name": "service_correction_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correction_kind": {
+          "name": "correction_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'storno'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "radiologist_email": {
+          "name": "radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "radiographer_email": {
+          "name": "radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_correction_booking_idx": {
+          "name": "service_correction_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "service_correction_source_unique": {
+          "name": "service_correction_source_unique",
+          "columns": [
+            "organization_id",
+            "source_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_correction_details_booking_id_bookings_id_fk": {
+          "name": "service_correction_details_booking_id_bookings_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_details_source_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_details_source_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_correction_details_check_1": {
+          "name": "service_correction_details_check_1",
+          "value": "`correction_kind`='storno'"
+        },
+        "service_correction_details_check_2": {
+          "name": "service_correction_details_check_2",
+          "value": "length(trim(`reason`)) >= 5"
+        },
+        "service_correction_details_check_3": {
+          "name": "service_correction_details_check_3",
+          "value": "`duration_minutes` > 0"
+        },
+        "service_correction_details_check_4": {
+          "name": "service_correction_details_check_4",
+          "value": "`anatomical_regions_count` > 0"
+        },
+        "service_correction_details_check_5": {
+          "name": "service_correction_details_check_5",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "service_correction_movements": {
+      "name": "service_correction_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_delta": {
+          "name": "anatomical_regions_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_correction_movement_source_idx": {
+          "name": "service_correction_movement_source_idx",
+          "columns": [
+            "organization_id",
+            "source_document_id"
+          ],
+          "isUnique": true
+        },
+        "service_correction_movement_document_idx": {
+          "name": "service_correction_movement_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_correction_movements_source_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_movements_source_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_correction_movements_check_1": {
+          "name": "service_correction_movements_check_1",
+          "value": "`quantity_delta`=-1"
+        },
+        "service_correction_movements_check_2": {
+          "name": "service_correction_movements_check_2",
+          "value": "`anatomical_regions_delta` < 0"
+        }
+      }
+    },
+    "service_delivery_details": {
+      "name": "service_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "radiologist_email": {
+          "name": "radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "radiographer_email": {
+          "name": "radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_delivery_booking_idx": {
+          "name": "service_delivery_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "service_delivery_details_booking_id_bookings_id_fk": {
+          "name": "service_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "service_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_delivery_details_check_1": {
+          "name": "service_delivery_details_check_1",
+          "value": "`duration_minutes` > 0"
+        },
+        "service_delivery_details_check_2": {
+          "name": "service_delivery_details_check_2",
+          "value": "`anatomical_regions_count` > 0"
+        },
+        "service_delivery_details_check_3": {
+          "name": "service_delivery_details_check_3",
+          "value": "`price_amount` >= 0"
+        },
+        "service_delivery_details_check_4": {
+          "name": "service_delivery_details_check_4",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "service_material_requirements": {
+      "name": "service_material_requirements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_material_requirements_service_idx": {
+          "name": "service_material_requirements_service_idx",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "active",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "service_material_requirements_active_unique": {
+          "name": "service_material_requirements_active_unique",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "item_id",
+            "warehouse_id"
+          ],
+          "isUnique": true,
+          "where": "`active` = 1"
+        }
+      },
+      "foreignKeys": {
+        "service_material_requirements_organization_id_organizations_id_fk": {
+          "name": "service_material_requirements_organization_id_organizations_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_material_requirements_item_id_inventory_items_id_fk": {
+          "name": "service_material_requirements_item_id_inventory_items_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_material_requirements_warehouse_id_warehouses_id_fk": {
+          "name": "service_material_requirements_warehouse_id_warehouses_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_material_requirements_check_1": {
+          "name": "service_material_requirements_check_1",
+          "value": "length(trim(`service_code`)) > 0"
+        },
+        "service_material_requirements_check_2": {
+          "name": "service_material_requirements_check_2",
+          "value": "`quantity` > 0"
+        },
+        "service_material_requirements_check_3": {
+          "name": "service_material_requirements_check_3",
+          "value": "`active` IN (0,1)"
+        }
+      }
+    },
+    "service_prices": {
+      "name": "service_prices",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services_delivered_movements": {
+      "name": "services_delivered_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "services_delivered_service_idx": {
+          "name": "services_delivered_service_idx",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "services_delivered_document_idx": {
+          "name": "services_delivered_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "services_delivered_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "services_delivered_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "services_delivered_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "services_delivered_movements_check_1": {
+          "name": "services_delivered_movements_check_1",
+          "value": "`quantity` > 0"
+        },
+        "services_delivered_movements_check_2": {
+          "name": "services_delivered_movements_check_2",
+          "value": "`anatomical_regions_count` > 0"
+        }
+      }
+    },
+    "staff_members": {
+      "name": "staff_members",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patronymic": {
+          "name": "patronymic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_rank": {
+          "name": "military_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_title": {
+          "name": "position_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "staff_members_phone_idx": {
+          "name": "staff_members_phone_idx",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true,
+          "where": "`phone` != ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_output_movements": {
+      "name": "staff_output_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "units_delta": {
+          "name": "units_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_output_member_idx": {
+          "name": "staff_output_member_idx",
+          "columns": [
+            "organization_id",
+            "member_email",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "staff_output_document_role_idx": {
+          "name": "staff_output_document_role_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "staff_role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "staff_output_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "staff_output_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "staff_output_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_output_movements_check_1": {
+          "name": "staff_output_movements_check_1",
+          "value": "`staff_role` IN ('radiologist','radiographer')"
+        },
+        "staff_output_movements_check_2": {
+          "name": "staff_output_movements_check_2",
+          "value": "`units_delta` <> 0"
+        },
+        "staff_output_movements_check_3": {
+          "name": "staff_output_movements_check_3",
+          "value": "`anatomical_regions_count` > 0"
+        }
+      }
+    },
+    "staff_saved_views": {
+      "name": "staff_saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_saved_views_owner_surface_idx": {
+          "name": "staff_saved_views_owner_surface_idx",
+          "columns": [
+            "organization_id",
+            "member_email",
+            "surface",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_saved_views_organization_id_organizations_id_fk": {
+          "name": "staff_saved_views_organization_id_organizations_id_fk",
+          "tableFrom": "staff_saved_views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_saved_views_member_email_staff_members_email_fk": {
+          "name": "staff_saved_views_member_email_staff_members_email_fk",
+          "tableFrom": "staff_saved_views",
+          "tableTo": "staff_members",
+          "columnsFrom": [
+            "member_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_sessions": {
+      "name": "staff_sessions",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "staff_sessions_expiry_idx": {
+          "name": "staff_sessions_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_shift_assignments": {
+      "name": "staff_shift_assignments",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_email": {
+          "name": "staff_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_code": {
+          "name": "preset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_index": {
+          "name": "team_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_date": {
+          "name": "anchor_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_shift_assignments_org_idx": {
+          "name": "staff_shift_assignments_org_idx",
+          "columns": [
+            "organization_id",
+            "preset_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_shift_assignments_organization_id_staff_email_memberships_organization_id_member_email_fk": {
+          "name": "staff_shift_assignments_organization_id_staff_email_memberships_organization_id_member_email_fk",
+          "tableFrom": "staff_shift_assignments",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "organization_id",
+            "staff_email"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "member_email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "staff_shift_assignments_organization_id_staff_email_pk": {
+          "columns": [
+            "organization_id",
+            "staff_email"
+          ],
+          "name": "staff_shift_assignments_organization_id_staff_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_shift_assignments_check_1": {
+          "name": "staff_shift_assignments_check_1",
+          "value": "`team_index` >= 1"
+        },
+        "staff_shift_assignments_check_2": {
+          "name": "staff_shift_assignments_check_2",
+          "value": "length(`anchor_date`) = 10"
+        }
+      }
+    },
+    "staff_shift_overrides": {
+      "name": "staff_shift_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_email": {
+          "name": "staff_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shift_date": {
+          "name": "shift_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_shift_overrides_org_date_idx": {
+          "name": "staff_shift_overrides_org_date_idx",
+          "columns": [
+            "organization_id",
+            "shift_date",
+            "staff_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_shift_overrides_organization_id_staff_email_staff_shift_assignments_organization_id_staff_email_fk": {
+          "name": "staff_shift_overrides_organization_id_staff_email_staff_shift_assignments_organization_id_staff_email_fk",
+          "tableFrom": "staff_shift_overrides",
+          "tableTo": "staff_shift_assignments",
+          "columnsFrom": [
+            "organization_id",
+            "staff_email"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "staff_email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_shift_overrides_check_1": {
+          "name": "staff_shift_overrides_check_1",
+          "value": "`kind` IN ('day','evening','night','duty','work','off','recovery','leave','sick','custom')"
+        },
+        "staff_shift_overrides_check_2": {
+          "name": "staff_shift_overrides_check_2",
+          "value": "length(`shift_date`) = 10"
+        }
+      }
+    },
+    "staff_tasks": {
+      "name": "staff_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_email": {
+          "name": "assigned_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_entity_type": {
+          "name": "source_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "staff_tasks_org_source_idx": {
+          "name": "staff_tasks_org_source_idx",
+          "columns": [
+            "organization_id",
+            "source",
+            "source_entity_type",
+            "source_entity_id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_open_automation_idx": {
+          "name": "staff_tasks_org_open_automation_idx",
+          "columns": [
+            "organization_id",
+            "automation_key"
+          ],
+          "isUnique": true,
+          "where": "`status` = 'open' AND `automation_key` <> ''"
+        },
+        "staff_tasks_org_booking_idx": {
+          "name": "staff_tasks_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_assignee_idx": {
+          "name": "staff_tasks_org_assignee_idx",
+          "columns": [
+            "organization_id",
+            "assigned_email",
+            "status",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_status_due_idx": {
+          "name": "staff_tasks_org_status_due_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "due_date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_tasks_check_1": {
+          "name": "staff_tasks_check_1",
+          "value": "status IN ('open','done')"
+        },
+        "staff_tasks_check_2": {
+          "name": "staff_tasks_check_2",
+          "value": "priority IN ('low','normal','high')"
+        }
+      }
+    },
+    "supplier_cash_movements": {
+      "name": "supplier_cash_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_cash_account_time_idx": {
+          "name": "supplier_cash_account_time_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_cash_payment_unique": {
+          "name": "supplier_cash_payment_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_cash_movements_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_cash_movements_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_cash_movements_cash_account_id_cash_accounts_id_fk": {
+          "name": "supplier_cash_movements_cash_account_id_cash_accounts_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "cash_accounts",
+          "columnsFrom": [
+            "cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_cash_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_cash_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_cash_movements_check_1": {
+          "name": "supplier_cash_movements_check_1",
+          "value": "`amount_delta` < 0"
+        }
+      }
+    },
+    "supplier_payable_movements": {
+      "name": "supplier_payable_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receipt_document_id": {
+          "name": "receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_payable_supplier_time_idx": {
+          "name": "supplier_payable_supplier_time_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payable_payment_allocation_unique": {
+          "name": "supplier_payable_payment_allocation_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id",
+            "receipt_document_id"
+          ],
+          "isUnique": true,
+          "where": "`movement_type`='payment_settlement'"
+        },
+        "supplier_payable_receipt_accrual_unique": {
+          "name": "supplier_payable_receipt_accrual_unique",
+          "columns": [
+            "organization_id",
+            "receipt_document_id",
+            "supplier_counterparty_id"
+          ],
+          "isUnique": true,
+          "where": "`movement_type`='receipt_accrual'"
+        }
+      },
+      "foreignKeys": {
+        "supplier_payable_movements_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_payable_movements_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payable_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_payable_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payable_movements_receipt_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "supplier_payable_movements_receipt_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "receipt_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payable_movements_check_1": {
+          "name": "supplier_payable_movements_check_1",
+          "value": "`movement_type` IN ('receipt_accrual','payment_settlement')"
+        },
+        "supplier_payable_movements_check_2": {
+          "name": "supplier_payable_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "supplier_payment_allocations": {
+      "name": "supplier_payment_allocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receipt_document_id": {
+          "name": "receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_payment_allocation_receipt_idx": {
+          "name": "supplier_payment_allocation_receipt_idx",
+          "columns": [
+            "organization_id",
+            "receipt_document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payment_allocation_unique": {
+          "name": "supplier_payment_allocation_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id",
+            "receipt_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_payment_allocations_receipt_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "supplier_payment_allocations_receipt_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payment_allocations",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "receipt_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_allocations_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_payment_allocations_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payment_allocations",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payment_allocations_check_1": {
+          "name": "supplier_payment_allocations_check_1",
+          "value": "`amount` > 0"
+        }
+      }
+    },
+    "supplier_payment_documents": {
+      "name": "supplier_payment_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "supplier_payment_supplier_state_idx": {
+          "name": "supplier_payment_supplier_state_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "state",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payment_org_number_idx": {
+          "name": "supplier_payment_org_number_idx",
+          "columns": [
+            "organization_id",
+            "number"
+          ],
+          "isUnique": true,
+          "where": "`number` <> ''"
+        },
+        "supplier_payment_org_id_idx": {
+          "name": "supplier_payment_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_payment_documents_organization_id_organizations_id_fk": {
+          "name": "supplier_payment_documents_organization_id_organizations_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_documents_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_payment_documents_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_documents_cash_account_id_cash_accounts_id_fk": {
+          "name": "supplier_payment_documents_cash_account_id_cash_accounts_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "cash_accounts",
+          "columnsFrom": [
+            "cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payment_documents_check_1": {
+          "name": "supplier_payment_documents_check_1",
+          "value": "`amount` > 0"
+        },
+        "supplier_payment_documents_check_2": {
+          "name": "supplier_payment_documents_check_2",
+          "value": "`state` IN ('draft','posted','cancelled')"
+        }
+      }
+    },
+    "telegram_link_tokens": {
+      "name": "telegram_link_tokens",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "telegram_link_tokens_patient_idx": {
+          "name": "telegram_link_tokens_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "telegram_link_tokens_identity_scope_idx": {
+          "name": "telegram_link_tokens_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "telegram_link_tokens_org_phone_idx": {
+          "name": "telegram_link_tokens_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "warehouses": {
+      "name": "warehouses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "warehouses_org_active_name_idx": {
+          "name": "warehouses_org_active_name_idx",
+          "columns": [
+            "organization_id",
+            "active",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "warehouses_one_default_idx": {
+          "name": "warehouses_one_default_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "`is_default`=1"
+        },
+        "warehouses_org_code_idx": {
+          "name": "warehouses_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "warehouses_org_id_idx": {
+          "name": "warehouses_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "warehouses_organization_id_organizations_id_fk": {
+          "name": "warehouses_organization_id_organizations_id_fk",
+          "tableFrom": "warehouses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "warehouses_check_1": {
+          "name": "warehouses_check_1",
+          "value": "`active` IN (0,1)"
+        },
+        "warehouses_check_2": {
+          "name": "warehouses_check_2",
+          "value": "`is_default` IN (0,1)"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -806,6 +806,13 @@
       "when": 1788771358737,
       "tag": "0115_patient_clinical_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 116,
+      "version": "6",
+      "when": 1788789947517,
+      "tag": "0116_protocol_method_ref",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/protocol-lifecycle.ts
+++ b/lib/protocol-lifecycle.ts
@@ -44,6 +44,7 @@ export function validateProtocolInputBounds(input: unknown): ProtocolInputBounds
 
   const topLevelChecks: Array<[unknown, number, string]> = [
     [raw.method, PROTOCOL_LIMITS.method, "Методика"],
+    [raw.methodRef, PROTOCOL_LIMITS.methodRef, "Джерело методики"],
     [raw.findings, PROTOCOL_LIMITS.narrative, "Опис"],
     [raw.conclusion, PROTOCOL_LIMITS.narrative, "Висновок"],
     [raw.recommendations, PROTOCOL_LIMITS.narrative, "Рекомендації"],

--- a/lib/protocols.ts
+++ b/lib/protocols.ts
@@ -29,6 +29,9 @@ export type ProtocolTemplate = {
   equipmentId: EquipmentType;
   modalityLabel: string;
   method: string;
+  // Джерело / стандарт методики (галузевий протокол, методика виробника тощо).
+  // Необовʼязкове: якщо порожнє — беремо типове за модальністю (defaultMethodRef).
+  methodRef?: string;
   sections: ProtocolSection[];
 };
 
@@ -39,6 +42,7 @@ export type ProtocolSectionValues = Record<string, Record<string, string>>;
 export type ProtocolDocument = {
   templateKey: string;
   method: string;
+  methodRef: string;
   sections: ProtocolSectionValues;
   findings: string;
   conclusion: string;
@@ -58,6 +62,7 @@ export const PROTOCOL_STATUS_LABELS: Record<ProtocolStatus, string> = {
 // Field length guards used by both the API and the editor.
 export const PROTOCOL_LIMITS = {
   method: 600,
+  methodRef: 300,
   field: 2000,
   narrative: 6000,
   number: 80,
@@ -413,6 +418,21 @@ export const PROTOCOL_TEMPLATES: ProtocolTemplate[] = [
   },
 ];
 
+// Типове джерело методики за модальністю — чесне узагальнення без вигаданих
+// номерів наказів; лікар уточнює конкретний стандарт у редакторі.
+export function defaultMethodRef(equipmentId: EquipmentType): string {
+  switch (equipmentId) {
+    case "ct":
+      return "Виконано за методикою виробника КТ-системи згідно з чинними галузевими протоколами променевої діагностики.";
+    case "fluoro":
+      return "Виконано за стандартною методикою цифрової флюорографії згідно з чинними галузевими протоколами.";
+    case "xray":
+      return "Виконано за стандартною методикою рентгенографії згідно з чинними галузевими протоколами.";
+    default:
+      return "Виконано згідно з чинними галузевими протоколами променевої діагностики.";
+  }
+}
+
 export function protocolTemplateByKey(key: string | null | undefined): ProtocolTemplate {
   return PROTOCOL_TEMPLATES.find((template) => template.key === key)
     || PROTOCOL_TEMPLATES[PROTOCOL_TEMPLATES.length - 1];
@@ -462,6 +482,7 @@ export function normalDocument(templateKey: string): ProtocolDocument {
   return {
     templateKey: template.key,
     method: template.method,
+    methodRef: template.methodRef || defaultMethodRef(template.equipmentId),
     sections,
     findings: "",
     conclusion: "",
@@ -480,6 +501,8 @@ export function renderProtocolText(document: ProtocolDocument): string {
   if (document.number) lines.push(`Протокол № ${document.number}`);
   const method = (document.method || template.method).trim();
   if (method) lines.push("", `Методика: ${method}`);
+  const methodRef = (document.methodRef || template.methodRef || defaultMethodRef(template.equipmentId)).trim();
+  if (methodRef) lines.push(`Джерело методики: ${methodRef}`);
   for (const section of template.sections) {
     const values = document.sections[section.key] || {};
     const rendered = section.fields
@@ -535,6 +558,7 @@ export function sanitizeDocument(input: unknown): ProtocolValidation {
   const document: ProtocolDocument = {
     templateKey,
     method: clip(raw.method, PROTOCOL_LIMITS.method),
+    methodRef: clip(raw.methodRef, PROTOCOL_LIMITS.methodRef),
     sections,
     findings: clip(raw.findings, PROTOCOL_LIMITS.narrative),
     conclusion: clip(raw.conclusion, PROTOCOL_LIMITS.narrative),

--- a/tests/protocol-method-ref.behavior.test.mjs
+++ b/tests/protocol-method-ref.behavior.test.mjs
@@ -1,0 +1,72 @@
+// Джерело методики / стандарт у протоколі: персистенція, round-trip і рендер.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { withD1, callWorker, jsonRequest, seedStaffSession } from "./helpers/d1.mjs";
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+async function addBooking(db, code = "MREF-1") {
+  const r = await db.prepare(
+    `INSERT INTO bookings (organization_id, code, name, phone, service, equipment_id,
+       desired_date, desired_time)
+     VALUES (1, ?, 'Пацієнт', '+380501112233', 'КТ ОГК', 'ct', '2026-09-01', '10:00')`
+  ).bind(code).run();
+  return Number(r.meta.last_row_id);
+}
+
+test("migration 0116 adds method_ref to protocols", async () => {
+  const migration = await read("drizzle/0116_protocol_method_ref.sql");
+  assert.match(migration, /ALTER TABLE `protocols` ADD `method_ref`/);
+  const journal = JSON.parse(await read("drizzle/meta/_journal.json"));
+  assert.ok(journal.entries.some((e) => e.tag === "0116_protocol_method_ref"));
+
+  await withD1(async (db, raw) => {
+    const cols = raw.prepare("PRAGMA table_info(protocols)").all().map((r) => r.name);
+    assert.ok(cols.includes("method_ref"));
+  });
+});
+
+test("methodRef persists through save, round-trips on read and lands in the revision", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "admin@example.com", role: "admin", organizationId: 1 });
+    const bookingId = await addBooking(db);
+    const methodRef = "Галузевий стандарт променевої діагностики (тест)";
+
+    const put = await callWorker(jsonRequest("/api/staff/protocols", {
+      bookingId, baseVersion: 0, templateKey: "ct_chest", status: "draft",
+      method: "Спіральне сканування ОГК", methodRef,
+      sections: {}, findings: "", conclusion: "", recommendations: "", number: "",
+    }, { method: "PUT", headers: { cookie } }), db);
+    assert.equal(put.status, 200);
+    assert.equal((await put.json()).ok, true);
+
+    // Round-trip через GET.
+    const get = await callWorker(jsonRequest(
+      `/api/staff/protocols?bookingId=${bookingId}`, undefined, { method: "GET", headers: { cookie } },
+    ), db);
+    assert.equal(get.status, 200);
+    const body = await get.json();
+    assert.equal(body.protocol.methodRef, methodRef);
+
+    // Записано в поточний документ протоколу.
+    const row = await db.prepare("SELECT method_ref AS m FROM protocols WHERE booking_id = ?").bind(bookingId).first();
+    assert.equal(row.m, methodRef);
+  });
+});
+
+test("protocol library renders the method source and ships modality defaults", async () => {
+  const src = await read("lib/protocols.ts");
+  assert.match(src, /export function defaultMethodRef/);
+  assert.match(src, /Джерело методики: \$\{methodRef\}/);
+  assert.match(src, /methodRef: clip\(raw\.methodRef, PROTOCOL_LIMITS\.methodRef\)/);
+  assert.match(src, /methodRef: template\.methodRef \|\| defaultMethodRef\(template\.equipmentId\)/);
+
+  const lifecycle = await read("lib/protocol-lifecycle.ts");
+  assert.match(lifecycle, /raw\.methodRef, PROTOCOL_LIMITS\.methodRef, "Джерело методики"/);
+
+  const route = await read("app/api/staff/protocols/route.ts");
+  assert.match(route, /method_ref AS methodRef/);
+  assert.match(route, /method_ref = excluded\.method_ref/);
+});


### PR DESCRIPTION
## Що зроблено

Радіологічний аналог «градації доказовості» з розбору health-os — **посилання на методику дослідження в шаблоні протоколу**. Поряд із наявним полем «Методика» додано **«Джерело методики / стандарт»** (`methodRef`).

- **Типові значення за модальністю** (`defaultMethodRef`): для КТ / рентгену / флюорографії — чесні узагальнені формулювання **без вигаданих номерів наказів**; лікар уточнює конкретний стандарт у редакторі.
- **Персистенція**: `protocols.method_ref` (міграція `0116`, згенерована `drizzle-kit` — журнал/снапшот у синхроні), з `sanitize` + перевіркою меж (≤300 символів).
- **Рендер**: потрапляє в текст протоколу (`renderProtocolText`: «Джерело методики: …»), тож видно в друку, копії тексту, експорті й у даних для ШІ-чернетки.
- **Редактор**: нове поле в конструкторі протоколів + якір у змісті + рядок у прев'ю; при зміні шаблону/«Заповнити норму» підставляється типове значення, якщо поле порожнє.

## Межі
Ревізії протоколів — це похідний знімок, який створюють **тригери БД**; їхній набір колонок навмисно не чіпав (щоб не втручатися в систему guard-тригерів append-only історії). Джерело методики зберігається в поточному документі протоколу — цього достатньо для друку/видачі. Це свідоме рішення, а не пропуск.

## Тести
- Міграція `0116` додає колонку; `PRAGMA` підтверджує наявність.
- Round-trip: `PUT` протоколу з `methodRef` → `GET` повертає його; значення в `protocols.method_ref`.
- Source-inspection: `defaultMethodRef`, рядок рендера, `sanitize`/bounds, SELECT/upsert колонки.
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — **1006/1006** (включно з `drizzle-generation-guard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_