### PR TITLE
design: іконки статусів, hover-картки й поліш кнопок

### DIFF
--- a/app/styles/02-workspace.css
+++ b/app/styles/02-workspace.css
@@ -942,3 +942,29 @@ button.apptEvent{border-top:0;border-right:0;border-bottom:0}
 .cfActions{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:10px}
 .cfActions input{padding:7px 10px;border:1px solid #cdd6d3;border-radius:6px;font-size:13px;min-width:220px}
 .button.compact.ghost{background:#eef2f0;color:#3a4744}
+
+/* Іконки статусів на бейджах/картках (монохром по currentColor) + м'який hover. */
+.kpiCard .kpiStatus::before,
+.cfBadge::before,
+.consistencyBadge.sev-high::before,
+.consistencyBadge.sev-medium::before,
+.consistencyBadge.sev-low::before{
+  content:"";display:inline-block;width:13px;height:13px;vertical-align:-2px;margin-right:5px;
+  background-color:currentColor;
+  -webkit-mask:var(--status-icon,var(--icon-ok)) center/contain no-repeat;
+  mask:var(--status-icon,var(--icon-ok)) center/contain no-repeat;
+}
+.kpiCard.st-alert{--status-icon:var(--icon-alert)}
+.kpiCard.st-warn{--status-icon:var(--icon-warn)}
+.kpiCard.st-ok{--status-icon:var(--icon-ok)}
+.cfBadge{--status-icon:var(--icon-alert)}
+.cfBadge.st-communicated{--status-icon:var(--icon-warn)}
+.consistencyBadge.sev-high{--status-icon:var(--icon-alert)}
+.consistencyBadge.sev-medium{--status-icon:var(--icon-warn)}
+.consistencyBadge.sev-low{--status-icon:var(--icon-ok)}
+.kpiCard,.cfItem,.consistencyItem{transition:box-shadow .14s ease, transform .14s ease}
+.kpiCard:hover,.cfItem:hover,.consistencyItem:hover{box-shadow:var(--ws-shadow-md);transform:translateY(-1px)}
+@media (prefers-reduced-motion: reduce){
+  .kpiCard,.cfItem,.consistencyItem{transition:none}
+  .kpiCard:hover,.cfItem:hover,.consistencyItem:hover{transform:none}
+}

--- a/app/styles/12-design-system.css
+++ b/app/styles/12-design-system.css
@@ -22,6 +22,22 @@
   --status-ok-bg: #e9f3ee;   --status-ok-fg: #166a46;   --status-ok-line: #2f9e6e;
   --status-warn-bg: #fdf3e1; --status-warn-fg: #8a5411; --status-warn-line: #d99a2b;
   --status-alert-bg: #fcebe8; --status-alert-fg: #a1301b; --status-alert-line: #d1442b;
+  /* Монохромні line-іконки статусів (маска по currentColor — адаптуються до кольору тексту). */
+  --icon-alert: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+  --icon-warn: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='9'/%3E%3Cpath d='M12 7v5l3 2'/%3E%3C/svg%3E");
+  --icon-ok: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='9'/%3E%3Cpath d='m8 12 2.5 2.5L16 9'/%3E%3C/svg%3E");
+}
+
+/* Спільний поліш кнопок у воркспейсі: м'який hover-лифт, тінь, кільце фокуса. */
+.workspaceShell .button {
+  transition: transform .12s ease, box-shadow .12s ease, filter .12s ease;
+}
+.workspaceShell .button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: var(--ws-shadow-sm); }
+.workspaceShell .button:active:not(:disabled) { transform: none; box-shadow: none; }
+.workspaceShell :where(button, a):focus-visible {
+  outline: 2px solid var(--ws-accent);
+  outline-offset: 2px;
+  border-radius: var(--ws-radius-sm);
 }
 
 .workspaceShell.themeDark {


### PR DESCRIPTION
## Що зроблено

Продовження дизайн-пасу — «красиві» **кнопки / картки / іконки** на дашборд-поверхнях, усе на спільних токенах (тема-залежно, **без нових залежностей**).

- **Іконки статусів**: монохромні line-іконки (⚠ трикутник / годинник / галочка) на бейджах KPI-пульта, критичних знахідок і неузгодженостей — через CSS `mask` по `currentColor`, тож колір збігається зі статусом і адаптується до теми. Токени `--icon-{alert,warn,ok}` у дизайн-системі (той самий підхід, що й монохромні іконки навігації).
- **Картки статусів**: м'яка hover-тінь (`--ws-shadow-md`) + легкий лифт; вимикається за `prefers-reduced-motion`.
- **Кнопки**: спільний hover-лифт + тінь і **кільце фокуса** (`:focus-visible`, доступність) у межах воркспейсу — узгоджені primary / secondary / ghost.

Лише CSS/токени — **жодних змін логіки**.

## Перевірка
- Візуально: рендер у Chromium (скриншот у чаті) — іконки, тіні, кнопки.
- `npm run build`, `npx tsc --noEmit`, `npm run lint` (0 помилок), `npm test` — **1047/1047**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnJKBeMHvTa5kehgGcikf)_