### PR TITLE
auth: двофакторна автентифікація персоналу (TOTP)

### DIFF
--- a/app/api/staff/2fa/route.ts
+++ b/app/api/staff/2fa/route.ts
@@ -1,0 +1,103 @@
+// Двофакторна автентифікація персоналу (TOTP). Самообслуговування: будь-який
+// співробітник вмикає/вимикає 2FA для ВЛАСНого акаунта; скидання чужого 2FA
+// (відновлення при втраті пристрою) — лише системний адміністратор.
+
+import { requireSelfServiceOrgContext, requireSystemOrgContext } from "../../../../lib/tenant";
+import { dbBinding } from "../../../../lib/db";
+import { audit } from "../../../../lib/audit";
+import { generateTotpSecret, otpauthUri, verifyTotp } from "../../../../lib/totp";
+
+const ISSUER = "RadiologyOS";
+const EMAIL_RE = /^[^\s@]+@[^\s@]+$/;
+
+type TotpRow = { totpSecret: string; totpEnabled: number };
+
+async function loadTotp(db: D1Database, email: string): Promise<TotpRow | null> {
+  return db.prepare(
+    "SELECT totp_secret AS totpSecret, totp_enabled AS totpEnabled FROM staff_members WHERE email = ? AND active = 1 LIMIT 1"
+  ).bind(email).first<TotpRow>();
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireSelfServiceOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const row = await loadTotp(db, ctx.member.email);
+  return Response.json(
+    { enabled: Number(row?.totpEnabled) === 1, staff: ctx.member },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+export async function POST(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const body = await request.json().catch(() => ({})) as { action?: string; code?: string; email?: string };
+  const action = String(body.action || "");
+  const code = String(body.code || "").replace(/\s+/g, "");
+
+  // Скидання чужого 2FA — окремий адмінський шлях.
+  if (action === "admin_reset") {
+    const admin = await requireSystemOrgContext(request, db);
+    if (!admin) return Response.json({ error: "Скидати 2FA може лише адміністратор" }, { status: 403 });
+    const target = String(body.email || "").trim().toLowerCase();
+    if (!EMAIL_RE.test(target)) return Response.json({ error: "Некоректний обліковий запис" }, { status: 400 });
+    const res = await db.prepare(
+      "UPDATE staff_members SET totp_secret = '', totp_enabled = 0 WHERE email = ?"
+    ).bind(target).run();
+    if (!res.meta.changes) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
+    await audit(db, {
+      organizationId: admin.organizationId, actorEmail: admin.member.email,
+      action: "totp_admin_reset", resource: "auth", targetId: target,
+    });
+    return Response.json({ ok: true });
+  }
+
+  const ctx = await requireSelfServiceOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Доступ лише для персоналу" }, { status: 403 });
+  const email = ctx.member.email;
+  const row = await loadTotp(db, email);
+  if (!row) return Response.json({ error: "Обліковий запис не знайдено" }, { status: 404 });
+
+  if (action === "begin") {
+    if (Number(row.totpEnabled) === 1) {
+      return Response.json({ error: "2FA вже увімкнено. Спершу вимкніть її." }, { status: 409 });
+    }
+    const secret = generateTotpSecret();
+    await db.prepare("UPDATE staff_members SET totp_secret = ?, totp_enabled = 0 WHERE email = ?").bind(secret, email).run();
+    return Response.json(
+      { ok: true, secret, otpauthUri: otpauthUri(secret, { label: email, issuer: ISSUER }) },
+      { headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  if (action === "confirm") {
+    if (Number(row.totpEnabled) === 1) return Response.json({ error: "2FA вже увімкнено" }, { status: 409 });
+    if (!row.totpSecret) return Response.json({ error: "Спершу почніть налаштування (begin)" }, { status: 400 });
+    if (!(await verifyTotp(row.totpSecret, code))) {
+      return Response.json({ error: "Невірний код. Перевірте час на пристрої та спробуйте ще раз." }, { status: 400 });
+    }
+    await db.prepare("UPDATE staff_members SET totp_enabled = 1 WHERE email = ?").bind(email).run();
+    await audit(db, {
+      organizationId: ctx.organizationId, actorEmail: email,
+      action: "totp_enabled", resource: "auth", targetId: email,
+    });
+    return Response.json({ ok: true, enabled: true });
+  }
+
+  if (action === "disable") {
+    if (Number(row.totpEnabled) !== 1) return Response.json({ error: "2FA не увімкнено" }, { status: 400 });
+    if (!(await verifyTotp(row.totpSecret, code))) {
+      return Response.json({ error: "Невірний код автентифікації" }, { status: 400 });
+    }
+    await db.prepare("UPDATE staff_members SET totp_secret = '', totp_enabled = 0 WHERE email = ?").bind(email).run();
+    await audit(db, {
+      organizationId: ctx.organizationId, actorEmail: email,
+      action: "totp_disabled", resource: "auth", targetId: email,
+    });
+    return Response.json({ ok: true, enabled: false });
+  }
+
+  return Response.json({ error: "Невідома дія" }, { status: 400 });
+}

--- a/app/api/staff/login/route.ts
+++ b/app/api/staff/login/route.ts
@@ -16,6 +16,7 @@ import {
 import { normalizeUkrainianPhone } from "../../../../lib/phone";
 import { dbBinding } from "../../../../lib/db";
 import { audit } from "../../../../lib/audit";
+import { verifyTotp } from "../../../../lib/totp";
 
 const STAFF_LOGIN_LIMIT = 10;
 const STAFF_LOGIN_WINDOW_MINUTES = 15;
@@ -101,22 +102,25 @@ export async function POST(request: Request) {
     return Response.json({ error: "Забагато спроб входу. Спробуйте за 15 хвилин." }, { status: 429 });
   }
 
-  const body = await request.json().catch(() => ({})) as { phone?: string; email?: string; password?: string };
+  const body = await request.json().catch(() => ({})) as { phone?: string; email?: string; password?: string; totpCode?: string };
   const phone = normalizeUkrainianPhone(String(body.phone || ""));
   const email = String(body.email || "").trim().toLowerCase().slice(0, 254);
   const password = String(body.password || "");
+  const totpCode = String(body.totpCode || "").replace(/\s+/g, "");
   if ((!phone && !email) || !password) {
     return Response.json({ error: "Вкажіть номер телефону і PIN-код" }, { status: 400 });
   }
 
   // Вхід за номером телефону (основний) або email (сумісність).
+  const memberColumns = "SELECT email, display_name AS displayName, role, password_hash AS passwordHash,"
+    + " totp_enabled AS totpEnabled, totp_secret AS totpSecret FROM staff_members";
+  type MemberRow = {
+    email: string; displayName: string; role: string; passwordHash: string;
+    totpEnabled: number; totpSecret: string;
+  };
   const member = phone
-    ? await db.prepare(
-        "SELECT email, display_name AS displayName, role, password_hash AS passwordHash FROM staff_members WHERE phone = ? AND active = 1 LIMIT 1"
-      ).bind(phone).first<{ email: string; displayName: string; role: string; passwordHash: string }>()
-    : await db.prepare(
-        "SELECT email, display_name AS displayName, role, password_hash AS passwordHash FROM staff_members WHERE email = ? AND active = 1 LIMIT 1"
-      ).bind(email).first<{ email: string; displayName: string; role: string; passwordHash: string }>();
+    ? await db.prepare(`${memberColumns} WHERE phone = ? AND active = 1 LIMIT 1`).bind(phone).first<MemberRow>()
+    : await db.prepare(`${memberColumns} WHERE email = ? AND active = 1 LIMIT 1`).bind(email).first<MemberRow>();
 
   // Known accounts are always throttled by one canonical account key, regardless
   // of whether the caller supplied phone or email. Unknown identifiers still get
@@ -195,6 +199,29 @@ export async function POST(request: Request) {
   }
 
   await clearIdentifierRateLimit(db, "staff-login-account", accountIdentifier);
+
+  // Second factor (TOTP) — only when enabled for this account. The prompt is
+  // shown ONLY after a correct password + active membership, so it never helps
+  // enumerate accounts. A missing code is not a failure; a wrong code is.
+  if (Number(member.totpEnabled) === 1) {
+    if (!totpCode) {
+      return Response.json({ needsTotp: true }, { status: 200, headers: { "cache-control": "no-store" } });
+    }
+    const totpOk = await verifyTotp(member.totpSecret, totpCode);
+    if (!totpOk) {
+      await recordIdentifierRateLimitFailure(
+        db, "staff-login-account", accountIdentifier, STAFF_LOGIN_LIMIT, STAFF_LOGIN_WINDOW_MINUTES,
+      );
+      await auditAuthEvent(db, {
+        memberEmail: member.email,
+        actorEmail: member.email,
+        action: "login_failed",
+        activeOnly: true,
+        details: { reason: "wrong_totp" },
+      });
+      return Response.json({ error: "Невірний код автентифікації" }, { status: 401 });
+    }
+  }
 
   if (passwordHashNeedsUpgrade(member.passwordHash)) {
     await db.prepare("UPDATE staff_members SET password_hash = ? WHERE email = ?")

--- a/app/staff/login/page.tsx
+++ b/app/staff/login/page.tsx
@@ -13,26 +13,68 @@ function safeReturnTo(): string {
 export default function StaffLoginPage() {
   const [status, setStatus] = useState<"idle" | "sending">("idle");
   const [error, setError] = useState("");
+  const [stage, setStage] = useState<"credentials" | "totp">("credentials");
+  // Зберігаємо облікові дані між кроками, щоб дослати їх разом із кодом 2FA.
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
+  async function attempt(payload: { phone: string; password: string; totpCode?: string }) {
     setStatus("sending"); setError("");
-    const data = new FormData(event.currentTarget);
     const response = await fetch("/api/staff/login", {
       method: "POST", headers: { "content-type": "application/json" },
-      body: JSON.stringify({ phone: String(data.get("phone") || ""), password: String(data.get("password") || "") }),
+      body: JSON.stringify(payload),
     });
-    const result = await response.json().catch(() => ({})) as { ok?: boolean; error?: string };
+    const result = await response.json().catch(() => ({})) as { ok?: boolean; needsTotp?: boolean; error?: string };
+    setStatus("idle");
+    if (result.needsTotp) { setStage("totp"); setError(""); return; }
     if (!response.ok || !result.ok) {
-      setStatus("idle");
       setError(result.error || "Не вдалося увійти");
       return;
     }
     window.location.assign(safeReturnTo());
   }
 
+  async function submitCredentials(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const p = String(data.get("phone") || "");
+    const pw = String(data.get("password") || "");
+    setPhone(p); setPassword(pw);
+    await attempt({ phone: p, password: pw });
+  }
+
+  async function submitTotp(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await attempt({ phone, password, totpCode });
+  }
+
+  if (stage === "totp") {
+    return <main className="loginShell">
+      <form className="loginCard" onSubmit={submitTotp}>
+        <span className="loginMark">R</span>
+        <h1>Підтвердження входу</h1>
+        <p>Введіть 6-значний код із застосунку-автентифікатора</p>
+        <label>
+          <span className="labelRow">Код автентифікації</span>
+          <input
+            name="totpCode" inputMode="numeric" autoComplete="one-time-code" maxLength={6}
+            placeholder="123456" autoFocus required pattern="[0-9]*"
+            value={totpCode} onChange={(e) => setTotpCode(e.target.value.replace(/\s+/g, ""))}
+          />
+        </label>
+        {error && <p className="loginError" role="alert">{error}</p>}
+        <button type="submit" disabled={status === "sending"}>{status === "sending" ? "Перевірка…" : "Підтвердити"}</button>
+        <button
+          type="button" className="loginBack" style={{ background: "none", border: 0, cursor: "pointer" }}
+          onClick={() => { setStage("credentials"); setTotpCode(""); setError(""); }}
+        >← Назад</button>
+      </form>
+    </main>;
+  }
+
   return <main className="loginShell">
-    <form className="loginCard" onSubmit={submit}>
+    <form className="loginCard" onSubmit={submitCredentials}>
       <span className="loginMark">R</span>
       <h1>RadiologyOS</h1>
       <p>Кабінет персоналу відділення променевої діагностики</p>

--- a/app/staff/profile/page.tsx
+++ b/app/staff/profile/page.tsx
@@ -22,6 +22,90 @@ type Profile = {
   active:number;
 };
 
+function TwoFactorSection() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [secret, setSecret] = useState("");
+  const [uri, setUri] = useState("");
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+  const [msg, setMsg] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await fetch("/api/staff/2fa", { cache: "no-store" });
+        const d = await r.json().catch(() => ({})) as { enabled?: boolean };
+        if (!cancelled) setEnabled(Boolean(d.enabled));
+      } catch {
+        if (!cancelled) setEnabled(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function post(action: string, extra: Record<string, unknown> = {}) {
+    setBusy(true); setErr(""); setMsg("");
+    try {
+      const r = await fetch("/api/staff/2fa", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action, ...extra }),
+      });
+      const d = await r.json().catch(() => ({})) as { ok?: boolean; secret?: string; otpauthUri?: string; error?: string };
+      if (!r.ok || !d.ok) { setErr(d.error || "Не вдалося виконати дію"); return null; }
+      return d;
+    } catch {
+      setErr("Мережа недоступна"); return null;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function begin() {
+    const d = await post("begin");
+    if (d) { setSecret(d.secret || ""); setUri(d.otpauthUri || ""); setCode(""); }
+  }
+  async function confirm() {
+    const d = await post("confirm", { code });
+    if (d) { setEnabled(true); setSecret(""); setUri(""); setCode(""); setMsg("Двофакторну автентифікацію увімкнено."); }
+  }
+  async function disable() {
+    const d = await post("disable", { code });
+    if (d) { setEnabled(false); setCode(""); setMsg("Двофакторну автентифікацію вимкнено."); }
+  }
+
+  return <section className="orgProfileCard">
+    <h3>Двофакторна автентифікація (2FA)</h3>
+    <p className="orgProfileHint">
+      Додатковий код із застосунку-автентифікатора (Google Authenticator, FreeOTP, Aegis) під час входу.
+      Наполегливо рекомендовано для адміністраторів. Працює офлайн — не залежить від SMS чи e-mail.
+    </p>
+    {err && <p className="notice bad" role="alert">{err}</p>}
+    {msg && <p className="notice good" role="status">{msg}</p>}
+    {enabled === null ? <p className="dashLoading">Завантаження…</p>
+      : enabled ? <div className="formGrid">
+        <p className="notice good">2FA увімкнено для вашого акаунта.</p>
+        <label>Код із застосунку, щоб вимкнути
+          <input value={code} onChange={(e) => setCode(e.target.value.replace(/\s+/g, ""))} inputMode="numeric" maxLength={6} placeholder="123456" />
+        </label>
+        <div><button className="button" type="button" onClick={() => void disable()} disabled={busy || code.length !== 6}>{busy ? "…" : "Вимкнути 2FA"}</button></div>
+      </div>
+      : secret ? <div className="formGrid">
+        <p className="orgProfileHint">1) Додайте акаунт у застосунок-автентифікатор — відскануйте QR або введіть ключ вручну:</p>
+        <label>Ключ (base32)
+          <input value={secret} readOnly onFocus={(e) => e.currentTarget.select()} style={{ fontFamily: "ui-monospace, monospace", letterSpacing: "0.08em" }} />
+        </label>
+        <p className="orgProfileHint">Або посилання для авто-додавання: <code style={{ wordBreak: "break-all" }}>{uri}</code></p>
+        <label>2) Введіть 6-значний код із застосунку для підтвердження
+          <input value={code} onChange={(e) => setCode(e.target.value.replace(/\s+/g, ""))} inputMode="numeric" maxLength={6} placeholder="123456" autoFocus />
+        </label>
+        <div><button className="button" type="button" onClick={() => void confirm()} disabled={busy || code.length !== 6}>{busy ? "…" : "Підтвердити й увімкнути"}</button></div>
+      </div>
+      : <div><button className="button" type="button" onClick={() => void begin()} disabled={busy}>{busy ? "…" : "Увімкнути 2FA"}</button></div>}
+  </section>;
+}
+
 export default function StaffProfilePage() {
   const [profile,setProfile] = useState<Profile|null>(null);
   const [error,setError] = useState("");
@@ -158,6 +242,8 @@ export default function StaffProfilePage() {
           <div><button className="button" type="submit" disabled={saving}>{saving ? "Змінюємо…":"Змінити PIN"}</button></div>
         </form>
       </section>
+
+      <TwoFactorSection />
 
       <section className="orgProfileCard">
         <h3>Службові дані</h3>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -104,6 +104,8 @@ export const staffMembers = sqliteTable("staff_members", {
 	contactEmail: text("contact_email").notNull().default(""),
 	militaryRank: text("military_rank").notNull().default(""),
 	positionTitle: text("position_title").notNull().default(""),
+	totpSecret: text("totp_secret").notNull().default(""),
+	totpEnabled: integer("totp_enabled").notNull().default(0),
 },
 table => [
 	uniqueIndex("staff_members_phone_idx").on(table.phone).where(sql.raw("`phone` != ''")),

--- a/drizzle/0117_staff_totp.sql
+++ b/drizzle/0117_staff_totp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `staff_members` ADD `totp_secret` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `staff_members` ADD `totp_enabled` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0117_snapshot.json
+++ b/drizzle/meta/0117_snapshot.json
@@ -1,0 +1,10117 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cccb857c-4f85-4f2f-8803-7d4466591d55",
+  "prevId": "b7edc240-7338-40f8-8453-d92d06f13a2d",
+  "tables": {
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "journey_id": {
+          "name": "journey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "page_key": {
+          "name": "page_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "analytics_events_journey_idx": {
+          "name": "analytics_events_journey_idx",
+          "columns": [
+            "organization_id",
+            "journey_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "analytics_events_org_event_time_idx": {
+          "name": "analytics_events_org_event_time_idx",
+          "columns": [
+            "organization_id",
+            "event_name",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "analytics_events_org_time_idx": {
+          "name": "analytics_events_org_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "analytics_events_check_1": {
+          "name": "analytics_events_check_1",
+          "value": "`event_name` IN ('page_view','service_view','booking_started','slot_selected','booking_created','payment_started','payment_completed','patient_arrived','study_completed')"
+        },
+        "analytics_events_check_2": {
+          "name": "analytics_events_check_2",
+          "value": "`patient_category` IN ('','civilian','military')"
+        },
+        "analytics_events_check_3": {
+          "name": "analytics_events_check_3",
+          "value": "`source` IN ('client','server')"
+        },
+        "analytics_events_check_4": {
+          "name": "analytics_events_check_4",
+          "value": "length(`journey_id`) <= 64"
+        },
+        "analytics_events_check_5": {
+          "name": "analytics_events_check_5",
+          "value": "length(`service_code`) <= 16"
+        },
+        "analytics_events_check_6": {
+          "name": "analytics_events_check_6",
+          "value": "length(`page_key`) <= 64"
+        }
+      }
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "appointment_details": {
+      "name": "appointment_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appointment_version": {
+          "name": "appointment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "appointment_booking_version_unique": {
+          "name": "appointment_booking_version_unique",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "appointment_version"
+          ],
+          "isUnique": true
+        },
+        "appointment_booking_history_idx": {
+          "name": "appointment_booking_history_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "appointment_version",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "appointment_details_booking_id_bookings_id_fk": {
+          "name": "appointment_details_booking_id_bookings_id_fk",
+          "tableFrom": "appointment_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "appointment_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "appointment_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "appointment_details_check_1": {
+          "name": "appointment_details_check_1",
+          "value": "`appointment_version` > 0"
+        },
+        "appointment_details_check_2": {
+          "name": "appointment_details_check_2",
+          "value": "`duration_minutes` > 0"
+        },
+        "appointment_details_check_3": {
+          "name": "appointment_details_check_3",
+          "value": "length(trim(`scheduled_date`)) > 0"
+        },
+        "appointment_details_check_4": {
+          "name": "appointment_details_check_4",
+          "value": "length(trim(`scheduled_time`)) > 0"
+        }
+      }
+    },
+    "booking_capacity_locks": {
+      "name": "booking_capacity_locks",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minute": {
+          "name": "minute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_code": {
+          "name": "booking_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "booking_capacity_locks_booking_idx": {
+          "name": "booking_capacity_locks_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "booking_capacity_locks_organization_id_equipment_id_booking_date_minute_pk": {
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "booking_date",
+            "minute"
+          ],
+          "name": "booking_capacity_locks_organization_id_equipment_id_booking_date_minute_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_comments": {
+      "name": "booking_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "booking_comments_org_author_idx": {
+          "name": "booking_comments_org_author_idx",
+          "columns": [
+            "organization_id",
+            "author_email",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "booking_comments_org_booking_idx": {
+          "name": "booking_comments_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_events": {
+      "name": "booking_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "booking_events_booking_idx": {
+          "name": "booking_events_booking_idx",
+          "columns": [
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_minute_offsets": {
+      "name": "booking_minute_offsets",
+      "columns": {
+        "minute_offset": {
+          "name": "minute_offset",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_requests": {
+      "name": "booking_requests",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_json": {
+          "name": "response_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "booking_staff_notes": {
+      "name": "booking_staff_notes",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookings": {
+      "name": "bookings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desired_date": {
+          "name": "desired_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desired_time": {
+          "name": "desired_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referral": {
+          "name": "referral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Уточню у адміністратора'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "clinical_indication": {
+          "name": "clinical_indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ct'"
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'civilian'"
+        },
+        "referral_type": {
+          "name": "referral_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "referral_number": {
+          "name": "referral_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "marketing_source": {
+          "name": "marketing_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_number": {
+          "name": "protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_status": {
+          "name": "protocol_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "protocol_updated_at": {
+          "name": "protocol_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_set'"
+        },
+        "payment_amount": {
+          "name": "payment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "nszu_status": {
+          "name": "nszu_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_applicable'"
+        },
+        "nszu_reference": {
+          "name": "nszu_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_radiologist_email": {
+          "name": "assigned_radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_radiographer_email": {
+          "name": "assigned_radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "protocol_ready_at": {
+          "name": "protocol_ready_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "protocol_issued_at": {
+          "name": "protocol_issued_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_email": {
+          "name": "patient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "consent_at": {
+          "name": "consent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "consent_source": {
+          "name": "consent_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_verified_at": {
+          "name": "military_verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_verified_by": {
+          "name": "military_verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "bookings_org_patient_idx": {
+          "name": "bookings_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "desired_date"
+          ],
+          "isUnique": false
+        },
+        "bookings_org_schedule_idx": {
+          "name": "bookings_org_schedule_idx",
+          "columns": [
+            "organization_id",
+            "desired_date",
+            "desired_time"
+          ],
+          "isUnique": false
+        },
+        "bookings_patient_idx": {
+          "name": "bookings_patient_idx",
+          "columns": [
+            "phone_normalized",
+            "desired_date"
+          ],
+          "isUnique": false
+        },
+        "bookings_staff_report_idx": {
+          "name": "bookings_staff_report_idx",
+          "columns": [
+            "assigned_radiologist_email",
+            "assigned_radiographer_email"
+          ],
+          "isUnique": false
+        },
+        "bookings_performed_report_idx": {
+          "name": "bookings_performed_report_idx",
+          "columns": [
+            "performed_at",
+            "equipment_id"
+          ],
+          "isUnique": false
+        },
+        "bookings_report_date_idx": {
+          "name": "bookings_report_date_idx",
+          "columns": [
+            "desired_date",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bookings_equipment_schedule_idx": {
+          "name": "bookings_equipment_schedule_idx",
+          "columns": [
+            "equipment_id",
+            "desired_date",
+            "desired_time"
+          ],
+          "isUnique": false
+        },
+        "bookings_code_unique": {
+          "name": "bookings_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "branches": {
+      "name": "branches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "branches_org_idx": {
+          "name": "branches_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "business_documents": {
+      "name": "business_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "reversed_document_id": {
+          "name": "reversed_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "basis_document_id": {
+          "name": "basis_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "business_documents_basis_idx": {
+          "name": "business_documents_basis_idx",
+          "columns": [
+            "organization_id",
+            "basis_document_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`basis_document_id` IS NOT NULL"
+        },
+        "business_documents_id_org_idx": {
+          "name": "business_documents_id_org_idx",
+          "columns": [
+            "id",
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "business_documents_org_type_state_idx": {
+          "name": "business_documents_org_type_state_idx",
+          "columns": [
+            "organization_id",
+            "document_type",
+            "state",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "business_documents_org_type_number_idx": {
+          "name": "business_documents_org_type_number_idx",
+          "columns": [
+            "organization_id",
+            "document_type",
+            "number"
+          ],
+          "isUnique": true,
+          "where": "`number` <> ''"
+        },
+        "business_documents_org_id_idx": {
+          "name": "business_documents_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "business_documents_organization_id_organizations_id_fk": {
+          "name": "business_documents_organization_id_organizations_id_fk",
+          "tableFrom": "business_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "business_documents_reversed_document_id_business_documents_id_fk": {
+          "name": "business_documents_reversed_document_id_business_documents_id_fk",
+          "tableFrom": "business_documents",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "reversed_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "business_documents_check_1": {
+          "name": "business_documents_check_1",
+          "value": "`document_type` IN (\n    'patient_order','appointment','service_delivery','payment','refund',\n    'inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count',\n    'study_performance','result_delivery','study_correction'\n  )"
+        },
+        "business_documents_check_2": {
+          "name": "business_documents_check_2",
+          "value": "`state` IN ('draft','posted','reversed','cancelled')"
+        }
+      }
+    },
+    "cash_accounts": {
+      "name": "cash_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cash'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "cash_accounts_org_type_active_idx": {
+          "name": "cash_accounts_org_type_active_idx",
+          "columns": [
+            "organization_id",
+            "account_type",
+            "currency",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "cash_accounts_one_default_idx": {
+          "name": "cash_accounts_one_default_idx",
+          "columns": [
+            "organization_id",
+            "account_type",
+            "currency"
+          ],
+          "isUnique": true,
+          "where": "`is_default`=1"
+        },
+        "cash_accounts_org_code_idx": {
+          "name": "cash_accounts_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "cash_accounts_org_id_idx": {
+          "name": "cash_accounts_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cash_accounts_organization_id_organizations_id_fk": {
+          "name": "cash_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "cash_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cash_accounts_check_1": {
+          "name": "cash_accounts_check_1",
+          "value": "`account_type` IN ('cash','bank','provider','other')"
+        },
+        "cash_accounts_check_2": {
+          "name": "cash_accounts_check_2",
+          "value": "`active` IN (0,1)"
+        },
+        "cash_accounts_check_3": {
+          "name": "cash_accounts_check_3",
+          "value": "`is_default` IN (0,1)"
+        }
+      }
+    },
+    "cash_movements": {
+      "name": "cash_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "cash_movements_account_time_idx": {
+          "name": "cash_movements_account_time_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`cash_account_id` IS NOT NULL"
+        },
+        "cash_movements_time_idx": {
+          "name": "cash_movements_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "cash_movements_document_idx": {
+          "name": "cash_movements_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cash_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "cash_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "cash_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cash_movements_check_1": {
+          "name": "cash_movements_check_1",
+          "value": "`movement_type` IN ('payment','refund')"
+        },
+        "cash_movements_check_2": {
+          "name": "cash_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "counterparties": {
+      "name": "counterparties",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'supplier'"
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "counterparties_org_kind_active_idx": {
+          "name": "counterparties_org_kind_active_idx",
+          "columns": [
+            "organization_id",
+            "kind",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "counterparties_org_code_idx": {
+          "name": "counterparties_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "counterparties_org_id_idx": {
+          "name": "counterparties_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "counterparties_organization_id_organizations_id_fk": {
+          "name": "counterparties_organization_id_organizations_id_fk",
+          "tableFrom": "counterparties",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "counterparties_check_1": {
+          "name": "counterparties_check_1",
+          "value": "`kind` IN ('supplier','payer','both','other')"
+        },
+        "counterparties_check_2": {
+          "name": "counterparties_check_2",
+          "value": "`active` IN (0,1)"
+        }
+      }
+    },
+    "custom_field_definitions": {
+      "name": "custom_field_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'booking'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "idx_custom_field_definitions_org_entity": {
+          "name": "idx_custom_field_definitions_org_entity",
+          "columns": [
+            "organization_id",
+            "entity_type",
+            "active",
+            "sort_order",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_field_definitions_organization_id_organizations_id_fk": {
+          "name": "custom_field_definitions_organization_id_organizations_id_fk",
+          "tableFrom": "custom_field_definitions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "custom_field_definitions_check_1": {
+          "name": "custom_field_definitions_check_1",
+          "value": "entity_type IN ('booking')"
+        },
+        "custom_field_definitions_check_2": {
+          "name": "custom_field_definitions_check_2",
+          "value": "field_type IN ('text','number','date','boolean','select')"
+        },
+        "custom_field_definitions_check_3": {
+          "name": "custom_field_definitions_check_3",
+          "value": "required IN (0,1)"
+        },
+        "custom_field_definitions_check_4": {
+          "name": "custom_field_definitions_check_4",
+          "value": "active IN (0,1)"
+        }
+      }
+    },
+    "custom_field_values": {
+      "name": "custom_field_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'booking'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "idx_custom_field_values_org_entity": {
+          "name": "idx_custom_field_values_org_entity",
+          "columns": [
+            "organization_id",
+            "entity_type",
+            "entity_id",
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_field_values_organization_id_organizations_id_fk": {
+          "name": "custom_field_values_organization_id_organizations_id_fk",
+          "tableFrom": "custom_field_values",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "custom_field_values_organization_id_definition_id_custom_field_definitions_organization_id_id_fk": {
+          "name": "custom_field_values_organization_id_definition_id_custom_field_definitions_organization_id_id_fk",
+          "tableFrom": "custom_field_values",
+          "tableTo": "custom_field_definitions",
+          "columnsFrom": [
+            "organization_id",
+            "definition_id"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "custom_field_values_check_1": {
+          "name": "custom_field_values_check_1",
+          "value": "entity_type IN ('booking')"
+        }
+      }
+    },
+    "departments": {
+      "name": "departments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "departments_org_idx": {
+          "name": "departments_org_idx",
+          "columns": [
+            "organization_id",
+            "branch_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "equipment_blocks": {
+      "name": "equipment_blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked_date": {
+          "name": "blocked_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "equipment_blocks_schedule_idx": {
+          "name": "equipment_blocks_schedule_idx",
+          "columns": [
+            "equipment_id",
+            "blocked_date",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "equipment_load_movements": {
+      "name": "equipment_load_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "minutes_delta": {
+          "name": "minutes_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "equipment_load_equipment_idx": {
+          "name": "equipment_load_equipment_idx",
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "equipment_load_document_idx": {
+          "name": "equipment_load_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "equipment_load_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "equipment_load_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "equipment_load_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "equipment_load_movements_check_1": {
+          "name": "equipment_load_movements_check_1",
+          "value": "`minutes_delta` <> 0"
+        }
+      }
+    },
+    "equipment_maintenance": {
+      "name": "equipment_maintenance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "assigned_email": {
+          "name": "assigned_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "downtime_start": {
+          "name": "downtime_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "downtime_end": {
+          "name": "downtime_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "equipment_maintenance_org_status_idx": {
+          "name": "equipment_maintenance_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "due_date",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "equipment_maintenance_org_equipment_idx": {
+          "name": "equipment_maintenance_org_equipment_idx",
+          "columns": [
+            "organization_id",
+            "equipment_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expense_movements": {
+      "name": "expense_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "inventory_movement_id": {
+          "name": "inventory_movement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_line_id": {
+          "name": "document_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_receipt_document_id": {
+          "name": "source_receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_receipt_line_id": {
+          "name": "source_receipt_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "expense_movements_inventory_movement_idx": {
+          "name": "expense_movements_inventory_movement_idx",
+          "columns": [
+            "organization_id",
+            "inventory_movement_id"
+          ],
+          "isUnique": true
+        },
+        "expense_movements_org_time_idx": {
+          "name": "expense_movements_org_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "expense_movements_org_item_time_idx": {
+          "name": "expense_movements_org_item_time_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "expense_movements_org_lot_idx": {
+          "name": "expense_movements_org_lot_idx",
+          "columns": [
+            "organization_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "expense_movements_unit_cost_nonnegative": {
+          "name": "expense_movements_unit_cost_nonnegative",
+          "value": "\"expense_movements\".\"unit_cost\" >= 0"
+        },
+        "expense_movements_amount_positive": {
+          "name": "expense_movements_amount_positive",
+          "value": "\"expense_movements\".\"amount_delta\" > 0"
+        }
+      }
+    },
+    "finance_document_details": {
+      "name": "finance_document_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_transaction_id": {
+          "name": "source_transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "finance_document_cash_account_idx": {
+          "name": "finance_document_cash_account_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "document_id"
+          ],
+          "isUnique": false,
+          "where": "`cash_account_id` IS NOT NULL"
+        },
+        "finance_document_details_source_transaction_idx": {
+          "name": "finance_document_details_source_transaction_idx",
+          "columns": [
+            "organization_id",
+            "source_transaction_id"
+          ],
+          "isUnique": true,
+          "where": "`source_transaction_id` IS NOT NULL"
+        },
+        "finance_document_details_booking_idx": {
+          "name": "finance_document_details_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "finance_document_details_booking_id_bookings_id_fk": {
+          "name": "finance_document_details_booking_id_bookings_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_source_document_id_business_documents_id_fk": {
+          "name": "finance_document_details_source_document_id_business_documents_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_source_transaction_id_payment_transactions_id_fk": {
+          "name": "finance_document_details_source_transaction_id_payment_transactions_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "payment_transactions",
+          "columnsFrom": [
+            "source_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_document_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "finance_document_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "finance_document_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "finance_document_details_check_1": {
+          "name": "finance_document_details_check_1",
+          "value": "`amount` > 0"
+        }
+      }
+    },
+    "imaging_studies": {
+      "name": "imaging_studies",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accession_number": {
+          "name": "accession_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "study_instance_uid": {
+          "name": "study_instance_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "series_count": {
+          "name": "series_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "instances_count": {
+          "name": "instances_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "study_status": {
+          "name": "study_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_linked'"
+        },
+        "study_datetime": {
+          "name": "study_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "imaging_studies_org_uid_idx": {
+          "name": "imaging_studies_org_uid_idx",
+          "columns": [
+            "organization_id",
+            "study_instance_uid"
+          ],
+          "isUnique": true,
+          "where": "study_instance_uid != ''"
+        },
+        "imaging_studies_org_idx": {
+          "name": "imaging_studies_org_idx",
+          "columns": [
+            "organization_id",
+            "study_status"
+          ],
+          "isUnique": false
+        },
+        "imaging_studies_status_idx": {
+          "name": "imaging_studies_status_idx",
+          "columns": [
+            "study_status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_count_lines": {
+      "name": "inventory_count_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "item_unit": {
+          "name": "item_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "book_quantity": {
+          "name": "book_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counted_quantity": {
+          "name": "counted_quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "inventory_count_lines_doc_line_idx": {
+          "name": "inventory_count_lines_doc_line_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": true
+        },
+        "inventory_count_lines_bucket_unique": {
+          "name": "inventory_count_lines_bucket_unique",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "warehouse_id",
+            "lot_id"
+          ],
+          "isUnique": true
+        },
+        "inventory_count_lines_warehouse_idx": {
+          "name": "inventory_count_lines_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_count_lines_item_id_inventory_items_id_fk": {
+          "name": "inventory_count_lines_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_count_lines_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_count_lines_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_count_lines_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "inventory_count_lines_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "inventory_count_lines",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_count_lines_book_nonnegative": {
+          "name": "inventory_count_lines_book_nonnegative",
+          "value": "book_quantity >= 0"
+        },
+        "inventory_count_lines_counted_nonnegative": {
+          "name": "inventory_count_lines_counted_nonnegative",
+          "value": "counted_quantity >= 0"
+        }
+      }
+    },
+    "inventory_document_lines": {
+      "name": "inventory_document_lines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination_warehouse_code": {
+          "name": "destination_warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "destination_warehouse_name": {
+          "name": "destination_warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "line_amount": {
+          "name": "line_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reservation_movement_id": {
+          "name": "reservation_movement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inventory_lines_reservation_idx": {
+          "name": "inventory_lines_reservation_idx",
+          "columns": [
+            "organization_id",
+            "reservation_movement_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`reservation_movement_id` IS NOT NULL"
+        },
+        "inventory_lines_destination_warehouse_idx": {
+          "name": "inventory_lines_destination_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "destination_warehouse_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`destination_warehouse_id` IS NOT NULL"
+        },
+        "inventory_lines_warehouse_idx": {
+          "name": "inventory_lines_warehouse_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_document_lines_supplier_idx": {
+          "name": "inventory_document_lines_supplier_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "document_id"
+          ],
+          "isUnique": false,
+          "where": "`supplier_counterparty_id` IS NOT NULL"
+        },
+        "inventory_document_lines_org_id_idx": {
+          "name": "inventory_document_lines_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        },
+        "inventory_document_lines_doc_line_idx": {
+          "name": "inventory_document_lines_doc_line_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "line_no"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inventory_document_lines_item_id_inventory_items_id_fk": {
+          "name": "inventory_document_lines_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_document_lines_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_booking_id_bookings_id_fk": {
+          "name": "inventory_document_lines_booking_id_bookings_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_document_lines_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "inventory_document_lines_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "inventory_document_lines",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_document_lines_check_1": {
+          "name": "inventory_document_lines_check_1",
+          "value": "`quantity` > 0"
+        },
+        "inventory_document_lines_check_2": {
+          "name": "inventory_document_lines_check_2",
+          "value": "`unit_cost` >= 0"
+        },
+        "inventory_document_lines_check_3": {
+          "name": "inventory_document_lines_check_3",
+          "value": "`line_amount` >= 0"
+        }
+      }
+    },
+    "inventory_items": {
+      "name": "inventory_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'шт'"
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "inventory_items_org_active_idx": {
+          "name": "inventory_items_org_active_idx",
+          "columns": [
+            "organization_id",
+            "active",
+            "name"
+          ],
+          "isUnique": false
+        },
+        "inventory_items_org_sku_idx": {
+          "name": "inventory_items_org_sku_idx",
+          "columns": [
+            "organization_id",
+            "sku"
+          ],
+          "isUnique": true,
+          "where": "`sku` <> ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_lots": {
+      "name": "inventory_lots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inventory_lots_supplier_idx": {
+          "name": "inventory_lots_supplier_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`supplier_counterparty_id` IS NOT NULL"
+        },
+        "inventory_lots_org_item_idx": {
+          "name": "inventory_lots_org_item_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "expires_on"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_lots_item_id_inventory_items_id_fk": {
+          "name": "inventory_lots_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_lots",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_movements": {
+      "name": "inventory_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_line_id": {
+          "name": "document_line_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warehouse_code": {
+          "name": "warehouse_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "inventory_movements_document_line_type_idx": {
+          "name": "inventory_movements_document_line_type_idx",
+          "columns": [
+            "organization_id",
+            "document_line_id",
+            "movement_type"
+          ],
+          "isUnique": true,
+          "where": "`document_line_id` IS NOT NULL"
+        },
+        "inventory_movements_warehouse_lot_idx": {
+          "name": "inventory_movements_warehouse_lot_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_movements_warehouse_item_idx": {
+          "name": "inventory_movements_warehouse_item_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`warehouse_id` IS NOT NULL"
+        },
+        "inventory_movements_document_idx": {
+          "name": "inventory_movements_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "`document_id` IS NOT NULL"
+        },
+        "inventory_movements_org_lot_idx": {
+          "name": "inventory_movements_org_lot_idx",
+          "columns": [
+            "organization_id",
+            "lot_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "inventory_movements_org_item_idx": {
+          "name": "inventory_movements_org_item_idx",
+          "columns": [
+            "organization_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_movements_item_id_inventory_items_id_fk": {
+          "name": "inventory_movements_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_movements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movements_lot_id_inventory_lots_id_fk": {
+          "name": "inventory_movements_lot_id_inventory_lots_id_fk",
+          "tableFrom": "inventory_movements",
+          "tableTo": "inventory_lots",
+          "columnsFrom": [
+            "lot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_reservation_movements": {
+      "name": "inventory_reservation_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appointment_document_id": {
+          "name": "appointment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "inventory_reservation_exact_movement_unique": {
+          "name": "inventory_reservation_exact_movement_unique",
+          "columns": [
+            "organization_id",
+            "appointment_document_id",
+            "requirement_id",
+            "movement_type"
+          ],
+          "isUnique": true
+        },
+        "inventory_reservation_balance_idx": {
+          "name": "inventory_reservation_balance_idx",
+          "columns": [
+            "organization_id",
+            "warehouse_id",
+            "item_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "inventory_reservation_booking_idx": {
+          "name": "inventory_reservation_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_reservation_movements_organization_id_organizations_id_fk": {
+          "name": "inventory_reservation_movements_organization_id_organizations_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_booking_id_bookings_id_fk": {
+          "name": "inventory_reservation_movements_booking_id_bookings_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_requirement_id_service_material_requirements_id_fk": {
+          "name": "inventory_reservation_movements_requirement_id_service_material_requirements_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "service_material_requirements",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_item_id_inventory_items_id_fk": {
+          "name": "inventory_reservation_movements_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_movements_warehouse_id_warehouses_id_fk": {
+          "name": "inventory_reservation_movements_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_reservation_appointment_tenant_fk": {
+          "name": "inventory_reservation_appointment_tenant_fk",
+          "tableFrom": "inventory_reservation_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "appointment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "inventory_reservation_movements_check_1": {
+          "name": "inventory_reservation_movements_check_1",
+          "value": "`movement_type` IN ('reserve','release')"
+        },
+        "inventory_reservation_movements_check_2": {
+          "name": "inventory_reservation_movements_check_2",
+          "value": "(`movement_type`='reserve' AND `quantity_delta` > 0) OR (`movement_type`='release' AND `quantity_delta` < 0)"
+        }
+      }
+    },
+    "memberships": {
+      "name": "memberships",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "memberships_member_idx": {
+          "name": "memberships_member_idx",
+          "columns": [
+            "member_email"
+          ],
+          "isUnique": false
+        },
+        "memberships_org_member_idx": {
+          "name": "memberships_org_member_idx",
+          "columns": [
+            "organization_id",
+            "member_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mwl_bridge_tokens": {
+      "name": "mwl_bridge_tokens",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "mwl_bridge_tokens_hash_idx": {
+          "name": "mwl_bridge_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mwl_patient_ids": {
+      "name": "mwl_patient_ids",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "mwl_patient_ids_org_patient_idx": {
+          "name": "mwl_patient_ids_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "mwl_patient_ids_organization_id_identity_key_pk": {
+          "columns": [
+            "organization_id",
+            "identity_key"
+          ],
+          "name": "mwl_patient_ids_organization_id_identity_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_integration_settings": {
+      "name": "organization_integration_settings",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_integration_settings_org_idx": {
+          "name": "organization_integration_settings_org_idx",
+          "columns": [
+            "organization_id",
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_integration_settings_organization_id_organizations_id_fk": {
+          "name": "organization_integration_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_integration_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_integration_settings_organization_id_key_pk": {
+          "columns": [
+            "organization_id",
+            "key"
+          ],
+          "name": "organization_integration_settings_organization_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_profiles": {
+      "name": "organization_profiles",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_type": {
+          "name": "profile_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hospital_radiology'"
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "feature_flags_json": {
+          "name": "feature_flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pacs_settings": {
+      "name": "pacs_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dicomweb_base_url": {
+          "name": "dicomweb_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "viewer_base_url": {
+          "name": "viewer_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ae_title": {
+          "name": "ae_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "pacs_settings_organization_idx": {
+          "name": "pacs_settings_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_communications": {
+      "name": "patient_communications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'call'"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'outbound'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_communications_org_patient_idx": {
+          "name": "patient_communications_org_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_comm_external_idx": {
+          "name": "patient_comm_external_idx",
+          "columns": [
+            "external_id"
+          ],
+          "isUnique": true,
+          "where": "`external_id` != ''"
+        },
+        "patient_communications_org_idx": {
+          "name": "patient_communications_org_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        },
+        "patient_communications_phone_idx": {
+          "name": "patient_communications_phone_idx",
+          "columns": [
+            "phone_normalized",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_notifications": {
+      "name": "patient_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "patient_notifications_org_idx": {
+          "name": "patient_notifications_org_idx",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": false
+        },
+        "patient_notifications_booking_idx": {
+          "name": "patient_notifications_booking_idx",
+          "columns": [
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_order_details": {
+      "name": "patient_order_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_order_patient_idx": {
+          "name": "patient_order_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "patient_order_booking_unique": {
+          "name": "patient_order_booking_unique",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "patient_order_details_booking_id_bookings_id_fk": {
+          "name": "patient_order_details_booking_id_bookings_id_fk",
+          "tableFrom": "patient_order_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_order_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "patient_order_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "patient_order_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "patient_order_details_check_1": {
+          "name": "patient_order_details_check_1",
+          "value": "`duration_minutes` > 0"
+        },
+        "patient_order_details_check_2": {
+          "name": "patient_order_details_check_2",
+          "value": "`price_amount` >= 0"
+        },
+        "patient_order_details_check_3": {
+          "name": "patient_order_details_check_3",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "patient_otp_challenges": {
+      "name": "patient_otp_challenges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cabinet_login'"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_otp_patient_idx": {
+          "name": "patient_otp_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_identity_scope_idx": {
+          "name": "patient_otp_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_expiry_idx": {
+          "name": "patient_otp_expiry_idx",
+          "columns": [
+            "expires_at",
+            "consumed_at"
+          ],
+          "isUnique": false
+        },
+        "patient_otp_phone_idx": {
+          "name": "patient_otp_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_profiles": {
+      "name": "patient_profiles",
+      "columns": {
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(lower(hex(randomblob(16))))"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "do_not_contact": {
+          "name": "do_not_contact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contrast_alert": {
+          "name": "contrast_alert",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allergy_note": {
+          "name": "allergy_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_profiles_org_updated_idx": {
+          "name": "patient_profiles_org_updated_idx",
+          "columns": [
+            "organization_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "patient_profiles_org_phone_idx": {
+          "name": "patient_profiles_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        },
+        "patient_profiles_phone_idx": {
+          "name": "patient_profiles_phone_idx",
+          "columns": [
+            "phone_normalized"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_sessions": {
+      "name": "patient_sessions",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_sessions_patient_idx": {
+          "name": "patient_sessions_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_identity_scope_idx": {
+          "name": "patient_sessions_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_org_phone_idx": {
+          "name": "patient_sessions_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "patient_sessions_expiry_idx": {
+          "name": "patient_sessions_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patient_settlement_movements": {
+      "name": "patient_settlement_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "patient_settlement_booking_idx": {
+          "name": "patient_settlement_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "patient_settlement_patient_idx": {
+          "name": "patient_settlement_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "patient_settlement_document_idx": {
+          "name": "patient_settlement_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "patient_settlement_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "patient_settlement_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "patient_settlement_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "patient_settlement_movements_check_1": {
+          "name": "patient_settlement_movements_check_1",
+          "value": "`movement_type` IN ('charge','payment','refund','adjustment')"
+        },
+        "patient_settlement_movements_check_2": {
+          "name": "patient_settlement_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "patient_telegram_identities": {
+      "name": "patient_telegram_identities",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "patient_telegram_patient_idx": {
+          "name": "patient_telegram_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "patient_telegram_chat_idx": {
+          "name": "patient_telegram_chat_idx",
+          "columns": [
+            "telegram_chat_id"
+          ],
+          "isUnique": false,
+          "where": "telegram_chat_id != ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "patient_telegram_identities_organization_id_phone_normalized_identity_kind_identity_value_pk": {
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value"
+          ],
+          "name": "patient_telegram_identities_organization_id_phone_normalized_identity_kind_identity_value_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payment_transactions": {
+      "name": "payment_transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refund_document_id": {
+          "name": "refund_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payment_transactions_one_linked_paid_booking_idx": {
+          "name": "payment_transactions_one_linked_paid_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true,
+          "where": "`status`='paid' AND `payment_document_id` IS NOT NULL"
+        },
+        "payment_transactions_refund_document_idx": {
+          "name": "payment_transactions_refund_document_idx",
+          "columns": [
+            "organization_id",
+            "refund_document_id"
+          ],
+          "isUnique": true,
+          "where": "`refund_document_id` IS NOT NULL"
+        },
+        "payment_transactions_payment_document_idx": {
+          "name": "payment_transactions_payment_document_idx",
+          "columns": [
+            "organization_id",
+            "payment_document_id"
+          ],
+          "isUnique": true,
+          "where": "`payment_document_id` IS NOT NULL"
+        },
+        "payment_transactions_provider_ref_idx": {
+          "name": "payment_transactions_provider_ref_idx",
+          "columns": [
+            "organization_id",
+            "provider",
+            "provider_reference"
+          ],
+          "isUnique": true,
+          "where": "provider_reference != ''"
+        },
+        "payment_transactions_booking_idx": {
+          "name": "payment_transactions_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "payment_transactions_check_1": {
+          "name": "payment_transactions_check_1",
+          "value": "amount >= 0"
+        },
+        "payment_transactions_check_2": {
+          "name": "payment_transactions_check_2",
+          "value": "status IN ('pending','paid','failed','refunded','cancelled')"
+        }
+      }
+    },
+    "printed_form_snapshots": {
+      "name": "printed_form_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_type": {
+          "name": "form_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_state": {
+          "name": "document_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "printed_service_act_state_unique": {
+          "name": "printed_service_act_state_unique",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "document_state"
+          ],
+          "isUnique": true,
+          "where": "`form_type`='service_act' AND `document_state` IN ('posted','reversed')"
+        },
+        "printed_form_snapshots_state_idx": {
+          "name": "printed_form_snapshots_state_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "document_state",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "printed_form_snapshots_document_idx": {
+          "name": "printed_form_snapshots_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "printed_form_snapshots_same_render_idx": {
+          "name": "printed_form_snapshots_same_render_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "form_type",
+            "template_version",
+            "sha256"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "printed_form_snapshots_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "printed_form_snapshots_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "printed_form_snapshots",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "printed_form_snapshots_check_1": {
+          "name": "printed_form_snapshots_check_1",
+          "value": "`form_type` IN (\n    'invoice','payment_receipt','service_act','referral','protocol','result',\n    'inventory_receipt','inventory_writeoff','inventory_transfer','inventory_count','service_note'\n  )"
+        },
+        "printed_form_snapshots_check_2": {
+          "name": "printed_form_snapshots_check_2",
+          "value": "`template_version` > 0"
+        }
+      }
+    },
+    "protocol_addenda": {
+      "name": "protocol_addenda",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "correction_text": {
+          "name": "correction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_version": {
+          "name": "signed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "protocol_addenda_status_idx": {
+          "name": "protocol_addenda_status_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "protocol_addenda_org_booking_idx": {
+          "name": "protocol_addenda_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protocol_addenda_check_1": {
+          "name": "protocol_addenda_check_1",
+          "value": "`length`(`id`) = 32 AND `id` NOT GLOB '*[^0-9a-f]*'"
+        },
+        "protocol_addenda_check_2": {
+          "name": "protocol_addenda_check_2",
+          "value": "`length`(`trim`(`reason`)) BETWEEN 1 AND 500"
+        },
+        "protocol_addenda_check_3": {
+          "name": "protocol_addenda_check_3",
+          "value": "`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000"
+        },
+        "protocol_addenda_check_4": {
+          "name": "protocol_addenda_check_4",
+          "value": "`length`(`trim`(`author_email`)) > 0"
+        },
+        "protocol_addenda_check_5": {
+          "name": "protocol_addenda_check_5",
+          "value": "`length`(`trim`(`updated_by`)) > 0"
+        },
+        "protocol_addenda_check_6": {
+          "name": "protocol_addenda_check_6",
+          "value": "`status` IN ('draft','ready','signed','issued')"
+        },
+        "protocol_addenda_check_7": {
+          "name": "protocol_addenda_check_7",
+          "value": "`base_protocol_version` > 0"
+        },
+        "protocol_addenda_check_8": {
+          "name": "protocol_addenda_check_8",
+          "value": "`version` > 0"
+        }
+      }
+    },
+    "protocol_addendum_revisions": {
+      "name": "protocol_addendum_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "addendum_id": {
+          "name": "addendum_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "correction_text": {
+          "name": "correction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "protocol_addendum_revisions_scope_idx": {
+          "name": "protocol_addendum_revisions_scope_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "addendum_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protocol_addendum_revisions_check_1": {
+          "name": "protocol_addendum_revisions_check_1",
+          "value": "`length`(`addendum_id`) = 32 AND `addendum_id` NOT GLOB '*[^0-9a-f]*'"
+        },
+        "protocol_addendum_revisions_check_2": {
+          "name": "protocol_addendum_revisions_check_2",
+          "value": "`length`(`trim`(`reason`)) BETWEEN 1 AND 500"
+        },
+        "protocol_addendum_revisions_check_3": {
+          "name": "protocol_addendum_revisions_check_3",
+          "value": "`length`(`trim`(`correction_text`)) BETWEEN 1 AND 12000"
+        },
+        "protocol_addendum_revisions_check_4": {
+          "name": "protocol_addendum_revisions_check_4",
+          "value": "`length`(`trim`(`saved_by`)) > 0"
+        },
+        "protocol_addendum_revisions_check_5": {
+          "name": "protocol_addendum_revisions_check_5",
+          "value": "`status` IN ('draft','ready','signed')"
+        },
+        "protocol_addendum_revisions_check_6": {
+          "name": "protocol_addendum_revisions_check_6",
+          "value": "`base_protocol_version` > 0"
+        },
+        "protocol_addendum_revisions_check_7": {
+          "name": "protocol_addendum_revisions_check_7",
+          "value": "`version` > 0"
+        }
+      }
+    },
+    "protocol_revisions": {
+      "name": "protocol_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "protocol_revisions_org_booking_idx": {
+          "name": "protocol_revisions_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "version"
+          ],
+          "isUnique": false
+        },
+        "protocol_revisions_booking_idx": {
+          "name": "protocol_revisions_booking_idx",
+          "columns": [
+            "booking_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "protocol_revisions_booking_id_bookings_id_fk": {
+          "name": "protocol_revisions_booking_id_bookings_id_fk",
+          "tableFrom": "protocol_revisions",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "protocols": {
+      "name": "protocols",
+      "columns": {
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'generic'"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "method_ref": {
+          "name": "method_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signed_version": {
+          "name": "signed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "protocols_org_number_idx": {
+          "name": "protocols_org_number_idx",
+          "columns": [
+            "organization_id",
+            "number"
+          ],
+          "isUnique": false
+        },
+        "protocols_org_idx": {
+          "name": "protocols_org_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "protocols_status_idx": {
+          "name": "protocols_status_idx",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_exports": {
+      "name": "report_exports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filters_json": {
+          "name": "filters_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "columns_json": {
+          "name": "columns_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'xlsx'"
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contains_personal_data": {
+          "name": "contains_personal_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "report_exports_created_idx": {
+          "name": "report_exports_created_idx",
+          "columns": [
+            "created_at",
+            "requested_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_limits": {
+      "name": "request_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "result_addendum_delivery_details": {
+      "name": "result_addendum_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addendum_id": {
+          "name": "addendum_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_number": {
+          "name": "base_protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_protocol_version": {
+          "name": "base_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addendum_version": {
+          "name": "addendum_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "result_addendum_delivery_addendum_unique": {
+          "name": "result_addendum_delivery_addendum_unique",
+          "columns": [
+            "organization_id",
+            "addendum_id"
+          ],
+          "isUnique": true
+        },
+        "result_addendum_delivery_booking_idx": {
+          "name": "result_addendum_delivery_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "result_addendum_delivery_document_idx": {
+          "name": "result_addendum_delivery_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "result_addendum_delivery_details_addendum_id_protocol_addenda_id_fk": {
+          "name": "result_addendum_delivery_details_addendum_id_protocol_addenda_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "protocol_addenda",
+          "columnsFrom": [
+            "addendum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_addendum_delivery_details_booking_id_bookings_id_fk": {
+          "name": "result_addendum_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_addendum_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "result_addendum_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "result_addendum_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "result_addendum_delivery_details_check_1": {
+          "name": "result_addendum_delivery_details_check_1",
+          "value": "`base_protocol_version` > 0"
+        },
+        "result_addendum_delivery_details_check_2": {
+          "name": "result_addendum_delivery_details_check_2",
+          "value": "`addendum_version` > 0"
+        }
+      }
+    },
+    "result_delivery_details": {
+      "name": "result_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_number": {
+          "name": "protocol_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_by": {
+          "name": "signed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "result_delivery_booking_unique": {
+          "name": "result_delivery_booking_unique",
+          "columns": [
+            "organization_id",
+            "booking_id"
+          ],
+          "isUnique": true
+        },
+        "result_delivery_document_idx": {
+          "name": "result_delivery_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "result_delivery_details_booking_id_bookings_id_fk": {
+          "name": "result_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "result_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "result_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "result_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "result_delivery_details_check_1": {
+          "name": "result_delivery_details_check_1",
+          "value": "`protocol_version` > 0"
+        }
+      }
+    },
+    "revenue_movements": {
+      "name": "revenue_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "revenue_time_idx": {
+          "name": "revenue_time_idx",
+          "columns": [
+            "organization_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "revenue_document_idx": {
+          "name": "revenue_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "revenue_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "revenue_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "revenue_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "revenue_movements_check_1": {
+          "name": "revenue_movements_check_1",
+          "value": "`movement_type` IN ('service_delivery','service_correction')"
+        },
+        "revenue_movements_check_2": {
+          "name": "revenue_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "saved_report_views": {
+      "name": "saved_report_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_key": {
+          "name": "report_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'register_turnover'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "configuration_json": {
+          "name": "configuration_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "saved_report_views_org_report_name_unique": {
+          "name": "saved_report_views_org_report_name_unique",
+          "columns": [
+            "organization_id",
+            "report_key",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "saved_report_views_org_report_idx": {
+          "name": "saved_report_views_org_report_idx",
+          "columns": [
+            "organization_id",
+            "report_key",
+            "updated_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "saved_report_views_report_key_check": {
+          "name": "saved_report_views_report_key_check",
+          "value": "`report_key` = 'register_turnover'"
+        },
+        "saved_report_views_name_check": {
+          "name": "saved_report_views_name_check",
+          "value": "length(trim(`name`)) BETWEEN 1 AND 80"
+        }
+      }
+    },
+    "security_audit_log": {
+      "name": "security_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "security_audit_created_idx": {
+          "name": "security_audit_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "actor_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_correction_details": {
+      "name": "service_correction_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correction_kind": {
+          "name": "correction_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'storno'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "radiologist_email": {
+          "name": "radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "radiographer_email": {
+          "name": "radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_correction_booking_idx": {
+          "name": "service_correction_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "service_correction_source_unique": {
+          "name": "service_correction_source_unique",
+          "columns": [
+            "organization_id",
+            "source_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_correction_details_booking_id_bookings_id_fk": {
+          "name": "service_correction_details_booking_id_bookings_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_details_source_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_details_source_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_correction_details_check_1": {
+          "name": "service_correction_details_check_1",
+          "value": "`correction_kind`='storno'"
+        },
+        "service_correction_details_check_2": {
+          "name": "service_correction_details_check_2",
+          "value": "length(trim(`reason`)) >= 5"
+        },
+        "service_correction_details_check_3": {
+          "name": "service_correction_details_check_3",
+          "value": "`duration_minutes` > 0"
+        },
+        "service_correction_details_check_4": {
+          "name": "service_correction_details_check_4",
+          "value": "`anatomical_regions_count` > 0"
+        },
+        "service_correction_details_check_5": {
+          "name": "service_correction_details_check_5",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "service_correction_movements": {
+      "name": "service_correction_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity_delta": {
+          "name": "quantity_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_delta": {
+          "name": "anatomical_regions_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_correction_movement_source_idx": {
+          "name": "service_correction_movement_source_idx",
+          "columns": [
+            "organization_id",
+            "source_document_id"
+          ],
+          "isUnique": true
+        },
+        "service_correction_movement_document_idx": {
+          "name": "service_correction_movement_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_correction_movements_source_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_movements_source_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "source_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_correction_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_correction_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_correction_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_correction_movements_check_1": {
+          "name": "service_correction_movements_check_1",
+          "value": "`quantity_delta`=-1"
+        },
+        "service_correction_movements_check_2": {
+          "name": "service_correction_movements_check_2",
+          "value": "`anatomical_regions_delta` < 0"
+        }
+      }
+    },
+    "service_delivery_details": {
+      "name": "service_delivery_details",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_category": {
+          "name": "patient_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_title": {
+          "name": "service_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "radiologist_email": {
+          "name": "radiologist_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "radiographer_email": {
+          "name": "radiographer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_delivery_booking_idx": {
+          "name": "service_delivery_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "service_delivery_details_booking_id_bookings_id_fk": {
+          "name": "service_delivery_details_booking_id_bookings_id_fk",
+          "tableFrom": "service_delivery_details",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "service_delivery_details_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "service_delivery_details",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_delivery_details_check_1": {
+          "name": "service_delivery_details_check_1",
+          "value": "`duration_minutes` > 0"
+        },
+        "service_delivery_details_check_2": {
+          "name": "service_delivery_details_check_2",
+          "value": "`anatomical_regions_count` > 0"
+        },
+        "service_delivery_details_check_3": {
+          "name": "service_delivery_details_check_3",
+          "value": "`price_amount` >= 0"
+        },
+        "service_delivery_details_check_4": {
+          "name": "service_delivery_details_check_4",
+          "value": "`charge_amount` >= 0"
+        }
+      }
+    },
+    "service_material_requirements": {
+      "name": "service_material_requirements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "service_material_requirements_service_idx": {
+          "name": "service_material_requirements_service_idx",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "active",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "service_material_requirements_active_unique": {
+          "name": "service_material_requirements_active_unique",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "item_id",
+            "warehouse_id"
+          ],
+          "isUnique": true,
+          "where": "`active` = 1"
+        }
+      },
+      "foreignKeys": {
+        "service_material_requirements_organization_id_organizations_id_fk": {
+          "name": "service_material_requirements_organization_id_organizations_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_material_requirements_item_id_inventory_items_id_fk": {
+          "name": "service_material_requirements_item_id_inventory_items_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_material_requirements_warehouse_id_warehouses_id_fk": {
+          "name": "service_material_requirements_warehouse_id_warehouses_id_fk",
+          "tableFrom": "service_material_requirements",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "service_material_requirements_check_1": {
+          "name": "service_material_requirements_check_1",
+          "value": "length(trim(`service_code`)) > 0"
+        },
+        "service_material_requirements_check_2": {
+          "name": "service_material_requirements_check_2",
+          "value": "`quantity` > 0"
+        },
+        "service_material_requirements_check_3": {
+          "name": "service_material_requirements_check_3",
+          "value": "`active` IN (0,1)"
+        }
+      }
+    },
+    "service_prices": {
+      "name": "service_prices",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services_delivered_movements": {
+      "name": "services_delivered_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "service_code": {
+          "name": "service_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "services_delivered_service_idx": {
+          "name": "services_delivered_service_idx",
+          "columns": [
+            "organization_id",
+            "service_code",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "services_delivered_document_idx": {
+          "name": "services_delivered_document_idx",
+          "columns": [
+            "organization_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "services_delivered_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "services_delivered_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "services_delivered_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "services_delivered_movements_check_1": {
+          "name": "services_delivered_movements_check_1",
+          "value": "`quantity` > 0"
+        },
+        "services_delivered_movements_check_2": {
+          "name": "services_delivered_movements_check_2",
+          "value": "`anatomical_regions_count` > 0"
+        }
+      }
+    },
+    "staff_members": {
+      "name": "staff_members",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patronymic": {
+          "name": "patronymic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "military_rank": {
+          "name": "military_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position_title": {
+          "name": "position_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "staff_members_phone_idx": {
+          "name": "staff_members_phone_idx",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true,
+          "where": "`phone` != ''"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_output_movements": {
+      "name": "staff_output_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "units_delta": {
+          "name": "units_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "anatomical_regions_count": {
+          "name": "anatomical_regions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_output_member_idx": {
+          "name": "staff_output_member_idx",
+          "columns": [
+            "organization_id",
+            "member_email",
+            "performed_at"
+          ],
+          "isUnique": false
+        },
+        "staff_output_document_role_idx": {
+          "name": "staff_output_document_role_idx",
+          "columns": [
+            "organization_id",
+            "document_id",
+            "staff_role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "staff_output_movements_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "staff_output_movements_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "staff_output_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_output_movements_check_1": {
+          "name": "staff_output_movements_check_1",
+          "value": "`staff_role` IN ('radiologist','radiographer')"
+        },
+        "staff_output_movements_check_2": {
+          "name": "staff_output_movements_check_2",
+          "value": "`units_delta` <> 0"
+        },
+        "staff_output_movements_check_3": {
+          "name": "staff_output_movements_check_3",
+          "value": "`anatomical_regions_count` > 0"
+        }
+      }
+    },
+    "staff_saved_views": {
+      "name": "staff_saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_email": {
+          "name": "member_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_saved_views_owner_surface_idx": {
+          "name": "staff_saved_views_owner_surface_idx",
+          "columns": [
+            "organization_id",
+            "member_email",
+            "surface",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_saved_views_organization_id_organizations_id_fk": {
+          "name": "staff_saved_views_organization_id_organizations_id_fk",
+          "tableFrom": "staff_saved_views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_saved_views_member_email_staff_members_email_fk": {
+          "name": "staff_saved_views_member_email_staff_members_email_fk",
+          "tableFrom": "staff_saved_views",
+          "tableTo": "staff_members",
+          "columnsFrom": [
+            "member_email"
+          ],
+          "columnsTo": [
+            "email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_sessions": {
+      "name": "staff_sessions",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "staff_sessions_expiry_idx": {
+          "name": "staff_sessions_expiry_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staff_shift_assignments": {
+      "name": "staff_shift_assignments",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_email": {
+          "name": "staff_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_code": {
+          "name": "preset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_index": {
+          "name": "team_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_date": {
+          "name": "anchor_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_shift_assignments_org_idx": {
+          "name": "staff_shift_assignments_org_idx",
+          "columns": [
+            "organization_id",
+            "preset_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_shift_assignments_organization_id_staff_email_memberships_organization_id_member_email_fk": {
+          "name": "staff_shift_assignments_organization_id_staff_email_memberships_organization_id_member_email_fk",
+          "tableFrom": "staff_shift_assignments",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "organization_id",
+            "staff_email"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "member_email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "staff_shift_assignments_organization_id_staff_email_pk": {
+          "columns": [
+            "organization_id",
+            "staff_email"
+          ],
+          "name": "staff_shift_assignments_organization_id_staff_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_shift_assignments_check_1": {
+          "name": "staff_shift_assignments_check_1",
+          "value": "`team_index` >= 1"
+        },
+        "staff_shift_assignments_check_2": {
+          "name": "staff_shift_assignments_check_2",
+          "value": "length(`anchor_date`) = 10"
+        }
+      }
+    },
+    "staff_shift_overrides": {
+      "name": "staff_shift_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staff_email": {
+          "name": "staff_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shift_date": {
+          "name": "shift_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "staff_shift_overrides_org_date_idx": {
+          "name": "staff_shift_overrides_org_date_idx",
+          "columns": [
+            "organization_id",
+            "shift_date",
+            "staff_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "staff_shift_overrides_organization_id_staff_email_staff_shift_assignments_organization_id_staff_email_fk": {
+          "name": "staff_shift_overrides_organization_id_staff_email_staff_shift_assignments_organization_id_staff_email_fk",
+          "tableFrom": "staff_shift_overrides",
+          "tableTo": "staff_shift_assignments",
+          "columnsFrom": [
+            "organization_id",
+            "staff_email"
+          ],
+          "columnsTo": [
+            "organization_id",
+            "staff_email"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_shift_overrides_check_1": {
+          "name": "staff_shift_overrides_check_1",
+          "value": "`kind` IN ('day','evening','night','duty','work','off','recovery','leave','sick','custom')"
+        },
+        "staff_shift_overrides_check_2": {
+          "name": "staff_shift_overrides_check_2",
+          "value": "length(`shift_date`) = 10"
+        }
+      }
+    },
+    "staff_tasks": {
+      "name": "staff_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_email": {
+          "name": "assigned_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "automation_key": {
+          "name": "automation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_entity_type": {
+          "name": "source_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "staff_tasks_org_source_idx": {
+          "name": "staff_tasks_org_source_idx",
+          "columns": [
+            "organization_id",
+            "source",
+            "source_entity_type",
+            "source_entity_id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_open_automation_idx": {
+          "name": "staff_tasks_org_open_automation_idx",
+          "columns": [
+            "organization_id",
+            "automation_key"
+          ],
+          "isUnique": true,
+          "where": "`status` = 'open' AND `automation_key` <> ''"
+        },
+        "staff_tasks_org_booking_idx": {
+          "name": "staff_tasks_org_booking_idx",
+          "columns": [
+            "organization_id",
+            "booking_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_assignee_idx": {
+          "name": "staff_tasks_org_assignee_idx",
+          "columns": [
+            "organization_id",
+            "assigned_email",
+            "status",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "staff_tasks_org_status_due_idx": {
+          "name": "staff_tasks_org_status_due_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "due_date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "staff_tasks_check_1": {
+          "name": "staff_tasks_check_1",
+          "value": "status IN ('open','done')"
+        },
+        "staff_tasks_check_2": {
+          "name": "staff_tasks_check_2",
+          "value": "priority IN ('low','normal','high')"
+        }
+      }
+    },
+    "supplier_cash_movements": {
+      "name": "supplier_cash_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_cash_account_time_idx": {
+          "name": "supplier_cash_account_time_idx",
+          "columns": [
+            "organization_id",
+            "cash_account_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_cash_payment_unique": {
+          "name": "supplier_cash_payment_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_cash_movements_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_cash_movements_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_cash_movements_cash_account_id_cash_accounts_id_fk": {
+          "name": "supplier_cash_movements_cash_account_id_cash_accounts_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "cash_accounts",
+          "columnsFrom": [
+            "cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_cash_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_cash_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_cash_movements",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_cash_movements_check_1": {
+          "name": "supplier_cash_movements_check_1",
+          "value": "`amount_delta` < 0"
+        }
+      }
+    },
+    "supplier_payable_movements": {
+      "name": "supplier_payable_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receipt_document_id": {
+          "name": "receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_payable_supplier_time_idx": {
+          "name": "supplier_payable_supplier_time_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payable_payment_allocation_unique": {
+          "name": "supplier_payable_payment_allocation_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id",
+            "receipt_document_id"
+          ],
+          "isUnique": true,
+          "where": "`movement_type`='payment_settlement'"
+        },
+        "supplier_payable_receipt_accrual_unique": {
+          "name": "supplier_payable_receipt_accrual_unique",
+          "columns": [
+            "organization_id",
+            "receipt_document_id",
+            "supplier_counterparty_id"
+          ],
+          "isUnique": true,
+          "where": "`movement_type`='receipt_accrual'"
+        }
+      },
+      "foreignKeys": {
+        "supplier_payable_movements_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_payable_movements_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payable_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_payable_movements_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payable_movements_receipt_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "supplier_payable_movements_receipt_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payable_movements",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "receipt_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payable_movements_check_1": {
+          "name": "supplier_payable_movements_check_1",
+          "value": "`movement_type` IN ('receipt_accrual','payment_settlement')"
+        },
+        "supplier_payable_movements_check_2": {
+          "name": "supplier_payable_movements_check_2",
+          "value": "`amount_delta` <> 0"
+        }
+      }
+    },
+    "supplier_payment_allocations": {
+      "name": "supplier_payment_allocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_document_id": {
+          "name": "payment_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receipt_document_id": {
+          "name": "receipt_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "supplier_payment_allocation_receipt_idx": {
+          "name": "supplier_payment_allocation_receipt_idx",
+          "columns": [
+            "organization_id",
+            "receipt_document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payment_allocation_unique": {
+          "name": "supplier_payment_allocation_unique",
+          "columns": [
+            "organization_id",
+            "payment_document_id",
+            "receipt_document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_payment_allocations_receipt_document_id_organization_id_business_documents_id_organization_id_fk": {
+          "name": "supplier_payment_allocations_receipt_document_id_organization_id_business_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payment_allocations",
+          "tableTo": "business_documents",
+          "columnsFrom": [
+            "receipt_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_allocations_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk": {
+          "name": "supplier_payment_allocations_payment_document_id_organization_id_supplier_payment_documents_id_organization_id_fk",
+          "tableFrom": "supplier_payment_allocations",
+          "tableTo": "supplier_payment_documents",
+          "columnsFrom": [
+            "payment_document_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payment_allocations_check_1": {
+          "name": "supplier_payment_allocations_check_1",
+          "value": "`amount` > 0"
+        }
+      }
+    },
+    "supplier_payment_documents": {
+      "name": "supplier_payment_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier_counterparty_id": {
+          "name": "supplier_counterparty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_id": {
+          "name": "cash_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cash_account_code": {
+          "name": "cash_account_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cash_account_name": {
+          "name": "cash_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UAH'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "supplier_payment_supplier_state_idx": {
+          "name": "supplier_payment_supplier_state_idx",
+          "columns": [
+            "organization_id",
+            "supplier_counterparty_id",
+            "state",
+            "occurred_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "supplier_payment_org_number_idx": {
+          "name": "supplier_payment_org_number_idx",
+          "columns": [
+            "organization_id",
+            "number"
+          ],
+          "isUnique": true,
+          "where": "`number` <> ''"
+        },
+        "supplier_payment_org_id_idx": {
+          "name": "supplier_payment_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "supplier_payment_documents_organization_id_organizations_id_fk": {
+          "name": "supplier_payment_documents_organization_id_organizations_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_documents_supplier_counterparty_id_counterparties_id_fk": {
+          "name": "supplier_payment_documents_supplier_counterparty_id_counterparties_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "counterparties",
+          "columnsFrom": [
+            "supplier_counterparty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "supplier_payment_documents_cash_account_id_cash_accounts_id_fk": {
+          "name": "supplier_payment_documents_cash_account_id_cash_accounts_id_fk",
+          "tableFrom": "supplier_payment_documents",
+          "tableTo": "cash_accounts",
+          "columnsFrom": [
+            "cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "supplier_payment_documents_check_1": {
+          "name": "supplier_payment_documents_check_1",
+          "value": "`amount` > 0"
+        },
+        "supplier_payment_documents_check_2": {
+          "name": "supplier_payment_documents_check_2",
+          "value": "`state` IN ('draft','posted','cancelled')"
+        }
+      }
+    },
+    "telegram_link_tokens": {
+      "name": "telegram_link_tokens",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_normalized": {
+          "name": "phone_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "identity_kind": {
+          "name": "identity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "identity_value": {
+          "name": "identity_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "telegram_link_tokens_patient_idx": {
+          "name": "telegram_link_tokens_patient_idx",
+          "columns": [
+            "organization_id",
+            "patient_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "telegram_link_tokens_identity_scope_idx": {
+          "name": "telegram_link_tokens_identity_scope_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized",
+            "identity_kind",
+            "identity_value",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "telegram_link_tokens_org_phone_idx": {
+          "name": "telegram_link_tokens_org_phone_idx",
+          "columns": [
+            "organization_id",
+            "phone_normalized"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "warehouses": {
+      "name": "warehouses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "warehouses_org_active_name_idx": {
+          "name": "warehouses_org_active_name_idx",
+          "columns": [
+            "organization_id",
+            "active",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "warehouses_one_default_idx": {
+          "name": "warehouses_one_default_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "`is_default`=1"
+        },
+        "warehouses_org_code_idx": {
+          "name": "warehouses_org_code_idx",
+          "columns": [
+            "organization_id",
+            "code"
+          ],
+          "isUnique": true,
+          "where": "`code` <> ''"
+        },
+        "warehouses_org_id_idx": {
+          "name": "warehouses_org_id_idx",
+          "columns": [
+            "organization_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "warehouses_organization_id_organizations_id_fk": {
+          "name": "warehouses_organization_id_organizations_id_fk",
+          "tableFrom": "warehouses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "warehouses_check_1": {
+          "name": "warehouses_check_1",
+          "value": "`active` IN (0,1)"
+        },
+        "warehouses_check_2": {
+          "name": "warehouses_check_2",
+          "value": "`is_default` IN (0,1)"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -813,6 +813,13 @@
       "when": 1788789947517,
       "tag": "0116_protocol_method_ref",
       "breakpoints": true
+    },
+    {
+      "idx": 117,
+      "version": "6",
+      "when": 1788810293111,
+      "tag": "0117_staff_totp",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/totp.ts
+++ b/lib/totp.ts
@@ -1,0 +1,124 @@
+// TOTP (RFC 6238) для двофакторної автентифікації персоналу — сумісно з
+// Google Authenticator / FreeOTP / Aegis тощо. Працює на Web Crypto (Cloudflare
+// Worker і Node ≥20). Файл самодостатній (без імпортів) — напряму тестовний.
+//
+// Секрет — base32 (RFC 4648). HOTP/TOTP на HMAC-SHA1, 6 цифр, крок 30 с. Це
+// ДРУГИЙ фактор поверх телефон+PIN, тож зберігання секрета в БД відділення
+// прийнятне; за потреби його можна додатково шифрувати ключем середовища.
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+export const TOTP_STEP_SECONDS = 30;
+export const TOTP_DIGITS = 6;
+
+export function base32Encode(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  return out;
+}
+
+export function base32Decode(input: string): Uint8Array {
+  const clean = input.toUpperCase().replace(/=+$/, "").replace(/\s+/g, "");
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of clean) {
+    const idx = BASE32_ALPHABET.indexOf(ch);
+    if (idx === -1) continue; // ігноруємо сторонні символи
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return new Uint8Array(out);
+}
+
+// Новий секрет: 20 випадкових байтів (160 біт) у base32.
+export function generateTotpSecret(): string {
+  return base32Encode(crypto.getRandomValues(new Uint8Array(20)));
+}
+
+function counterBytes(counter: number): Uint8Array {
+  const buf = new Uint8Array(8);
+  // 64-бітний лічильник big-endian; поділ на 2^32 щоб уникнути обмежень 32-біт.
+  let hi = Math.floor(counter / 0x1_0000_0000);
+  let lo = counter % 0x1_0000_0000;
+  for (let i = 7; i >= 4; i -= 1) { buf[i] = lo & 0xff; lo = Math.floor(lo / 256); }
+  for (let i = 3; i >= 0; i -= 1) { buf[i] = hi & 0xff; hi = Math.floor(hi / 256); }
+  return buf;
+}
+
+async function hotp(secret: string, counter: number, digits = TOTP_DIGITS): Promise<string> {
+  const keyBytes = base32Decode(secret);
+  const key = await crypto.subtle.importKey(
+    "raw", keyBytes as unknown as ArrayBuffer, { name: "HMAC", hash: "SHA-1" }, false, ["sign"],
+  );
+  const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, counterBytes(counter) as unknown as ArrayBuffer));
+  const offset = sig[sig.length - 1] & 0x0f;
+  const bin = ((sig[offset] & 0x7f) << 24)
+    | ((sig[offset + 1] & 0xff) << 16)
+    | ((sig[offset + 2] & 0xff) << 8)
+    | (sig[offset + 3] & 0xff);
+  return String(bin % 10 ** digits).padStart(digits, "0");
+}
+
+// Код TOTP для моменту now (мс). За замовчуванням — поточний час.
+export async function totp(
+  secret: string,
+  { now = Date.now(), step = TOTP_STEP_SECONDS, digits = TOTP_DIGITS }: { now?: number; step?: number; digits?: number } = {},
+): Promise<string> {
+  return hotp(secret, Math.floor(now / 1000 / step), digits);
+}
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+// Перевірка коду з допуском ±window кроків (типово ±1 = ±30 с проти розсинхро-
+// нізації годинника). Порівняння сталого часу.
+export async function verifyTotp(
+  secret: string,
+  code: string,
+  { now = Date.now(), step = TOTP_STEP_SECONDS, digits = TOTP_DIGITS, window = 1 }: {
+    now?: number; step?: number; digits?: number; window?: number;
+  } = {},
+): Promise<boolean> {
+  const normalized = String(code || "").replace(/\s+/g, "");
+  if (!/^\d+$/.test(normalized) || normalized.length !== digits || !secret) return false;
+  const base = Math.floor(now / 1000 / step);
+  for (let w = -window; w <= window; w += 1) {
+    const candidate = await hotp(secret, base + w, digits);
+    if (timingSafeEqualStr(candidate, normalized)) return true;
+  }
+  return false;
+}
+
+// otpauth:// URI для QR/ручного додавання в застосунок-автентифікатор.
+export function otpauthUri(
+  secret: string,
+  { label, issuer }: { label: string; issuer: string },
+): string {
+  const l = encodeURIComponent(`${issuer}:${label}`);
+  const params = new URLSearchParams({
+    secret,
+    issuer,
+    algorithm: "SHA1",
+    digits: String(TOTP_DIGITS),
+    period: String(TOTP_STEP_SECONDS),
+  });
+  return `otpauth://totp/${l}?${params.toString()}`;
+}

--- a/tests/staff-2fa.behavior.test.mjs
+++ b/tests/staff-2fa.behavior.test.mjs
@@ -1,0 +1,119 @@
+// Двофакторна автентифікація персоналу: гейт на вході, самозапис (enroll),
+// вимкнення й адмінське скидання — end-to-end через воркер.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, callWorker, jsonRequest, seedStaffSession } from "./helpers/d1.mjs";
+import { totp, generateTotpSecret } from "../lib/totp.ts";
+import { hashPassword } from "../lib/auth.ts";
+import { normalizeUkrainianPhone } from "../lib/phone.ts";
+
+const PIN = "135791";
+const RAW_PHONE = "0501112233";
+
+// Створює співробітника з логіном (телефон+PIN) і, за потреби, увімкненим 2FA.
+async function seedLoginMember(db, { email, role = "admin", secret = "" } = {}) {
+  await seedStaffSession(db, { email, role, organizationId: 1 });
+  const phone = normalizeUkrainianPhone(RAW_PHONE);
+  await db.prepare(
+    "UPDATE staff_members SET phone = ?, password_hash = ?, totp_secret = ?, totp_enabled = ? WHERE email = ?"
+  ).bind(phone, await hashPassword(PIN), secret, secret ? 1 : 0, email).run();
+  return phone;
+}
+
+const login = (db, body) => callWorker(jsonRequest("/api/staff/login", body, { method: "POST" }), db);
+
+test("login is gated by TOTP once 2FA is enabled", async () => {
+  await withD1(async (db) => {
+    const secret = generateTotpSecret();
+    await seedLoginMember(db, { email: "boss@example.com", role: "admin", secret });
+
+    // Правильний PIN без коду → просять другий фактор, сесію не видають.
+    const step1 = await login(db, { phone: RAW_PHONE, password: PIN });
+    assert.equal(step1.status, 200);
+    assert.equal((await step1.json()).needsTotp, true);
+    assert.equal(step1.headers.get("set-cookie"), null);
+
+    // Невірний код → 401.
+    const bad = await login(db, { phone: RAW_PHONE, password: PIN, totpCode: "000000" });
+    assert.equal(bad.status, 401);
+
+    // Вірний код → вхід і сесія.
+    const good = await login(db, { phone: RAW_PHONE, password: PIN, totpCode: await totp(secret) });
+    assert.equal(good.status, 200);
+    assert.equal((await good.json()).ok, true);
+    assert.match(good.headers.get("set-cookie") || "", /rid_session=/);
+  });
+});
+
+test("wrong PIN still fails before any TOTP prompt (no account enumeration)", async () => {
+  await withD1(async (db) => {
+    await seedLoginMember(db, { email: "boss@example.com", role: "admin", secret: generateTotpSecret() });
+    const res = await login(db, { phone: RAW_PHONE, password: "000000" });
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.ok(!body.needsTotp); // код не пропонується, поки PIN невірний
+  });
+});
+
+test("self-enrollment: begin → confirm enables 2FA; wrong confirm code is rejected", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+
+    const begin = await callWorker(jsonRequest("/api/staff/2fa", { action: "begin" }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(begin.status, 200);
+    const { secret, otpauthUri } = await begin.json();
+    assert.match(secret, /^[A-Z2-7]+$/);
+    assert.match(otpauthUri, /^otpauth:\/\/totp\//);
+
+    // Поки не підтверджено — 2FA вимкнена.
+    const midEnabled = await db.prepare("SELECT totp_enabled AS e FROM staff_members WHERE email = 'reg@example.com'").first();
+    assert.equal(midEnabled.e, 0);
+
+    const wrong = await callWorker(jsonRequest("/api/staff/2fa", { action: "confirm", code: "000000" }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(wrong.status, 400);
+
+    const ok = await callWorker(jsonRequest("/api/staff/2fa", { action: "confirm", code: await totp(secret) }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(ok.status, 200);
+    assert.equal((await ok.json()).enabled, true);
+    const row = await db.prepare("SELECT totp_enabled AS e FROM staff_members WHERE email = 'reg@example.com'").first();
+    assert.equal(row.e, 1);
+  });
+});
+
+test("self-disable requires a valid current code", async () => {
+  await withD1(async (db) => {
+    const secret = generateTotpSecret();
+    const cookie = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+    await db.prepare("UPDATE staff_members SET totp_secret = ?, totp_enabled = 1 WHERE email = 'reg@example.com'").bind(secret).run();
+
+    const wrong = await callWorker(jsonRequest("/api/staff/2fa", { action: "disable", code: "000000" }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(wrong.status, 400);
+
+    const ok = await callWorker(jsonRequest("/api/staff/2fa", { action: "disable", code: await totp(secret) }, { method: "POST", headers: { cookie } }), db);
+    assert.equal(ok.status, 200);
+    const row = await db.prepare("SELECT totp_enabled AS e, totp_secret AS s FROM staff_members WHERE email = 'reg@example.com'").first();
+    assert.equal(row.e, 0);
+    assert.equal(row.s, "");
+  });
+});
+
+test("admin can reset another member's 2FA; a non-admin cannot", async () => {
+  await withD1(async (db) => {
+    await seedStaffSession(db, { email: "victim@example.com", role: "registrar", organizationId: 1 });
+    await db.prepare("UPDATE staff_members SET totp_secret = 'X', totp_enabled = 1 WHERE email = 'victim@example.com'").run();
+
+    const regCookie = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+    const denied = await callWorker(jsonRequest("/api/staff/2fa", { action: "admin_reset", email: "victim@example.com" }, { method: "POST", headers: { cookie: regCookie } }), db);
+    assert.equal(denied.status, 403);
+    const still = await db.prepare("SELECT totp_enabled AS e FROM staff_members WHERE email = 'victim@example.com'").first();
+    assert.equal(still.e, 1); // не скинуто
+
+    const adminCookie = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    const ok = await callWorker(jsonRequest("/api/staff/2fa", { action: "admin_reset", email: "victim@example.com" }, { method: "POST", headers: { cookie: adminCookie } }), db);
+    assert.equal(ok.status, 200);
+    const row = await db.prepare("SELECT totp_enabled AS e, totp_secret AS s FROM staff_members WHERE email = 'victim@example.com'").first();
+    assert.equal(row.e, 0);
+    assert.equal(row.s, "");
+  });
+});

--- a/tests/totp.test.mjs
+++ b/tests/totp.test.mjs
@@ -1,0 +1,43 @@
+// TOTP (RFC 6238) — чиста криптологіка. Звірка з офіційними тест-векторами
+// стандарту (SHA-1, секрет ASCII "12345678901234567890"), 6 цифр.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  base32Encode, base32Decode, generateTotpSecret, totp, verifyTotp,
+} from "../lib/totp.ts";
+
+const RFC_SECRET = base32Encode(new TextEncoder().encode("12345678901234567890"));
+
+test("base32 encode/decode round-trips and matches the RFC seed", () => {
+  assert.equal(RFC_SECRET, "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ");
+  const bytes = new Uint8Array([1, 2, 3, 4, 5, 250, 255]);
+  assert.deepEqual([...base32Decode(base32Encode(bytes))], [...bytes]);
+});
+
+test("totp reproduces RFC 6238 SHA-1 vectors (last 6 digits)", async () => {
+  assert.equal(await totp(RFC_SECRET, { now: 59_000 }), "287082"); // T=59  → 94287082
+  assert.equal(await totp(RFC_SECRET, { now: 1111111109_000 }), "081804"); // → 07081804
+  assert.equal(await totp(RFC_SECRET, { now: 1234567890_000 }), "005924"); // → 89005924
+  assert.equal(await totp(RFC_SECRET, { now: 2000000000_000 }), "279037"); // → 69279037
+});
+
+test("verifyTotp accepts the current code, tolerates ±1 step, rejects wrong/malformed", async () => {
+  const now = 1234567890_000;
+  const code = await totp(RFC_SECRET, { now });
+  assert.equal(await verifyTotp(RFC_SECRET, code, { now }), true);
+  // Код попереднього кроку приймається в межах вікна ±1 (розсинхрон годинника).
+  assert.equal(await verifyTotp(RFC_SECRET, code, { now: now + 30_000 }), true);
+  // За межами вікна — вже ні.
+  assert.equal(await verifyTotp(RFC_SECRET, code, { now: now + 120_000 }), false);
+  assert.equal(await verifyTotp(RFC_SECRET, "000000", { now }), false);
+  assert.equal(await verifyTotp(RFC_SECRET, "12345", { now }), false); // не 6 цифр
+  assert.equal(await verifyTotp(RFC_SECRET, "abcdef", { now }), false);
+  assert.equal(await verifyTotp("", code, { now }), false); // без секрета
+});
+
+test("generateTotpSecret yields a decodable 20-byte (160-bit) base32 secret", () => {
+  const s = generateTotpSecret();
+  assert.match(s, /^[A-Z2-7]+$/);
+  assert.equal(base32Decode(s).length, 20);
+});


### PR DESCRIPTION
## Що зроблено

За мотивами Savvy (2FA), під профіль ризику військової частини — **другий фактор для входу персоналу**. Обрано **TOTP** (застосунок-автентифікатор: Google Authenticator / FreeOTP / Aegis): працює **офлайн**, не залежить від SMS/e-mail-шлюзів.

### Компоненти
- **`lib/totp.ts`** — RFC 6238 (HMAC-SHA1, 6 цифр, крок 30 с, вікно ±1) на Web Crypto; base32, генерація секрета, `otpauth://`-URI. Самодостатній (тестовний напряму), звірений з **офіційними тест-векторами** стандарту.
- **Міграція `0117`**: `staff_members` += `totp_secret`, `totp_enabled`.
- **Вхід** (`/api/staff/login`): якщо 2FA увімкнена — після вірного PIN просимо код (`needsTotp`); без коду сесію **не** видаємо; невірний код = 401 і лічиться у throttling. Підказка 2FA з'являється **лише після** вірного пароля — без витоку існування акаунтів.
- **`/api/staff/2fa`**: самозапис (`begin`→`confirm`) і самовимкнення (з кодом) — будь-яка роль для **власного** акаунта; **`admin_reset`** — лише системний адмін (відновлення при втраті пристрою). Усі зміни — в security-лог (`totp_enabled` / `totp_disabled` / `totp_admin_reset`).
- **UI**: крок вводу коду на сторінці входу; секція «Двофакторна автентифікація» в особистому кабінеті (ключ base32 + `otpauth`-URI для сканування, підтвердження, вимкнення).

### Безпека / межі
- Секрет — **другий** фактор поверх телефон+PIN; зберігається в БД відділення. За потреби його можна додатково шифрувати ключем середовища — свідомо лишив окремим кроком, щоб не вводити тут керування ключами й ризик локауту.
- Відновлення при втраті автентифікатора — через `admin_reset` (адмін), а не бекап-коди (можливий наступний крок).
- Наразі 2FA **опційна** (рекомендована для адмінів); примусове ввімкнення за роллю — можливий наступний крок.

## Тести
- RFC-вектори TOTP + вікно/валідація/base32.
- Гейт входу: `needsTotp` без коду, 401 на невірний, вхід+сесія на вірний; невірний PIN не показує підказку 2FA.
- Самозапис (begin→confirm, відмова на невірний код), самовимкнення (з кодом), `admin_reset` (адмін проти не-адміна, tenant-scoped).
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — **1023/1023** (включно з drizzle-generation-guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_