### PR TITLE
reports: звіт завантаженості обладнання (потужність/факт/простій)

### DIFF
--- a/app/api/staff/reports/utilization/route.ts
+++ b/app/api/staff/reports/utilization/route.ts
@@ -1,0 +1,83 @@
+// Звіт завантаженості обладнання: потужність за графіком vs фактично виконано
+// та заброньовано, простій. Агрегат без даних пацієнтів — доступний
+// адміністратору й завідувачу відділення (management-контекст).
+
+import { requireManagementOrgContext } from "../../../../../lib/tenant";
+import { getOrganizationSchedule } from "../../../../../lib/tenant-schedule";
+import { EQUIP_KEYS, EQUIP_LABELS, hoursFor, isEquipmentDayOpen } from "../../../../../lib/schedule";
+import {
+  datesInRange, dailyCapacityMinutes, summarizeUtilization, utilizationRow,
+} from "../../../../../lib/equipment-utilization";
+import { dbBinding } from "../../../../../lib/db";
+import { audit } from "../../../../../lib/audit";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function defaultRange(): { from: string; to: string } {
+  const now = new Date();
+  const to = now.toISOString().slice(0, 10);
+  const fromDate = new Date(now);
+  fromDate.setUTCDate(fromDate.getUTCDate() - 29);
+  return { from: fromDate.toISOString().slice(0, 10), to };
+}
+
+export async function GET(request: Request) {
+  const db = dbBinding();
+  if (!db) return Response.json({ error: "База тимчасово недоступна" }, { status: 503 });
+  const ctx = await requireManagementOrgContext(request, db);
+  if (!ctx) return Response.json({ error: "Звіт доступний адміністратору або завідувачу відділення" }, { status: 403 });
+  const orgId = ctx.organizationId;
+
+  const url = new URL(request.url);
+  const def = defaultRange();
+  const from = DATE_RE.test(url.searchParams.get("from") || "") ? url.searchParams.get("from")! : def.from;
+  const to = DATE_RE.test(url.searchParams.get("to") || "") ? url.searchParams.get("to")! : def.to;
+  if (from > to) return Response.json({ error: "Початок періоду пізніше за кінець" }, { status: 400 });
+
+  const schedule = await getOrganizationSchedule(db, orgId);
+  const dates = datesInRange(from, to);
+
+  const [performed, booked] = await Promise.all([
+    db.prepare(
+      `SELECT equipment_id AS equipmentId, COALESCE(SUM(duration_minutes),0) AS minutes, COUNT(*) AS n
+       FROM bookings
+       WHERE organization_id = ? AND performed_at != '' AND substr(performed_at,1,10) BETWEEN ? AND ?
+       GROUP BY equipment_id`
+    ).bind(orgId, from, to).all<{ equipmentId: string; minutes: number; n: number }>(),
+    db.prepare(
+      `SELECT equipment_id AS equipmentId, COALESCE(SUM(duration_minutes),0) AS minutes
+       FROM bookings
+       WHERE organization_id = ? AND desired_date BETWEEN ? AND ? AND status != 'cancelled'
+       GROUP BY equipment_id`
+    ).bind(orgId, from, to).all<{ equipmentId: string; minutes: number }>(),
+  ]);
+
+  const performedBy = new Map((performed.results || []).map((r) => [r.equipmentId, r]));
+  const bookedBy = new Map((booked.results || []).map((r) => [r.equipmentId, Number(r.minutes)]));
+
+  const rows = EQUIP_KEYS.map((equip) => {
+    const hours = hoursFor(schedule, equip);
+    const workingDays = dates.filter((d) => isEquipmentDayOpen(d, schedule, equip)).length;
+    const perf = performedBy.get(equip);
+    return utilizationRow({
+      equipmentId: equip,
+      label: EQUIP_LABELS[equip] || equip,
+      workingDays,
+      dailyCapacityMinutes: dailyCapacityMinutes(hours),
+      performedMinutes: Number(perf?.minutes || 0),
+      performedCount: Number(perf?.n || 0),
+      bookedMinutes: bookedBy.get(equip) || 0,
+    });
+  });
+  const totals = summarizeUtilization(rows);
+
+  await audit(db, {
+    organizationId: orgId,
+    actorEmail: ctx.member.email,
+    action: "equipment_utilization_viewed",
+    resource: "report",
+    details: { from, to },
+  });
+
+  return Response.json({ from, to, rows, totals, staff: ctx.member }, { headers: { "cache-control": "no-store" } });
+}

--- a/app/staff/command-palette.tsx
+++ b/app/staff/command-palette.tsx
@@ -47,6 +47,7 @@ const COMMANDS: { label: string; hint: string; href: string }[] = [
   { label: "Регістри", hint: "карта регістрів", href: "/staff/registers" },
   { label: "Обороти регістрів", hint: "оборотно-сальдовий", href: "/staff/reports/registers" },
   { label: "Звіти відділення", hint: "аналітика", href: "/staff/reports" },
+  { label: "Завантаженість обладнання", hint: "потужність / факт / простій", href: "/staff/reports/utilization" },
   { label: "Маржинальність послуг", hint: "план / факт матеріалів", href: "/staff/reports/material-margin" },
   { label: "Контроль матеріалів", hint: "план / факт списання", href: "/staff/reports/material-consumption-control" },
   // Склад

--- a/app/staff/reports/page.tsx
+++ b/app/staff/reports/page.tsx
@@ -161,7 +161,7 @@ export default function ReportsPage() {
       <section className="reportBuilder">
         <div className="reportBuilderHead">
           <div><p className="eyebrow">Конструктор</p><h2>Оберіть потрібний реєстр</h2></div>
-          <p>Усі шаблони експортуються у справжній Excel. ПІБ і телефони не включаються, але деталізовані медичні реєстри все одно потребують захищеного зберігання.</p>
+          <p>Усі шаблони експортуються у справжній Excel. ПІБ і телефони не включаються, але деталізовані медичні реєстри все одно потребують захищеного зберігання. Окремо: <a href="/staff/reports/utilization">Завантаженість обладнання →</a></p>
         </div>
         <div className="reportTemplateTabs">
           {(Object.values(REPORT_TEMPLATES)).map((item)=><button

--- a/app/staff/reports/utilization/page.tsx
+++ b/app/staff/reports/utilization/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import StaffWorkspaceShell from "../../workspace-shell";
+import { roleLabelUk } from "../../../../lib/labels";
+
+type Row = {
+  equipmentId: string; label: string; workingDays: number;
+  capacityMinutes: number; performedMinutes: number; performedCount: number;
+  bookedMinutes: number; utilizationPct: number; bookedPct: number; idleMinutes: number;
+};
+type Totals = Omit<Row, "equipmentId" | "label">;
+type Staff = { email: string; displayName: string; role: string };
+
+const hrs = (m: number) => (m / 60).toLocaleString("uk-UA", { maximumFractionDigits: 1 });
+
+function defaultRange() {
+  const to = new Date();
+  const from = new Date(to);
+  from.setUTCDate(from.getUTCDate() - 29);
+  return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+}
+
+function UtilBar({ pct }: { pct: number }) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const tone = pct >= 85 ? "#b53a2b" : pct >= 55 ? "var(--green)" : "var(--orange)";
+  return <div className="reportBarTrack" title={`${pct}%`}>
+    <i style={{ width: `${clamped}%`, background: tone }} />
+  </div>;
+}
+
+export default function UtilizationReportPage() {
+  const init = defaultRange();
+  const [from, setFrom] = useState(init.from);
+  const [to, setTo] = useState(init.to);
+  const [rows, setRows] = useState<Row[]>([]);
+  const [totals, setTotals] = useState<Totals | null>(null);
+  const [staff, setStaff] = useState<Staff | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async (f: string, t: string) => {
+    try {
+      const res = await fetch(`/api/staff/reports/utilization?from=${f}&to=${t}`, { cache: "no-store" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(data.error || "Не вдалося завантажити звіт"); return; }
+      setError(""); setRows(data.rows || []); setTotals(data.totals || null); setStaff(data.staff || null);
+    } catch {
+      setError("Мережа недоступна");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { (async () => { await load(init.from, init.to); })(); }, [load, init.from, init.to]);
+
+  function apply() { setLoading(true); void load(from, to); }
+
+  return <StaffWorkspaceShell
+    active="reports"
+    title="Завантаженість обладнання"
+    description="Потужність за графіком проти фактично виконаного та заброньованого — з простоєм по кожному апарату."
+    staffName={staff?.displayName || staff?.email}
+    staffRole={roleLabelUk(staff?.role)}
+  >
+    {error ? <section className="accessDenied"><b>Захищений розділ</b><p>{error}. Увійдіть через дозволений робочий обліковий запис.</p><a className="button compact" href="/staff/login?returnTo=%2Fstaff%2Freports%2Futilization">Увійти для роботи</a></section> :
+    <section className="reportPanel">
+      <div className="utilFilters">
+        <label>Від <input type="date" value={from} max={to} onChange={(e) => setFrom(e.target.value)} /></label>
+        <label>До <input type="date" value={to} min={from} onChange={(e) => setTo(e.target.value)} /></label>
+        <button type="button" className="button" onClick={apply} disabled={loading}>{loading ? "…" : "Оновити"}</button>
+        <a className="button compact" href="/staff/reports">← До звітів</a>
+      </div>
+      {loading ? <p className="empty">Рахуємо…</p> :
+        <div className="reportTableScroll">
+          <table className="utilTable">
+            <thead>
+              <tr>
+                <th>Апарат</th><th>Робочих днів</th><th>Потужність, год</th>
+                <th>Виконано, год</th><th>Завантаження</th><th>Заброньовано</th><th>Простій, год</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => <tr key={r.equipmentId}>
+                <td>{r.label}</td>
+                <td className="num">{r.workingDays}</td>
+                <td className="num">{hrs(r.capacityMinutes)}</td>
+                <td className="num">{hrs(r.performedMinutes)} <small>({r.performedCount})</small></td>
+                <td><div className="utilCell"><UtilBar pct={r.utilizationPct} /><b>{r.utilizationPct}%</b></div></td>
+                <td className="num">{r.bookedPct}%</td>
+                <td className="num">{hrs(r.idleMinutes)}</td>
+              </tr>)}
+            </tbody>
+            {totals && <tfoot>
+              <tr>
+                <th>Разом</th>
+                <th className="num">{totals.workingDays}</th>
+                <th className="num">{hrs(totals.capacityMinutes)}</th>
+                <th className="num">{hrs(totals.performedMinutes)} <small>({totals.performedCount})</small></th>
+                <th className="num">{totals.utilizationPct}%</th>
+                <th className="num">{totals.bookedPct}%</th>
+                <th className="num">{hrs(totals.idleMinutes)}</th>
+              </tr>
+            </tfoot>}
+          </table>
+        </div>}
+      <p className="utilHint">Потужність = робочі дні за графіком × денне вікно апарата мінус обід. «Виконано» — за фактом проведення (performed_at), «заброньовано» — усі незскасовані записи періоду. Свято зменшує потужність, лише якщо його додано у вихідні дні графіка.</p>
+    </section>}
+  </StaffWorkspaceShell>;
+}

--- a/app/styles/02-workspace.css
+++ b/app/styles/02-workspace.css
@@ -893,3 +893,19 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 
 /* Підказка під полем «Джерело методики» в редакторі протоколу. */
 .protocolFieldHint{display:block;margin-top:5px;font-size:11px;color:#71807c}
+
+/* Звіт завантаженості обладнання (/staff/reports/utilization). */
+.utilFilters{display:flex;gap:12px;align-items:end;flex-wrap:wrap;margin-bottom:16px}
+.utilFilters label{display:flex;flex-direction:column;gap:4px;font-size:12px;color:#5c6a66}
+.utilFilters input{padding:8px 10px;border:1px solid #cdd6d3;border-radius:6px}
+.utilFilters a{margin-left:auto}
+.utilTable{width:100%;border-collapse:collapse;font-size:13px}
+.utilTable th,.utilTable td{padding:9px 12px;border-bottom:1px solid #eceae3;text-align:left}
+.utilTable thead th{font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:#71807c;font-weight:900}
+.utilTable td.num,.utilTable th.num{text-align:right;font-variant-numeric:tabular-nums}
+.utilTable tfoot th{font-weight:800;border-top:2px solid #dfe4e2}
+.utilTable small{color:#8a9793}
+.utilCell{display:flex;align-items:center;gap:10px;min-width:140px}
+.utilCell .reportBarTrack{flex:1}
+.utilCell b{font-variant-numeric:tabular-nums;font-size:12px}
+.utilHint{margin-top:14px;font-size:11px;color:#71807c;line-height:1.5}

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -134,6 +134,7 @@
 ### Звіти — *Адмін*
 
 - Звіти відділення — `/staff/reports`
+- Завантаженість обладнання — `/staff/reports/utilization` *(також Завідувач)*
 - Обороти регістрів — `/staff/reports/registers`
 - Дебіторська заборгованість — `/staff/reports/receivables`
 - Маржинальність послуг — `/staff/reports/material-margin`

--- a/lib/equipment-utilization.ts
+++ b/lib/equipment-utilization.ts
@@ -1,0 +1,92 @@
+// Завантаженість обладнання: доступна потужність (робочі хвилини за графіком),
+// фактично виконано, заплановано (заброньовано) і простій — за період.
+//
+// Чиста логіка без залежностей (напряму тестовна). Графік і робочі дні бере
+// маршрут із lib/schedule (потужність = робочі дні × денне вікно мінус обід).
+
+export type EquipmentUtilization = {
+  equipmentId: string;
+  label: string;
+  workingDays: number;
+  capacityMinutes: number;
+  performedMinutes: number;
+  performedCount: number;
+  bookedMinutes: number;
+  utilizationPct: number; // виконано ÷ потужність
+  bookedPct: number;      // заброньовано ÷ потужність
+  idleMinutes: number;    // потужність − виконано (не менше 0)
+};
+
+function toMin(t: string): number {
+  const m = /^(\d{2}):(\d{2})$/.exec(t || "");
+  return m ? Number(m[1]) * 60 + Number(m[2]) : 0;
+}
+
+// Корисні робочі хвилини на день для апарата: вікно (end−start) мінус обідня
+// перерва, якщо вона в межах вікна.
+export function dailyCapacityMinutes(hours: { start: string; end: string; breakStart?: string; breakEnd?: string }): number {
+  const start = toMin(hours.start);
+  const end = toMin(hours.end);
+  if (end <= start) return 0;
+  let minutes = end - start;
+  if (hours.breakStart && hours.breakEnd) {
+    const bs = toMin(hours.breakStart);
+    const be = toMin(hours.breakEnd);
+    if (be > bs && bs >= start && be <= end) minutes -= (be - bs);
+  }
+  return Math.max(minutes, 0);
+}
+
+// Усі дати YYYY-MM-DD у діапазоні [from, to] включно.
+export function datesInRange(from: string, to: string): string[] {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) return [];
+  const out: string[] = [];
+  const cur = new Date(`${from}T00:00:00Z`);
+  const end = new Date(`${to}T00:00:00Z`);
+  if (Number.isNaN(cur.getTime()) || Number.isNaN(end.getTime()) || cur > end) return [];
+  // Обмеження безпеки: не більше ~2 років діапазону.
+  for (let guard = 0; cur <= end && guard < 800; guard += 1) {
+    out.push(cur.toISOString().slice(0, 10));
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return out;
+}
+
+const pct = (part: number, whole: number): number =>
+  whole > 0 ? Math.round((part / whole) * 1000) / 10 : 0;
+
+export function utilizationRow(input: {
+  equipmentId: string; label: string; workingDays: number; dailyCapacityMinutes: number;
+  performedMinutes: number; performedCount: number; bookedMinutes: number;
+}): EquipmentUtilization {
+  const capacityMinutes = Math.max(input.workingDays, 0) * Math.max(input.dailyCapacityMinutes, 0);
+  return {
+    equipmentId: input.equipmentId,
+    label: input.label,
+    workingDays: input.workingDays,
+    capacityMinutes,
+    performedMinutes: input.performedMinutes,
+    performedCount: input.performedCount,
+    bookedMinutes: input.bookedMinutes,
+    utilizationPct: pct(input.performedMinutes, capacityMinutes),
+    bookedPct: pct(input.bookedMinutes, capacityMinutes),
+    idleMinutes: Math.max(capacityMinutes - input.performedMinutes, 0),
+  };
+}
+
+export function summarizeUtilization(rows: EquipmentUtilization[]): Omit<EquipmentUtilization, "equipmentId" | "label"> {
+  const sum = (pick: (r: EquipmentUtilization) => number) => rows.reduce((a, r) => a + pick(r), 0);
+  const capacityMinutes = sum((r) => r.capacityMinutes);
+  const performedMinutes = sum((r) => r.performedMinutes);
+  const bookedMinutes = sum((r) => r.bookedMinutes);
+  return {
+    workingDays: rows.reduce((a, r) => Math.max(a, r.workingDays), 0),
+    capacityMinutes,
+    performedMinutes,
+    performedCount: sum((r) => r.performedCount),
+    bookedMinutes,
+    utilizationPct: pct(performedMinutes, capacityMinutes),
+    bookedPct: pct(bookedMinutes, capacityMinutes),
+    idleMinutes: Math.max(capacityMinutes - performedMinutes, 0),
+  };
+}

--- a/tests/equipment-utilization.behavior.test.mjs
+++ b/tests/equipment-utilization.behavior.test.mjs
@@ -1,0 +1,67 @@
+// Звіт завантаженості обладнання: потужність/факт/бронювання, RBAC, ізоляція.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withD1, callWorker, jsonRequest, seedStaffSession } from "./helpers/d1.mjs";
+
+const FROM = "2026-07-13";
+const TO = "2026-07-19"; // 7 днів → рівно одна неділя закрита → 6 робочих днів
+
+async function ctBooking(db, { org = 1, code, date, time, dur, status = "confirmed", performedAt = "" } = {}) {
+  await db.prepare(
+    `INSERT INTO bookings (organization_id, code, name, phone, service, equipment_id,
+       desired_date, desired_time, duration_minutes, status, performed_at)
+     VALUES (?, ?, 'П', '+380501112233', 'КТ', 'ct', ?, ?, ?, ?, ?)`
+  ).bind(org, code, date, time, dur, status, performedAt).run();
+}
+
+const report = (db, cookie, from = FROM, to = TO) =>
+  callWorker(jsonRequest(`/api/staff/reports/utilization?from=${from}&to=${to}`, undefined, { method: "GET", headers: { cookie } }), db);
+
+test("utilization: capacity from schedule, performed vs booked, idle", async () => {
+  await withD1(async (db) => {
+    const cookie = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    // Виконане КТ (45 хв) + заплановане КТ (30 хв) + скасоване (не рахується).
+    await ctBooking(db, { code: "U-DONE", date: "2026-07-15", time: "10:00", dur: 45, status: "completed", performedAt: "2026-07-15 10:45:00" });
+    await ctBooking(db, { code: "U-PLAN", date: "2026-07-16", time: "11:00", dur: 30, status: "confirmed" });
+    await ctBooking(db, { code: "U-CANC", date: "2026-07-17", time: "12:00", dur: 30, status: "cancelled" });
+
+    const res = await report(db, cookie);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const ct = body.rows.find((r) => r.equipmentId === "ct");
+    assert.equal(ct.workingDays, 6);              // 6 відкритих днів у 7-денному вікні
+    assert.equal(ct.capacityMinutes, 2880);       // 6 × 480 (08:00–17:00 мінус обід)
+    assert.equal(ct.performedMinutes, 45);        // лише виконане
+    assert.equal(ct.performedCount, 1);
+    assert.equal(ct.bookedMinutes, 75);           // 45 + 30, без скасованого
+    assert.equal(ct.utilizationPct, 1.6);         // 45/2880
+    assert.equal(ct.idleMinutes, 2835);           // 2880 − 45
+    assert.equal(body.totals.performedMinutes, 45);
+  });
+});
+
+test("utilization report is limited to management roles", async () => {
+  await withD1(async (db) => {
+    const reg = await seedStaffSession(db, { email: "reg@example.com", role: "registrar", organizationId: 1 });
+    assert.equal((await report(db, reg)).status, 403); // реєстратор — ні
+
+    const head = await seedStaffSession(db, { email: "head@example.com", role: "department_head", organizationId: 1 });
+    assert.equal((await report(db, head)).status, 200); // завідувач — так
+
+    const admin = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    assert.equal((await report(db, admin)).status, 200);
+  });
+});
+
+test("utilization isolates performed studies by organization", async () => {
+  await withD1(async (db) => {
+    await db.prepare("INSERT INTO organizations (id, slug, name, active) VALUES (2, 'other', 'Other', 1)").run();
+    const cookie = await seedStaffSession(db, { email: "boss@example.com", role: "admin", organizationId: 1 });
+    await ctBooking(db, { org: 2, code: "FOREIGN", date: "2026-07-15", time: "10:00", dur: 45, status: "completed", performedAt: "2026-07-15 10:45:00" });
+
+    const body = await (await report(db, cookie)).json();
+    const ct = body.rows.find((r) => r.equipmentId === "ct");
+    assert.equal(ct.performedMinutes, 0); // чужі дослідження не враховано
+  });
+});

--- a/tests/equipment-utilization.test.mjs
+++ b/tests/equipment-utilization.test.mjs
@@ -1,0 +1,54 @@
+// Завантаженість обладнання — чиста логіка потужності/простою.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  dailyCapacityMinutes, datesInRange, utilizationRow, summarizeUtilization,
+} from "../lib/equipment-utilization.ts";
+
+test("dailyCapacityMinutes = вікно мінус обід у межах вікна", () => {
+  assert.equal(dailyCapacityMinutes({ start: "08:00", end: "17:00", breakStart: "13:00", breakEnd: "14:00" }), 480);
+  assert.equal(dailyCapacityMinutes({ start: "10:00", end: "15:00", breakStart: "13:00", breakEnd: "14:00" }), 240);
+  assert.equal(dailyCapacityMinutes({ start: "09:30", end: "16:00", breakStart: "13:00", breakEnd: "14:00" }), 330);
+  assert.equal(dailyCapacityMinutes({ start: "08:00", end: "17:00" }), 540); // без обіду
+  assert.equal(dailyCapacityMinutes({ start: "08:00", end: "17:00", breakStart: "18:00", breakEnd: "19:00" }), 540); // обід поза вікном ігнорується
+  assert.equal(dailyCapacityMinutes({ start: "17:00", end: "08:00" }), 0); // некоректне вікно
+});
+
+test("datesInRange повертає всі дати включно, порожньо на некоректних", () => {
+  assert.deepEqual(datesInRange("2026-07-13", "2026-07-15"), ["2026-07-13", "2026-07-14", "2026-07-15"]);
+  assert.equal(datesInRange("2026-07-13", "2026-07-19").length, 7);
+  assert.deepEqual(datesInRange("2026-07-15", "2026-07-13"), []); // from > to
+  assert.deepEqual(datesInRange("bad", "2026-07-13"), []);
+});
+
+test("utilizationRow рахує потужність, завантаження, простій", () => {
+  const r = utilizationRow({
+    equipmentId: "ct", label: "КТ", workingDays: 6, dailyCapacityMinutes: 480,
+    performedMinutes: 720, performedCount: 16, bookedMinutes: 960,
+  });
+  assert.equal(r.capacityMinutes, 2880); // 6 × 480
+  assert.equal(r.utilizationPct, 25);    // 720/2880
+  assert.equal(r.bookedPct, 33.3);       // 960/2880 → 33.333 → 33.3
+  assert.equal(r.idleMinutes, 2160);     // 2880 − 720
+});
+
+test("utilizationRow: нульова потужність не ділить на нуль", () => {
+  const r = utilizationRow({ equipmentId: "x", label: "X", workingDays: 0, dailyCapacityMinutes: 480, performedMinutes: 0, performedCount: 0, bookedMinutes: 0 });
+  assert.equal(r.capacityMinutes, 0);
+  assert.equal(r.utilizationPct, 0);
+  assert.equal(r.idleMinutes, 0);
+});
+
+test("summarizeUtilization підсумовує та бере максимум робочих днів", () => {
+  const rows = [
+    utilizationRow({ equipmentId: "ct", label: "КТ", workingDays: 6, dailyCapacityMinutes: 480, performedMinutes: 480, performedCount: 10, bookedMinutes: 600 }),
+    utilizationRow({ equipmentId: "xray", label: "Рентген", workingDays: 6, dailyCapacityMinutes: 240, performedMinutes: 240, performedCount: 12, bookedMinutes: 240 }),
+  ];
+  const t = summarizeUtilization(rows);
+  assert.equal(t.capacityMinutes, 2880 + 1440);
+  assert.equal(t.performedMinutes, 720);
+  assert.equal(t.performedCount, 22);
+  assert.equal(t.workingDays, 6);
+  assert.equal(t.idleMinutes, (2880 + 1440) - 720);
+});


### PR DESCRIPTION
## Що зроблено

За гілкою **«Операционка»** майндмепа медбізнесу («загрузка», «производственная мощность», «потери») — звіт ефективності використання апаратів. Новий екран **`/staff/reports/utilization`** по кожному апарату (КТ / рентген / флюоро):

- **Потужність** = робочі дні за графіком × денне вікно апарата мінус обід. Джерело — той самий налаштований графік відділення (`getOrganizationSchedule` / `isEquipmentDayOpen`), що керує бронюванням, тож цифри **узгоджені з записом**.
- **Виконано** (за `performed_at`) з кількістю досліджень, **заброньовано** (усі незскасовані записи періоду), **% завантаження**, **% бронювання** і **простій** (потужність − виконано).
- Підсумок по всіх апаратах; кольоровий бар (зелений/помаранчевий/червоний за рівнем).

## Доступ і межі
- **Адміністратор і завідувач відділення** (`requireManagementOrgContext`) — це агрегат **без даних пацієнтів**, тож завідувач бачить операційну картину, не отримуючи доступу до карток.
- Запис у security-лог (`equipment_utilization_viewed`), tenant-scoped.
- Точки входу: посилання на сторінці звітів, команд-палітра, `docs/sitemap.md`.

## Архітектура
- `lib/equipment-utilization.ts` — чиста логіка (`dailyCapacityMinutes` = вікно−обід, `datesInRange`, `utilizationRow`, `summarizeUtilization`), тестовна напряму.
- Маршрут з'єднує графік (`lib/schedule`/`tenant-schedule`) із агрегатами `bookings`.

## Тести
- Юніт: вікно мінус обід (КТ 480 / рентген 240 / флюоро 330), діапазон дат, %/простій/підсумок, захист від ділення на нуль.
- End-to-end: потужність 6×480=2880 у 7-денному вікні, виконане vs заброньоване vs скасоване, RBAC (реєстратор 403; завідувач і адмін 200), ізоляція за організацією.
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — **1031/1031**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_